### PR TITLE
Fix ModuleListPresenter tests

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -364,6 +364,8 @@
 		B1A32BDA21599C700071B41E /* APIAssignment+Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A32BD921599C700071B41E /* APIAssignment+Requestable.swift */; };
 		B1A32BDC21599F1C0071B41E /* APISubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A32BDB21599F1C0071B41E /* APISubmission.swift */; };
 		B1A32BE22159A3100071B41E /* APIAssignmentRequestableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A32BE12159A3100071B41E /* APIAssignmentRequestableTests.swift */; };
+		B1A464BB225669140052F8DF /* DispatchExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A464BA225669140052F8DF /* DispatchExtensions.swift */; };
+		B1A464BD225669B50052F8DF /* DispatchExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A464BC225669B50052F8DF /* DispatchExtensionsTests.swift */; };
 		B1A6BC762189F9AE000515E3 /* TestsFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3B0CEB762150408A00D07CFA /* TestsFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		B1A6BC7A218A062E000515E3 /* MediaCommentType.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A6BC79218A062E000515E3 /* MediaCommentType.swift */; };
 		B1A6BC7E218A317A000515E3 /* APIAssignmentOverride.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A6BC7D218A317A000515E3 /* APIAssignmentOverride.swift */; };
@@ -962,6 +964,8 @@
 		B1A32BDB21599F1C0071B41E /* APISubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISubmission.swift; sourceTree = "<group>"; };
 		B1A32BE12159A3100071B41E /* APIAssignmentRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAssignmentRequestableTests.swift; sourceTree = "<group>"; };
 		B1A32BE5215A81350071B41E /* GetAssignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetAssignment.swift; sourceTree = "<group>"; };
+		B1A464BA225669140052F8DF /* DispatchExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchExtensions.swift; sourceTree = "<group>"; };
+		B1A464BC225669B50052F8DF /* DispatchExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchExtensionsTests.swift; sourceTree = "<group>"; };
 		B1A6BC79218A062E000515E3 /* MediaCommentType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaCommentType.swift; sourceTree = "<group>"; };
 		B1A6BC7D218A317A000515E3 /* APIAssignmentOverride.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAssignmentOverride.swift; sourceTree = "<group>"; };
 		B1A6BC7F218A32F3000515E3 /* APIAssignmentOverride+Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIAssignmentOverride+Requestable.swift"; sourceTree = "<group>"; };
@@ -1496,6 +1500,7 @@
 			children = (
 				7DF9BF03215191840099026B /* BundleExtensions.swift */,
 				B1EA5AF5212E67CE00DABC5F /* DateExtensions.swift */,
+				B1A464BA225669140052F8DF /* DispatchExtensions.swift */,
 				3B69253F21A12E020023ED75 /* Int64Extensions.swift */,
 				B192833721C07A4E008D1B9B /* LoggerExtensions.swift */,
 				3B346754213052C700F9BC2E /* NSErrorExtensions.swift */,
@@ -1583,6 +1588,7 @@
 				3B5369E3219D0FD000D3F62E /* URLExtensionsTests.swift */,
 				7D80AC5A212DB0B500C40ECE /* URLResponseExtensionsTests.swift */,
 				B1A890B9224ED6A300CEE000 /* UIScrollViewExtensionsTests.swift */,
+				B1A464BC225669B50052F8DF /* DispatchExtensionsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -2260,6 +2266,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B15CA279221DE9660014FB02 /* APIModuleRequestable.swift in Sources */,
+				B1A464BB225669140052F8DF /* DispatchExtensions.swift in Sources */,
 				9FAE410121B6C56D00FE7F58 /* APIExternalTool.swift in Sources */,
 				9FD504F22180C5F600B395BA /* AsyncBlockOperation.swift in Sources */,
 				78151DCB21AE75D400692862 /* APIDiscussion.swift in Sources */,
@@ -2591,6 +2598,7 @@
 				7D5C871F2239A45300D99651 /* GetSubmissionCommentsTests.swift in Sources */,
 				7D80AC56212CF41900C40ECE /* APIRequestableTests.swift in Sources */,
 				7D8B78FB215EC9BE005E08F1 /* BrandTests.swift in Sources */,
+				B1A464BD225669B50052F8DF /* DispatchExtensionsTests.swift in Sources */,
 				7D062AFB2124A14700677F66 /* ContextTests.swift in Sources */,
 				B17F23AD21378E3800771F86 /* PaginatedUseCaseTest.swift in Sources */,
 				7DAFB46521A4693B00311275 /* LocalizationManagerTests.swift in Sources */,

--- a/Core/Core/Extensions/DispatchExtensions.swift
+++ b/Core/Core/Extensions/DispatchExtensions.swift
@@ -1,0 +1,30 @@
+//
+// Copyright (C) 2019-present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+/// Performs `closure` on the main thread
+///
+/// If the executing thread is already the main thread, the `closure`
+/// is executed immediately.
+public func performUIUpdate(using closure: @escaping () -> Void) {
+    // If we are already on the main thread, execute the closure directly
+    if Thread.isMainThread {
+        closure()
+    } else {
+        DispatchQueue.main.async(execute: closure)
+    }
+}

--- a/Core/Core/Store/Store.swift
+++ b/Core/Core/Store/Store.swift
@@ -91,21 +91,9 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
     }
 
     private func notify() {
-        let runNotifyEvents = {
+        performUIUpdate {
             self.eventHandler()
             self.changes = []
-        }
-
-        //  when this code was calling `DispatchQueue.main.async` when already on the main thread,
-        //  it caused a small delay that was inadequate for toolbar color on viewController transitions,
-        //  caused a noticeable flicker.
-        //  https://github.com/instructure/canvas-ios/pull/42
-        if !Thread.isMainThread {
-            DispatchQueue.main.async {
-                runNotifyEvents()
-            }
-        } else {
-            runNotifyEvents()
         }
     }
 
@@ -131,7 +119,7 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
             if let urlResponse = urlResponse {
                 self?.next = self?.useCase.getNext(from: urlResponse)
             }
-            DispatchQueue.main.async {
+            performUIUpdate {
                 callback?(response)
             }
         }
@@ -155,7 +143,7 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
 
     public func getNextPage(_ callback: ((U.Response?) -> Void)? = nil) {
         guard let next = next else {
-            DispatchQueue.main.async {
+            performUIUpdate {
                 callback?(nil)
             }
             return
@@ -169,7 +157,7 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
             if let urlResponse = urlResponse {
                 self?.next = self?.useCase.getNext(from: urlResponse)
             }
-            DispatchQueue.main.async {
+            performUIUpdate {
                 callback?(response)
             }
         }

--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -63,6 +63,9 @@ extension UseCase {
     }
 
     public func fetch(environment: AppEnvironment = .shared, force: Bool = false, _ callback: @escaping RequestCallback) {
+        // Make sure we write to the database that initiated this request
+        let database = environment.database
+
         environment.database.perform { client in
             guard force || self.hasExpired(in: client) else {
                 callback(nil, nil, nil) // FIXME: Return cached data?
@@ -73,7 +76,7 @@ extension UseCase {
                     callback(response, urlResponse, error)
                     return
                 }
-                environment.database.performBackgroundTask { client in
+                database.performBackgroundTask { client in
                     do {
                         try self.write(response: response, urlResponse: urlResponse, to: client)
                         self.updateTTL(in: client)

--- a/Core/CoreTests/Extensions/DispatchExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/DispatchExtensionsTests.swift
@@ -1,0 +1,41 @@
+//
+// Copyright (C) 2019-present Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, version 3 of the License.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import XCTest
+import Core
+
+class DispatchExtensionsTests: XCTestCase {
+    func testPerformUIUpdateExecutesImmediately() {
+        var result = false
+        performUIUpdate {
+            result = true
+        }
+        XCTAssertTrue(result)
+    }
+
+    func testPerformUIUpdateDispatchesToMainQueue() {
+        let expectation = self.expectation(description: "on main thread")
+        DispatchQueue.global().async {
+            performUIUpdate {
+                if Thread.isMainThread {
+                    expectation.fulfill()
+                }
+            }
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
+}

--- a/Core/CoreTests/Extensions/DispatchExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/DispatchExtensionsTests.swift
@@ -1,17 +1,17 @@
 //
 // Copyright (C) 2019-present Instructure, Inc.
 //
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, version 3 of the License.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
+// http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 import Foundation

--- a/Core/CoreTests/Store/StoreTests.swift
+++ b/Core/CoreTests/Store/StoreTests.swift
@@ -111,20 +111,12 @@ class StoreTests: CoreTestCase {
 
         wait(for: [eventsExpectation], timeout: 1.0)
 
-        let loading = snapshots[0]
-        let notLoading = snapshots[1]
-        let loaded = snapshots[2]
-
-        // loading
+        let loading = snapshots.first!
         XCTAssertEqual(loading.count, 0)
         XCTAssertTrue(loading.pending)
         XCTAssertNil(loading.error)
 
-        // not loading
-        XCTAssertFalse(notLoading.pending)
-        XCTAssertNil(notLoading.error)
-
-        // loaded
+        let loaded = snapshots.last!
         XCTAssertEqual(loaded.count, 1)
         XCTAssertFalse(loaded.pending)
         XCTAssertEqual(loaded.objects.first?.id, "1")
@@ -143,17 +135,10 @@ class StoreTests: CoreTestCase {
 
         wait(for: [eventsExpectation], timeout: 1.0)
 
-        let loading = snapshots[0]
-        let notLoading = snapshots[1]
-        let loaded = snapshots[2]
-
-        // loading
+        let loading = snapshots.first!
         XCTAssertTrue(loading.pending)
 
-        // not loading
-        XCTAssertFalse(notLoading.pending)
-
-        // loaded
+        let loaded = snapshots.last!
         XCTAssertFalse(loaded.pending)
     }
 
@@ -197,20 +182,12 @@ class StoreTests: CoreTestCase {
 
         wait(for: [eventsExpectation], timeout: 1.0)
 
-        let loading = snapshots[0]
-        let notLoading = snapshots[1]
-        let error = snapshots[2]
-
-        // loading
+        let loading = snapshots.first!
         XCTAssertEqual(loading.count, 0)
         XCTAssertTrue(loading.pending)
         XCTAssertNil(loading.error)
 
-        // not loading
-        XCTAssertEqual(notLoading.count, 0)
-        XCTAssertFalse(notLoading.pending)
-
-        // error
+        let error = snapshots.last!
         XCTAssertEqual(error.count, 0)
         XCTAssertFalse(error.pending)
         XCTAssertEqual(error.error?.localizedDescription, "network error")
@@ -228,20 +205,12 @@ class StoreTests: CoreTestCase {
 
         wait(for: [eventsExpectation], timeout: 1.0)
 
-        let loading = snapshots[0]
-        let notLoading = snapshots[1]
-        let error = snapshots[2]
-
-        // loading
+        let loading = snapshots.first!
         XCTAssertEqual(loading.count, 0)
         XCTAssertTrue(loading.pending)
         XCTAssertNil(loading.error)
 
-        // not loading
-        XCTAssertEqual(notLoading.count, 0)
-        XCTAssertFalse(notLoading.pending)
-
-        // error
+        let error = snapshots.last!
         XCTAssertEqual(error.count, 0)
         XCTAssertFalse(error.pending)
         XCTAssertEqual(error.error?.localizedDescription, "write error")

--- a/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
@@ -43,12 +43,16 @@ class ModuleListPresenterTests: TeacherTestCase {
         func showAlert(title: String?, message: String?) {
         }
 
+        var onShowPending: (() -> Void)?
         func showPending() {
             refreshing = true
+            onShowPending?()
         }
 
+        var onHidePending: (() -> Void)?
         func hidePending() {
             refreshing = false
+            onHidePending?()
         }
 
         var onScrollToIndexPath: ((IndexPath) -> Void)?
@@ -205,16 +209,19 @@ class ModuleListPresenterTests: TeacherTestCase {
         let request = GetModulesRequest(courseID: "1")
         let response = [APIModule.make(["name": "Refreshed"])]
         api.mock(request, value: response, response: nil, error: nil)
-        let expectation = XCTestExpectation(description: "modules refreshed")
+        let refreshed = expectation(description: "modules refreshed")
+        refreshed.assertForOverFulfill = false
+        let pending = expectation(description: "start pending")
+        let stopPending = expectation(description: "stop pending")
+        view.onShowPending = pending.fulfill
+        view.onHidePending = stopPending.fulfill
         view.onReloadModules = {
             if self.presenter.modules.count == 1, self.presenter.modules[0]?.name == "Refreshed" {
-                expectation.fulfill()
+                refreshed.fulfill()
             }
         }
         presenter.forceRefresh()
-        XCTAssertTrue(view.refreshing)
-        wait(for: [expectation], timeout: 1)
-        XCTAssertFalse(view.refreshing)
+        wait(for: [pending, refreshed, stopPending], timeout: 1)
     }
 
     func testScrollsToModule() {

--- a/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
@@ -147,7 +147,7 @@ class ModuleListPresenterTests: TeacherTestCase {
 
     func testReloadCourse() {
         let expectation = XCTestExpectation(description: "reloaded")
-        view.onReloadModules = {
+        view.onReloadCourse = {
             if self.presenter.course != nil {
                 expectation.fulfill()
             }


### PR DESCRIPTION
[ignore-commit-lint]

The main issue here was that `UseCase.fetch` callbacks were being
completed in tests that did not initiate them.

- TestA kicks off a request for courses and a request for modules
- TestA waits until courses load then the test would finish
- TestB starts
- TestB mocks modules request
- TestB requests modules
- TestA's request for modules would finish
- **TestA's modules would get written to TestB's db**
- TestB's request for modules would finish
- TestB's modules would get written to TestB's db
- TestB would fail because too many modules were written

This is due to UseCases retaining themselves until the callbacks
complete and not having a way to cancel a UseCase..

We should _probably_ support canceling at some point but in the
meantime, ensuring that we write to the same database that initiated the
`fetch` fixes test issues since we re-create the db for every test.