### PR TITLE
Fix anonymous grading in new DocViewer

### DIFF
--- a/Core/Core/API/APIDocViewer.swift
+++ b/Core/Core/API/APIDocViewer.swift
@@ -17,7 +17,7 @@
 import Foundation
 
 struct APIDocViewerMetadata: Codable {
-    let annotations: APIDocViewerAnnotationsMetadata
+    let annotations: APIDocViewerAnnotationsMetadata?
     let panda_push: APIDocViewerPandaPushMetadata?
     let rotations: [String: UInt]?
     let urls: APIDocViewerURLsMetadata
@@ -37,8 +37,10 @@ enum APIDocViewerPermissions: String, Codable {
 
 struct APIDocViewerPandaPushMetadata: Codable {
     let host: String
-    let annotations_channel: String
-    let annotations_token: String
+    let annotations_channel: String?
+    let annotations_token: String?
+    let document_channel: String?
+    let document_token: String?
 }
 
 struct APIDocViewerURLsMetadata: Codable {

--- a/Core/Core/DocViewer/DocViewerPresenter.swift
+++ b/Core/Core/DocViewer/DocViewerPresenter.swift
@@ -58,15 +58,17 @@ class DocViewerPresenter: NSObject {
             let api = URLSessionAPI(accessToken: nil, baseURL: sessionURL)
             self?.metadata = metadata
             let document = PSPDFDocument(url: localURL)
-            document.defaultAnnotationUsername = metadata.annotations.user_name
-            document.didCreateDocumentProviderBlock = { documentProvider in
-                let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, metadata: metadata.annotations, annotations: useCase.annotations, api: api, sessionID: sessionID)
-                provider.docViewerDelegate = self
-                documentProvider.annotationManager.annotationProviders.insert(provider, at: 0)
-                self?.annotationProvider = provider
-                for (pageKey, rawRotation) in metadata.rotations ?? [:] {
-                    if let pageIndex = PageIndex(pageKey), let rotation = Rotation(rawValue: rawRotation) {
-                        documentProvider.setRotationOffset(rotation, forPageAt: pageIndex)
+            if let annotationMeta = metadata.annotations {
+                document.defaultAnnotationUsername = annotationMeta.user_name
+                document.didCreateDocumentProviderBlock = { documentProvider in
+                    let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, metadata: annotationMeta, annotations: useCase.annotations, api: api, sessionID: sessionID)
+                    provider.docViewerDelegate = self
+                    documentProvider.annotationManager.annotationProviders.insert(provider, at: 0)
+                    self?.annotationProvider = provider
+                    for (pageKey, rawRotation) in metadata.rotations ?? [:] {
+                        if let pageIndex = PageIndex(pageKey), let rotation = Rotation(rawValue: rawRotation) {
+                            documentProvider.setRotationOffset(rotation, forPageAt: pageIndex)
+                        }
                     }
                 }
             }

--- a/Core/Core/DocViewer/DocViewerUseCase.swift
+++ b/Core/Core/DocViewer/DocViewerUseCase.swift
@@ -40,7 +40,7 @@ class DocViewerUseCase: OperationSet {
         addSequence([ getMeta, BlockOperation {
             guard let metadata = getMeta.response else { return }
             self.metadata = metadata
-            if metadata.annotations.enabled == true {
+            if metadata.annotations?.enabled == true {
                 self.loadAnnotations(docViewerAPI: docViewerAPI, sessionID: sessionID)
             }
             if let downloadURL = URL(string: metadata.urls.pdf_download.absoluteString, relativeTo: sessionURL) {

--- a/Core/Core/Extensions/OperationQueueExtensions.swift
+++ b/Core/Core/Extensions/OperationQueueExtensions.swift
@@ -22,7 +22,7 @@ extension OperationQueue {
     public func addOperationWithErrorHandling(_ group: OperationSet, sendErrorsTo view: ErrorViewController?) {
         addOperation(group, errorHandler: { error in
             if let error = error {
-                view?.showError(error)
+                DispatchQueue.main.async { view?.showError(error) }
             }
         })
     }


### PR DESCRIPTION
Properly handle the case where annotation metadata is not returned.

refs: MBL-11927
affects: none
release note: none