### PR TITLE
Fix Studio submissions with multiple form submits

### DIFF
--- a/Student/Student/Submissions/ArcSubmission/ArcSubmissionPresenter.swift
+++ b/Student/Student/Submissions/ArcSubmission/ArcSubmissionPresenter.swift
@@ -56,7 +56,6 @@ class ArcSubmissionPresenter {
             let urlRaw = graph.first?["url"] as? String,
             let url = URL(string: urlRaw)
         else {
-            callback(NSError.internalError())
             return
         }
         submit(url: url, callback: callback)

--- a/Student/Student/Submissions/ArcSubmission/ArcSubmissionViewController.swift
+++ b/Student/Student/Submissions/ArcSubmission/ArcSubmissionViewController.swift
@@ -91,12 +91,17 @@ class ArcSubmissionViewController: UIViewController, ArcSubmissionView {
 
     var js: String {
         return """
+            HTMLFormElement.prototype.originalSubmit = HTMLFormElement.prototype.submit
             HTMLFormElement.prototype.submit = function() {
                 let formData = {}
                 for (const [ name, value ] of new FormData(this)) {
                     formData[name] = value
                 }
-                window.webkit.messageHandlers.submit.postMessage(formData)
+                if (formData.content_items == null) {
+                    this.originalSubmit.call(this, arguments)
+                } else {
+                    window.webkit.messageHandlers.submit.postMessage(formData)
+                }
             }
         """
     }

--- a/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
@@ -122,6 +122,6 @@ class ArcSubmissionPresenterTests: PersistenceTestCase {
         presenter.submit(form: form) { _ in
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: .2)
+        wait(for: [expectation], timeout: 0.2)
     }
 }

--- a/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
@@ -114,13 +114,14 @@ class ArcSubmissionPresenterTests: PersistenceTestCase {
         )
         api.mock(request, value: nil, response: nil, error: NSError.instructureError("doh"))
         let form: [String: Any] = [
+            "hello": "i am a submit body that can be ignored",
             "content_items": "{ \"@graph\": [ {\"oops\": \"https://arc.com/media/1\"} ] }",
         ]
-        let expectation = XCTestExpectation(description: "submit form")
-        presenter.submit(form: form) { error in
-            XCTAssertNotNil(error)
+        let expectation = XCTestExpectation(description: "submit form callback should not be called if form body is unrecognized")
+        expectation.isInverted = true
+        presenter.submit(form: form) { _ in
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: .2)
     }
 }


### PR DESCRIPTION
refs: MBL-12851
affects: student
release note: none

We have to selectively intercept the submit event because
apparently a form element can get submitted before the content loads.