### PR TITLE
Wrap long link text in webviews

### DIFF
--- a/CanvasCore/CanvasCore/Pages/UI/Rendering/PageTemplate.html
+++ b/CanvasCore/CanvasCore/Pages/UI/Rendering/PageTemplate.html
@@ -14,6 +14,7 @@
     }
     a {
       color: #0081bd;
+      overflow-wrap: break-word;
     }
     p {
       color: #444;

--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -90,6 +90,7 @@ open class CoreWebView: WKWebView {
             }
             a {
                 color: \(link.hexString);
+                overflow-wrap: break-word;
             }
             h2 {
                 font-weight: 300;


### PR DESCRIPTION
refs: MBL-12320
affects: Student, Teacher
release note: Wraps long anchor text to fit in the screen width