### PR TITLE
Show syllabus in detail on iPad

### DIFF
--- a/rn/Teacher/src/modules/courses/CourseNavigation.js
+++ b/rn/Teacher/src/modules/courses/CourseNavigation.js
@@ -106,7 +106,7 @@ export class CourseNavigation extends Component<CourseNavigationProps, any> {
         if (tab.id === 'pages') {
           const url = `/courses/${this.props.courseID}/pages`
           this.props.navigator.show(url)
-        } else if (isTeacher()) {
+        } else if (isTeacher() || tab.id === 'syllabus') {
           this.props.navigator.show(tab.html_url)
         } else if (tab.id === 'home' && this.props.course && this.props.course.default_view === 'wiki') {
           const url = `/courses/${this.props.courseID}/pages/front_page`

--- a/rn/Teacher/src/modules/courses/__tests__/CourseNavigation.test.js
+++ b/rn/Teacher/src/modules/courses/__tests__/CourseNavigation.test.js
@@ -296,6 +296,28 @@ describe('CourseNavigation', () => {
       .simulate('Press', tab)
     expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/pages')
   })
+
+  it('navigates to syllabus', () => {
+    const tab = template.tab({
+      id: 'syllabus',
+      html_url: '/courses/1/syllabus',
+    })
+    const props = {
+      ...defaultProps,
+      tabs: [tab],
+      navigator: template.navigator({
+        show: jest.fn(),
+      }),
+    }
+
+    const tree = shallow(<CourseNavigation {...props} />)
+    tree
+      .find('TabsList').first().dive()
+      .find('OnLayout').first().dive()
+      .find('[testID="courses-details.tab.syllabus"]')
+      .simulate('Press', tab)
+    expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/syllabus')
+  })
 })
 
 describe('mapStateToProps', () => {


### PR DESCRIPTION
[ignore-commit-lint]

Verified with David that the syllabus should show up on the detail side
of the split view controller. Tapping an assignment pushes onto the
detail.