### PR TITLE
Fix tests with XCUITest

### DIFF
--- a/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
+++ b/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
@@ -56,6 +56,7 @@ extension SubmissionFilesViewController: UITableViewDataSource, UITableViewDeleg
         cell.checkView?.isHidden = (file.id != presenter?.selectedFileID)
         let fileID = file.id ?? ""
         cell.checkView?.accessibilityIdentifier = "SubmissionFilesElement.cell.\(fileID).checkView"
+        cell.checkView?.isAccessibilityElement = true
         cell.accessibilityIdentifier = "SubmissionFilesElement.cell.\(fileID)"
         return cell
     }

--- a/Student/StudentUITests/Submissions/SubmissionComments/SubmissionCommentsTests.swift
+++ b/Student/StudentUITests/Submissions/SubmissionComments/SubmissionCommentsTests.swift
@@ -110,6 +110,7 @@ class SubmissionCommentsTests: StudentTest {
         SubmissionDetailsElement.drawerGripper.tap() // Make it full height.
 
         XCTAssertFalse(SubmissionComments.addCommentButton.isEnabled)
+        SubmissionComments.commentTextView.tap()
         SubmissionComments.commentTextView.typeText("First!")
         XCTAssertTrue(SubmissionComments.addCommentButton.isEnabled)
 

--- a/Student/StudentUITests/Tests/StudentTest.swift
+++ b/Student/StudentUITests/Tests/StudentTest.swift
@@ -49,7 +49,7 @@ class StudentTest: XCTestCase {
         // This sleep helps ensure old views got cleaned up, so EG2 doesn't find them accidentally.
         sleep(1) // FIXME: Remove this and fix flakiness better.
 
-        getApp = { return EarlGreyDriver(xcuiApp!, testCase: self) }
+        getApp = { return DriverFactory.getXCUITestDriver(xcuiApp!, testCase: self) }
     }
 
     func show(_ route: String) {


### PR DESCRIPTION
[ignore-commit-lint]

* XCUITest's `isHittable` will only ever be true if the element has `isAccessibilityElement = true` and by default it is `false` for `UIImageView`s
* We have to `.tap()` text inputs before we can `typeText()`