### PR TITLE
Remove Keychain.currentSession

### DIFF
--- a/Canvas/Canvas/CanvasAppDelegate.swift
+++ b/Canvas/Canvas/CanvasAppDelegate.swift
@@ -29,9 +29,9 @@ import Core
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
+    var window: UIWindow? = MasqueradableWindow(frame: UIScreen.main.bounds)
     @objc let loginConfig = LoginConfiguration(mobileVerifyName: "iCanvas", logo: UIImage(named: "student-logomark")!, fullLogo: UIImage(named: "student-logo")!)
     @objc var session: Session?
-    var window: UIWindow?
 
     let appID = Bundle.main.bundleIdentifier ?? "com.instructure.icanvas"
     let appGroup = "group.com.instructure.icanvas"
@@ -56,8 +56,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
         TheKeymaster.fetchesBranding = true
         TheKeymaster.delegate = loginConfig
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-        
-        window = MasqueradableWindow(frame: UIScreen.main.bounds)
+
         showLoadingState()
         window?.makeKeyAndVisible()
         
@@ -348,11 +347,11 @@ extension AppDelegate: NativeLoginManagerDelegate {
     }
     
     func didLogout(_ controller: UIViewController) {
-        if let entry = Keychain.currentSession {
-            Keychain.removeEntry(entry)
+        if let entry = environment.currentSession {
             environment.userDidLogout(session: entry)
             CoreWebView.stopCookieKeepAlive()
         }
+        Keychain.clearEntries()
         NotificationKitController.deregisterPushNotifications { _ in
             // this is a no-op because we don't want errors to prevent logging out
         }

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -38,7 +38,6 @@ open class AppEnvironment {
     }
 
     public func userDidLogin(session: KeychainEntry) {
-        Keychain.currentSession = session
         database = NSPersistentContainer.create(session: session)
         api = URLSessionAPI(accessToken: session.accessToken, actAsUserID: session.actAsUserID, baseURL: session.baseURL)
         currentSession = session
@@ -47,7 +46,6 @@ open class AppEnvironment {
 
     public func userDidLogout(session: KeychainEntry) {
         guard session == currentSession else { return }
-        Keychain.currentSession = nil
         database.destroy()
         database = globalDatabase
         api = URLSessionAPI()

--- a/Core/Core/Keychain/Keychain.swift
+++ b/Core/Core/Keychain/Keychain.swift
@@ -117,8 +117,6 @@ public class Keychain {
 
     public static let key = "CanvasUsers"
 
-    public static var currentSession: KeychainEntry?
-
     public static var mostRecentSession: KeychainEntry? {
         return entries.reduce(nil) { (latest: KeychainEntry?, entry: KeychainEntry) -> KeychainEntry? in
             if let latest = latest, latest.lastUsedAt > entry.lastUsedAt {

--- a/Core/Core/Login/LoginStartPresenter.swift
+++ b/Core/Core/Login/LoginStartPresenter.swift
@@ -64,8 +64,8 @@ class LoginStartPresenter {
                 if Keychain.entries.contains(entry) {
                     Keychain.addEntry(entry)
                 }
-                if Keychain.currentSession == entry {
-                    Keychain.currentSession = entry
+                if AppEnvironment.shared.currentSession == entry {
+                    AppEnvironment.shared.currentSession = entry
                 }
             }
             self?.loadEntries()

--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -52,7 +52,7 @@ open class CoreWebView: WKWebView {
     }
 
     @discardableResult
-    open override func loadHTMLString(_ string: String, baseURL: URL? = Keychain.currentSession?.baseURL) -> WKNavigation? {
+    open override func loadHTMLString(_ string: String, baseURL: URL? = AppEnvironment.shared.currentSession?.baseURL) -> WKNavigation? {
         return super.loadHTMLString(html(for: string), baseURL: baseURL)
     }
 

--- a/Core/CoreTests/Login/LoginStartPresenterTests.swift
+++ b/Core/CoreTests/Login/LoginStartPresenterTests.swift
@@ -34,7 +34,7 @@ class LoginStartPresenterTests: XCTestCase {
         super.setUp()
         Keychain.config = KeychainConfig(service: "com.instructure.service", accessGroup: nil)
         Keychain.clearEntries()
-        Keychain.currentSession = nil
+        AppEnvironment.shared.currentSession = nil
     }
 
     func testViewIsReady() {
@@ -47,7 +47,7 @@ class LoginStartPresenterTests: XCTestCase {
         let bob = KeychainEntry.make(lastUsedAt: Date(), userID: "3", userName: "Bob")
         Keychain.addEntry(bill)
         Keychain.addEntry(bob)
-        Keychain.currentSession = bill
+        AppEnvironment.shared.currentSession = bill
         let presenter = LoginStartPresenter(loginDelegate: self, view: self)
         presenter.session = mockSession
         presenter.viewIsReady()
@@ -55,7 +55,7 @@ class LoginStartPresenterTests: XCTestCase {
         let poll = expectation(for: NSPredicate(value: true), evaluatedWith: presenter) { self.logins?[0].userAvatarURL != nil }
         wait(for: [poll], timeout: 5)
         XCTAssertEqual(logins?[0].userAvatarURL, URL(string: "avatar"))
-        XCTAssertEqual(Keychain.currentSession?.userAvatarURL, URL(string: "avatar"))
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.userAvatarURL, URL(string: "avatar"))
     }
 
     func testCycleAuthMethod() {

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -29,12 +29,8 @@ let ParentAppRefresherTTL: TimeInterval = 5.minutes
 
 @UIApplicationMain
 class ParentAppDelegate: UIResponder, UIApplicationDelegate {
-
-    var environment: AppEnvironment!
-
-    var window: UIWindow?
+    var window: UIWindow? = MasqueradableWindow(frame: UIScreen.main.bounds)
     var legacySession: Session?
-    var session: KeychainEntry?
     @objc let loginConfig = LoginConfiguration(mobileVerifyName: "iosParent",
                                          logo: UIImage(named: "parent-logomark")!,
                                          fullLogo: UIImage(named: "parent-logo")!,
@@ -50,13 +46,17 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         return vc
     }
 
+    lazy var environment: AppEnvironment = {
+        let env = AppEnvironment.shared
+        env.router = Parent.router
+        // env.backgroundAPIManager.eventsHandler = self
+        return env
+    }()
+
     let hasFabric = (Bundle.main.object(forInfoDictionaryKey: "Fabric") as? [String: Any])?["APIKey"] != nil
     let hasFirebase = FirebaseOptions.defaultOptions()?.apiKey != nil
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        environment = AppEnvironment.shared
-        environment.router = Parent.router
-
         setupCrashlytics()
         ResetAppIfNecessary()
         if hasFirebase {
@@ -66,8 +66,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         TheKeymaster.fetchesBranding = false
         TheKeymaster.delegate = loginConfig
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-        
-        window = MasqueradableWindow(frame: UIScreen.main.bounds)
+
         showLoadingState()
         window?.makeKeyAndVisible()
         
@@ -105,7 +104,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     
     @objc func openCanvasURL(_ url: URL) -> Bool {
         if url.scheme == "canvas-parent" {
-            if let _ = session {
+            if environment.currentSession != nil {
                 Router.sharedInstance.route(visibleController, toURL: url, modal: false)
             } else if let window = window, let vc = Router.sharedInstance.viewControllerForURL(url) {
                 Router.sharedInstance.route(window, toRootViewController: vc)
@@ -139,7 +138,6 @@ extension ParentAppDelegate {
             return
         }
 
-        self.session = lastSession
         self.legacySession = Session(baseURL: lastSession.baseURL, user: SessionUser(id: lastSession.userID, name: lastSession.userName, avatarURL: lastSession.userAvatarURL), token: lastSession.accessToken)
         self.didLogin(lastSession)
     }
@@ -229,9 +227,9 @@ extension ParentAppDelegate: NativeLoginManagerDelegate {
         guard let legacySession = self.legacySession else {
             return
         }
-        Keychain.currentSession = session
         Keychain.addEntry(session)
         environment.userDidLogin(session: session)
+        CoreWebView.keepCookieAlive(for: environment)
 
         // UX requires that students are given color schemes in a specific order.
         // The method call below ensures that we always start with the first color scheme.
@@ -293,11 +291,13 @@ extension ParentAppDelegate: NativeLoginManagerDelegate {
     }
     
     func didLogout(_ controller: UIViewController) {
-        guard let window = self.window else { return }
-        Keychain.clearEntries()
-        if let session = session {
-            environment.userDidLogout(session: session)
+        if let entry = environment.currentSession {
+            environment.userDidLogout(session: entry)
+            CoreWebView.stopCookieKeepAlive()
         }
+        Keychain.clearEntries()
+
+        guard let window = window else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: {
             window.rootViewController = controller
         }, completion:nil)

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -49,7 +49,6 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     lazy var environment: AppEnvironment = {
         let env = AppEnvironment.shared
         env.router = Parent.router
-        // env.backgroundAPIManager.eventsHandler = self
         return env
     }()
 

--- a/Student/Student/AppDelegate.swift
+++ b/Student/Student/AppDelegate.swift
@@ -22,7 +22,7 @@ import UserNotifications
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDelegate, AppEnvironmentDelegate {
-    let window = UIWindow(frame: UIScreen.main.bounds)
+    var window: UIWindow? = UIWindow(frame: UIScreen.main.bounds)
 
     lazy var environment: AppEnvironment = {
         let env = AppEnvironment.shared
@@ -37,12 +37,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
 
         if let session = Keychain.mostRecentSession {
-            window.rootViewController = LoadingViewController.create()
+            window?.rootViewController = LoadingViewController.create()
             userDidLogin(keychainEntry: session)
         } else {
-            window.rootViewController = LoginNavigationController.create(loginDelegate: self, fromLaunch: true)
+            window?.rootViewController = LoginNavigationController.create(loginDelegate: self, fromLaunch: true)
         }
-        window.makeKeyAndVisible()
+        window?.makeKeyAndVisible()
 
         return true
     }
@@ -84,10 +84,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     }
 
     func showRootView() {
+        guard let window = window else { return }
         let controller = RootViewController.create()
         controller.view.layoutIfNeeded()
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
-            self.window.rootViewController = controller
+            window.rootViewController = controller
         }, completion: nil)
 
         // FIXME: Move to dev menu
@@ -101,8 +102,9 @@ extension AppDelegate: LoginDelegate {
     var loginLogo: UIImage { return UIImage(named: "CanvasStudent")! }
 
     func changeUser() {
+        guard let window = window else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {
-            self.window.rootViewController = LoginNavigationController.create(loginDelegate: self)
+            window.rootViewController = LoginNavigationController.create(loginDelegate: self)
         }, completion: nil)
     }
 
@@ -125,8 +127,8 @@ extension AppDelegate: LoginDelegate {
     func userDidLogout(keychainEntry: KeychainEntry) {
         Keychain.removeEntry(keychainEntry)
         // TODO: Deregister push notifications?
+        guard environment.currentSession == keychainEntry else { return }
         environment.userDidLogout(session: keychainEntry)
-        guard Keychain.currentSession == keychainEntry else { return }
         CoreWebView.stopCookieKeepAlive()
         changeUser()
     }
@@ -142,7 +144,7 @@ extension AppDelegate {
         alert.addAction(UIAlertAction(title: NSLocalizedString("Close App", bundle: .student, comment: ""), style: .default) { _ in
             UIControl().sendAction(#selector(NSXPCConnection.suspend), to: UIApplication.shared, for: nil)
         })
-        window.rootViewController?.present(alert, animated: true)
+        window?.rootViewController?.present(alert, animated: true)
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
@@ -153,7 +155,7 @@ extension AppDelegate {
     }
 
     func topMostViewController() -> UIViewController? {
-        return window.rootViewController?.topMostViewController()
+        return window?.rootViewController?.topMostViewController()
     }
 }
 

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -59,7 +59,7 @@ public let router = Router(routes: [
     },
 
     RouteHandler(.assignmentFileUpload(courseID: ":courseID", assignmentID: ":assignmentID"), name: "assignment_file_upload") { _, params in
-        guard let courseID = params["courseID"], let assignmentID = params["assignmentID"], let userID = Keychain.currentSession?.userID else {
+        guard let courseID = params["courseID"], let assignmentID = params["assignmentID"], let userID = AppEnvironment.shared.currentSession?.userID else {
             return nil
         }
         let presenter = SubmissionFilePresenter(courseID: courseID, assignmentID: assignmentID, userID: userID)

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -53,9 +53,9 @@ class RoutesTests: XCTestCase {
     }
 
     func testAssignmentFileUpload() {
-        Keychain.currentSession = nil
+        AppEnvironment.shared.currentSession = nil
         XCTAssertNil(router.match(Route.assignmentFileUpload(courseID: "1", assignmentID: "1").url))
-        Keychain.currentSession = KeychainEntry.make()
+        AppEnvironment.shared.currentSession = KeychainEntry.make()
         XCTAssert(router.match(Route.assignmentFileUpload(courseID: "1", assignmentID: "1").url) is FilePickerViewController)
     }
 

--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -29,9 +29,8 @@ import React
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterDelegate {
-
+    var window: UIWindow? = MasqueradableWindow(frame: UIScreen.main.bounds)
     @objc let loginConfig = LoginConfiguration(mobileVerifyName: "iosTeacher", logo: UIImage(named: "teacher-logomark")!, fullLogo: UIImage(named: "teacher-logo")!)
-    var window: UIWindow?
 
     let hasFabric = (Bundle.main.object(forInfoDictionaryKey: "Fabric") as? [String: Any])?["APIKey"] != nil
     let hasFirebase = FirebaseOptions.defaultOptions()?.apiKey != nil
@@ -57,7 +56,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setupForPushNotifications()
         preparePSPDFKit()
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
-        window = MasqueradableWindow(frame: UIScreen.main.bounds)
         showLoadingState()
         window?.makeKeyAndVisible()
         UIApplication.shared.reactive.applicationIconBadgeNumber <~ TabBarBadgeCounts.applicationIconBadgeNumber
@@ -209,12 +207,12 @@ extension AppDelegate: NativeLoginManagerDelegate {
     }
     
     func didLogout(_ controller: UIViewController) {
-        if let entry = Keychain.currentSession {
-            Keychain.removeEntry(entry)
+        if let entry = environment.currentSession {
             environment.userDidLogout(session: entry)
             CoreWebView.stopCookieKeepAlive()
         }
         guard let window = self.window else { return }
+        Keychain.clearEntries()
         
         UIView.transition(with: window, duration: 0.5, options: .transitionCrossDissolve, animations: {
             window.rootViewController = controller


### PR DESCRIPTION
environment.currentSession is the source of truth for logged in state.
Don't have multiple sources of truth, so we don't have to keep them in sync.

extra: align window setup & keychain management

refs: none
affects: none
release note: none