### PR TITLE
Fix masquerading as user in a different locale

### DIFF
--- a/Core/Core/ActAsUser/ActAsUserViewController.storyboard
+++ b/Core/Core/ActAsUser/ActAsUserViewController.storyboard
@@ -68,7 +68,7 @@
                                                     </constraints>
                                                     <nil key="textColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="16"/>
-                                                    <textInputTraits key="textInputTraits"/>
+                                                    <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular16"/>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>

--- a/Core/Core/ActAsUser/ActAsUserViewController.swift
+++ b/Core/Core/ActAsUser/ActAsUserViewController.swift
@@ -105,9 +105,7 @@ public class ActAsUserViewController: UITableViewController {
             return
         }
         presenter?.didSubmit(domain: domain, userID: userID) { [weak self] err in
-            if err == nil {
-                self?.dismiss(animated: true, completion: nil)
-            } else {
+            if err != nil {
                 self?.showMasqueradingError()
             }
         }


### PR DESCRIPTION
[ignore-commit-lint]

Switching locale prompts a needed alert that would get dismissed. We
don't need to dismiss since we animate to a new root view controller
when we masquerade.

pork: remove auto correct from domain field in masquerade screen.