### PR TITLE
Mock Notifications & Todo tests

### DIFF
--- a/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
+++ b/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
@@ -18,10 +18,24 @@
 
 import XCTest
 import TestsFoundation
+@testable import Core
 
 class NotificationsListTests: CanvasUITests {
-    func xtestNotificationItemsDisplayed() {
+    override var user: UITestUser? { return nil }
+
+    func testNotificationItemsDisplayed() {
+        mockDataRequest(URLRequest(url: URL(string: "https://canvas.instructure.com/api/v1/users/self/profile?per_page=50")!), data: """
+        {"id":1,"name":"Bob","short_name":"Bob","sortable_name":"Bob","locale":"en"}
+        """.data(using: .utf8))
+        mockEncodableRequest("/api/v1/users/self/activity_stream?per_page=99", value: [
+            APIActivity.make(),
+            APIActivity.make(id: "2", title: "Another Notification"),
+        ], response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 200, httpVersion: nil, headerFields: nil))
+
+        logIn(domain: "canvas.instructure.com", token: "t")
         TabBar.notificationsTab.tap()
+
         app.find(labelContaining: "Assignment Created").waitToExist()
+        app.find(labelContaining: "Another Notification").waitToExist()
     }
 }

--- a/Canvas/CanvasUITests/Todo/TodoListTests.swift
+++ b/Canvas/CanvasUITests/Todo/TodoListTests.swift
@@ -18,13 +18,26 @@
 
 import XCTest
 import TestsFoundation
+@testable import Core
 
 class TodoListTests: CanvasUITests {
-    func xtestTodoItemsDisplayed() {
+    override var user: UITestUser? { return nil }
+
+    func testTodoItemsDisplayed() {
+        mockDataRequest(URLRequest(url: URL(string: "https://canvas.instructure.com/api/v1/users/self/profile?per_page=50")!), data: """
+        {"id":1,"name":"Bob","short_name":"Bob","sortable_name":"Bob","locale":"en"}
+        """.data(using: .utf8))
+        mockEncodableRequest("/api/v1/users/self/todo?per_page=99", value: [
+            APITodo.make(assignment: .make(name: "One", due_at: Date().add(.day, number: 1))),
+            APITodo.make(assignment: .make(id: "2", name: "Two")),
+        ], response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 200, httpVersion: nil, headerFields: nil))
+
+        logIn(domain: "canvas.instructure.com", token: "t")
         TabBar.todoTab.tap()
-        app.find(labelContaining: "Past Due").waitToExist()
+
+        app.find(labelContaining: "One").waitToExist()
+        app.find(labelContaining: "Two").waitToExist()
         app.find(labelContaining: "Due:").waitToExist()
-        app.find(labelContaining: "Jun").waitToExist()
-        app.find(labelContaining: "assignments").waitToExist()
+        app.find(labelContaining: "No Due Date").waitToExist()
     }
 }

--- a/CanvasCore/CanvasCore/Assignments/Submission/New Submission/ArcVideoPickerViewController.swift
+++ b/CanvasCore/CanvasCore/Assignments/Submission/New Submission/ArcVideoPickerViewController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 import WebKit
-
+import Core
 
 public class ArcVideoPickerViewController: UIViewController {
     
@@ -58,14 +58,9 @@ public class ArcVideoPickerViewController: UIViewController {
         webView.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
         
         // https://mobiledev.instructure.com/courses/24219/external_tools/282032/resource_selection?launch_type=homework_submission&assignment_id=405404
-        APIBridge.shared().call("getAuthenticatedSessionURL", args: [arcLTIURL.absoluteString]) { [weak self] response, error in
-            if let data = response as? [String: Any],
-                let sessionURL = data["session_url"] as? String,
-                let url = URL(string: sessionURL) {
-                self?.webView.loadRequest(URLRequest(url: url))
-            } else if let url = self?.arcLTIURL {
-                self?.webView.loadRequest(URLRequest(url: url))
-            }
+        let url = arcLTIURL
+        AppEnvironment.shared.api.makeRequest(GetWebSessionRequest(to: url)) { [weak self] response, _, _ in
+            DispatchQueue.main.async { self?.webView.loadRequest(URLRequest(url: response?.session_url ?? url)) }
         }
     }
     

--- a/CanvasCore/CanvasCore/Quizzes/Taking a Quiz/NonNativeQuizTakingViewController.swift
+++ b/CanvasCore/CanvasCore/Quizzes/Taking a Quiz/NonNativeQuizTakingViewController.swift
@@ -79,14 +79,9 @@ class NonNativeQuizTakingViewController: UIViewController {
         if let host = urlForTakingQuiz.host {
             quizHostName = host
         }
-        APIBridge.shared().call("getAuthenticatedSessionURL", args: [urlForTakingQuiz.absoluteString]) { [weak self] response, error in
-            if let data = response as? [String: Any],
-                let sessionURL = data["session_url"] as? String,
-                let url = URL(string: sessionURL) {
-                self?.webView.loadRequest(URLRequest(url: url))
-            } else if let url = self?.urlForTakingQuiz {
-                self?.webView.loadRequest(URLRequest(url: url))
-            }
+        let url = urlForTakingQuiz
+        AppEnvironment.shared.api.makeRequest(GetWebSessionRequest(to: url)) { [weak self] response, _, _ in
+            DispatchQueue.main.async { self?.webView.loadRequest(URLRequest(url: response?.session_url ?? url)) }
         }
     }
     

--- a/CanvasCore/CanvasCore/Session/Session.swift
+++ b/CanvasCore/CanvasCore/Session/Session.swift
@@ -21,6 +21,7 @@ import ReactiveSwift
 import Marshal
 import WebKit // fixes random "library not loaded" errors.
 import AVFoundation // fixes random "library not loaded" errors.
+import Core
 
 let LocalStoreAppGroupName = "group.com.instructure.Contexts"
 
@@ -52,7 +53,7 @@ open class Session: NSObject {
         self.localStoreDirectory = localStoreDirectory
         let config = URLSessionConfiguration.default
         config.httpAdditionalHeaders = defaultHTTPHeaders
-        URLSession = Foundation.URLSession(configuration: config)
+        URLSession = URLSessionAPI.delegateURLSession(config, nil, nil)
     }
     
     @objc open var sessionID: String {

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -169,6 +169,8 @@
 		7D6410EE2280C345008FA345 /* ActAsUserWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6410ED2280C345008FA345 /* ActAsUserWindow.swift */; };
 		7D6A2BE2214C11AD00DB15C4 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6A2BE1214C11AD00DB15C4 /* Route.swift */; };
 		7D6A2BE4214C538F00DB15C4 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6A2BE3214C538F00DB15C4 /* RouteTests.swift */; };
+		7D6C8C6922EA0A6E00E5ADD8 /* APIActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6C8C6822EA0A6E00E5ADD8 /* APIActivity.swift */; };
+		7D6C8C6D22EFA0D400E5ADD8 /* APITodo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6C8C6C22EFA0D400E5ADD8 /* APITodo.swift */; };
 		7D7110BF213890AD0085C2E5 /* RouteHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7110BE213890AD0085C2E5 /* RouteHandler.swift */; };
 		7D7110C12138910D0085C2E5 /* RouteHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7110C02138910D0085C2E5 /* RouteHandlerTests.swift */; };
 		7D7110CA2139A57A0085C2E5 /* URLComponentsExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7110C92139A57A0085C2E5 /* URLComponentsExtensions.swift */; };
@@ -864,6 +866,8 @@
 		7D6410ED2280C345008FA345 /* ActAsUserWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActAsUserWindow.swift; sourceTree = "<group>"; };
 		7D6A2BE1214C11AD00DB15C4 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		7D6A2BE3214C538F00DB15C4 /* RouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
+		7D6C8C6822EA0A6E00E5ADD8 /* APIActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIActivity.swift; sourceTree = "<group>"; };
+		7D6C8C6C22EFA0D400E5ADD8 /* APITodo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITodo.swift; sourceTree = "<group>"; };
 		7D7110BE213890AD0085C2E5 /* RouteHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteHandler.swift; sourceTree = "<group>"; };
 		7D7110C02138910D0085C2E5 /* RouteHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteHandlerTests.swift; sourceTree = "<group>"; };
 		7D7110C92139A57A0085C2E5 /* URLComponentsExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLComponentsExtensions.swift; sourceTree = "<group>"; };
@@ -1882,6 +1886,7 @@
 				7D80AC11212B4F8E00C40ECE /* API.swift */,
 				7D80AC22212B8A2100C40ECE /* APIAccount.swift */,
 				7D80AC20212B89C500C40ECE /* APIAccountRequestable.swift */,
+				7D6C8C6822EA0A6E00E5ADD8 /* APIActivity.swift */,
 				B1A32BD721599C610071B41E /* APIAssignment.swift */,
 				B1A6BC7D218A317A000515E3 /* APIAssignmentOverride.swift */,
 				B1A6BC7F218A32F3000515E3 /* APIAssignmentOverride+Requestable.swift */,
@@ -1931,6 +1936,7 @@
 				9FCD79D32188DC4E0054293A /* APISubmissionRequestable.swift */,
 				7D80AC0B212B4C6F00C40ECE /* APITab.swift */,
 				7D8262F0212B28FE00BD268D /* APITabRequestable.swift */,
+				7D6C8C6C22EFA0D400E5ADD8 /* APITodo.swift */,
 				7D80AC02212B445200C40ECE /* APIUser.swift */,
 				7D80AC04212B461F00C40ECE /* APIUserRequestable.swift */,
 				3B3467D32135B7B700F9BC2E /* ID.swift */,
@@ -2688,6 +2694,7 @@
 				7DD6CC6B21BD6DB1004C4BB6 /* LoadingViewController.swift in Sources */,
 				B14B704D228F30A100B568D6 /* UploadFileComment.swift in Sources */,
 				9FBE5367223C1EE9001EC40C /* APIPermissionsRequestable.swift in Sources */,
+				7D6C8C6922EA0A6E00E5ADD8 /* APIActivity.swift in Sources */,
 				7D4D5EB2213F2A200080AC14 /* UIImageViewExtensions.swift in Sources */,
 				7D1219242243340200D3BF5C /* KeyboardTransitioning.swift in Sources */,
 				7836B0D22199021500FA25AE /* ShareExtensionViewController.swift in Sources */,
@@ -2735,6 +2742,7 @@
 				3B635B2D225CD377001F353D /* APICalendarRequestable.swift in Sources */,
 				3B6D23E72267B9000040D3FE /* APIRubricAssessment.swift in Sources */,
 				9FD504EC2180BF1A00B395BA /* File.swift in Sources */,
+				7D6C8C6D22EFA0D400E5ADD8 /* APITodo.swift in Sources */,
 				3B34674B213051FD00F9BC2E /* LoginWebViewController.swift in Sources */,
 				7D5AA3C62294AF9400438667 /* GetSSOLogin.swift in Sources */,
 				3B635B33225CDC95001F353D /* CalendarEvent.swift in Sources */,

--- a/Core/Core/API/API.swift
+++ b/Core/Core/API/API.swift
@@ -51,8 +51,8 @@ public struct URLSessionAPI: API {
         configuration.urlCache = nil
         return URLSession(configuration: configuration)
     }()
-    public static var delegateURLSession = { (configuration: URLSessionConfiguration, delegate: URLSessionDelegate?) -> URLSession in
-        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: nil)
+    public static var delegateURLSession = { (configuration: URLSessionConfiguration, delegate: URLSessionDelegate?, delegateQueue: OperationQueue?) -> URLSession in
+        return URLSession(configuration: configuration, delegate: delegate, delegateQueue: delegateQueue)
     }
 
     public init(
@@ -111,5 +111,11 @@ public struct URLSessionAPI: API {
         print("to", request.url ?? "")
         #endif
         return urlSession.uploadTask(with: request, fromFile: url)
+    }
+}
+
+extension URLSession {
+    @objc public static func getDefaultURLSession() -> URLSession {
+        return URLSessionAPI.defaultURLSession
     }
 }

--- a/Core/Core/API/APIActivity.swift
+++ b/Core/Core/API/APIActivity.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2018-present  Instructure, Inc.
+// Copyright (C) 2019-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -18,32 +18,26 @@
 
 import Foundation
 
-public enum ContextType: String, Codable {
-    case account, course, group, user, section
-
-    public var pathComponent: String {
-        return "\(self)s"
-    }
+public enum ActivityType: String, Codable {
+    case announcement = "Announcement"
+    case assessmentRequest = "AssessmentRequest"
+    case collaboration = "Collaboration"
+    case conference = "WebConference"
+    case conversation = "Conversation"
+    case discussion = "DiscussionTopic"
+    case message = "Message"
+    case submission = "Submission"
 }
 
-public protocol Context {
-    var contextType: ContextType { get }
-    var id: String { get }
-}
-
-public protocol APIContext: Context {
-    var id: ID { get }
-}
-extension APIContext {
-    var id: String { return id.value }
-}
-
-public extension Context {
-    var canvasContextID: String {
-        return "\(contextType)_\(id)"
-    }
-
-    var pathComponent: String {
-        return "\(contextType.pathComponent)/\(id)"
-    }
+struct APIActivity: Codable {
+    let id: ID
+    let title: String
+    let message: String
+    let html_url: URL
+    let created_at: Date
+    let updated_at: Date
+    let type: ActivityType
+    let context_type: ContextType
+    let course_id: ID?
+    let group_id: ID?
 }

--- a/Core/Core/API/APITodo.swift
+++ b/Core/Core/API/APITodo.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2018-present  Instructure, Inc.
+// Copyright (C) 2019-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -18,32 +18,18 @@
 
 import Foundation
 
-public enum ContextType: String, Codable {
-    case account, course, group, user, section
-
-    public var pathComponent: String {
-        return "\(self)s"
-    }
+public enum TodoType: String, Codable {
+    case grading, submitting
 }
 
-public protocol Context {
-    var contextType: ContextType { get }
-    var id: String { get }
-}
-
-public protocol APIContext: Context {
-    var id: ID { get }
-}
-extension APIContext {
-    var id: String { return id.value }
-}
-
-public extension Context {
-    var canvasContextID: String {
-        return "\(contextType)_\(id)"
-    }
-
-    var pathComponent: String {
-        return "\(contextType.pathComponent)/\(id)"
-    }
+struct APITodo: Codable {
+    let type: TodoType
+    let ignore: URL
+    let ignore_permanently: URL
+    let html_url: URL
+    let needs_grading_count: UInt?
+    let assignment: APIAssignment
+    let context_type: ContextType
+    let course_id: ID?
+    let group_id: ID?
 }

--- a/Core/Core/Use Cases/UploadManager.swift
+++ b/Core/Core/Use Cases/UploadManager.swift
@@ -54,7 +54,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
         }
         let configuration = URLSessionConfiguration.background(withIdentifier: "com.instructure.core.file-uploads")
         configuration.sharedContainerIdentifier = Bundle.main.appGroupID()
-        let session = URLSessionAPI.delegateURLSession(configuration, self)
+        let session = URLSessionAPI.delegateURLSession(configuration, self, nil)
         validSession = session
         return session
     }

--- a/Core/Core/Use Cases/UploadMedia.swift
+++ b/Core/Core/Use Cases/UploadMedia.swift
@@ -23,7 +23,7 @@ public class UploadMedia: NSObject, URLSessionDelegate, URLSessionDataDelegate {
     var env = AppEnvironment.shared
     let database = UploadManager.shared.database
     lazy var context = database.newBackgroundContext()
-    lazy var urlSession = URLSessionAPI.delegateURLSession(.ephemeral, self)
+    lazy var urlSession = URLSessionAPI.delegateURLSession(.ephemeral, self, nil)
     var mediaAPI: API?
     var task: URLSessionTask?
     var callback: (String?, Error?) -> Void = { _, _ in }

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -57,7 +57,7 @@ class CoreTestCase: XCTestCase {
         environment.logger = logger
         environment.currentSession = currentSession
         notificationManager = NotificationManager(notificationCenter: notificationCenter, logger: logger)
-        URLSessionAPI.delegateURLSession = { _, _ in MockURLSession() }
+        URLSessionAPI.delegateURLSession = { _, _, _ in MockURLSession() }
         UploadManager.shared = MockUploadManager()
         MockUploadManager.reset()
         UUID.reset()

--- a/Core/CoreTests/Use Cases/UploadManagerTests.swift
+++ b/Core/CoreTests/Use Cases/UploadManagerTests.swift
@@ -44,7 +44,7 @@ class UploadManagerTests: CoreTestCase {
         super.setUp()
 
         manager.notificationManager = notificationManager
-        URLSessionAPI.delegateURLSession = { _, _ in self.backgroundSession }
+        URLSessionAPI.delegateURLSession = { _, _, _ in self.backgroundSession }
         MockURLSession.reset()
     }
 

--- a/Student/StudentUITests/StudentUITestCase.swift
+++ b/Student/StudentUITests/StudentUITestCase.swift
@@ -31,6 +31,7 @@ class StudentUITestCase: UITestCase {
             app.launch()
         }
         reset()
+        mockDownload(URL(string: ".")!) // Use only mock data
     }
 
     func navBarColorHex() -> String? {

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		7D47769A21AF396500B441CE /* APIQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D47769921AF396500B441CE /* APIQuiz.swift */; };
 		7D5C87232239A9EE00D99651 /* SubmissionCommentFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5C87222239A9EE00D99651 /* SubmissionCommentFixture.swift */; };
 		7D63F794215D8FC100151E49 /* APIBrandVariablesFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D63F793215D8FC100151E49 /* APIBrandVariablesFixture.swift */; };
+		7D6C8C6B22EA0C5900E5ADD8 /* APIActivityFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6C8C6A22EA0C5900E5ADD8 /* APIActivityFixture.swift */; };
+		7D6C8C6F22EFA29F00E5ADD8 /* APITodoFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6C8C6E22EFA29F00E5ADD8 /* APITodoFixture.swift */; };
 		7D903C0822BBE80D009D9E9E /* UITestUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D903C0722BBE80D009D9E9E /* UITestUser.swift */; };
 		7D903C0A22BC1329009D9E9E /* LoginStart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D903C0922BC1329009D9E9E /* LoginStart.swift */; };
 		7D903C0C22BC132E009D9E9E /* LoginWeb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D903C0B22BC132E009D9E9E /* LoginWeb.swift */; };
@@ -104,6 +106,8 @@
 		7D47769921AF396500B441CE /* APIQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIQuiz.swift; sourceTree = "<group>"; };
 		7D5C87222239A9EE00D99651 /* SubmissionCommentFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentFixture.swift; sourceTree = "<group>"; };
 		7D63F793215D8FC100151E49 /* APIBrandVariablesFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariablesFixture.swift; sourceTree = "<group>"; };
+		7D6C8C6A22EA0C5900E5ADD8 /* APIActivityFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIActivityFixture.swift; sourceTree = "<group>"; };
+		7D6C8C6E22EFA29F00E5ADD8 /* APITodoFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APITodoFixture.swift; sourceTree = "<group>"; };
 		7D903C0722BBE80D009D9E9E /* UITestUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestUser.swift; sourceTree = "<group>"; };
 		7D903C0922BC1329009D9E9E /* LoginStart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginStart.swift; sourceTree = "<group>"; };
 		7D903C0B22BC132E009D9E9E /* LoginWeb.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWeb.swift; sourceTree = "<group>"; };
@@ -231,6 +235,7 @@
 			isa = PBXGroup;
 			children = (
 				7DB0A1D321C1C90D009ABB40 /* APIAccountResultsFixture.swift */,
+				7D6C8C6A22EA0C5900E5ADD8 /* APIActivityFixture.swift */,
 				B1A32BDD2159A1D70071B41E /* APIAssignmentFixture.swift */,
 				7D63F793215D8FC100151E49 /* APIBrandVariablesFixture.swift */,
 				3B635B38225CE613001F353D /* APICalendarEventFixture.swift */,
@@ -249,6 +254,7 @@
 				3B6386A62264F781002DEE72 /* APIRubricFixture.swift */,
 				B1A32BDF2159A28D0071B41E /* APISubmissionFixture.swift */,
 				3B0CEBA021504C2500D07CFA /* APITabFixture.swift */,
+				7D6C8C6E22EFA29F00E5ADD8 /* APITodoFixture.swift */,
 				7DB0A1C821C07F39009ABB40 /* APIUserFixture.swift */,
 			);
 			path = API;
@@ -465,6 +471,7 @@
 				B1A32BE02159A28D0071B41E /* APISubmissionFixture.swift in Sources */,
 				B150C6382298D6F20096D58C /* APIExternalToolFixture.swift in Sources */,
 				3B0CEBA321504C2500D07CFA /* APITabFixture.swift in Sources */,
+				7D6C8C6B22EA0C5900E5ADD8 /* APIActivityFixture.swift in Sources */,
 				3B0CEB722150406400D07CFA /* CourseFixture.swift in Sources */,
 				7DB0A1C921C07F39009ABB40 /* APIUserFixture.swift in Sources */,
 				7D903C1922C1513D009D9E9E /* NavBar.swift in Sources */,
@@ -511,6 +518,7 @@
 				B15DCD57224121FA0044A8A2 /* MockUploadManager.swift in Sources */,
 				9F4B53AE218100BC0056A557 /* APIFileFixture.swift in Sources */,
 				3B0CEB752150406400D07CFA /* TTLFixture.swift in Sources */,
+				7D6C8C6F22EFA29F00E5ADD8 /* APITodoFixture.swift in Sources */,
 				9F1CEA5D22400CE0000BB98F /* PermissionsFixture.swift in Sources */,
 				7DCF204A216D6668003AF358 /* QuizFixture.swift in Sources */,
 				7D37BE8F21C8398D0063FAAC /* DiscussionEntryFixture.swift in Sources */,

--- a/TestsFoundation/TestsFoundation/API/MockURLSession.swift
+++ b/TestsFoundation/TestsFoundation/API/MockURLSession.swift
@@ -70,7 +70,7 @@ public class MockURLSession: URLSession {
     static let isSetup: Bool = {
         URLSessionAPI.defaultURLSession = MockURLSession()
         URLSessionAPI.cachingURLSession = MockURLSession()
-        URLSessionAPI.delegateURLSession = { _, _ in MockURLSession() }
+        URLSessionAPI.delegateURLSession = { _, _, _ in MockURLSession() }
         NoFollowRedirect.session = MockURLSession()
         AppEnvironment.shared.api = URLSessionAPI(accessToken: nil, actAsUserID: nil, baseURL: nil, urlSession: MockURLSession())
         return true

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APIActivityFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APIActivityFixture.swift
@@ -1,0 +1,48 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import Core
+
+extension APIActivity {
+    public static func make(
+        id: ID = "1",
+        title: String = "Assignment Created: Assignment 1",
+        message: String = "Assignment 1",
+        html_url: URL = URL(string: "/courses/1/assignments/1")!,
+        created_at: Date = Date(),
+        updated_at: Date = Date(),
+        type: ActivityType = .message,
+        context_type: ContextType = .course,
+        course_id: ID? = "1",
+        group_id: ID? = nil
+    ) -> APIActivity {
+        return APIActivity(
+            id: id,
+            title: title,
+            message: message,
+            html_url: html_url,
+            created_at: created_at,
+            updated_at: updated_at,
+            type: type,
+            context_type: context_type,
+            course_id: course_id,
+            group_id: group_id
+        )
+    }
+}

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APITodoFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APITodoFixture.swift
@@ -1,0 +1,46 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import Core
+
+extension APITodo {
+    public static func make(
+        type: TodoType = .submitting,
+        ignore: URL = URL(string: "https://canvas.instructure.com/api/v1/users/self/todo_ignore/1")!,
+        ignore_permanently: URL = URL(string: "https://canvas.instructure.com/api/v1/users/self/todo_ignore/1")!,
+        html_url: URL = URL(string: "https://canvas.instructure.com/api/v1/courses/1/assignments/1")!,
+        needs_grading_count: UInt? = nil,
+        assignment: APIAssignment = .make(),
+        context_type: ContextType = .course,
+        course_id: ID? = "1",
+        group_id: ID? = nil
+    ) -> APITodo {
+        return APITodo(
+            type: type,
+            ignore: ignore,
+            ignore_permanently: ignore_permanently,
+            html_url: html_url,
+            needs_grading_count: needs_grading_count,
+            assignment: assignment,
+            context_type: context_type,
+            course_id: course_id,
+            group_id: group_id
+        )
+    }
+}

--- a/TestsFoundation/TestsFoundation/UITestCase/UITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITestCase/UITestCase.swift
@@ -102,12 +102,10 @@ open class UITestCase: XCTestCase {
         error: String? = nil,
         noCallback: Bool = false
     ) {
-        let api = URLSessionAPI()
-        let request = try! requestable.urlRequest(relativeTo: api.baseURL, accessToken: api.accessToken, actAsUserID: api.actAsUserID)
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601
         let data = value.flatMap { try! encoder.encode($0) }
-        return mockDataRequest(request, data: data, response: response, error: error, noCallback: noCallback)
+        return mockEncodedData(requestable, data: data, response: response, error: error, noCallback: noCallback)
     }
 
     open func mockEncodedData<R: APIRequestable>(
@@ -120,6 +118,20 @@ open class UITestCase: XCTestCase {
         let api = URLSessionAPI()
         let request = try! requestable.urlRequest(relativeTo: api.baseURL, accessToken: api.accessToken, actAsUserID: api.actAsUserID)
         return mockDataRequest(request, data: data, response: response, error: error, noCallback: noCallback)
+    }
+
+    open func mockEncodableRequest<D: Codable>(
+        _ path: String,
+        value: D? = nil,
+        response: HTTPURLResponse? = nil,
+        error: String? = nil,
+        noCallback: Bool = false
+    ) {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = value.flatMap { try! encoder.encode($0) }
+        let api = URLSessionAPI()
+        mockDataRequest(URLRequest(url: URL(string: path, relativeTo: api.baseURL)!), data: data, response: response, error: error, noCallback: noCallback)
     }
 
     open func mockDataRequest(

--- a/rn/Teacher/index.ios.js
+++ b/rn/Teacher/index.ios.js
@@ -123,11 +123,13 @@ const loginHandler = async ({
 
   setSession(session)
 
-  try {
-    await getUser('self')
-  } catch (err) {
-    if (err.response && err.response.status === 401) {
-      return NativeLogin.logout()
+  if (!NativeModules.SettingsManager.settings.IS_UI_TEST) {
+    try {
+      await getUser('self')
+    } catch (err) {
+      if (err.response && err.response.status === 401) {
+        return NativeLogin.logout()
+      }
     }
   }
 

--- a/rn/Teacher/src/common/login-verify.js
+++ b/rn/Teacher/src/common/login-verify.js
@@ -24,6 +24,9 @@ import canvas from '../canvas-api'
 // if the user has an invalid login, the promise will send `true`. Otherwise it will send `false`
 export default async function loginVerify (): Promise<boolean> {
   return new Promise((resolve, reject) => {
+    if (NativeModules.SettingsManager.settings.IS_UI_TEST) {
+      return resolve(false)
+    }
     canvas.getUserProfile('self')
       .then(() => resolve(false))
       .catch((e) => {

--- a/rn/Teacher/src/redux/actions/async-tracker.js
+++ b/rn/Teacher/src/redux/actions/async-tracker.js
@@ -82,7 +82,7 @@ export const asyncActions: Reducer<any, any> = handleActions({
     const name = action.payload.name
     const record = {
       ...state[name],
-      pending: state[name].pending - 1,
+      pending: (state[name] && state[name].pending || 0) - 1,
       lastResolvedDate: new Date(),
       lastError: undefined,
     }
@@ -96,7 +96,7 @@ export const asyncActions: Reducer<any, any> = handleActions({
     const lastError = action.payload.error
     const record = {
       ...state[name],
-      pending: state[name].pending - 1,
+      pending: (state[name] && state[name].pending || 0) - 1,
       lastError,
     }
     return {


### PR DESCRIPTION
Makes more api calls mockable (Session.swift, CKIClient).
js api calls are still not mockable, and the login validation is disabled for UI tests.

refs: none
affects: Student
release note: none