### PR TITLE
fix rubric bug with core data

### DIFF
--- a/Core/Core/Database/CoreData/Models/Rubric.swift
+++ b/Core/Core/Database/CoreData/Models/Rubric.swift
@@ -36,6 +36,7 @@ public final class Rubric: NSManagedObject, WriteableModel {
         model.longDesc = item.long_description
         model.points = item.points
         model.criterionUseRange = item.criterion_use_range
+        model.assignmentID = item.assignmentID ?? ""
 
         if let ratings = model.ratings {
             try context.delete(Array(ratings))
@@ -72,6 +73,7 @@ public final class RubricRating: NSManagedObject, WriteableModel {
         model.desc = item.description
         model.longDesc = item.long_description
         model.points = item.points
+        model.assignmentID = item.assignmentID ?? ""
         return model
     }
 }

--- a/Core/CoreTests/Use Cases/GetAssignmentsTests.swift
+++ b/Core/CoreTests/Use Cases/GetAssignmentsTests.swift
@@ -261,7 +261,9 @@ class GetAssignmentsTests: CoreTestCase {
         let assignment = assignments.first
         XCTAssertNotNil(assignment)
         XCTAssertNotNil(assignment?.rubric)
+        XCTAssertEqual(assignment?.rubric?.first?.assignmentID, "2")
         XCTAssertNotNil(assignment?.rubric?.first?.ratings?.first)
+        XCTAssertEqual(assignment?.rubric?.first?.ratings?.first?.assignmentID, "2")
     }
 
     func testItChangesRubrics() {
@@ -343,6 +345,7 @@ class GetAssignmentsTests: CoreTestCase {
         XCTAssertNotNil(assignment)
         XCTAssertNotNil(assignment?.rubric)
         XCTAssertEqual(assignment?.rubric?.first?.ratings?.first?.id, "2")
+        XCTAssertEqual(assignment?.rubric?.first?.ratings?.first?.assignmentID, "2")
         XCTAssertEqual(assignment?.rubric?.first?.ratings?.count, 1)
     }
 }


### PR DESCRIPTION
refs: MBL-11320
affects: none
release note: none