### PR TITLE
Fix the widget to work with users with more than 10 favorited courses

### DIFF
--- a/Canvas/GradesWidget/Base.lproj/MainInterface.storyboard
+++ b/Canvas/GradesWidget/Base.lproj/MainInterface.storyboard
@@ -18,17 +18,26 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="500"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alwaysBounceVertical="YES" scrollEnabled="NO" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="5Mh-TY-EQc">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="5Mh-TY-EQc">
                                 <rect key="frame" x="0.0" y="20" width="320" height="480"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="sectionIndexBackgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </tableView>
+                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="iAh-JB-PVm" customClass="DynamicButton" customModule="Core">
+                                <rect key="frame" x="16" y="454" width="73" height="30"/>
+                                <state key="normal" title="View More"/>
+                                <connections>
+                                    <action selector="openApp:" destination="3tg-Or-QnS" eventType="touchUpInside" id="iYG-BH-nRq"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="Qbg-Ss-BfW" firstAttribute="trailing" secondItem="5Mh-TY-EQc" secondAttribute="trailing" id="00y-dj-aEv"/>
                             <constraint firstItem="5Mh-TY-EQc" firstAttribute="leading" secondItem="Qbg-Ss-BfW" secondAttribute="leading" id="NeM-0J-p1b"/>
                             <constraint firstItem="5Mh-TY-EQc" firstAttribute="top" secondItem="Qbg-Ss-BfW" secondAttribute="top" id="Pdg-xp-fhT"/>
+                            <constraint firstItem="Qbg-Ss-BfW" firstAttribute="bottom" secondItem="iAh-JB-PVm" secondAttribute="bottom" constant="16" id="Y0f-zs-5b3"/>
+                            <constraint firstItem="iAh-JB-PVm" firstAttribute="leading" secondItem="Qbg-Ss-BfW" secondAttribute="leading" constant="16" id="brW-BG-XU7"/>
                             <constraint firstItem="Qbg-Ss-BfW" firstAttribute="bottom" secondItem="5Mh-TY-EQc" secondAttribute="bottom" id="oY0-hx-TkO"/>
                         </constraints>
                         <viewLayoutGuide key="safeArea" id="Qbg-Ss-BfW"/>
@@ -36,6 +45,7 @@
                     <size key="freeformSize" width="320" height="500"/>
                     <connections>
                         <outlet property="tableView" destination="5Mh-TY-EQc" id="2hX-gd-XeV"/>
+                        <outlet property="viewMoreButton" destination="iAh-JB-PVm" id="oA4-6B-LeQ"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fLA-OA-07B" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Canvas/GradesWidget/Base.lproj/MainInterface.storyboard
+++ b/Canvas/GradesWidget/Base.lproj/MainInterface.storyboard
@@ -27,7 +27,7 @@
                                 <rect key="frame" x="16" y="454" width="73" height="30"/>
                                 <state key="normal" title="View More"/>
                                 <connections>
-                                    <action selector="openApp:" destination="3tg-Or-QnS" eventType="touchUpInside" id="iYG-BH-nRq"/>
+                                    <action selector="openApp:" destination="3tg-Or-QnS" eventType="primaryActionTriggered" id="UIa-f9-YQy"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Canvas/GradesWidget/GradesTodayWidgetPresenter.swift
+++ b/Canvas/GradesWidget/GradesTodayWidgetPresenter.swift
@@ -23,7 +23,7 @@ class GradesTodayWidgetPresenter {
     weak var view: GradesTodayWidgetViewController?
 
     lazy var courses: Store<GetCourses> = {
-        let useCase = GetCourses(showFavorites: true)
+        let useCase = GetCourses(showFavorites: true, perPage: 99)
         return env.subscribe(useCase, { [weak self] in
             self?.view?.reload()
         })
@@ -49,9 +49,9 @@ class GradesTodayWidgetPresenter {
     }
 
     func viewIsReady() {
-        courses.refresh(force: false)
+        courses.refresh(force: true)
         colors.refresh(force: false)
-        submissions.refresh(force: false)
+        submissions.refresh(force: true)
     }
 
 }

--- a/Core/Core/API/APICourseRequestable.swift
+++ b/Core/Core/API/APICourseRequestable.swift
@@ -21,6 +21,7 @@ public struct GetCoursesRequest: APIRequestable {
     public typealias Response = [APICourse]
 
     let includeUnpublished: Bool
+    var perPage = 10
 
     public let path = "courses"
     public var query: [APIQueryItem] {
@@ -39,6 +40,7 @@ public struct GetCoursesRequest: APIRequestable {
                 "total_scores",
             ]),
             .array("state", state),
+            .value("per_page", String(perPage)),
         ]
     }
 }

--- a/Core/Core/API/APICourseRequestable.swift
+++ b/Core/Core/API/APICourseRequestable.swift
@@ -21,7 +21,12 @@ public struct GetCoursesRequest: APIRequestable {
     public typealias Response = [APICourse]
 
     let includeUnpublished: Bool
-    var perPage = 10
+    var perPage: Int
+
+    init(includeUnpublished: Bool, perPage: Int = 10) {
+        self.includeUnpublished = includeUnpublished
+        self.perPage = perPage
+    }
 
     public let path = "courses"
     public var query: [APIQueryItem] {

--- a/Core/Core/Use Cases/GetCourses.swift
+++ b/Core/Core/Use Cases/GetCourses.swift
@@ -18,15 +18,19 @@ import Foundation
 
 public class GetCourses: CollectionUseCase {
     public typealias Model = Course
+
     var showFavorites: Bool
-    public init(showFavorites: Bool = false) {
+    var perPage: Int
+
+    public init(showFavorites: Bool = false, perPage: Int = 10) {
         self.showFavorites = showFavorites
+        self.perPage = perPage
     }
 
     public let cacheKey: String? = "get-courses"
 
     public var request: GetCoursesRequest {
-        return GetCoursesRequest(includeUnpublished: true)
+        return GetCoursesRequest(includeUnpublished: true, perPage: self.perPage)
     }
 
     public var scope: Scope {

--- a/Core/CoreTests/API/APICourseRequestableTests.swift
+++ b/Core/CoreTests/API/APICourseRequestableTests.swift
@@ -30,8 +30,9 @@ class APICourseRequestableTests: XCTestCase {
             URLQueryItem(name: "include[]", value: "total_scores"),
             URLQueryItem(name: "state[]", value: "available"),
             URLQueryItem(name: "state[]", value: "completed"),
+            URLQueryItem(name: "per_page", value: "10"),
         ])
-        XCTAssertEqual(GetCoursesRequest(includeUnpublished: true).queryItems, [
+        XCTAssertEqual(GetCoursesRequest(includeUnpublished: true, perPage: 20).queryItems, [
             URLQueryItem(name: "include[]", value: "course_image"),
             URLQueryItem(name: "include[]", value: "current_grading_period_scores"),
             URLQueryItem(name: "include[]", value: "favorites"),
@@ -42,6 +43,7 @@ class APICourseRequestableTests: XCTestCase {
             URLQueryItem(name: "state[]", value: "available"),
             URLQueryItem(name: "state[]", value: "completed"),
             URLQueryItem(name: "state[]", value: "unpublished"),
+            URLQueryItem(name: "per_page", value: "20"),
         ])
     }
 


### PR DESCRIPTION
Also fixes collapsed sizing on iPad

refs: MBL-12392
affects: Student
release note: Fixed the grades widget to work better with iPad and users with more than 10 favorited courses

Test Plan:
 - Try the users in the ticket on both iPad and iPhone 8