### PR TITLE
MBL-12888 - if assignment details description is empty, show "No Content"

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -248,4 +248,9 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
     func submitAssignmentButtonIsHidden() -> Bool {
         return assignment?.lockStatus != .unlocked
     }
+
+    func assignmentDescription() -> String {
+        if let desc = assignments.first?.descriptionHTML, !desc.isEmpty { return desc }
+        return NSLocalizedString("No Content", comment: "")
+    }
 }

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -228,7 +228,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
         descriptionHeadingLabel?.text = quiz == nil
             ? NSLocalizedString("Description", bundle: .student, comment: "")
             : NSLocalizedString("Instructions", bundle: .student, comment: "")
-        descriptionView?.loadHTMLString(assignment.descriptionHTML, baseURL: baseURL)
+        descriptionView?.loadHTMLString(presenter?.assignmentDescription() ?? "", baseURL: baseURL)
         updateGradeCell(assignment)
 
         submissionButtonView?.isHidden = !assignment.isSubmittable

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -374,6 +374,16 @@ class AssignmentDetailsPresenterTests: PersistenceTestCase {
 
         XCTAssertEqual(pageViewLogger.eventName, "/courses/\(c.id)/assignments/\(a.id)")
     }
+
+    func testAssignmentDescription() {
+        let a = Assignment.make()
+        XCTAssertEqual(presenter.assignmentDescription(), a.descriptionHTML)
+    }
+
+    func testAssignmentDescriptionThatIsEmpty() {
+        Assignment.make(from: .make(description: ""))
+        XCTAssertEqual(presenter.assignmentDescription(), "No Content")
+    }
 }
 
 extension AssignmentDetailsPresenterTests: AssignmentDetailsViewProtocol {


### PR DESCRIPTION
refs: MBL-12888
affects: Student
release note: none