### PR TITLE
Fix getNextPage test

### DIFF
--- a/Core/Core/Store/Store.swift
+++ b/Core/Core/Store/Store.swift
@@ -150,7 +150,6 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate {
         }
         self.next = nil
         let useCase = GetNextUseCase(parent: self.useCase, request: next)
-        print("get next")
         useCase.fetch(environment: env, force: true) { [weak self] response, urlResponse, error in
             if let error = error {
                 self?.error = error

--- a/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
@@ -288,16 +288,22 @@ class ModuleListPresenterTests: TeacherTestCase {
             ])
         ]
         api.mock(page2Request, value: page2Response, response: nil, error: nil)
-        let expectation = XCTestExpectation(description: "got next page")
+        var expectation = XCTestExpectation(description: "first page")
         view.onReloadModules = {
             if self.presenter.modules.count == 1 {
-                self.presenter.getNextPage()
-            } else if self.presenter.modules.count == 2 {
                 expectation.fulfill()
             }
         }
         presenter.viewIsReady()
-        wait(for: [expectation], timeout: 2.0)
+        wait(for: [expectation], timeout: 1.0)
+        expectation = XCTestExpectation(description: "second page")
+        view.onReloadModules = {
+            if self.presenter.modules.count == 2 {
+                expectation.fulfill()
+            }
+        }
+        presenter.getNextPage()
+        wait(for: [expectation], timeout: 1.0)
     }
 
     func testTappedSection() {


### PR DESCRIPTION
refs: none
affects: teacher
release note: none

This is a needed improvement since `getNextPage` might get called a
bunch of times with detecting the end of scroll view. This should also
fix some flaky tests.