### PR TITLE
Add submission type to a11y label

### DIFF
--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
@@ -47,8 +47,9 @@ class SubmissionCommentFileView: UIControl {
     func update(submission: Submission) {
         accessibilityIdentifier = "SubmissionComments.attemptView.\(submission.attempt)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("View submission attempt %d", bundle: .student, comment: ""),
-            submission.attempt
+            NSLocalizedString("View submission attempt %d. %@", bundle: .student, comment: ""),
+            submission.attempt,
+            submission.type?.localizedString ?? ""
         )
         iconView?.image = submission.icon
         nameLabel?.text = submission.type?.localizedString


### PR DESCRIPTION
This affects new student

refs: MBL-12456
affects: Student
release note: none