### PR TITLE
Save credentials in new keychain

### DIFF
--- a/Canvas/Canvas/CanvasAppDelegate.swift
+++ b/Canvas/Canvas/CanvasAppDelegate.swift
@@ -321,8 +321,7 @@ extension AppDelegate: NativeLoginManagerDelegate {
             Analytics.setUserProperty(client.baseURL?.absoluteString, forName: "base_url")
         }
         if let entry = client.keychainEntry {
-            // TODO: Persist this keychain entry
-            Keychain.currentSession = entry
+            Keychain.addEntry(entry)
             environment.userDidLogin(session: entry)
             CoreWebView.keepCookieAlive(for: environment)
         }
@@ -348,6 +347,11 @@ extension AppDelegate: NativeLoginManagerDelegate {
     }
     
     func didLogout(_ controller: UIViewController) {
+        if let entry = Keychain.currentSession {
+            Keychain.removeEntry(entry)
+            environment.userDidLogout(session: entry)
+            CoreWebView.stopCookieKeepAlive()
+        }
         NotificationKitController.deregisterPushNotifications { _ in
             // this is a no-op because we don't want errors to prevent logging out
         }

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -43,9 +43,22 @@ open class AppEnvironment {
     }
 
     public func userDidLogin(session: KeychainEntry) {
-        self.database = NSPersistentContainer.create(session: session)
-        self.api = URLSessionAPI(accessToken: session.accessToken, actAsUserID: session.actAsUserID, baseURL: session.baseURL)
-        self.currentSession = session
+        Keychain.currentSession = session
+        database = NSPersistentContainer.create(session: session)
+        api = URLSessionAPI(accessToken: session.accessToken, actAsUserID: session.actAsUserID, baseURL: session.baseURL)
+        currentSession = session
+        backgroundAPIManager.session = session
+        backgroundAPIManager.database = database
+        Logger.shared.database = database
+    }
+
+    public func userDidLogout(session: KeychainEntry) {
+        try? NSPersistentContainer.destroy(session: session)
+        guard session == currentSession else { return }
+        Keychain.currentSession = nil
+        database = globalDatabase
+        api = URLSessionAPI()
+        currentSession = nil
         backgroundAPIManager.session = session
         backgroundAPIManager.database = database
         Logger.shared.database = database

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -24,4 +24,15 @@ class AppEnvironmentTests: CoreTestCase {
         XCTAssertEqual(env.api.accessToken, "token")
         XCTAssertEqual(env.backgroundAPI.accessToken, "token")
     }
+
+    func testUserDidLogout() {
+        let env = AppEnvironment()
+        let current = KeychainEntry.make(accessToken: "token")
+        env.userDidLogin(session: current)
+        env.userDidLogout(session: KeychainEntry.make(userID: "7"))
+        XCTAssertEqual(env.api.accessToken, "token")
+        env.userDidLogout(session: current)
+        XCTAssertNil(env.api.accessToken)
+        XCTAssertNil(env.currentSession)
+    }
 }

--- a/Student/Student/AppDelegate.swift
+++ b/Student/Student/AppDelegate.swift
@@ -71,7 +71,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     }
 
     func setup(session: KeychainEntry) {
-        Keychain.currentSession = session
         environment.userDidLogin(session: session)
         CoreWebView.keepCookieAlive(for: environment)
         let getBrand = GetBrandVariables(env: environment, force: true)
@@ -121,9 +120,9 @@ extension AppDelegate: LoginDelegate {
     func userDidLogout(keychainEntry: KeychainEntry) {
         Keychain.removeEntry(keychainEntry)
         // TODO: Deregister push notifications?
-        try? NSPersistentContainer.destroy(session: keychainEntry)
+        environment.userDidLogout(session: keychainEntry)
         guard Keychain.currentSession == keychainEntry else { return }
-        Keychain.currentSession = nil
+        CoreWebView.stopCookieKeepAlive()
         changeUser()
     }
 }

--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -189,9 +189,9 @@ extension AppDelegate: NativeLoginManagerDelegate {
         }
 
         if let entry = client.keychainEntry {
-            // TODO: Persist this keychain entry
-            Keychain.currentSession = entry
+            Keychain.addEntry(entry)
             environment.userDidLogin(session: entry)
+            CoreWebView.keepCookieAlive(for: environment)
         }
 
         if let locale = client.effectiveLocale {
@@ -207,6 +207,11 @@ extension AppDelegate: NativeLoginManagerDelegate {
     }
     
     func didLogout(_ controller: UIViewController) {
+        if let entry = Keychain.currentSession {
+            Keychain.removeEntry(entry)
+            environment.userDidLogout(session: entry)
+            CoreWebView.stopCookieKeepAlive()
+        }
         guard let window = self.window else { return }
         
         UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: {


### PR DESCRIPTION
This is in prep for moving to the new login views. If login has been saved to the new keychain, switching to the new login flow won't log users out.

refs: none
affects: none
release note: none