### PR TITLE
Add more Core tests

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -118,6 +118,7 @@
 		7D37BE8D21C837840063FAAC /* SubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D37BE8C21C837840063FAAC /* SubmissionTests.swift */; };
 		7D37BE9121C849D10063FAAC /* DocViewerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D37BE9021C849D10063FAAC /* DocViewerPresenterTests.swift */; };
 		7D47769C21AF3A0200B441CE /* QuizQuestionType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D47769B21AF3A0200B441CE /* QuizQuestionType.swift */; };
+		7D4C3D59222D9E41001B1198 /* LTIToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4C3D58222D9E41001B1198 /* LTIToolsTests.swift */; };
 		7D4D5EB2213F2A200080AC14 /* UIImageViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D4D5EB1213F2A200080AC14 /* UIImageViewExtensions.swift */; };
 		7D4D5EB721402CAA0080AC14 /* TestImage.png in Resources */ = {isa = PBXBuildFile; fileRef = 7D4D5EB421402CA90080AC14 /* TestImage.png */; };
 		7D4D5EB821402CAA0080AC14 /* TestImage.svg in Resources */ = {isa = PBXBuildFile; fileRef = 7D4D5EB521402CA90080AC14 /* TestImage.svg */; };
@@ -693,6 +694,7 @@
 		7D37BE8C21C837840063FAAC /* SubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionTests.swift; sourceTree = "<group>"; };
 		7D37BE9021C849D10063FAAC /* DocViewerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerPresenterTests.swift; sourceTree = "<group>"; };
 		7D47769B21AF3A0200B441CE /* QuizQuestionType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizQuestionType.swift; sourceTree = "<group>"; };
+		7D4C3D58222D9E41001B1198 /* LTIToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LTIToolsTests.swift; sourceTree = "<group>"; };
 		7D4D5EB1213F2A200080AC14 /* UIImageViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageViewExtensions.swift; sourceTree = "<group>"; };
 		7D4D5EB421402CA90080AC14 /* TestImage.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = TestImage.png; sourceTree = "<group>"; };
 		7D4D5EB521402CA90080AC14 /* TestImage.svg */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
@@ -1075,6 +1077,7 @@
 				DFE1FF1E212F5E2C003F27AA /* Keychain */,
 				B1E789B321B1AD720087FE4A /* Logger */,
 				3B3467512130527000F9BC2E /* Login */,
+				7D4C3D57222D9E22001B1198 /* LTI */,
 				7D062AF521249E5800677F66 /* Models */,
 				B1911CEA21C849AE00F42F91 /* Notifications */,
 				3BE2C76D219335FA004B8E5E /* Presenter */,
@@ -1380,6 +1383,14 @@
 				B19792FE2176A0F00000369C /* TabTests.swift */,
 			);
 			path = Models;
+			sourceTree = "<group>";
+		};
+		7D4C3D57222D9E22001B1198 /* LTI */ = {
+			isa = PBXGroup;
+			children = (
+				7D4C3D58222D9E41001B1198 /* LTIToolsTests.swift */,
+			);
+			path = LTI;
 			sourceTree = "<group>";
 		};
 		7D4D5EB321402CA90080AC14 /* Fixtures */ = {
@@ -2346,6 +2357,7 @@
 				7D80AC19212B697600C40ECE /* APIGroup+Requestable+Tests.swift in Sources */,
 				7D2DC31B219CE469008FE29A /* DocViewerUseCaseTests.swift in Sources */,
 				B195DC622133326900797FE4 /* GetCourseTest.swift in Sources */,
+				7D4C3D59222D9E41001B1198 /* LTIToolsTests.swift in Sources */,
 				3BE2C76F219335FA004B8E5E /* ColoredNavViewProtocol.swift in Sources */,
 				7DFB2CF921C978D40077DEEE /* GetCustomColorsTests.swift in Sources */,
 				B171A10B21BA13CF000325D3 /* UpdateFileUploadTests.swift in Sources */,

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -1,0 +1,62 @@
+//
+// Copyright (C) 2019-present Instructure, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import XCTest
+@testable import Core
+
+class LTIToolsTests: CoreTestCase {
+    func testGetSessionlessLaunchURL() {
+        let tools = LTITools(
+            env: environment,
+            context: ContextModel(.course, id: "1"),
+            id: nil,
+            url: nil,
+            launchType: nil,
+            assignmentID: nil,
+            moduleItemID: nil
+        )
+        let request = GetSessionlessLaunchURLRequest(context: ContextModel(.course, id: "1"), id: nil, url: nil, assignmentID: nil, moduleItemID: nil, launchType: nil)
+        let actualURL = URL(string: "/someplace")!
+
+        api.mock(request)
+        var url: URL?
+        let doneNil = expectation(description: "callback completed")
+        tools.getSessionlessLaunchURL { result in
+            url = result
+            doneNil.fulfill()
+        }
+        wait(for: [doneNil], timeout: 1)
+        XCTAssertNil(url)
+
+        api.mock(request, value: APIGetSessionlessLaunchResponse(id: "", name: "", url: actualURL), error: APIRequestableError.invalidPath(""))
+        let doneError = expectation(description: "callback completed")
+        tools.getSessionlessLaunchURL { result in
+            url = result
+            doneError.fulfill()
+        }
+        wait(for: [doneError], timeout: 1)
+        XCTAssertNil(url)
+
+        api.mock(request, value: APIGetSessionlessLaunchResponse(id: "", name: "", url: actualURL))
+        let doneValue = expectation(description: "callback completed")
+        tools.getSessionlessLaunchURL { result in
+            url = result
+            doneValue.fulfill()
+        }
+        wait(for: [doneValue], timeout: 1)
+        XCTAssertEqual(url, actualURL)
+    }
+}

--- a/scripts/coverage/coverage.js
+++ b/scripts/coverage/coverage.js
@@ -37,6 +37,7 @@ if (!scheme) {
 }
 
 const coverageFolder = `scripts/coverage/${scheme.toLowerCase()}`
+const resultBundlePath = `scripts/coverage/${scheme.toLowerCase()}.xcresult`
 
 try {
   runTests()
@@ -49,17 +50,19 @@ try {
 
 function runTests() {
   if (!test || !device || !os) { return }
+  run(`rm -rf ${resultBundlePath}`)
   run(
     `xcodebuild test -scheme ${scheme} -workspace Canvas.xcworkspace \
     -sdk iphonesimulator \
-    -destination 'platform=iOS Simulator,name=${device},OS=${os}'`,
+    -destination 'platform=iOS Simulator,name=${device},OS=${os}' \
+    -resultBundlePath ${resultBundlePath}`,
     { stdio: 'inherit' }
   )
 }
 
 function reportCoverage () {
   console.log('Finding Xcode coverage report')
-  let folder = `scripts/coverage/${scheme.toLowerCase()}.xcresult`
+  let folder = resultBundlePath
   if (!existsSync(folder)) {
     const settings = run(`xcrun xcodebuild -showBuildSettings -workspace AllTheThings.xcworkspace -scheme ${scheme}`)
     folder = join(settings.match(/BUILD_DIR = (.*)/)[1], '../../Logs/Test/*.xcresult')


### PR DESCRIPTION
Also make the `coverage --test` save results to the preferred location.

refs: none
affects: none
release note: none