### PR TITLE
Preview html course files rather than download and embed

### DIFF
--- a/rn/Teacher/src/modules/files/ViewFile.js
+++ b/rn/Teacher/src/modules/files/ViewFile.js
@@ -294,9 +294,9 @@ export default class ViewFile extends Component<Props, State> {
         let { baseURL } = getSession()
         let url = baseURL
         if (this.props.context && this.props.contextID) {
-          url += `${this.props.context}/${this.props.contextID}/`
+          url += `/${this.props.context}/${this.props.contextID}`
         }
-        url += `files/${this.props.fileID}/preview`
+        url += `/files/${this.props.fileID}/preview`
         return (
           <CanvasWebView
             source={{ uri: url }}

--- a/rn/Teacher/src/modules/files/ViewFile.js
+++ b/rn/Teacher/src/modules/files/ViewFile.js
@@ -46,6 +46,7 @@ import { isTeacher } from '../app'
 import CanvasWebView from '../../common/components/CanvasWebView'
 import { alertError } from '../../redux/middleware/error-handler'
 import ModalOverlay from '../../common/components/ModalOverlay'
+import { getSession } from '../../canvas-api/session'
 
 type Props = {
   context?: CanvasContext,
@@ -283,6 +284,26 @@ export default class ViewFile extends Component<Props, State> {
               {i18n('Previewing this file type is not supported')}
             </Text>
           </View>
+        )
+      case 'html':
+        // some people use files as a web server to serve html content and
+        // when they do they might include relative links to other files in the course
+        // which won't work with the download url. We must build a preview url that will
+        // redirect the webview to the server that serves file content in order for the
+        // relative urls to function properly
+        let { baseURL } = getSession()
+        let url = baseURL
+        if (this.props.context && this.props.contextID) {
+          url += `${this.props.context}/${this.props.contextID}/`
+        }
+        url += `files/${this.props.fileID}/preview`
+        return (
+          <CanvasWebView
+            source={{ uri: url }}
+            style={styles.document}
+            onError={this.handleError}
+            navigator={this.props.navigator}
+          />
         )
       default:
         return (

--- a/rn/Teacher/src/modules/files/__tests__/ViewFile.test.js
+++ b/rn/Teacher/src/modules/files/__tests__/ViewFile.test.js
@@ -157,7 +157,7 @@ describe('ViewFile', () => {
     await Promise.resolve()
     await updatedState(tree)
     tree.update()
-    expect(tree.find('CanvasWebView').props().source.uri).toEqual('http://mobiledev.instructure.com/courses/1/files/24/preview')
+    expect(tree.find('CanvasWebView').props().source.uri).toEqual('http://mobiledev.instructure.com//courses/1/files/24/preview')
   })
 
   it('renders an error message if loading fails', async () => {

--- a/rn/Teacher/src/modules/files/__tests__/ViewFile.test.js
+++ b/rn/Teacher/src/modules/files/__tests__/ViewFile.test.js
@@ -150,6 +150,16 @@ describe('ViewFile', () => {
     expect(tree.find('ActivityIndicator').length).toBe(1)
   })
 
+  it('renders html', async () => {
+    props.file.mime_class = 'html'
+    const tree = shallow(<ViewFile {...props} />)
+    await Promise.resolve()
+    await Promise.resolve()
+    await updatedState(tree)
+    tree.update()
+    expect(tree.find('CanvasWebView').props().source.uri).toEqual('http://mobiledev.instructure.com/courses/1/files/24/preview')
+  })
+
   it('renders an error message if loading fails', async () => {
     let promise = Promise.resolve({ statusCode: 500 })
     downloadFile.mockImplementationOnce(() => ({


### PR DESCRIPTION
refs: MBL-12194
affects: Teacher
release note: Previewing html course files will resolve relative urls to other course files