### PR TITLE
Fix file switching on ipad

### DIFF
--- a/rn/Teacher/src/modules/speedgrader/SubmissionGrader.js
+++ b/rn/Teacher/src/modules/speedgrader/SubmissionGrader.js
@@ -163,7 +163,7 @@ export default class SubmissionGrader extends Component<SubmissionGraderProps, S
       case 1:
         return <CommentsTab {...this.props} />
       case 2:
-        return <FilesTab {...this.props} />
+        return <FilesTab {...this.props} isWide={this.isWide()} />
       default:
         const showToolTip = this.toolTip ? this.toolTip.showToolTip : undefined
         const dismissToolTip = this.toolTip ? this.toolTip.dismissToolTip : undefined
@@ -219,6 +219,8 @@ export default class SubmissionGrader extends Component<SubmissionGraderProps, S
     }
     this.props.closeModal()
   }
+
+  isWide = () => this.state.width > COMPACT_DEVICE_WIDTH
 
   renderCompact (width: number, height: number) {
     return (
@@ -298,7 +300,7 @@ export default class SubmissionGrader extends Component<SubmissionGraderProps, S
 
   render () {
     const { width, height } = this.state
-    if (width > COMPACT_DEVICE_WIDTH) {
+    if (this.isWide()) {
       return this.renderWide(width, height)
     } else {
       return this.renderCompact(width, height)

--- a/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SubmissionGrader.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SubmissionGrader.test.js.snap
@@ -64,6 +64,7 @@ exports[`SubmissionGrader renders 1`] = `
             "changeTab": [Function],
             "context": Object {},
             "donePressed": [Function],
+            "isWide": [Function],
             "onDragBegan": [Function],
             "onLayout": [Function],
             "props": Object {
@@ -196,6 +197,7 @@ exports[`SubmissionGrader renders 1`] = `
             "changeTab": [Function],
             "context": Object {},
             "donePressed": [Function],
+            "isWide": [Function],
             "onDragBegan": [Function],
             "onLayout": [Function],
             "props": Object {
@@ -319,6 +321,7 @@ exports[`SubmissionGrader renders 1`] = `
               "changeTab": [Function],
               "context": Object {},
               "donePressed": [Function],
+              "isWide": [Function],
               "onDragBegan": [Function],
               "onLayout": [Function],
               "props": Object {
@@ -494,6 +497,7 @@ exports[`SubmissionGrader renders wide 1`] = `
                 "changeTab": [Function],
                 "context": Object {},
                 "donePressed": [Function],
+                "isWide": [Function],
                 "onDragBegan": [Function],
                 "onLayout": [Function],
                 "props": Object {
@@ -599,6 +603,7 @@ exports[`SubmissionGrader renders wide 1`] = `
                 "changeTab": [Function],
                 "context": Object {},
                 "donePressed": [Function],
+                "isWide": [Function],
                 "onDragBegan": [Function],
                 "onLayout": [Function],
                 "props": Object {
@@ -818,6 +823,7 @@ exports[`SubmissionGrader renders wide 1`] = `
                 "changeTab": [Function],
                 "context": Object {},
                 "donePressed": [Function],
+                "isWide": [Function],
                 "onDragBegan": [Function],
                 "onLayout": [Function],
                 "props": Object {
@@ -923,6 +929,7 @@ exports[`SubmissionGrader renders wide 1`] = `
                 "changeTab": [Function],
                 "context": Object {},
                 "donePressed": [Function],
+                "isWide": [Function],
                 "onDragBegan": [Function],
                 "onLayout": [Function],
                 "props": Object {

--- a/rn/Teacher/src/modules/speedgrader/components/CanvadocViewer.js
+++ b/rn/Teacher/src/modules/speedgrader/components/CanvadocViewer.js
@@ -24,6 +24,8 @@ type Props = {
   config: {
     drawerInset: number,
     previewPath: string,
+    filename: string,
+    fallbackURL: string,
   },
   style?: any,
 }
@@ -33,9 +35,12 @@ export default class CanvadocViewer extends Component<Props> {
     return (
       this.props.style !== newProps.style ||
       this.props.config.drawerInset !== newProps.config.drawerInset ||
-      this.props.config.previewPath !== newProps.config.previewPath
+      this.props.config.previewPath !== newProps.config.previewPath ||
+      this.props.config.filename !== newProps.config.filename ||
+      this.props.config.fallbackURL !== newProps.config.fallbackURL
     )
   }
+
   render () {
     return <CanvadocView {...this.props} />
   }

--- a/rn/Teacher/src/modules/speedgrader/components/FilesTab.js
+++ b/rn/Teacher/src/modules/speedgrader/components/FilesTab.js
@@ -49,7 +49,9 @@ export class FilesTab extends Component<FileTabProps> {
   selectFile = (index: number) => {
     if (this.props.submissionID) {
       this.props.selectFile(this.props.submissionID, index)
-      this.props.drawerState.snapTo(0, true)
+      if (!this.props.isWide) {
+        this.props.drawerState.snapTo(0, true)
+      }
     }
   }
 
@@ -188,6 +190,7 @@ type RouterProps = {
   submissionProps: Object,
   selectedIndex: ?number,
   drawerState: DrawerState,
+  isWide: boolean,
 }
 
 type FileTabDataProps = {

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/CanvadocViewer.test.js
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/CanvadocViewer.test.js
@@ -26,6 +26,8 @@ describe('Canvadoc viewer', () => {
     const config = {
       drawerInset: 0,
       previewPath: template.attachment().preview_url,
+      filename: template.attachment().filename,
+      fallbackURL: template.attachment().url,
     }
     const tree = shallow(<CanvadocViewer config={config} />)
     expect(tree).toMatchSnapshot()
@@ -35,6 +37,8 @@ describe('Canvadoc viewer', () => {
     const config = {
       drawerInset: 0,
       previewPath: template.attachment().preview_url,
+      filename: template.attachment().filename,
+      fallbackURL: template.attachment().url,
     }
     const tree = shallow(<CanvadocViewer config={config} />)
     expect(tree.instance().shouldComponentUpdate({
@@ -42,6 +46,15 @@ describe('Canvadoc viewer', () => {
     })).toBe(false)
     expect(tree.instance().shouldComponentUpdate({
       config: { ...config, drawerInset: 62 },
+    })).toBe(true)
+    expect(tree.instance().shouldComponentUpdate({
+      config: { ...config, previewPath: 'https://google.com' },
+    })).toBe(true)
+    expect(tree.instance().shouldComponentUpdate({
+      config: { ...config, filename: 'file.jpg' },
+    })).toBe(true)
+    expect(tree.instance().shouldComponentUpdate({
+      config: { ...config, fallbackURL: 'https://google.com' },
     })).toBe(true)
   })
 })

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/FilesTab.test.js
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/FilesTab.test.js
@@ -117,6 +117,7 @@ let defaultProps = {
   selectedIndex: 0,
   selectedAttachmentIndex: null,
   drawerState: new DrawerState(),
+  isWide: false,
 }
 
 let withIndex = {
@@ -191,6 +192,24 @@ describe('SpeedGraderFilesTab', () => {
     thirdRow.props.onPress()
     expect(withIndex.selectFile).toHaveBeenCalled()
     expect(drawerState.snapTo).toHaveBeenCalledWith(0, true)
+  })
+
+  it('changes the selected file and doesnt close the drawer when wide', () => {
+    const drawerState = new DrawerState()
+    drawerState.snapTo = jest.fn()
+    const props = {
+      ...withIndex,
+      drawerState,
+      isWide: true,
+    }
+    let tree = renderer.create(
+      <FilesTab {...props} />
+    ).toJSON()
+
+    const thirdRow = explore(tree).selectByID('speedgrader.files.row2') || {}
+    thirdRow.props.onPress()
+    expect(withIndex.selectFile).toHaveBeenCalled()
+    expect(drawerState.snapTo).not.toHaveBeenCalled()
   })
 
   it('ignores attachments for URL Submissions', () => {

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/__snapshots__/CanvadocViewer.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/__snapshots__/CanvadocViewer.test.js.snap
@@ -5,6 +5,8 @@ exports[`Canvadoc viewer renders the native component 1`] = `
   config={
     Object {
       "drawerInset": 0,
+      "fallbackURL": "http://canvaslms.com/bookreport",
+      "filename": "Attachment 1.jpg",
       "previewPath": "/",
     }
   }


### PR DESCRIPTION
Also don't close the files tab on wide layout

refs: MBL-12092
affects: Teacher
release notes: Fixed a bug where switching files on ipad in Speed Grader wouldn't always switch the file