### PR TITLE
Remove Scoped protocol

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -55,11 +55,6 @@ open class AppEnvironment {
 
     public static let shared = AppEnvironment()
 
-    public func subscribe<T: Scoped>(_ scoped: T.Type, _ name: T.ScopeKeys) -> FetchedResultsController<T> {
-        let scope = T.scope(forName: name)
-        return database.fetchedResultsController(predicate: scope.predicate, sortDescriptors: scope.order, sectionNameKeyPath: scope.sectionNameKeyPath)
-    }
-
     public func subscribe<U>(_ useCase: U, _ callback: @escaping Store<U>.EventHandler) -> Store<U> where U: UseCase {
         return Store(env: self, useCase: useCase, eventHandler: callback)
     }

--- a/Core/Core/Database/CoreData/Models/Course.swift
+++ b/Core/Core/Database/CoreData/Models/Course.swift
@@ -110,22 +110,3 @@ extension Course {
         return scoreString
     }
 }
-
-extension Course: Scoped {
-    public enum ScopeKeys {
-        case details(String)
-        case all
-        case favorites
-    }
-
-    public static func scope(forName name: ScopeKeys) -> Scope {
-        switch name {
-        case let .details(id):
-            return .where(#keyPath(Course.id), equals: id)
-        case .all:
-            return .all(orderBy: #keyPath(Course.name))
-        case .favorites:
-            return .where(#keyPath(Course.isFavorite), equals: true, orderBy: #keyPath(Course.name))
-        }
-    }
-}

--- a/Core/Core/Database/CoreData/Models/File.swift
+++ b/Core/Core/Database/CoreData/Models/File.swift
@@ -91,19 +91,6 @@ final public class File: NSManagedObject {
     }
 }
 
-extension File: Scoped {
-    public enum ScopeKeys {
-        case details(String)
-    }
-
-    public static func scope(forName name: ScopeKeys) -> Scope {
-        switch name {
-        case let .details(id):
-            return .where(#keyPath(File.id), equals: id)
-        }
-    }
-}
-
 extension File: WriteableModel {
     public typealias JSON = APIFile
 

--- a/Core/Core/Database/CoreData/Models/Group.swift
+++ b/Core/Core/Database/CoreData/Models/Group.swift
@@ -60,19 +60,3 @@ extension Group {
         return .named(.ash)
     }
 }
-
-extension Group: Scoped {
-    public enum ScopeKeys {
-        case details(String)
-        case dashboard
-    }
-
-    public static func scope(forName name: ScopeKeys) -> Scope {
-        switch name {
-        case let .details(id):
-            return .where(#keyPath(Group.id), equals: id)
-        case .dashboard:
-            return .where(#keyPath(Group.concluded), equals: false, orderBy: #keyPath(Group.name))
-        }
-    }
-}

--- a/Core/Core/Database/CoreData/Models/LogEvent.swift
+++ b/Core/Core/Database/CoreData/Models/LogEvent.swift
@@ -23,19 +23,12 @@ public class LogEvent: NSManagedObject {
     @NSManaged public var message: String
 }
 
-extension LogEvent: Scoped {
-    public enum ScopeKeys {
-        case all
-        case type(LoggableType)
-    }
-
-    public static func scope(forName name: LogEvent.ScopeKeys) -> Scope {
-        switch name {
-        case .all:
+extension LogEvent {
+    public static func scope(forType type: LoggableType?) -> Scope {
+        guard let type = type else {
             let order = NSSortDescriptor(key: #keyPath(LogEvent.timestamp), ascending: false)
             return Scope(predicate: .all, order: [order])
-        case let .type(type):
-            return Scope.where(#keyPath(LogEvent.typeRaw), equals: type.rawValue)
         }
+        return Scope.where(#keyPath(LogEvent.typeRaw), equals: type.rawValue)
     }
 }

--- a/Core/Core/Database/CoreData/Models/Submission.swift
+++ b/Core/Core/Database/CoreData/Models/Submission.swift
@@ -77,23 +77,6 @@ final public class Submission: NSManagedObject {
     }
 }
 
-extension Submission: Scoped {
-    public enum ScopeKeys {
-        case forUserOnAssignment(String, String)
-    }
-
-    public static func scope(forName name: Submission.ScopeKeys) -> Scope {
-        switch name {
-        case let .forUserOnAssignment(assignmentID, userID):
-            let assignmentPredicate = Scope.where(#keyPath(Submission.assignmentID), equals: assignmentID).predicate
-            let userPredicate = Scope.where(#keyPath(Submission.userID), equals: userID).predicate
-            let compoundPredicate = NSCompoundPredicate(andPredicateWithSubpredicates: [assignmentPredicate, userPredicate])
-            let sort = NSSortDescriptor(key: #keyPath(Submission.attempt), ascending: true)
-            return Scope(predicate: compoundPredicate, order: [sort])
-        }
-    }
-}
-
 extension Submission: WriteableModel {
     public typealias JSON = APISubmission
 

--- a/Core/Core/Database/CoreData/Models/Tab.swift
+++ b/Core/Core/Database/CoreData/Models/Tab.swift
@@ -57,16 +57,3 @@ public class Tab: NSManagedObject {
         visibility = item.visibility
     }
 }
-
-extension Tab: Scoped {
-    public enum ScopeKeys {
-        case context(Context)
-    }
-
-    public static func scope(forName name: ScopeKeys) -> Scope {
-        switch name {
-        case let .context(context):
-            return .where(#keyPath(Tab.contextRaw), equals: context.canvasContextID, orderBy: #keyPath(Tab.position))
-        }
-    }
-}

--- a/Core/Core/Database/Scope.swift
+++ b/Core/Core/Database/Scope.swift
@@ -40,8 +40,3 @@ public struct Scope: Equatable {
         return Scope(predicate: .all, order: [sort])
     }
 }
-
-public protocol Scoped {
-    associatedtype ScopeKeys
-    static func scope(forName name: ScopeKeys) -> Scope
-}

--- a/Core/Core/Logger/LogEventList/LogEventListViewController.swift
+++ b/Core/Core/Logger/LogEventList/LogEventListViewController.swift
@@ -15,6 +15,7 @@
 //
 
 import Foundation
+import UIKit
 
 protocol LogEventListViewProtocol: ErrorViewController {
     func reloadData()
@@ -50,13 +51,13 @@ public class LogEventListViewController: UIViewController, LogEventListViewProto
         let alert = UIAlertController(title: "Filter", message: nil, preferredStyle: .actionSheet)
         for type in LoggableType.allCases {
             let action = UIAlertAction(title: type.rawValue, style: .default) { _ in
-                self.presenter?.applyFilter(.type(type))
+                self.presenter?.applyFilter(type)
             }
             alert.addAction(action)
         }
         if presenter?.currentFilter != nil {
             let clear = UIAlertAction(title: "Clear filter", style: .destructive) { _ in
-                self.presenter?.applyFilter(.all)
+                self.presenter?.applyFilter(nil)
             }
             alert.addAction(clear)
         }
@@ -76,16 +77,16 @@ public class LogEventListViewController: UIViewController, LogEventListViewProto
 
 extension LogEventListViewController: UITableViewDataSource, UITableViewDelegate {
     public func numberOfSections(in tableView: UITableView) -> Int {
-        return 1
+        return presenter?.events.numberOfSections ?? 1
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return presenter?.numberOfEvents ?? 0
+        return presenter?.events.count ?? 0
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeue(LoggableCell.self, for: indexPath)
-        cell.loggable = presenter?.logEvent(for: indexPath)
+        cell.loggable = presenter?.events[indexPath]
         return cell
     }
 }

--- a/Core/Core/Use Cases/DownloadFile.swift
+++ b/Core/Core/Use Cases/DownloadFile.swift
@@ -52,8 +52,7 @@ public class DownloadFile: OperationSet {
             guard let fileID = self?.fileID else {
                 return
             }
-            let scope = File.scope(forName: .details(fileID))
-            guard let file: File = client.fetch(predicate: scope.predicate, sortDescriptors: nil).first else {
+            guard let file: File = client.fetch(predicate: .id(fileID), sortDescriptors: nil).first else {
                 return
             }
             self?.serverFileURL = file.url
@@ -106,8 +105,7 @@ public class DownloadFile: OperationSet {
             guard let fileID = self?.fileID, let localFileURL = self?.localFileURL else {
                 return
             }
-            let scope = File.scope(forName: .details(fileID))
-            guard let file: File = client.fetch(predicate: scope.predicate, sortDescriptors: nil).first else {
+            guard let file: File = client.fetch(predicate: .id(fileID), sortDescriptors: nil).first else {
                 return
             }
             file.localFileURL = localFileURL

--- a/Core/CoreTests/Database/Models/CourseTests.swift
+++ b/Core/CoreTests/Database/Models/CourseTests.swift
@@ -19,41 +19,6 @@ import XCTest
 @testable import Core
 
 class CourseTests: CoreTestCase {
-    func testDetailsScopeOnlyIncludesCourse() {
-        let course = Course.make(["id": "1"])
-        let other = Course.make(["id": "2"])
-        let list = environment.subscribe(Course.self, .details("1"))
-        list.performFetch()
-        let objects = list.fetchedObjects
-        XCTAssertEqual(objects?.count, 1)
-        XCTAssertEqual(objects?.contains(course), true)
-        XCTAssertEqual(objects?.contains(other), false)
-    }
-
-    func testAllScope() {
-        let one = Course.make(["id": "1"])
-        let two = Course.make(["id": "2"])
-        let list = environment.subscribe(Course.self, .all)
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects?.count, 2)
-        XCTAssertEqual(objects?.contains(one), true)
-        XCTAssertEqual(objects?.contains(two), true)
-    }
-
-    func testFavoritesScopeOnlyIncludesFavorites() {
-        let favorite = Course.make(["id": "1", "isFavorite": true])
-        let nonFavorite = Course.make(["id": "1", "isFavorite": false])
-        let list = environment.subscribe(Course.self, .favorites)
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects?.count, 1)
-        XCTAssertEqual(objects?.first, favorite)
-        XCTAssertEqual(objects?.contains(nonFavorite), false)
-    }
-
     func testColor() {
         let a = Course.make()
         _ = Color.make()

--- a/Core/CoreTests/Database/Models/GroupTests.swift
+++ b/Core/CoreTests/Database/Models/GroupTests.swift
@@ -19,40 +19,6 @@ import XCTest
 @testable import Core
 
 class GroupTests: CoreTestCase {
-    func testDetailsScopeOnlyIncludesGroup() {
-        let group = Group.make(["id": "1"])
-        Group.make(["id": "2"])
-        let list = environment.subscribe(Group.self, .details("1"))
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects?.count, 1)
-        XCTAssertEqual(objects, [group])
-    }
-
-    func testDashboardScopeDoesNotIncludeConcluded() {
-        let notConcluded = Group.make(["id": "1", "concluded": false])
-        Group.make(["id": "2", "concluded": true])
-        let list = environment.subscribe(Group.self, .dashboard)
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects?.count, 1)
-        XCTAssertEqual(objects, [notConcluded])
-    }
-
-    func testDashboardScopeOrdersByName() {
-        let a = Group.make(["id": "1", "name": "a"])
-        let b = Group.make(["id": "2", "name": "b"])
-        let c = Group.make(["id": "3", "name": "c"])
-        let list = environment.subscribe(Group.self, .dashboard)
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects?.count, 3)
-        XCTAssertEqual(objects, [a, b, c])
-    }
-
     func testColorWithNoLinkOrCourse() {
         let a = Group.make()
         _ = Color.make()

--- a/Core/CoreTests/Database/Models/SubmissionTests.swift
+++ b/Core/CoreTests/Database/Models/SubmissionTests.swift
@@ -59,19 +59,6 @@ class SubmissionTests: CoreTestCase {
         XCTAssertEqual(submission.discussionEntriesOrdered.first?.id, "1")
     }
 
-    func testUserAssignmentScope() {
-        let one = Submission.make(["assignmentID": "2", "attempt": 1, "userID": "3"])
-        let two = Submission.make(["assignmentID": "2", "attempt": 2, "userID": "3"])
-        let three = Submission.make(["assignmentID": "2", "attempt": 3, "userID": "3"])
-        let other = Submission.make(["assignmentID": "7"])
-        let list = environment.subscribe(Submission.self, .forUserOnAssignment("2", "3"))
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects, [one, two, three])
-        XCTAssertEqual(objects?.contains(other), false)
-    }
-
     func testMediaSubmission() {
         let submission = Submission.make(["mediaComment": MediaComment.make()])
         XCTAssertNotNil(submission.mediaComment)

--- a/Core/CoreTests/Database/Models/TabTests.swift
+++ b/Core/CoreTests/Database/Models/TabTests.swift
@@ -42,17 +42,4 @@ class TabTests: CoreTestCase {
         tab.visibilityRaw = "bogus"
         XCTAssertEqual(tab.visibility, .none)
     }
-
-    func testContextScope() {
-        let one = Tab.make(["contextRaw": "course_1", "position": 0])
-        let two = Tab.make(["contextRaw": "course_1", "position": 1])
-        let three = Tab.make(["contextRaw": "course_1", "position": 2])
-        let otherTab = Tab.make(["contextRaw": "group_1"])
-        let list = environment.subscribe(Tab.self, .context(ContextModel(.course, id: "1")))
-        list.performFetch()
-        let objects = list.fetchedObjects
-
-        XCTAssertEqual(objects, [one, two, three])
-        XCTAssertEqual(objects?.contains(otherTab), false)
-    }
 }

--- a/Core/CoreTests/Logger/LogEventList/LogEventListPresenterTests.swift
+++ b/Core/CoreTests/Logger/LogEventList/LogEventListPresenterTests.swift
@@ -37,41 +37,18 @@ class LogEventListPresenterTests: CoreTestCase {
         presenter = LogEventListPresenter(env: environment, view: view)
     }
 
-    func testNumberOfEventsZero() {
-        presenter.viewIsReady()
-        XCTAssertEqual(presenter.numberOfEvents, 0)
-    }
-
-    func testNumberOfEventsNonZero() {
-        LogEvent.make()
-        LogEvent.make()
-        presenter.viewIsReady()
-        XCTAssertEqual(presenter.numberOfEvents, 2)
-    }
-
-    func testLogEventForIndexPath() {
-        let expectedOne = LogEvent.make(["timestamp": Date().addDays(-1)])
-        let expectedTwo = LogEvent.make(["timestamp": Date().addDays(-2)])
-        presenter.viewIsReady()
-        let one = presenter.logEvent(for: IndexPath(row: 0, section: 0))
-        let two = presenter.logEvent(for: IndexPath(row: 1, section: 0))
-
-        XCTAssertEqual(expectedOne.timestamp, one?.timestamp)
-        XCTAssertEqual(expectedTwo.timestamp, two?.timestamp)
-    }
-
     func testApplyFilter() {
         LogEvent.make(["typeRaw": LoggableType.log.rawValue])
         LogEvent.make(["typeRaw": LoggableType.error.rawValue])
         presenter.viewIsReady()
-        XCTAssertEqual(presenter.numberOfEvents, 2)
+        XCTAssertEqual(presenter.events.count, 2)
 
         view.reloadDataExpectation = XCTestExpectation()
-        presenter.applyFilter(.type(.log))
+        presenter.applyFilter(.log)
 
         wait(for: [view.reloadDataExpectation], timeout: 0.1)
-        XCTAssertEqual(presenter.numberOfEvents, 1)
-        let event = presenter.logEvent(for: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(presenter.events.count, 1)
+        let event = presenter.events[IndexPath(row: 0, section: 0)]
         XCTAssertEqual(event?.type, .log)
     }
 
@@ -79,18 +56,18 @@ class LogEventListPresenterTests: CoreTestCase {
         LogEvent.make(["typeRaw": LoggableType.log.rawValue])
         LogEvent.make(["typeRaw": LoggableType.error.rawValue])
         presenter.viewIsReady()
-        XCTAssertEqual(presenter.numberOfEvents, 2)
+        XCTAssertEqual(presenter.events.count, 2)
 
         // Filter to only show errors
         view.reloadDataExpectation = XCTestExpectation()
-        presenter.applyFilter(.type(.log))
+        presenter.applyFilter(.log)
         wait(for: [view.reloadDataExpectation], timeout: 0.1)
-        XCTAssertEqual(presenter.numberOfEvents, 1)
+        XCTAssertEqual(presenter.events.count, 1)
 
-        // Apply filter back to .all
+        // Apply filter back to nil
         view.reloadDataExpectation = XCTestExpectation()
-        presenter.applyFilter(.all)
+        presenter.applyFilter(nil)
         wait(for: [view.reloadDataExpectation], timeout: 0.1)
-        XCTAssertEqual(presenter.numberOfEvents, 2)
+        XCTAssertEqual(presenter.events.count, 2)
     }
 }


### PR DESCRIPTION
We were not using this much, and it seemed more overhead than help.
Scope is used heavily in UseCases so that remains.

refs: none
affects: none
release note: none