### PR TITLE
Update MDM login flow

### DIFF
--- a/Canvas/Canvas.xcodeproj/xcshareddata/xcschemes/Canvas.xcscheme
+++ b/Canvas/Canvas.xcodeproj/xcshareddata/xcschemes/Canvas.xcscheme
@@ -71,10 +71,6 @@
             argument = "-FIRDebugEnabled"
             isEnabled = "NO">
          </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-com.apple.configuration.managed &apos;&lt;dict&gt;&lt;key&gt;enableDemo&lt;/key&gt;&lt;true/&gt;&lt;key&gt;username&lt;/key&gt;&lt;string&gt;username&lt;/string&gt;&lt;key&gt;password&lt;/key&gt;&lt;string&gt;password&lt;/string&gt;&lt;/dict&gt;&apos;"
-            isEnabled = "NO">
-         </CommandLineArgument>
       </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable

--- a/Core/CoreTests/API/APITests.swift
+++ b/Core/CoreTests/API/APITests.swift
@@ -139,7 +139,7 @@ class APITests: XCTestCase {
             XCTAssertNil(error)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 5.0)
         XCTAssertNotNil(task)
     }
 

--- a/Core/CoreTests/AppEnvironment/MDMManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/MDMManagerTests.swift
@@ -24,7 +24,7 @@ class MDMManagerTests: XCTestCase {
         MDMManager.reset()
     }
 
-    func testOnLoginConfiguredInstructure() {
+    func testOnLoginConfigured() {
         var login: MDMLogin?
         let expectation = XCTestExpectation(description: "on login configured")
         MDMManager.shared.onLoginConfigured {
@@ -34,24 +34,8 @@ class MDMManagerTests: XCTestCase {
         MDMManager.mockDefaults()
         NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: nil)
         wait(for: [expectation], timeout: 0.1)
-        XCTAssertEqual(login?.host, "canvas.instructure.com")
-        XCTAssertEqual(login?.username, "canvas")
-        XCTAssertEqual(login?.password, "password")
-        XCTAssertNotNil(MDMManager.shared.login)
-    }
-
-    func testOnLoginConfiguredApple() {
-        var login: MDMLogin?
-        let expectation = XCTestExpectation(description: "on login configured")
-        MDMManager.shared.onLoginConfigured {
-            login = $0
-            expectation.fulfill()
-        }
-        MDMManager.mockAppleDefaults()
-        NotificationCenter.default.post(name: UserDefaults.didChangeNotification, object: nil)
-        wait(for: [expectation], timeout: 0.1)
         XCTAssertNotNil(login?.host)
-        XCTAssertEqual(login?.host, Secret.appleDemoHost.string)
+        XCTAssertEqual(login?.host, "canvas.instructure.com")
         XCTAssertEqual(login?.username, "apple")
         XCTAssertEqual(login?.password, "titaniumium")
         XCTAssertNotNil(MDMManager.shared.login)

--- a/Core/CoreTests/Helpers/MockMDMManager.swift
+++ b/Core/CoreTests/Helpers/MockMDMManager.swift
@@ -18,30 +18,17 @@ import Foundation
 @testable import Core
 
 extension MDMManager {
-    static func mockAppleDefaults() {
-        let key = MDMProvider.apple.rawValue
+    static func mockDefaults() {
         let defaults: [String: Any] = [
             "enableDemo": true,
             "username": "apple",
             "password": "titaniumium",
-        ]
-        UserDefaults.standard.set(defaults, forKey: key)
-    }
-
-    static func mockDefaults() {
-        let key = MDMProvider.instructure.rawValue
-        let defaults: [String: Any] = [
-            "enableLogin": true,
             "host": "canvas.instructure.com",
-            "username": "canvas",
-            "password": "password",
         ]
-        UserDefaults.standard.set(defaults, forKey: key)
+        UserDefaults.standard.set(defaults, forKey: MDMManager.MDMUserDefaultsKey)
     }
 
     static func reset() {
-        MDMProvider.allCases.forEach {
-            UserDefaults.standard.set(nil, forKey: $0.rawValue)
-        }
+        UserDefaults.standard.set(nil, forKey: MDMManager.MDMUserDefaultsKey)
     }
 }

--- a/Core/CoreTests/Login/LoginWebPresenterTests.swift
+++ b/Core/CoreTests/Login/LoginWebPresenterTests.swift
@@ -188,8 +188,8 @@ class LoginWebPresenterTests: XCTestCase {
         let username = scripts[0]
         let password = scripts[1]
         let submit = scripts[2]
-        XCTAssertEqual(username, "document.querySelector('input[name=\"pseudonym_session[unique_id]\"]').value = \"canvas\"")
-        XCTAssertEqual(password, "document.querySelector('input[name=\"pseudonym_session[password]\"]').value = \"password\"")
+        XCTAssertEqual(username, "document.querySelector('input[name=\"pseudonym_session[unique_id]\"]').value = \"apple\"")
+        XCTAssertEqual(password, "document.querySelector('input[name=\"pseudonym_session[password]\"]').value = \"titaniumium\"")
         XCTAssertEqual(submit, "document.querySelector('#login_form').submit()")
     }
 

--- a/Parent/Parent.xcodeproj/xcshareddata/xcschemes/Parent.xcscheme
+++ b/Parent/Parent.xcodeproj/xcshareddata/xcschemes/Parent.xcscheme
@@ -67,10 +67,6 @@
             argument = "-com.apple.CoreData.ConcurrencyDebug 1"
             isEnabled = "YES">
          </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-com.apple.configuration.managed &apos;&lt;dict&gt;&lt;key&gt;enableDemo&lt;/key&gt;&lt;true/&gt;&lt;key&gt;username&lt;/key&gt;&lt;string&gt;username&lt;/string&gt;&lt;key&gt;password&lt;/key&gt;&lt;string&gt;password&lt;/string&gt;&lt;/dict&gt;&apos;"
-            isEnabled = "NO">
-         </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/README.md
+++ b/README.md
@@ -204,3 +204,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+
+## MDM Configurations
+
+MDM Profile settings are saved in `UserDefaults.standard` and keyed by
+`com.apple.configuration.managed`.
+
+Use our `MDMManager` to observe changes such as managed logins.
+
+You can test this locally with command line arguments.
+
+`Scheme` > `Edit Scheme` > `Run` > `Arguments` > `Arguments Passed on Launch`
+
+```
+-com.apple.configuration.managed '<dict><key>enableDemo</key><true/><key>username</key><string>student</string><key>password</key><string>Canvas2019</string><key>host</key><string>canvas.instructure.com</string></dict>'
+```
+
+Change the `username`, `password`, and `host` to your test credentials.

--- a/Student/Student.xcodeproj/xcshareddata/xcschemes/Student.xcscheme
+++ b/Student/Student.xcodeproj/xcshareddata/xcschemes/Student.xcscheme
@@ -101,10 +101,6 @@
             argument = "RouterDebug"
             isEnabled = "NO">
          </CommandLineArgument>
-         <CommandLineArgument
-            argument = "-com.apple.configuration.managed &apos;&lt;dict&gt;&lt;key&gt;enableDemo&lt;/key&gt;&lt;true/&gt;&lt;key&gt;username&lt;/key&gt;&lt;string&gt;username&lt;/string&gt;&lt;key&gt;password&lt;/key&gt;&lt;string&gt;password&lt;/string&gt;&lt;/dict&gt;&apos;"
-            isEnabled = "NO">
-         </CommandLineArgument>
       </CommandLineArguments>
       <AdditionalOptions>
       </AdditionalOptions>

--- a/rn/Teacher/ios/Teacher.xcodeproj/xcshareddata/xcschemes/Teacher.xcscheme
+++ b/rn/Teacher/ios/Teacher.xcodeproj/xcshareddata/xcschemes/Teacher.xcscheme
@@ -138,12 +138,6 @@
             ReferencedContainer = "container:Teacher.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <CommandLineArguments>
-         <CommandLineArgument
-            argument = "-com.apple.configuration.managed &apos;&lt;dict&gt;&lt;key&gt;enableDemo&lt;/key&gt;&lt;true/&gt;&lt;key&gt;username&lt;/key&gt;&lt;string&gt;username&lt;/string&gt;&lt;key&gt;password&lt;/key&gt;&lt;string&gt;password&lt;/string&gt;&lt;/dict&gt;&apos;"
-            isEnabled = "NO">
-         </CommandLineArgument>
-      </CommandLineArguments>
       <EnvironmentVariables>
          <EnvironmentVariable
             key = "OS_ACTIVITY_MODE"


### PR DESCRIPTION
refs: none
affects: student, teacher, parent
release note: none

* Always use the one configuration key (I misunderstood how this worked before)
* Move documentation to README