### PR TITLE
Better handle docviewer retry_after

### DIFF
--- a/Core/Core/DocViewer/DocViewerSession.swift
+++ b/Core/Core/DocViewer/DocViewerSession.swift
@@ -64,7 +64,13 @@ public class DocViewerSession: NSObject, URLSessionTaskDelegate {
         guard error == nil, let sessionURL = sessionURL else { return notify() }
         self.sessionID = sessionURL.lastPathComponent
         self.sessionURL = sessionURL
-        task = api.makeRequest(GetDocViewerMetadataRequest(path: sessionURL.absoluteString)) { [weak self] metadata, _, error in
+        task = api.makeRequest(GetDocViewerMetadataRequest(path: sessionURL.absoluteString)) { [weak self] metadata, response, error in
+            if (response as? HTTPURLResponse)?.statusCode == 202 {
+                DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(2)) {
+                    self?.loadMetadata(sessionURL: sessionURL)
+                }
+                return
+            }
             self?.error = error
             if error == nil, let metadata = metadata, let downloadURL = URL(string: metadata.urls.pdf_download.absoluteString, relativeTo: sessionURL) {
                 self?.metadata = metadata

--- a/Core/CoreTests/DocViewer/DocViewerSessionTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerSessionTests.swift
@@ -98,9 +98,12 @@ class DocViewerSessionTests: CoreTestCase {
         let metadata = APIDocViewerMetadata.make()
         let session = DocViewerSession { notified.fulfill() }
         session.api = api
-        api.mock(GetDocViewerMetadataRequest(path: sessionURL.absoluteString), value: metadata)
+        api.mock(GetDocViewerMetadataRequest(path: sessionURL.absoluteString), response: HTTPURLResponse(url: sessionURL, statusCode: 202, httpVersion: nil, headerFields: nil))
         session.loadMetadata(sessionURL: sessionURL)
-        wait(for: [notified], timeout: 1)
+
+        api.mock(GetDocViewerMetadataRequest(path: sessionURL.absoluteString), value: metadata)
+        wait(for: [notified], timeout: 4)
+
         XCTAssertNil(session.error)
         XCTAssertEqual(session.metadata, metadata)
         XCTAssertEqual(session.remoteURL, URL(string: "download", relativeTo: sessionURL))


### PR DESCRIPTION
This assumes that docviewer always tells us to wait 2 seconds when it sends a 202.

refs: MBL-12877
affects: Student
release note: none