### PR TITLE
dispatch.main.async call when already on main thread causes small delay that is noticeable when setting navbar colors

### DIFF
--- a/Core/Core/Store/Store.swift
+++ b/Core/Core/Store/Store.swift
@@ -91,9 +91,21 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
     }
 
     private func notify() {
-        DispatchQueue.main.async {
+        let runNotifyEvents = {
             self.eventHandler()
             self.changes = []
+        }
+
+        //  when this code was calling `DispatchQueue.main.async` when already on the main thread,
+        //  it caused a small delay that was inadequate for toolbar color on viewController transitions,
+        //  caused a noticeable flicker.
+        //  https://github.com/instructure/canvas-ios/pull/42
+        if !Thread.isMainThread {
+            DispatchQueue.main.async {
+                runNotifyEvents()
+            }
+        } else {
+            runNotifyEvents()
         }
     }
 

--- a/Student/Student/Courses/CourseNavigation/CourseNavigationPresenter.swift
+++ b/Student/Student/Courses/CourseNavigation/CourseNavigationPresenter.swift
@@ -47,7 +47,6 @@ class CourseNavigationPresenter {
     func viewIsReady() {
         courses.refresh()
         tabs.refresh()
-        update()
     }
 
     func update() {

--- a/Student/Student/Groups/GroupNavigation/GroupNavigationPresenter.swift
+++ b/Student/Student/Groups/GroupNavigation/GroupNavigationPresenter.swift
@@ -52,7 +52,6 @@ class GroupNavigationPresenter {
     func viewIsReady() {
         groups.refresh()
         tabs.refresh()
-        update()
     }
 
     func update() {


### PR DESCRIPTION
[ignore-commit-lint]