### PR TITLE
Fix a crash on startup

### DIFF
--- a/CanvasCore/CanvasCore/Session/NSURLSession+ThreeLegit.swift
+++ b/CanvasCore/CanvasCore/Session/NSURLSession+ThreeLegit.swift
@@ -133,8 +133,8 @@ extension Session {
     }
 
     public func resumeTask(_ task: URLSessionTask) -> SignalProducer<(Data, URLResponse), NSError> {
-        return SignalProducer { observer, disposable in
-            self.completionHandlerByTask[task] = { [weak self] task, error in
+        return SignalProducer { [weak self] observer, disposable in
+            self?.completionHandlerByTask[task] = { task, error in
                 if let data = self?.responseDataByTask[task], let response = task.response {
                     observer.send(value: (data, response))
                     observer.sendCompleted()


### PR DESCRIPTION
[ignore-commit-lint]

I got a `BAD_ACCESS` error here. It originated from trying to set up
push notifications in `getNotificationPreferencesSetup`.

I'm not positive that this will fix the crash but it seems like we
should not strongly retain `self` here.

I tested areas of the app that use this ThreeLegit stuff and they
appear to still be working.