### PR TITLE
Change number pad to decimal pad

### DIFF
--- a/rn/Teacher/src/modules/speedgrader/components/RubricItem.js
+++ b/rn/Teacher/src/modules/speedgrader/components/RubricItem.js
@@ -98,7 +98,7 @@ export default class RubricItem extends Component<RubricItemProps, RubricItemSta
       }],
       'plain-text',
       this.isCustomGrade() ? String(this.state.selectedPoints) : '',
-      'number-pad'
+      'decimal-pad'
     )
   }
 

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/RubricItem.test.js
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/RubricItem.test.js
@@ -167,6 +167,7 @@ describe('RubricItem', () => {
     button.props.onPress()
 
     expect(AlertIOS.prompt).toHaveBeenCalled()
+    expect(AlertIOS.prompt.mock.calls[0][5]).toEqual('decimal-pad')
     AlertIOS.prompt.mock.calls[0][2][1].onPress('12')
     expect(defaultProps.changeRating).toHaveBeenCalledWith(defaultProps.rubricItem.id, 12, undefined)
     expect(AccessibilityInfo.setAccessibilityFocus).toHaveBeenCalled()


### PR DESCRIPTION
refs: MBL-11019
affects: Teacher
release note: Can now enter decimals on custom rubric item scores
test plan: credentials in the ticket