### PR TITLE
Fix VO on logout

### DIFF
--- a/rn/Teacher/src/modules/profile/Profile.js
+++ b/rn/Teacher/src/modules/profile/Profile.js
@@ -101,9 +101,10 @@ export class Profile extends Component<Object, State> {
     } catch (e) {}
   }
 
-  logout = () => {
+  logout = async () => {
     purgeUserStoreData()
     httpCache.purgeUserData()
+    await this.props.navigator.dismiss()
     NativeModules.NativeLogin.logout()
   }
 
@@ -112,8 +113,9 @@ export class Profile extends Component<Object, State> {
     LTITools.launchExternalTool(url)
   }
 
-  switchUser = () => {
+  switchUser = async () => {
     logEvent('change_user_selected')
+    await this.props.navigator.dismiss()
     NativeModules.NativeLogin.changeUser()
   }
 

--- a/rn/Teacher/src/modules/profile/__tests__/Profile.test.js
+++ b/rn/Teacher/src/modules/profile/__tests__/Profile.test.js
@@ -138,15 +138,18 @@ describe('Profile Tests', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('logout methods called', () => {
+  it('logout methods called', async () => {
     const instance = renderer.create(
       <Profile { ...defaultProps } />
     ).getInstance()
 
-    instance.logout()
+    await instance.logout()
     expect(NativeModules.NativeLogin.logout).toHaveBeenCalled()
-    instance.switchUser()
+    expect(defaultProps.navigator.dismiss).toHaveBeenCalled()
+    defaultProps.navigator.dismiss.mockClear()
+    await instance.switchUser()
     expect(NativeModules.NativeLogin.changeUser).toHaveBeenCalled()
+    expect(defaultProps.navigator.dismiss).toHaveBeenCalled()
   })
 
   it('navigate to lti gauge tool', async () => {


### PR DESCRIPTION
[ignore-commit-lint]

The profile drawer was sticking around on `Change User` and 'Logout`
so VO would focus an invisible drawer on the login screen.