### PR TITLE
Post module item completion requirements

### DIFF
--- a/Canvas/Canvas/Modules/ModuleDetailsViewController.swift
+++ b/Canvas/Canvas/Modules/ModuleDetailsViewController.swift
@@ -68,6 +68,8 @@ class ModuleDetailsViewController: CanvasCore.TableViewController, PageViewEvent
         super.viewDidLoad()
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 44
+
+        NotificationCenter.default.addObserver(self, selector: #selector(requirementCompleted), name: .CompletedModuleItemRequirement, object: nil)
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -98,5 +100,9 @@ class ModuleDetailsViewController: CanvasCore.TableViewController, PageViewEvent
         default:
             return
         }
+    }
+
+    @objc func requirementCompleted() {
+        refresher?.refresh(true)
     }
 }

--- a/Canvas/Canvas/Shrug/Router+Canvas.swift
+++ b/Canvas/Canvas/Shrug/Router+Canvas.swift
@@ -488,6 +488,9 @@ extension TechDebt.Router: RouterProtocol {
         if options?.contains(.modal) == true {
             opts["modal"] = true
         }
+        if options?.contains(.formSheet) == true {
+            opts["formSheet"] = true
+        }
         route(from: from, to: url, withOptions: opts)
     }
 }

--- a/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
+++ b/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
@@ -8,7 +8,6 @@
 // License, or (at your option) any later version.
 //
 // This program is distributed in the hope that it will be useful,
-l
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.

--- a/Canvas/TechDebt/iCanvas/Router.m
+++ b/Canvas/TechDebt/iCanvas/Router.m
@@ -249,6 +249,9 @@
     if (destinationViewController && options && options[@"modal"]) {
         HelmNavigationController *navigation = [[HelmNavigationController alloc] initWithRootViewController:destinationViewController];
         [destinationViewController addModalDismissButtonWithButtonTitle:nil];
+        if (options[@"formSheet"]) {
+            navigation.modalPresentationStyle = UIModalPresentationFormSheet;
+        }
         [sourceController presentViewController:navigation animated:YES completion:nil];
         return destinationViewController;
     }

--- a/CanvasCore/CanvasCore/Persistence/So Refreshing/Refresher.swift
+++ b/CanvasCore/CanvasCore/Persistence/So Refreshing/Refresher.swift
@@ -105,14 +105,15 @@ open class SignalProducerRefresher<Value>: NSObject, Refresher {
 
     @objc open func refresh(_ forced: Bool) {
         guard forced || shouldRefresh else { return }
+        DispatchQueue.main.async {
+            self.refreshControl.beginRefreshing()
 
-        refreshControl.beginRefreshing()
+            if let scrollView = self.refreshControl.superview as? UIScrollView, forced || self.shouldRefresh {
+                scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentOffset.y - self.refreshControl.frame.size.height), animated: true)
+            }
 
-        if let scrollView = refreshControl.superview as? UIScrollView, forced || shouldRefresh {
-            scrollView.setContentOffset(CGPoint(x: 0, y: scrollView.contentOffset.y - refreshControl.frame.size.height), animated: true)
+            self.beginRefresh(self.refreshControl)
         }
-
-        beginRefresh(refreshControl)
     }
 
     @objc open func cancel() {

--- a/CanvasCore/CanvasCore/Session/Session.swift
+++ b/CanvasCore/CanvasCore/Session/Session.swift
@@ -36,17 +36,6 @@ open class Session: NSObject {
     @objc open var token: String?
     public let localStoreDirectory: LocalStoreDirectory
 
-    public typealias ProgressBlock = (_ bytesSent: Int64, _ totalBytes: Int64)->()
-    open var progressUpdateByTask: [URLSessionTask: ProgressBlock] = [:]
-
-    public typealias TaskCompletionHandler = (URLSessionTask, NSError?)->()
-    open var completionHandlerByTask: [URLSessionTask: TaskCompletionHandler] = [:]
-
-    public typealias BackgroundCompletionHandler = (NSError?)->Void
-    open var completionHandlerByBackgroundIdentifier: [String: BackgroundCompletionHandler] = [:]
-
-    @objc open var responseDataByTask: [URLSessionTask: Data] = [:]
-
     @objc public static var unauthenticated: Session {
         return Session(baseURL: URL(string: "https://canvas.instructure.com/")!, user: SessionUser(id: "", name: ""), token: nil)
     }
@@ -61,18 +50,9 @@ open class Session: NSObject {
         self.baseURL = baseURL
         self.token = token
         self.localStoreDirectory = localStoreDirectory
-
-        
-        URLSession = Foundation.URLSession.shared
-        
-        super.init()
-
-        // set up the authorized session with default headers
         let config = URLSessionConfiguration.default
         config.httpAdditionalHeaders = defaultHTTPHeaders
-        let opQ = OperationQueue()
-        opQ.name = "com.instructure.TooLegit.URLSessionDelegate"
-        self.URLSession = Foundation.URLSession(configuration: config, delegate: self, delegateQueue:opQ)
+        URLSession = Foundation.URLSession(configuration: config)
     }
     
     @objc open var sessionID: String {
@@ -160,45 +140,5 @@ extension Session {
     @objc public func compare(_ session: Session) -> Bool {
         // Same if Token is equal or userID & baseURL are equal
         return (self.token == session.token) || (session.user.id == self.user.id && session.baseURL.absoluteString == self.baseURL.absoluteString)
-    }
-
-    @objc public func copyToBackgroundSessionWithIdentifier(_ identifier: String, sharedContainerIdentifier: String?) -> Session {
-        guard let session = Session.fromJSON(self.dictionaryValue()) else {
-            fatalError("session couldn't parse itself")
-        }
-
-        let config = URLSessionConfiguration.background(withIdentifier: identifier)
-        config.httpAdditionalHeaders = URLSession.configuration.httpAdditionalHeaders
-        config.sharedContainerIdentifier = sharedContainerIdentifier
-        let backgroundSession = Foundation.URLSession(configuration: config, delegate: session, delegateQueue: nil)
-        session.URLSession = backgroundSession
-        return session
-    }
-}
-
-extension Session: URLSessionTaskDelegate {
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didSendBodyData bytesSent: Int64, totalBytesSent: Int64, totalBytesExpectedToSend: Int64) {
-        let progressUpdateByTask = self.progressUpdateByTask
-        progressUpdateByTask[task]?(totalBytesSent, totalBytesExpectedToSend)
-    }
-    
-    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
-        progressUpdateByTask[task] = nil
-        completionHandlerByTask[task]?(task, error as NSError?)
-        completionHandlerByTask[task] = nil
-        responseDataByTask[task] = nil
-
-        if let identifier = session.configuration.identifier {
-            completionHandlerByBackgroundIdentifier[identifier]?(error as NSError?)
-            completionHandlerByBackgroundIdentifier[identifier] = nil
-        }
-    }
-}
-
-extension Session: URLSessionDataDelegate {
-    public func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
-        var responseData = responseDataByTask[dataTask] ?? Data()
-        responseData.append(data)
-        responseDataByTask[dataTask] = responseData
     }
 }

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -410,6 +410,9 @@
 		B18359A822244E230005A918 /* AccessIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18359A722244E230005A918 /* AccessIconView.swift */; };
 		B18359AA222450DE0005A918 /* AccessIconView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B18359A9222450DE0005A918 /* AccessIconView.xib */; };
 		B183F99D225297F2000A6930 /* PublishedIconView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B183F99C225297F2000A6930 /* PublishedIconView.swift */; };
+		B1846D0F22E8FBC000BC4C4A /* NotificationCenterExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1846D0E22E8FBC000BC4C4A /* NotificationCenterExtensions.swift */; };
+		B1846D1122E8FEBD00BC4C4A /* ModuleItemCompletionRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1846D1022E8FEBD00BC4C4A /* ModuleItemCompletionRequirement.swift */; };
+		B1846D1322EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1846D1222EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift */; };
 		B1911CE921C8460000F42F91 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1911CE821C8460000F42F91 /* NotificationManager.swift */; };
 		B1911CEC21C849BE00F42F91 /* NotificationManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1911CEB21C849BE00F42F91 /* NotificationManagerTests.swift */; };
 		B1911CF121C851AD00F42F91 /* ProcessInfoExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1911CF021C851AD00F42F91 /* ProcessInfoExtensions.swift */; };
@@ -1099,6 +1102,9 @@
 		B18359A722244E230005A918 /* AccessIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessIconView.swift; sourceTree = "<group>"; };
 		B18359A9222450DE0005A918 /* AccessIconView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccessIconView.xib; sourceTree = "<group>"; };
 		B183F99C225297F2000A6930 /* PublishedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedIconView.swift; sourceTree = "<group>"; };
+		B1846D0E22E8FBC000BC4C4A /* NotificationCenterExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensions.swift; sourceTree = "<group>"; };
+		B1846D1022E8FEBD00BC4C4A /* ModuleItemCompletionRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemCompletionRequirement.swift; sourceTree = "<group>"; };
+		B1846D1222EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCenterExtensionsTests.swift; sourceTree = "<group>"; };
 		B1911CE821C8460000F42F91 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		B1911CEB21C849BE00F42F91 /* NotificationManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManagerTests.swift; sourceTree = "<group>"; };
 		B1911CF021C851AD00F42F91 /* ProcessInfoExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoExtensions.swift; sourceTree = "<group>"; };
@@ -1499,6 +1505,7 @@
 				B1A6BC79218A062E000515E3 /* MediaCommentType.swift */,
 				B15CA27D221DFA450014FB02 /* Module.swift */,
 				B1F1328D224BBBC7002C0555 /* ModuleItem.swift */,
+				B1846D1022E8FEBD00BC4C4A /* ModuleItemCompletionRequirement.swift */,
 				B1F13289224BAD43002C0555 /* ModuleItemType.swift */,
 				9FBE536C223C32E7001EC40C /* Permissions.swift */,
 				7DF4001C217509D6007E5F81 /* Quiz.swift */,
@@ -1757,6 +1764,7 @@
 				B1A464BA225669140052F8DF /* DispatchExtensions.swift */,
 				3B69253F21A12E020023ED75 /* Int64Extensions.swift */,
 				B192833721C07A4E008D1B9B /* LoggerExtensions.swift */,
+				B1846D0E22E8FBC000BC4C4A /* NotificationCenterExtensions.swift */,
 				3B346754213052C700F9BC2E /* NSErrorExtensions.swift */,
 				B1C783EE2241EA3700DD89A9 /* NSManagedObjectContextExtensions.swift */,
 				7DF4FFE421714952007E5F81 /* NSNumberExtensions.swift */,
@@ -1833,6 +1841,7 @@
 				7DD694802194CE8C00BA4984 /* DateExtensionsTests.swift */,
 				B1A464BC225669B50052F8DF /* DispatchExtensionsTests.swift */,
 				7DC4A558222EFC9900FA03DC /* Int64ExtensionsTests.swift */,
+				B1846D1222EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift */,
 				7DC4A55A222EFE0E00FA03DC /* NSErrorExtensionsTests.swift */,
 				B1C783F22241ECEB00DD89A9 /* NSManagedObjectContextExtensionsTests.swift */,
 				7D20F61A21C31CE900B77E5E /* UICollectionViewExtensionsTests.swift */,
@@ -2533,6 +2542,7 @@
 				9FBE5369223C2522001EC40C /* PermissionName.swift in Sources */,
 				B1911CE921C8460000F42F91 /* NotificationManager.swift in Sources */,
 				9FBE536D223C32E7001EC40C /* Permissions.swift in Sources */,
+				B1846D0F22E8FBC000BC4C4A /* NotificationCenterExtensions.swift in Sources */,
 				7D29D2F7218A29FE0036437C /* DocViewerAnnotationToolbar.swift in Sources */,
 				9FAA5900223A98A300FEC3F8 /* DrawerTransitioning.swift in Sources */,
 				7D80AC0A212B4A8D00C40ECE /* APIGroup.swift in Sources */,
@@ -2584,6 +2594,7 @@
 				3BBCF844224C193B004B519D /* HorizontalMenuView.swift in Sources */,
 				7D1758C1215A8F5600F88613 /* ListFormatter.swift in Sources */,
 				B19792F1217536230000369C /* Database.xcdatamodeld in Sources */,
+				B1846D1122E8FEBD00BC4C4A /* ModuleItemCompletionRequirement.swift in Sources */,
 				7D819FFF228DB48C00C61EDD /* GetQuiz.swift in Sources */,
 				7D29D2F9218A2BC60036437C /* DocViewerConstants.swift in Sources */,
 				7D8262F3212B2E3100BD268D /* APIFavoriteRequestable.swift in Sources */,
@@ -2825,6 +2836,7 @@
 				9FD504EA2180BE2900B395BA /* APIFileRequestableTests.swift in Sources */,
 				3BD364AF225E36FC006CEBD8 /* CalendarEventItemTests.swift in Sources */,
 				7DCF1EAC216BC360003AF358 /* CourseDefaultViewTests.swift in Sources */,
+				B1846D1322EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift in Sources */,
 				78151DCF21AE7E0500692862 /* APIDiscussionRequestableTests.swift in Sources */,
 				3B3467C921349EC100F9BC2E /* LoginWebPresenterTests.swift in Sources */,
 				7DF4001B2174FA24007E5F81 /* UITableViewExtensionsTests.swift in Sources */,

--- a/Core/Core/Extensions/NotificationCenterExtensions.swift
+++ b/Core/Core/Extensions/NotificationCenterExtensions.swift
@@ -8,7 +8,6 @@
 // License, or (at your option) any later version.
 //
 // This program is distributed in the hope that it will be useful,
-l
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
@@ -17,12 +16,14 @@ l
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import XCTest
-import TestsFoundation
+import Foundation
 
-class NotificationsListTests: CanvasUITests {
-    func testNotificationItemsDisplayed() {
-        TabBar.notificationsTab.tap()
-        app.find(labelContaining: "Assignment Created").waitToExist()
+extension NSNotification.Name {
+    public static var CompletedModuleItemRequirement = NSNotification.Name("com.instructure.core.notification.ModuleItemProgress")
+}
+
+extension NotificationCenter {
+    public func post(moduleItem: ModuleItemType, completedRequirement requirement: ModuleItemCompletionRequirement, courseID: String) {
+        post(name: .CompletedModuleItemRequirement, object: nil, userInfo: ["requirement": requirement, "moduleItem": moduleItem, "courseID": courseID])
     }
 }

--- a/Core/Core/Models/ModuleItemCompletionRequirement.swift
+++ b/Core/Core/Models/ModuleItemCompletionRequirement.swift
@@ -8,7 +8,6 @@
 // License, or (at your option) any later version.
 //
 // This program is distributed in the hope that it will be useful,
-l
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
@@ -17,12 +16,9 @@ l
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import XCTest
-import TestsFoundation
+import Foundation
 
-class NotificationsListTests: CanvasUITests {
-    func testNotificationItemsDisplayed() {
-        TabBar.notificationsTab.tap()
-        app.find(labelContaining: "Assignment Created").waitToExist()
-    }
+public enum ModuleItemCompletionRequirement: String {
+    case view
+    case submit
 }

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -46,8 +46,14 @@ public extension RouterProtocol {
                     view.addDoneButton()
                 }
                 let nav = view as? UINavigationController ?? UINavigationController(rootViewController: view)
+                if options?.contains(.formSheet) == true {
+                    nav.modalPresentationStyle = .formSheet
+                }
                 from.present(nav, animated: true, completion: nil)
             } else {
+                if options?.contains(.formSheet) == true {
+                    view.modalPresentationStyle = .formSheet
+                }
                 from.present(view, animated: true, completion: nil)
             }
         } else {
@@ -68,6 +74,7 @@ public class Router: RouterProtocol {
         public static let modal = RouteOptions(rawValue: 1)
         public static let embedInNav = RouteOptions(rawValue: 2)
         public static let addDoneButton = RouteOptions(rawValue: 4)
+        public static let formSheet = RouteOptions(rawValue: 8)
     }
 
     private let handlers: [RouteHandler]

--- a/Core/Core/Use Cases/CreateSubmission.swift
+++ b/Core/Core/Use Cases/CreateSubmission.swift
@@ -63,11 +63,20 @@ public class CreateSubmission: APIUseCase {
         return Scope(predicate: predicate, order: [sort])
     }
 
+    public func makeRequest(environment: AppEnvironment, completionHandler: @escaping (APISubmission?, URLResponse?, Error?) -> Void) {
+        environment.api.makeRequest(request) { [weak self] response, urlResponse, error in
+            guard let self = self else { return }
+            if error == nil {
+                NotificationCenter.default.post(moduleItem: .assignment(self.assignmentID), completedRequirement: .submit, courseID: self.context.id)
+            }
+            completionHandler(response, urlResponse, error)
+        }
+    }
+
     public func write(response: APISubmission?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         guard let item = response else {
             return
         }
         Submission.save(item, in: client)
-        Logger.shared.log("created a submission")
     }
 }

--- a/Core/CoreTests/Extensions/NotificationCenterExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/NotificationCenterExtensionsTests.swift
@@ -1,0 +1,39 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import Foundation
+@testable import Core
+
+class NotificationExtensionTests: XCTestCase {
+    func testPostModuleItemCompletedRequirement() {
+        let expectation = XCTestExpectation(description: "notification")
+        var notification: Notification?
+        let token = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) {
+            notification = $0
+            expectation.fulfill()
+        }
+        NotificationCenter.default.post(moduleItem: .assignment("2"), completedRequirement: .submit, courseID: "1")
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertNotNil(notification)
+        XCTAssertEqual(notification?.userInfo?["requirement"] as? ModuleItemCompletionRequirement, .submit)
+        XCTAssertEqual(notification?.userInfo?["moduleItem"] as? ModuleItemType, .assignment("2"))
+        XCTAssertEqual(notification?.userInfo?["courseID"] as? String, "1")
+        NotificationCenter.default.removeObserver(token)
+    }
+}

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -65,6 +65,18 @@ class RouterTests: XCTestCase {
         XCTAssert(mockView.presented?.isKind(of: UINavigationController.self) == false)
     }
 
+    func testRouteFormSheet() {
+        let mockView = MockViewController()
+        let router = Router(routes: [
+            RouteHandler("/formSheet", name: "formSheet") { _, _ in
+                return UIViewController()
+            },
+            ])
+        router.route(to: URLComponents(string: "/formSheet")!, from: mockView, options: [.modal, .formSheet])
+        XCTAssertNotNil(mockView.presented)
+        XCTAssertEqual(mockView.presented?.modalPresentationStyle, .formSheet)
+    }
+
     func testRouteModalEmbeddedInNav() {
         let mockView = MockViewController()
         let router = Router(routes: [

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -71,7 +71,7 @@ class RouterTests: XCTestCase {
             RouteHandler("/formSheet", name: "formSheet") { _, _ in
                 return UIViewController()
             },
-            ])
+        ])
         router.route(to: URLComponents(string: "/formSheet")!, from: mockView, options: [.modal, .formSheet])
         XCTAssertNotNil(mockView.presented)
         XCTAssertEqual(mockView.presented?.modalPresentationStyle, .formSheet)

--- a/Core/CoreTests/Use Cases/CreateSubmissionTests.swift
+++ b/Core/CoreTests/Use Cases/CreateSubmissionTests.swift
@@ -53,4 +53,39 @@ class CreateSubmissionTests: CoreTestCase {
         XCTAssertEqual(submission?.latePolicyStatus, .late)
         XCTAssertEqual(submission?.pointsDeducted, 10)
     }
+
+    func testItPostsModuleCompletedRequirement() {
+        let context = ContextModel(.course, id: "1")
+        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(submission_type: .online_text_entry)))
+        api.mock(request, value: nil)
+        let expectation = XCTestExpectation(description: "notification")
+        var notification: Notification?
+        let token = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) {
+            notification = $0
+            expectation.fulfill()
+        }
+        let useCase = CreateSubmission(context: context, assignmentID: "2", userID: "3", submissionType: .online_text_entry)
+        useCase.makeRequest(environment: environment) { _, _, _ in }
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertNotNil(notification)
+        XCTAssertEqual(notification?.userInfo?["requirement"] as? ModuleItemCompletionRequirement, .submit)
+        XCTAssertEqual(notification?.userInfo?["moduleItem"] as? ModuleItemType, .assignment("2"))
+        XCTAssertEqual(notification?.userInfo?["courseID"] as? String, "1")
+        NotificationCenter.default.removeObserver(token)
+    }
+
+    func testItDoesNotPostModuleCompletedRequirementIfError() {
+        let context = ContextModel(.course, id: "1")
+        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(submission_type: .online_text_entry)))
+        api.mock(request, error: NSError.instructureError("oops"))
+        let expectation = XCTestExpectation(description: "notification")
+        expectation.isInverted = true
+        let token = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) { _ in
+            expectation.fulfill()
+        }
+        let useCase = CreateSubmission(context: context, assignmentID: "2", userID: "3", submissionType: .online_text_entry)
+        useCase.makeRequest(environment: environment) { _, _, _ in }
+        wait(for: [expectation], timeout: 0.2)
+        NotificationCenter.default.removeObserver(token)
+    }
 }

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -146,6 +146,7 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
             selector: #selector(uploadSubmitted(notification:)),
             name: UploadManager.AssignmentSubmittedNotification, object: nil
         )
+        NotificationCenter.default.post(moduleItem: .assignment(assignmentID), completedRequirement: .view, courseID: courseID)
     }
 
     func refresh() {

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
@@ -51,6 +51,7 @@ enum SubmissionButtonAlertView {
                     let controller = AudioRecorderViewController.create()
                     controller.delegate = presenter
                     controller.view.backgroundColor = UIColor.named(.backgroundLightest)
+                    controller.modalPresentationStyle = .formSheet
                     presenter?.view?.present(controller, animated: true, completion: nil)
                 } else {
                     presenter?.view?.showPermissionError(.microphone)

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -124,7 +124,7 @@ class SubmissionButtonPresenter: NSObject {
             pickFiles(for: assignment)
         case .online_url:
             let route = Route.assignmentUrlSubmission(courseID: courseID, assignmentID: assignment.id, userID: userID)
-            env.router.route(to: route, from: view, options: [.modal, .embedInNav])
+            env.router.route(to: route, from: view, options: [.modal, .embedInNav, .formSheet])
         case .none, .not_graded, .on_paper:
             break
         }
@@ -135,6 +135,7 @@ class SubmissionButtonPresenter: NSObject {
         guard case let .some(arcID) = arcID, let userID = assignment.submission?.userID else { return }
         let arc = ArcSubmissionViewController.create(environment: env, courseID: assignment.courseID, assignmentID: assignment.id, userID: userID, arcID: arcID)
         let nav = UINavigationController(rootViewController: arc)
+        nav.modalPresentationStyle = .formSheet
         view?.present(nav, animated: true, completion: nil)
     }
 }
@@ -152,7 +153,9 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
         }
         filePicker.utis = allowedUTIs
         filePicker.delegate = self
-        view?.present(UINavigationController(rootViewController: filePicker), animated: true, completion: nil)
+        let nav = UINavigationController(rootViewController: filePicker)
+        nav.modalPresentationStyle = .formSheet
+        view?.present(nav, animated: true, completion: nil)
     }
 
     func submit(_ controller: FilePickerViewController) {

--- a/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
+++ b/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
@@ -68,10 +68,12 @@ class TextSubmissionViewController: UIViewController, ErrorViewController, RichC
     @objc func submit(_ sender: Any? = nil) {
         editor?.getHTML { (html: String) in
             self.presenter?.submit(html) { [weak self] error in
-                if let error = error {
-                    self?.showError(error)
-                } else {
-                    self?.dismiss(animated: true, completion: nil)
+                DispatchQueue.main.async {
+                    if let error = error {
+                        self?.showError(error)
+                    } else {
+                        self?.dismiss(animated: true, completion: nil)
+                    }
                 }
             }
         }

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -350,6 +350,22 @@ class AssignmentDetailsPresenterTests: PersistenceTestCase {
         XCTAssertFalse( presenter.submitAssignmentButtonIsHidden() )
     }
 
+    func testPostsViewCompletedRequirement() {
+        let expectation = XCTestExpectation(description: "notification")
+        var notification: Notification?
+        let token = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) {
+            notification = $0
+            expectation.fulfill()
+        }
+        presenter.viewIsReady()
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertNotNil(notification)
+        XCTAssertEqual(notification?.userInfo?["requirement"] as? ModuleItemCompletionRequirement, .view)
+        XCTAssertEqual(notification?.userInfo?["moduleItem"] as? ModuleItemType, .assignment("1"))
+        XCTAssertEqual(notification?.userInfo?["courseID"] as? String, "1")
+        NotificationCenter.default.removeObserver(token)
+    }
+
     func setupIsHiddenTest(lockStatus: LockStatus) {
         Course.make()
         switch lockStatus {


### PR DESCRIPTION
pork: Refactor Session.swift to not use URLSession delegate methods
and to use callbacks instead. This fixes some of the bad access errors
we were getting when accessing the stored completion handlers.

pork: use formSheet for most submission types (per Dave's request)

refs: MBL-12870
affects: student
release note: none