### PR TITLE
Add a11y label to share button in AttachmentView

### DIFF
--- a/rn/Teacher/src/common/components/AttachmentView.js
+++ b/rn/Teacher/src/common/components/AttachmentView.js
@@ -176,6 +176,7 @@ export default class AttachmentView extends Component<Props, State> {
         drawUnderNavBar
         rightBarButtons={[{
           testID: 'attachment-view.share-btn',
+          accessibilityLabel: i18n('Share'),
           image: Images.share,
           action: this.share,
         }]}


### PR DESCRIPTION
refs: MBL-12489
affects: student, teacher
release note: Accessibility improvements