### PR TITLE
Fix routing to url submission

### DIFF
--- a/Canvas/Canvas/Shrug/Router+Canvas.swift
+++ b/Canvas/Canvas/Shrug/Router+Canvas.swift
@@ -125,6 +125,13 @@ extension TechDebt.Router {
             }
             return nil
         }
+
+        addContextRoute([.course], subPath: "assignments/:assignmentID/submissions/:userID/urlsubmission") { _, params in
+            if FeatureFlags.featureFlagEnabled(.newStudentAssignmentView), let url = params["url"] as? URL {
+                return StudentReborn.router.match(.parse(url))
+            }
+            return nil
+        }
         
         addContextRoute([.course], subPath: "assignments-fromHomeTab") { contextID, _ in
             return HelmViewController(


### PR DESCRIPTION
refs: MBL-12458
affects: student
release note: none

This was the smallest code change possible to make it work. Don't
_really_ need this route at all so I can remove it and just present the
URL submission view controller if we'd rather do that.