### PR TITLE
Add course card info test

### DIFF
--- a/Canvas/CanvasUITests/CanvasUITests.swift
+++ b/Canvas/CanvasUITests/CanvasUITests.swift
@@ -26,6 +26,9 @@ class CanvasUITests: UITestCase {
         continueAfterFailure = false
         if app.state != .runningForeground {
             launch()
+            if currentSession() != nil {
+                Dashboard.coursesLabel.waitToExist()
+            }
         }
         reset()
         if let user = user {

--- a/Canvas/CanvasUITests/Dashboard/DashboardTests.swift
+++ b/Canvas/CanvasUITests/Dashboard/DashboardTests.swift
@@ -51,6 +51,11 @@ class DashboardTests: CanvasUITests {
         Dashboard.coursesLabel.waitToExist()
         Dashboard.courseCard(id: "263").waitToExist()
     }
+    
+    func testCourseCardInfo() {
+        Dashboard.courseCard(id: "263").waitToExist()
+        XCTAssertEqual(Dashboard.courseCard(id: "263").label, "Assignments")
+    }
 
     func testSeeAllButtonDisplaysCorrectCourses() {
         Dashboard.seeAllButton.tap()

--- a/rn/Teacher/src/modules/courses/components/CourseCard.js
+++ b/rn/Teacher/src/modules/courses/components/CourseCard.js
@@ -120,7 +120,7 @@ export default class CourseCard extends Component<Props, State> {
           testID={'course-' + course.id}
           onPress={this.onPress}
           accessibilityTraits='button'
-          accessibilityLabel={`${course.name} ${gradeDisplay || ''}`}
+          accessibilityLabel={`${course.name} ${gradeDisplay || ''}`.trim()}
           underlayColor='transparent'
         >
           <View style={styles.cardContainer}>

--- a/rn/Teacher/src/modules/courses/components/__tests__/__snapshots__/CourseCard.test.js.snap
+++ b/rn/Teacher/src/modules/courses/components/__tests__/__snapshots__/CourseCard.test.js.snap
@@ -3,7 +3,7 @@
 exports[`renders 1`] = `
 <A11yGroup>
   <TouchableHighlight
-    accessibilityLabel="Learn React Native "
+    accessibilityLabel="Learn React Native"
     accessibilityTraits="button"
     onLayout={[Function]}
     onPress={[Function]}
@@ -676,7 +676,7 @@ exports[`renders with a grade even if the grade does not exist 1`] = `
 exports[`renders with empty image url 1`] = `
 <A11yGroup>
   <TouchableHighlight
-    accessibilityLabel="Learn React Native "
+    accessibilityLabel="Learn React Native"
     accessibilityTraits="button"
     onLayout={[Function]}
     onPress={[Function]}
@@ -857,7 +857,7 @@ exports[`renders with empty image url 1`] = `
 exports[`renders with image url 1`] = `
 <A11yGroup>
   <TouchableHighlight
-    accessibilityLabel="Learn React Native "
+    accessibilityLabel="Learn React Native"
     accessibilityTraits="button"
     onLayout={[Function]}
     onPress={[Function]}
@@ -1050,7 +1050,7 @@ exports[`renders with image url 1`] = `
 exports[`renders without image url 1`] = `
 <A11yGroup>
   <TouchableHighlight
-    accessibilityLabel="Learn React Native "
+    accessibilityLabel="Learn React Native"
     accessibilityTraits="button"
     onLayout={[Function]}
     onPress={[Function]}
@@ -1231,7 +1231,7 @@ exports[`renders without image url 1`] = `
 exports[`renders without the color overlay 1`] = `
 <A11yGroup>
   <TouchableHighlight
-    accessibilityLabel="Learn React Native "
+    accessibilityLabel="Learn React Native"
     accessibilityTraits="button"
     onLayout={[Function]}
     onPress={[Function]}

--- a/rn/Teacher/src/modules/dashboard/__tests__/__snapshots__/Dashboard.test.js.snap
+++ b/rn/Teacher/src/modules/dashboard/__tests__/__snapshots__/Dashboard.test.js.snap
@@ -127,7 +127,7 @@ exports[`Dashboard Doesnt render groups when in the teacher app 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Biology 101 "
+            accessibilityLabel="Biology 101"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -323,7 +323,7 @@ exports[`Dashboard Doesnt render groups when in the teacher app 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="American Literature Psysicks foobar hello world 401 "
+            accessibilityLabel="American Literature Psysicks foobar hello world 401"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -519,7 +519,7 @@ exports[`Dashboard Doesnt render groups when in the teacher app 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -730,7 +730,7 @@ exports[`Dashboard Only renders courses when !isFullDashboard 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Biology 101 "
+            accessibilityLabel="Biology 101"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -926,7 +926,7 @@ exports[`Dashboard Only renders courses when !isFullDashboard 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="American Literature Psysicks foobar hello world 401 "
+            accessibilityLabel="American Literature Psysicks foobar hello world 401"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -1122,7 +1122,7 @@ exports[`Dashboard Only renders courses when !isFullDashboard 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -1361,7 +1361,7 @@ exports[`Dashboard Only renders courses when !isFullDashboard 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -1686,7 +1686,7 @@ exports[`Dashboard render 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Biology 101 "
+            accessibilityLabel="Biology 101"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -1882,7 +1882,7 @@ exports[`Dashboard render 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="American Literature Psysicks foobar hello world 401 "
+            accessibilityLabel="American Literature Psysicks foobar hello world 401"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -2078,7 +2078,7 @@ exports[`Dashboard render 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -2403,7 +2403,7 @@ exports[`Dashboard render while pending 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Biology 101 "
+            accessibilityLabel="Biology 101"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -2599,7 +2599,7 @@ exports[`Dashboard render while pending 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="American Literature Psysicks foobar hello world 401 "
+            accessibilityLabel="American Literature Psysicks foobar hello world 401"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -2795,7 +2795,7 @@ exports[`Dashboard render while pending 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -4214,7 +4214,7 @@ exports[`Dashboard renders course invites 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Biology 101 "
+            accessibilityLabel="Biology 101"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -4410,7 +4410,7 @@ exports[`Dashboard renders course invites 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="American Literature Psysicks foobar hello world 401 "
+            accessibilityLabel="American Literature Psysicks foobar hello world 401"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}
@@ -4606,7 +4606,7 @@ exports[`Dashboard renders course invites 1`] = `
       <item>
         <A11yGroup>
           <TouchableHighlight
-            accessibilityLabel="Foobar 102 "
+            accessibilityLabel="Foobar 102"
             accessibilityTraits="button"
             onLayout={[Function]}
             onPress={[Function]}


### PR DESCRIPTION
Testing the color seemed like fragile code we didn't want to maintain, and the course code is not in the a11y tree, so it only tests the name.

refs: MBL-12570
affects: none
release note: none