### PR TITLE
Add transparent background to PSPDFKit text tool

### DIFF
--- a/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsConstants.swift
+++ b/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsConstants.swift
@@ -20,10 +20,10 @@ import UIKit
 import PSPDFKit
 import PSPDFKitUI
 
-let standardCanvadocsColors: [UIColor] = CanvadocsAnnotationColor.allColors.map { $0.color }
-let highlightCanvadocsColors: [UIColor] = CanvadocsHighlightColor.allColors.map { $0.color }
+let standardCanvadocsColors: [UIColor] = CanvadocsAnnotationColor.allCases.map { $0.color }
+let highlightCanvadocsColors: [UIColor] = CanvadocsHighlightColor.allCases.map { $0.color }
 
-enum CanvadocsAnnotationColor: String {
+enum CanvadocsAnnotationColor: String, CaseIterable {
     case red = "#EE0612"
     case orange = "#FC5E13"
     case yellow = "#FCB900"
@@ -34,24 +34,20 @@ enum CanvadocsAnnotationColor: String {
     case pink = "#C31FA8"
     case purple = "#741865"
     case darkGray = "#363636"
-    
-    static var allColors: [CanvadocsAnnotationColor] = [.red, .orange, .yellow, .brown, .green, .darkBlue, .blue, .pink, .purple, .darkGray]
-    
+
     var color: UIColor {
         return UIColor.colorFromHexString(self.rawValue)!
     }
 }
 
-enum CanvadocsHighlightColor: String {
+enum CanvadocsHighlightColor: String, CaseIterable {
     case red = "#FF9999"
     case orange = "#FFC166"
     case yellow = "#FCE680"
     case green = "#99EBA4"
     case blue = "#80D0FF"
     case pink = "#FFB9F1"
-    
-    static var allColors: [CanvadocsHighlightColor] = [.red, .orange, .yellow, .green, .blue, .pink]
-    
+
     var color: UIColor {
         return UIColor.colorFromHexString(self.rawValue)!
     }

--- a/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsPDFDocumentPresenter.swift
+++ b/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsPDFDocumentPresenter.swift
@@ -143,7 +143,9 @@ open class CanvadocsPDFDocumentPresenter: NSObject {
 
         let highlightPresets = highlightCanvadocsColors.map { return PSPDFColorPreset(color: $0) }
         let inkPresets = standardCanvadocsColors.map { return PSPDFColorPreset(color: $0) }
-        let textPresets = standardCanvadocsColors.map { return PSPDFColorPreset(color: $0, fill: .white, alpha: 1) }
+        let textColorPresets = standardCanvadocsColors.map { return PSPDFColorPreset(color: $0, fill: .white, alpha: 1) }
+        let textFillPresets = standardCanvadocsColors.map { return PSPDFColorPreset(color: $0, fill: .clear, alpha: 1) }
+        let textPresets = textColorPresets + textFillPresets
         styleManager.setPresets(highlightPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.highlight.rawValue), type: AnnotationStyleType.colorPreset)
         styleManager.setPresets(inkPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.ink.rawValue), type: .colorPreset)
         styleManager.setPresets(inkPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.square.rawValue), type: .colorPreset)
@@ -161,7 +163,7 @@ open class CanvadocsPDFDocumentPresenter: NSObject {
         styleManager.setLastUsedValue(CanvadocsAnnotationColor.red.color, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.strikeOut.rawValue))
         styleManager.setLastUsedValue(CanvadocsAnnotationColor.blue.color, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.stamp.rawValue))
         styleManager.setLastUsedValue(UIColor.black, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
-        styleManager.setLastUsedValue(UIColor.white, forProperty: "fillColor", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
+        styleManager.setLastUsedValue(UIColor.clear, forProperty: "fillColor", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
         styleManager.setLastUsedValue("Verdana", forProperty: "fontName", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
         styleManager.setLastUsedValue(14, forProperty: "fontSize", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
         styleManager.setLastUsedValue(2.0, forProperty: "lineWidth", forKey: AnnotationStateVariantID(rawValue: AnnotationString.ink.rawValue))

--- a/CanvasCore/CanvasCore/Annotations/Pre Submission/PreSubmissionPDFDocumentPresenter.swift
+++ b/CanvasCore/CanvasCore/Annotations/Pre Submission/PreSubmissionPDFDocumentPresenter.swift
@@ -80,6 +80,13 @@ open class PreSubmissionPDFDocumentPresenter: NSObject {
     @objc func stylePSPDFKit() {
         let styleManager = PSPDFKit.sharedInstance.styleManager
         styleManager.setupDefaultStylesIfNeeded()
+
+        let textColorPresets = CanvadocsAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color, fill: .white, alpha: 1) }
+        let textFillPresets = CanvadocsAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color, fill: .clear, alpha: 1) }
+        let textPresets = textColorPresets + textFillPresets
+        styleManager.setPresets(textPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue), type: .colorPreset)
+        styleManager.setLastUsedValue(UIColor.black, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
+        styleManager.setLastUsedValue(UIColor.clear, forProperty: "fillColor", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
     }
 
     @objc open func getPDFViewController() -> UIViewController {

--- a/Core/Core/DocViewer/DocViewerConstants.swift
+++ b/Core/Core/DocViewer/DocViewerConstants.swift
@@ -84,7 +84,9 @@ func stylePSPDFKit() {
 
     let highlightPresets = DocViewerHighlightColor.allCases.map { return PSPDFColorPreset(color: $0.color) }
     let inkPresets = DocViewerAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color) }
-    let textPresets = DocViewerAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color, fill: .white, alpha: 1) }
+    let textColorPresets = DocViewerAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color, fill: .white, alpha: 1) }
+    let textFillPresets = DocViewerAnnotationColor.allCases.map { return PSPDFColorPreset(color: $0.color, fill: .clear, alpha: 1) }
+    let textPresets = textColorPresets + textFillPresets
     styleManager.setPresets(highlightPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.highlight.rawValue), type: AnnotationStyleType.colorPreset)
     styleManager.setPresets(inkPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.ink.rawValue), type: .colorPreset)
     styleManager.setPresets(inkPresets, forKey: AnnotationStateVariantID(rawValue: AnnotationString.square.rawValue), type: .colorPreset)
@@ -102,7 +104,7 @@ func stylePSPDFKit() {
     styleManager.setLastUsedValue(DocViewerAnnotationColor.red.color, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.strikeOut.rawValue))
     styleManager.setLastUsedValue(DocViewerAnnotationColor.blue.color, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.stamp.rawValue))
     styleManager.setLastUsedValue(UIColor.black, forProperty: "color", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
-    styleManager.setLastUsedValue(UIColor.white, forProperty: "fillColor", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
+    styleManager.setLastUsedValue(UIColor.clear, forProperty: "fillColor", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
     styleManager.setLastUsedValue("Verdana", forProperty: "fontName", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
     styleManager.setLastUsedValue(14, forProperty: "fontSize", forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue))
     styleManager.setLastUsedValue(2.0, forProperty: "lineWidth", forKey: AnnotationStateVariantID(rawValue: AnnotationString.ink.rawValue))

--- a/Core/CoreTests/DocViewer/DocViewerConstantsTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerConstantsTests.swift
@@ -42,5 +42,20 @@ class DocViewerConstantsTests: XCTestCase {
            "color",
            forKey: AnnotationStateVariantID(rawValue: AnnotationString.ink.rawValue)
         ) as? UIColor, DocViewerAnnotationColor.red.color)
+        XCTAssertEqual(PSPDFKit.sharedInstance.styleManager.lastUsedProperty(
+            "fillColor",
+            forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue)
+        ) as? UIColor, .clear)
+        XCTAssertEqual(PSPDFKit.sharedInstance.styleManager.lastUsedProperty(
+            "color",
+            forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue)
+        ) as? UIColor, .black)
+        let textPresets = PSPDFKit.sharedInstance.styleManager.presets(forKey: AnnotationStateVariantID(rawValue: AnnotationString.freeText.rawValue), type: .colorPreset) as? [PSPDFColorPreset]
+        XCTAssertNotNil(textPresets)
+        XCTAssertEqual(textPresets?.count, DocViewerAnnotationColor.allCases.count * 2)
+        for annotationColor in DocViewerAnnotationColor.allCases {
+            XCTAssertTrue(textPresets?.contains { $0.color == annotationColor.color && $0.fillColor?.hexString == UIColor.white.hexString } == true)
+            XCTAssertTrue(textPresets?.contains { $0.color == annotationColor.color && $0.fillColor == nil } == true)
+        }
     }
 }


### PR DESCRIPTION
refs: MBL-12169
affects: student, teacher
release note: Added an option to give text annotations a transparent background and made that the default