### PR TITLE
Fix crash when course invites restricted by date

### DIFF
--- a/rn/Teacher/src/modules/dashboard/Dashboard.js
+++ b/rn/Teacher/src/modules/dashboard/Dashboard.js
@@ -316,6 +316,12 @@ export class Dashboard extends React.Component<Props, State> {
     // Course Invites
     if (this.props.enrollments.length > 0) {
       let courseInvites = this.props.enrollments.filter(en => {
+        if (en.course_id) {
+          const course = this.props.allCourses[en.course_id]
+          if (course.access_restricted_by_date) {
+            return false
+          }
+        }
         return en.displayState === 'acted' || en.enrollment_state === 'invited'
       })
       sections.push({

--- a/rn/Teacher/src/modules/dashboard/__tests__/Dashboard.test.js
+++ b/rn/Teacher/src/modules/dashboard/__tests__/Dashboard.test.js
@@ -352,6 +352,54 @@ describe('Dashboard', () => {
     App.setCurrentApp(currentApp)
   })
 
+  it('filters invites restricted by date', async () => {
+    let currentApp = App.current().appId
+    App.setCurrentApp('student')
+
+    const course1 = template.course({
+      id: '1',
+      access_restricted_by_date: true,
+    })
+    const course2 = template.course({ id: '2' })
+    const allCourses = {
+      [course1.id]: course1,
+      [course2.id]: course2,
+    }
+    const courses = [course1, course2]
+
+    const enrollments = [
+      template.enrollment({
+        id: '1',
+        course_id: course1.id,
+        enrollment_state: 'invited',
+      }),
+      template.enrollment({
+        id: '2',
+        course_id: course2.id,
+        enrollment_state: 'invited',
+      }),
+    ]
+
+    let props = {
+      ...defaultProps,
+      enrollments,
+      allCourses,
+      courses,
+      sections,
+    }
+
+    let screen = shallow(<Dashboard {...props} />)
+    const layout = { width: 340, height: 400 }
+    screen.find('SectionList').simulate('Layout', { nativeEvent: { layout } })
+    await screen.update()
+    const sections = screen.find('SectionList').prop('sections')
+    const inviteSection = sections[0]
+    expect(inviteSection.data).toHaveLength(1)
+    expect(inviteSection.data[0].id).toEqual('2')
+
+    App.setCurrentApp(currentApp)
+  })
+
   it('handles accept invite', () => {
     let currentApp = App.current().appId
 


### PR DESCRIPTION
refs: MBL-12240
affects: student
release note: Fixed a bug that would cause an error when a user was invited to a course that had not yet started