### PR TITLE
Fix jest testing to work in other timeZones

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -93,7 +93,7 @@ function handleAffects (message) {
     app[0].toUpperCase() + app.slice(1).toLowerCase()
   )
   const valid = ['Student', 'Teacher', 'Parent', 'None']
-  const invalid = apps.filter(app => valid.includes(app))
+  const invalid = apps.filter(app => !valid.includes(app))
   if (invalid.length > 0) {
     fail(`You have included an invalid app. Valid values are: ${valid.join(', ')}`)
     return

--- a/rn/Teacher/i18n/setup.js
+++ b/rn/Teacher/i18n/setup.js
@@ -76,6 +76,7 @@ export default function (locale: ?string): void {
         'MMMM d': { month: 'long', day: 'numeric' },
         'MMM d': { month: 'short', day: 'numeric' },
         'M/d/yyyy': { day: 'numeric', month: 'numeric', year: 'numeric' },
+        'MMM d, YYYY': { day: 'numeric', month: 'short', year: 'numeric' },
       },
     },
   })

--- a/rn/Teacher/test/scripts/jestSetup.js
+++ b/rn/Teacher/test/scripts/jestSetup.js
@@ -28,11 +28,22 @@ import * as React from 'react'
 
 import * as template from '../../src/__templates__'
 
+import i18n from 'format-message'
 import setupI18n from '../../i18n/setup'
 import { shouldTrackAsyncActions } from '../../src/redux/middleware/redux-promise'
 import { enableAllFeaturesFlagsForTesting } from '@common/feature-flags'
 
 setupI18n('en')
+
+// Make most date rendering use a consistent timeZone.
+const formats = i18n.setup().formats
+for (const key of Object.keys(formats.date)) {
+  formats.date[key].timeZone = 'America/Denver'
+}
+for (const key of Object.keys(formats.time)) {
+  formats.time[key].timeZone = 'America/Denver'
+}
+
 shouldTrackAsyncActions(false)
 setSession(template.session())
 enableAllFeaturesFlagsForTesting()


### PR DESCRIPTION
refs: none
affects: none
release note: none