### PR TITLE
Auto bulk_message when >= 100 recipients

### DIFF
--- a/rn/Teacher/src/modules/address-book/AddressBook.js
+++ b/rn/Teacher/src/modules/address-book/AddressBook.js
@@ -123,6 +123,9 @@ export class AddressBook extends Component<AddressBookProps, State> {
       item = {
         id: this.props.context,
         name: this.props.name,
+        user_count: item.user_count || (this.state.searchResults || []).reduce((count: number, result: AddressBookResult) => (
+          count + (result.user_count || 0)
+        ), 0),
       }
     }
 

--- a/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
+++ b/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
@@ -155,12 +155,25 @@ describe('AddressBook', () => {
     props.name = 'Teachers'
     props.onSelect = jest.fn()
     const screen = shallow(<AddressBook {...props} />)
+    screen.instance()._requestFinished([
+      templates.addressBookResult({
+        id: '1',
+        name: 'Teachers 1',
+        user_count: 55,
+      }),
+      templates.addressBookResult({
+        id: '2',
+        name: 'Teachers 2',
+        user_count: 147,
+      }),
+    ])
     const list = screen.find('FlatList')
     const row = shallow(screen.instance()._renderRow({ item: list.props().data[0] }))
     row.simulate('press')
     expect(props.onSelect).toHaveBeenCalledWith([{
       id: 'course_1_teachers',
       name: 'Teachers',
+      user_count: 202,
     }])
   })
 

--- a/rn/Teacher/src/modules/inbox/Compose.js
+++ b/rn/Teacher/src/modules/inbox/Compose.js
@@ -124,6 +124,12 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
     )
   }
 
+  mustSendAll () {
+    return this.state.recipients.reduce((count: number, result: AddressBookResult) => (
+      count + (result.user_count || 1)
+    ), 0) >= 100
+  }
+
   sendMessage = () => {
     const state = this.state
     const convo: CreateConversationParameters = {
@@ -136,7 +142,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
       context_code: state.contextCode || undefined,
     }
 
-    if (this.state.sendToAll) {
+    if (this.mustSendAll() || state.sendToAll) {
       convo.bulk_message = 1
     }
 
@@ -329,7 +335,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
                 border='bottom'
                 title={i18n('Send individual message to each recipient')}
                 onValueChange={this.toggleSendAll}
-                value={this.state.sendToAll}
+                value={this.mustSendAll() || this.state.sendToAll}
                 identifier='compose-message.send-all-toggle'
               />
             }


### PR DESCRIPTION
Had to calculate the number of recipient in the top-level group by summing the sub-groups.

refs: MBL-12089
affects: Student, Teacher
release note: Fixed error when sending messages to 100 or more recipients