### PR TITLE
Allow bundle display name to be translated

### DIFF
--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -47,7 +47,7 @@ function run(cmd, args, opts) {
 }
 
 async function exportTranslations() {
-  const keysToSkip = ['CFBundleName', 'CFBundleDisplayName']
+  const keysToSkip = ['CFBundleName']
   const toUpload = []
   const localizeInfoPlistOfTheseProjects = ['canvas', 'parent', 'teacher_native']
   for (const project of projects) {


### PR DESCRIPTION
This should allow the grades widget and submit assignment extension to be translated.

refs: MBL-12711
affects: Student, Teacher, Parent
release note: none