### PR TITLE
MBL-12702 fix startup manager init

### DIFF
--- a/CanvasCore/CanvasCore/React Native Modules/PushNotifications.h
+++ b/CanvasCore/CanvasCore/React Native Modules/PushNotifications.h
@@ -21,6 +21,7 @@
 
 @interface PushNotifications : NSObject<RCTBridgeModule>
 
++ (void)recordUserInfo:(NSDictionary *)userInfo;
 + (void)recordNotification:(UNNotification *)notification;
 
 @end

--- a/CanvasCore/CanvasCore/React Native Modules/PushNotifications.m
+++ b/CanvasCore/CanvasCore/React Native Modules/PushNotifications.m
@@ -23,12 +23,15 @@ NSString * const PushNotificationsStorageKey = @"PushNotificationsStorageKey";
 
 @implementation PushNotifications
 
-+ (void)recordNotification:(UNNotification *)notification
-{
-    NSDictionary *payload = notification.request.content.userInfo;
++ (void)recordUserInfo:(NSDictionary *) userInfo {
     NSArray *existing = [[NSUserDefaults standardUserDefaults] arrayForKey:PushNotificationsStorageKey];
-    NSArray *all = existing ? [existing arrayByAddingObject:payload] : @[payload];
+    NSArray *all = existing ? [existing arrayByAddingObject:userInfo] : @[userInfo];
     [[NSUserDefaults standardUserDefaults] setObject:all forKey:PushNotificationsStorageKey];
+}
+
++ (void)recordNotification:(UNNotification *)notification {
+    NSDictionary *payload = notification.request.content.userInfo;
+    [PushNotifications recordUserInfo: payload];
 }
 
 RCT_EXPORT_MODULE()


### PR DESCRIPTION
push `userInfo` payload is coming in the launchOptions of appDelegate method.  We are not handling that.

refs: MBL-12702
affects: Student
release note: fix push bug