### PR TITLE
After recording, set session back to playback

### DIFF
--- a/Canvas/Canvas/CanvasAppDelegate.swift
+++ b/Canvas/Canvas/CanvasAppDelegate.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import UIKit
 import TechDebt
 import PSPDFKit
@@ -54,6 +55,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
         NotificationKitController.setupForPushNotifications(delegate: self)
         TheKeymaster.fetchesBranding = true
         TheKeymaster.delegate = loginConfig
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
         
         window = MasqueradableWindow(frame: UIScreen.main.bounds)
         showLoadingState()

--- a/CanvasCore/CanvasCore/Media/AudioRecorder.swift
+++ b/CanvasCore/CanvasCore/Media/AudioRecorder.swift
@@ -95,6 +95,7 @@ class AudioRecorder: NSObject {
         recorder = nil
         do {
             try AVAudioSession.sharedInstance().setActive(false)
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
         } catch let e {
             print("erro stopping the recording session \(e)")
         }

--- a/Core/Core/AudioVideo/AudioRecorderViewController.swift
+++ b/Core/Core/AudioVideo/AudioRecorderViewController.swift
@@ -108,6 +108,7 @@ public class AudioRecorderViewController: UIViewController, ErrorViewController 
         stopButton?.isHidden = true
         do {
             try AVAudioSession.sharedInstance().setActive(false)
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
         } catch {
             showError(error)
         }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import UIKit
 import CanvasCore
 import CanvasKeymaster
@@ -64,6 +65,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         
         TheKeymaster.fetchesBranding = false
         TheKeymaster.delegate = loginConfig
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
         
         window = MasqueradableWindow(frame: UIScreen.main.bounds)
         showLoadingState()

--- a/Student/Student/AppDelegate.swift
+++ b/Student/Student/AppDelegate.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import UIKit
 import CoreData
 import Core
@@ -33,6 +34,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         environment.logger.log(#function)
         DocViewerViewController.setup(.studentPSPDFKitLicense)
         setupNotifications()
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
 
         if let session = Keychain.mostRecentSession {
             window.rootViewController = LoadingViewController.create()

--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import UIKit
 import CanvasKeymaster
 import ReactiveSwift
@@ -55,6 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         }
         setupForPushNotifications()
         preparePSPDFKit()
+        try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
         window = MasqueradableWindow(frame: UIScreen.main.bounds)
         showLoadingState()
         window?.makeKeyAndVisible()


### PR DESCRIPTION
This should fix video comment playback after recording an audio comment.

refs: none
affects: none
release note: none