### PR TITLE
Update PSPDFKit, and check for empty string annotation state

### DIFF
--- a/CanvasCore/CanvasCore/PDF/CanvadocView.swift
+++ b/CanvasCore/CanvasCore/PDF/CanvadocView.swift
@@ -275,7 +275,7 @@ public class CanvadocView: UIView {
 
 extension CanvadocView: PSPDFAnnotationStateManagerDelegate {
     public func annotationStateManager(_ manager: PSPDFAnnotationStateManager, didChangeState oldState: AnnotationString?, to newState: AnnotationString?, variant oldVariant: AnnotationVariantString?, to newVariant: AnnotationVariantString?) {
-        if let _ = newState {
+        if let state = newState, !state.rawValue.isEmpty {
             setScrollEnabled(false)
         } else {
             setScrollEnabled(true)

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" == 8.1.3
+binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" == 8.3.1

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" "8.1.3"
+binary "https://customers.pspdfkit.com/carthage/mq7ic2x5FCWWUCuxWct2g87YfR9hpK/pspdfkit.json" "8.3.1"
 github "google/EarlGrey" "913fa9802585fe2739aeb99084aa28cd514aaf72"
 github "instructure/SwiftUITest" "ca28f10a3ca0b7c5e700076d435c507e501251b6"


### PR DESCRIPTION
refs: MBL-12335
affects: Teacher
release note: Fixed scrolling between submissions in speed grader