### PR TITLE
Avoid bad access crash in Session

### DIFF
--- a/Canvas/CanvasUITests/Inbox/InboxTests.swift
+++ b/Canvas/CanvasUITests/Inbox/InboxTests.swift
@@ -18,8 +18,6 @@ import XCTest
 import TestsFoundation
 
 class InboxTests: CanvasUITests {
-    override var user: User? { return .student1 }
-
     func testCannotMessageEntireClassWhenDisabled() {
         //Dashboard
         Dashboard.inboxTab.tap()


### PR DESCRIPTION
[ignore-commit-lint]

One of our [top crashes](https://console.firebase.google.com/u/0/project/delta-essence-114723/crashlytics/app/ios:com.instructure.icanvas/issues/5ce6b9ddf8b88c2963b4a4ec)
in Student is this super awesome stack trace:

```
__51-[NSURLSession delegate_task:didCompleteWithError:]_block_invoke.182 + 252
```

Gabe has been seeing a crash in `Session.swift` `urlSession(session:task:didCompleteWithError:)`
when running the UI tests. The two look very related.

It's possible that multiple threads
are trying to mutate `completionHandlerByTask`. I'm hoping that by making
copies we can avoid `EXC_BAD_ACCESS` here.