### PR TITLE
Downgrade PSPDFKit to 8.1.3 to avoid breaking speedgrader

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" == 8.2.2
+binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" == 8.1.3

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" "8.2.2"
+binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" "8.1.3"
 github "google/EarlGrey" "f26066ee142f4d2708f95da19c21fd2c7a1b0a1d"
 github "instructure/SwiftUITest" "fed9568e4d5d109447b511388cdc158625e431b4"


### PR DESCRIPTION
refs: MBL-12335
affects: Teacher
release note: none