### PR TITLE
OAuth doesn't always send email

### DIFF
--- a/Core/Core/API/APIOAuth.swift
+++ b/Core/Core/API/APIOAuth.swift
@@ -37,5 +37,5 @@ public struct APIOAuthUser: Codable, Equatable {
     let id: ID
     let name: String
     let effective_locale: String
-    let email: String
+    let email: String?
 }


### PR DESCRIPTION
This was preventing me from logging in in the reborn app.

refs: none
affects: none
release note: none