### PR TITLE
Fix crash when course is restricted by date

### DIFF
--- a/rn/Teacher/src/modules/app/__tests__/index.test.js
+++ b/rn/Teacher/src/modules/app/__tests__/index.test.js
@@ -29,6 +29,13 @@ describe('App', () => {
     })
 
     describe('filterCourse', () => {
+      it('filters courses access restricted by date', () => {
+        const restricted = templates.course({ access_restricted_by_date: true })
+        const available = templates.course({ access_restricted_by_date: false })
+        const result = [restricted, available].filter(app.filterCourse)
+        expect(result).toEqual([available])
+      })
+
       it('filters courses based on enrollment types', () => {
         let courses = [
           templates.course({ enrollments: [templates.enrollment({ type: 'teacher' })] }),
@@ -40,6 +47,22 @@ describe('App', () => {
 
         const result = courses.filter(app.filterCourse)
         expect(result.every(c => c.enrollments && c.enrollments[0].type !== 'student')).toEqual(true)
+      })
+    })
+  })
+
+  describe('student', () => {
+    beforeEach(() => {
+      App.setCurrentApp('student')
+      app = App.current()
+    })
+
+    describe('filterCourse', () => {
+      it('filters courses access restricted by date', () => {
+        const restricted = templates.course({ access_restricted_by_date: true })
+        const available = templates.course({ access_restricted_by_date: false })
+        const result = [restricted, available].filter(app.filterCourse)
+        expect(result).toEqual([available])
       })
     })
   })

--- a/rn/Teacher/src/modules/app/index.js
+++ b/rn/Teacher/src/modules/app/index.js
@@ -25,6 +25,7 @@ export type App = {
 const teacher = {
   appId: 'teacher',
   filterCourse: (course: Course): boolean => {
+    if (course.access_restricted_by_date) return false
     const enrollments = course.enrollments
     if (!enrollments) return false
     return enrollments.some((e) =>
@@ -40,7 +41,7 @@ const teacher = {
 
 const student = {
   appId: 'student',
-  filterCourse: (course: Course): boolean => true,
+  filterCourse: (course: Course): boolean => !course.access_restricted_by_date,
 }
 
 const parent = {

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -110,7 +110,6 @@ export function mapStateToProps (state: AppState): CourseSelectDataProps {
   let courses = Object.keys(state.entities.courses)
     .map(id => state.entities.courses[id].course)
     .filter(App.current().filterCourse)
-    .filter(course => !course.access_restricted_by_date)
   let pending = !!state.favoriteCourses.pending
 
   const favoriteCourses = courses.filter((course) => course.is_favorite)

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -110,6 +110,7 @@ export function mapStateToProps (state: AppState): CourseSelectDataProps {
   let courses = Object.keys(state.entities.courses)
     .map(id => state.entities.courses[id].course)
     .filter(App.current().filterCourse)
+    .filter(course => !course.access_restricted_by_date)
   let pending = !!state.favoriteCourses.pending
 
   const favoriteCourses = courses.filter((course) => course.is_favorite)

--- a/rn/Teacher/src/modules/inbox/Inbox.js
+++ b/rn/Teacher/src/modules/inbox/Inbox.js
@@ -116,10 +116,12 @@ export class Inbox extends Component<InboxProps, any> {
     return (
       <View style={styles.container}>
         <FilterHeader selected={this.props.scope} onFilterChange={this._onChangeFilter} />
-        <CourseFilter courses={this.props.courses}
-          selectedCourse={this.state.selectedCourse}
-          onClearFilter={this._clearCourseFilter}
-          onSelectFilter={this._updateCourseFilter} />
+        { this.props.courses && this.props.courses.length > 0 &&
+          <CourseFilter courses={this.props.courses}
+            selectedCourse={this.state.selectedCourse}
+            onClearFilter={this._clearCourseFilter}
+            onSelectFilter={this._updateCourseFilter} />
+        }
         { conversations.length === 0 && this.props.pending
           ? this._renderLoading()
           : <FlatList
@@ -188,10 +190,13 @@ export function mapStateToProps ({ inbox, entities }: AppState) {
   const scope = inbox.selectedScope
   const scopeData = inbox[scope]
   const conversations = scopeData.refs.map((id) => inbox.conversations[id] && inbox.conversations[id].data).filter(Boolean)
-  const courses = Object.keys(entities.courses).reduce((acc, id) => {
-    acc.push(entities.courses[id].course)
-    return acc
-  }, []).filter(App.current().filterCourse)
+  const courses = Object.keys(entities.courses)
+    .reduce((acc, id) => {
+      acc.push(entities.courses[id].course)
+      return acc
+    }, [])
+    .filter(App.current().filterCourse)
+    .filter(course => !course.access_restricted_by_date)
   return {
     conversations,
     scope,

--- a/rn/Teacher/src/modules/inbox/Inbox.js
+++ b/rn/Teacher/src/modules/inbox/Inbox.js
@@ -196,7 +196,6 @@ export function mapStateToProps ({ inbox, entities }: AppState) {
       return acc
     }, [])
     .filter(App.current().filterCourse)
-    .filter(course => !course.access_restricted_by_date)
   return {
     conversations,
     scope,

--- a/rn/Teacher/src/modules/inbox/__tests__/Inbox.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/Inbox.test.js
@@ -17,6 +17,7 @@
 /* eslint-disable flowtype/require-valid-file-annotation */
 import 'react-native'
 import React from 'react'
+import { shallow } from 'enzyme'
 import { Inbox, handleRefresh, shouldRefresh, mapStateToProps, Refreshed } from '../Inbox'
 import Navigator from '../../../routing/Navigator'
 import setProps from '../../../../test/helpers/setProps'
@@ -53,258 +54,302 @@ let defaultProps = {
 
 beforeEach(() => jest.resetAllMocks())
 
-it('renders correctly', () => {
-  const tree = renderer.create(
-    <Inbox {...defaultProps} />
-  ).toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-it('selected an item from the inbox', () => {
-  const tree = renderer.create(
-    <Inbox {...defaultProps} />
-  ).toJSON()
-  const row = explore(tree).selectByID(`inbox.conversation-${c1.id}`) || {}
-  row.props.onPress(c1.id)
-  expect(defaultProps.navigator.show).toHaveBeenCalledWith(
-    '/conversations/1',
-  )
-})
-
-it('doesnt call refresh function if there is no next function', () => {
-  let instance = renderer.create(
-    <Inbox {...defaultProps} />
-  ).getInstance()
-
-  expect(instance.getNextPage()).toBeFalsy()
-  expect(defaultProps.refreshInboxAll).not.toHaveBeenCalled
-})
-
-it('calls the refresh function with next if next is present', () => {
-  let next = jest.fn()
-  let instance = renderer.create(
-    <Inbox {...defaultProps} next={next} />
-  ).getInstance()
-
-  instance.getNextPage()
-  expect(defaultProps.refreshInboxAll).toHaveBeenCalledWith(next)
-})
-
-it('renders with an empty state', () => {
-  const tree = renderer.create(
-    <Inbox {...defaultProps} conversations={[]} />
-  ).toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-it('renders the starred empty state', () => {
-  const tree = renderer.create(
-    <Inbox {...defaultProps} conversations={[]} scope='starred' />
-  ).toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-it('renders the activity indicator when loading conversations', () => {
-  const tree = renderer.create(
-    <Inbox {...defaultProps} conversations={[]} pending={true} />
-  ).toJSON()
-  expect(tree).toMatchSnapshot()
-})
-
-it('calls navigator.show when addMessage is called', () => {
-  const instance = renderer.create(
-    <Inbox {...defaultProps} />
-  ).getInstance()
-
-  instance.addMessage()
-  expect(defaultProps.navigator.show).toHaveBeenCalledWith(
-    '/conversations/compose',
-    { modal: true }
-  )
-})
-
-it('mapStateToProps', () => {
-  const c1 = template.conversation({
-    id: '1',
+describe('Inbox', () => {
+  it('renders correctly', () => {
+    const tree = renderer.create(
+      <Inbox {...defaultProps} />
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
   })
-  const c2 = template.conversation({
-    id: '2',
+
+  it('selected an item from the inbox', () => {
+    const tree = renderer.create(
+      <Inbox {...defaultProps} />
+    ).toJSON()
+    const row = explore(tree).selectByID(`inbox.conversation-${c1.id}`) || {}
+    row.props.onPress(c1.id)
+    expect(defaultProps.navigator.show).toHaveBeenCalledWith(
+      '/conversations/1',
+    )
   })
-  const course1 = template.course({ id: '1' })
-  const course2 = template.course({ id: '2' })
-  const appState = {
-    inbox: {
-      conversations: {
-        '1': { data: c1 },
-        '2': { data: c2 },
-      },
-      selectedScope: 'all',
-      all: { refs: [c1.id, c2.id] },
-    },
-    entities: {
-      courses: {
-        '1': { course: course1 },
-        '2': { course: course2 },
-      },
-    },
-  }
 
-  const results = mapStateToProps(appState)
-  expect(results).toMatchObject({
-    conversations: [c1, c2],
-    courses: [course1, course2],
+  it('doesnt call refresh function if there is no next function', () => {
+    let instance = renderer.create(
+      <Inbox {...defaultProps} />
+    ).getInstance()
+
+    expect(instance.getNextPage()).toBeFalsy()
+    expect(defaultProps.refreshInboxAll).not.toHaveBeenCalled
   })
-})
 
-it('_onChangeFilter', () => {
-  const updateInboxSelectedScope = jest.fn()
-  const instance = renderer.create(
-    <Inbox conversations={[]} updateInboxSelectedScope={updateInboxSelectedScope} />
-  ).getInstance()
-  instance._onChangeFilter()
-  expect(updateInboxSelectedScope).toHaveBeenCalled()
-})
+  it('calls the refresh function with next if next is present', () => {
+    let next = jest.fn()
+    let instance = renderer.create(
+      <Inbox {...defaultProps} next={next} />
+    ).getInstance()
 
-it('updates on scope change', () => {
-  const tree = renderer.create(
-    <Inbox conversations={[]} scope='all' />
-  )
+    instance.getNextPage()
+    expect(defaultProps.refreshInboxAll).toHaveBeenCalledWith(next)
+  })
 
-  let props = {
-    scope: 'unread',
-    refreshInboxUnread: jest.fn(),
-    refreshCourses: jest.fn(),
-  }
+  it('renders with an empty state', () => {
+    const tree = renderer.create(
+      <Inbox {...defaultProps} conversations={[]} />
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 
-  setProps(tree, props)
-  expect(props.refreshInboxUnread).toHaveBeenCalled()
+  it('renders the starred empty state', () => {
+    const tree = renderer.create(
+      <Inbox {...defaultProps} conversations={[]} scope='starred' />
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 
-  props = {
-    scope: 'unread',
-    refreshInboxUnread: jest.fn(),
-    refreshCourses: jest.fn(),
-  }
+  it('renders the activity indicator when loading conversations', () => {
+    const tree = renderer.create(
+      <Inbox {...defaultProps} conversations={[]} pending={true} />
+    ).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 
-  setProps(tree, props)
-  expect(props.refreshInboxUnread).not.toHaveBeenCalled()
-  expect(props.refreshCourses).not.toHaveBeenCalled()
-})
+  it('calls navigator.show when addMessage is called', () => {
+    const instance = renderer.create(
+      <Inbox {...defaultProps} />
+    ).getInstance()
 
-it('refreshed component', () => {
-  const props = {
-    conversations: [],
-    refreshCourses: jest.fn(),
-    refreshInboxAll: jest.fn(),
-    scope: 'all',
-    courses: [template.course()],
-  }
+    instance.addMessage()
+    expect(defaultProps.navigator.show).toHaveBeenCalledWith(
+      '/conversations/compose',
+      { modal: true }
+    )
+  })
 
-  const tree = renderer.create(
-    <Refreshed {...props} />
-  )
-  expect(tree.toJSON()).toMatchSnapshot()
-  tree.getInstance().refresh()
-  setProps(tree, props)
-  expect(props.refreshCourses).not.toHaveBeenCalled()
-  expect(props.refreshInboxAll).toHaveBeenCalled()
-})
+  it('_onChangeFilter', () => {
+    const updateInboxSelectedScope = jest.fn()
+    const instance = renderer.create(
+      <Inbox conversations={[]} updateInboxSelectedScope={updateInboxSelectedScope} />
+    ).getInstance()
+    instance._onChangeFilter()
+    expect(updateInboxSelectedScope).toHaveBeenCalled()
+  })
 
-it('should call the right functions in handleRefresh', () => {
-  let props = {
-    refreshInboxAll: jest.fn(),
-    scope: 'all',
-    refreshCourses: jest.fn(),
-    courses: [],
-  }
-  handleRefresh(props)
-  expect(props.refreshInboxAll).toHaveBeenCalled()
-  expect(props.refreshCourses).toHaveBeenCalled()
+  it('updates on scope change', () => {
+    const tree = renderer.create(
+      <Inbox conversations={[]} scope='all' />
+    )
 
-  props = {
-    refreshInboxUnread: jest.fn(),
-    scope: 'unread',
-    refreshCourses: jest.fn(),
-  }
-  handleRefresh(props)
-  expect(props.refreshInboxUnread).toHaveBeenCalled()
+    let props = {
+      scope: 'unread',
+      refreshInboxUnread: jest.fn(),
+      refreshCourses: jest.fn(),
+    }
 
-  props = {
-    refreshInboxStarred: jest.fn(),
-    scope: 'starred',
-    refreshCourses: jest.fn(),
-  }
-  handleRefresh(props)
-  expect(props.refreshInboxStarred).toHaveBeenCalled()
+    setProps(tree, props)
+    expect(props.refreshInboxUnread).toHaveBeenCalled()
 
-  props = {
-    refreshInboxSent: jest.fn(),
-    scope: 'sent',
-    refreshCourses: jest.fn(),
-  }
-  handleRefresh(props)
-  expect(props.refreshInboxSent).toHaveBeenCalled()
+    props = {
+      scope: 'unread',
+      refreshInboxUnread: jest.fn(),
+      refreshCourses: jest.fn(),
+    }
 
-  props = {
-    refreshInboxArchived: jest.fn(),
-    scope: 'archived',
-    refreshCourses: jest.fn(),
-  }
-  handleRefresh(props)
-  expect(props.refreshInboxArchived).toHaveBeenCalled()
-})
+    setProps(tree, props)
+    expect(props.refreshInboxUnread).not.toHaveBeenCalled()
+    expect(props.refreshCourses).not.toHaveBeenCalled()
+  })
 
-it('does not refresh courses if present', () => {
-  const props = {
-    refreshInboxArchived: jest.fn(),
-    scope: 'archived',
-    refreshCourses: jest.fn(),
-    courses: [template.course()],
-  }
-  handleRefresh(props)
-  expect(props.refreshCourses).not.toHaveBeenCalled()
-})
-
-it('filters conversations based on course', () => {
-  const courses = [
-    { id: '1' },
-    { id: '2' },
-  ]
-  const tree = renderer.create(
-    <Inbox {...defaultProps} courses={courses} scope='all' />
-  )
-  const instance = tree.getInstance()
-  instance.setState({ selectedCourse: '1' })
-  const node = tree.toJSON()
-  expect(node).toMatchSnapshot()
-})
-
-describe('Inbox shouldRefresh', () => {
-  it('returns true when there are no conversations', () => {
-    expect(shouldRefresh({
+  it('refreshed component', () => {
+    const props = {
       conversations: [],
+      refreshCourses: jest.fn(),
+      refreshInboxAll: jest.fn(),
       scope: 'all',
-      courses: [],
-      next () {},
-      navigator: new Navigator(''),
-    })).toBe(true)
+      courses: [template.course()],
+    }
+
+    const tree = renderer.create(
+      <Refreshed {...props} />
+    )
+    expect(tree.toJSON()).toMatchSnapshot()
+    tree.getInstance().refresh()
+    setProps(tree, props)
+    expect(props.refreshCourses).not.toHaveBeenCalled()
+    expect(props.refreshInboxAll).toHaveBeenCalled()
   })
 
-  it('returns true when there is no next', () => {
-    expect(shouldRefresh({
-      conversations: [ template.conversation({}) ],
+  it('should call the right functions in handleRefresh', () => {
+    let props = {
+      refreshInboxAll: jest.fn(),
       scope: 'all',
+      refreshCourses: jest.fn(),
       courses: [],
-      navigator: new Navigator(''),
-    })).toBe(true)
+    }
+    handleRefresh(props)
+    expect(props.refreshInboxAll).toHaveBeenCalled()
+    expect(props.refreshCourses).toHaveBeenCalled()
+
+    props = {
+      refreshInboxUnread: jest.fn(),
+      scope: 'unread',
+      refreshCourses: jest.fn(),
+    }
+    handleRefresh(props)
+    expect(props.refreshInboxUnread).toHaveBeenCalled()
+
+    props = {
+      refreshInboxStarred: jest.fn(),
+      scope: 'starred',
+      refreshCourses: jest.fn(),
+    }
+    handleRefresh(props)
+    expect(props.refreshInboxStarred).toHaveBeenCalled()
+
+    props = {
+      refreshInboxSent: jest.fn(),
+      scope: 'sent',
+      refreshCourses: jest.fn(),
+    }
+    handleRefresh(props)
+    expect(props.refreshInboxSent).toHaveBeenCalled()
+
+    props = {
+      refreshInboxArchived: jest.fn(),
+      scope: 'archived',
+      refreshCourses: jest.fn(),
+    }
+    handleRefresh(props)
+    expect(props.refreshInboxArchived).toHaveBeenCalled()
   })
 
-  it('returns false when there is next & conversations', () => {
-    expect(shouldRefresh({
-      conversations: [ template.conversation({}) ],
-      scope: 'all',
+  it('does not refresh courses if present', () => {
+    const props = {
+      refreshInboxArchived: jest.fn(),
+      scope: 'archived',
+      refreshCourses: jest.fn(),
+      courses: [template.course()],
+    }
+    handleRefresh(props)
+    expect(props.refreshCourses).not.toHaveBeenCalled()
+  })
+
+  it('filters conversations based on course', () => {
+    const courses = [
+      { id: '1' },
+      { id: '2' },
+    ]
+    const tree = renderer.create(
+      <Inbox {...defaultProps} courses={courses} scope='all' />
+    )
+    const instance = tree.getInstance()
+    instance.setState({ selectedCourse: '1' })
+    const node = tree.toJSON()
+    expect(node).toMatchSnapshot()
+  })
+
+  it('shows CourseFilter', () => {
+    const course = template.course({ id: '1' })
+    const props = {
+      ...defaultProps,
+      courses: [course],
+    }
+    const view = shallow(<Inbox {...props} />)
+    expect(view.find('CourseFilter')).toHaveLength(1)
+  })
+
+  it('hides CourseFilter when no courses', () => {
+    const props = {
+      ...defaultProps,
       courses: [],
-      next () {},
-      navigator: new Navigator(''),
-    })).toBe(false)
+    }
+    const view = shallow(<Inbox {...props} />)
+    expect(view.find('CourseFilter')).toHaveLength(0)
+  })
+
+  describe('shouldRefresh', () => {
+    it('returns true when there are no conversations', () => {
+      expect(shouldRefresh({
+        conversations: [],
+        scope: 'all',
+        courses: [],
+        next () {},
+        navigator: new Navigator(''),
+      })).toBe(true)
+    })
+
+    it('returns true when there is no next', () => {
+      expect(shouldRefresh({
+        conversations: [ template.conversation({}) ],
+        scope: 'all',
+        courses: [],
+        navigator: new Navigator(''),
+      })).toBe(true)
+    })
+
+    it('returns false when there is next & conversations', () => {
+      expect(shouldRefresh({
+        conversations: [ template.conversation({}) ],
+        scope: 'all',
+        courses: [],
+        next () {},
+        navigator: new Navigator(''),
+      })).toBe(false)
+    })
+  })
+})
+
+describe('mapStateToProps', () => {
+  it('maps state to props', () => {
+    const c1 = template.conversation({
+      id: '1',
+    })
+    const c2 = template.conversation({
+      id: '2',
+    })
+    const course1 = template.course({ id: '1' })
+    const course2 = template.course({ id: '2' })
+    const appState = {
+      inbox: {
+        conversations: {
+          '1': { data: c1 },
+          '2': { data: c2 },
+        },
+        selectedScope: 'all',
+        all: { refs: [c1.id, c2.id] },
+      },
+      entities: {
+        courses: {
+          '1': { course: course1 },
+          '2': { course: course2 },
+        },
+      },
+    }
+
+    const results = mapStateToProps(appState)
+    expect(results).toMatchObject({
+      conversations: [c1, c2],
+      courses: [course1, course2],
+    })
+  })
+
+  it('filters courses restricted by date', () => {
+    const course1 = template.course({ id: '1', access_restricted_by_date: true })
+    const course2 = template.course({ id: '2', access_restricted_by_date: false })
+    const appState = {
+      inbox: {
+        conversations: { },
+        selectedScope: 'all',
+        all: { refs: [] },
+      },
+      entities: {
+        courses: {
+          '1': { course: course1 },
+          '2': { course: course2 },
+        },
+      },
+    }
+
+    const results = mapStateToProps(appState)
+    expect(results.courses).toEqual([course2])
   })
 })

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Inbox.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Inbox.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`filters conversations based on course 1`] = `
+exports[`Inbox filters conversations based on course 1`] = `
 <RCTSafeAreaView
   style={
     Object {
@@ -673,7 +673,7 @@ exports[`filters conversations based on course 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`refreshed component 1`] = `
+exports[`Inbox refreshed component 1`] = `
 <RCTSafeAreaView
   style={
     Object {
@@ -1212,7 +1212,7 @@ exports[`refreshed component 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`renders correctly 1`] = `
+exports[`Inbox renders correctly 1`] = `
 <RCTSafeAreaView
   style={
     Object {
@@ -2096,7 +2096,7 @@ exports[`renders correctly 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`renders the activity indicator when loading conversations 1`] = `
+exports[`Inbox renders the activity indicator when loading conversations 1`] = `
 <RCTSafeAreaView
   style={
     Object {
@@ -2572,7 +2572,7 @@ exports[`renders the activity indicator when loading conversations 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`renders the starred empty state 1`] = `
+exports[`Inbox renders the starred empty state 1`] = `
 <RCTSafeAreaView
   style={
     Object {
@@ -3111,7 +3111,7 @@ exports[`renders the starred empty state 1`] = `
 </RCTSafeAreaView>
 `;
 
-exports[`renders with an empty state 1`] = `
+exports[`Inbox renders with an empty state 1`] = `
 <RCTSafeAreaView
   style={
     Object {

--- a/rn/Teacher/src/modules/inbox/components/CourseFilter.js
+++ b/rn/Teacher/src/modules/inbox/components/CourseFilter.js
@@ -77,7 +77,7 @@ export default class CourseFilter extends Component<CourseFilterProps, any> {
   }
 
   renderFilterButton = () => {
-    if (!this.props.courses || this.props.courses.length === 0) {
+    if (!this.props.courses) {
       return <ActivityIndicator />
     }
     let title = i18n('Filter')


### PR DESCRIPTION
refs: MBL-12311
affects: student
release note: Fixed a crash in Inbox when a student was enrolled in a past or future course

Fixes the crash on the course filter as well as fixes a related bug in the
`Compose` course picker.