### PR TITLE
Mock React Native requests

### DIFF
--- a/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
+++ b/Canvas/CanvasUITests/Notifications/NotificationsListTests.swift
@@ -24,10 +24,8 @@ class NotificationsListTests: CanvasUITests {
     override var user: UITestUser? { return nil }
 
     func testNotificationItemsDisplayed() {
-        mockDataRequest(URLRequest(url: URL(string: "https://canvas.instructure.com/api/v1/users/self/profile?per_page=50")!), data: """
-        {"id":1,"name":"Bob","short_name":"Bob","sortable_name":"Bob","locale":"en"}
-        """.data(using: .utf8))
-        mockEncodableRequest("/api/v1/users/self/activity_stream?per_page=99", value: [
+        mockBaseRequests()
+        mockEncodableRequest("users/self/activity_stream?per_page=99", value: [
             APIActivity.make(),
             APIActivity.make(id: "2", title: "Another Notification"),
         ], response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 200, httpVersion: nil, headerFields: nil))

--- a/Canvas/CanvasUITests/Todo/TodoListTests.swift
+++ b/Canvas/CanvasUITests/Todo/TodoListTests.swift
@@ -24,10 +24,8 @@ class TodoListTests: CanvasUITests {
     override var user: UITestUser? { return nil }
 
     func testTodoItemsDisplayed() {
-        mockDataRequest(URLRequest(url: URL(string: "https://canvas.instructure.com/api/v1/users/self/profile?per_page=50")!), data: """
-        {"id":1,"name":"Bob","short_name":"Bob","sortable_name":"Bob","locale":"en"}
-        """.data(using: .utf8))
-        mockEncodableRequest("/api/v1/users/self/todo?per_page=99", value: [
+        mockBaseRequests()
+        mockEncodableRequest("users/self/todo?per_page=99", value: [
             APITodo.make(assignment: .make(name: "One", due_at: Date().add(.day, number: 1))),
             APITodo.make(assignment: .make(id: "2", name: "Two")),
         ], response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 200, httpVersion: nil, headerFields: nil))

--- a/CanvasCore/CanvasCore.xcodeproj/project.pbxproj
+++ b/CanvasCore/CanvasCore.xcodeproj/project.pbxproj
@@ -472,6 +472,7 @@
 		7D0215A321BAE703009A8E69 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D0215A221BAE703009A8E69 /* Core.framework */; };
 		7D0F8D8421347CD50092E8F8 /* SVGImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0F8D8321347CD50092E8F8 /* SVGImageView.swift */; };
 		7D6410EC2280B74E008FA345 /* NativeLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D6410EB2280B74E008FA345 /* NativeLoginManager.swift */; };
+		7D6C8C7522F2335A00E5ADD8 /* MockHTTPRequestHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 7D6C8C7422F2335A00E5ADD8 /* MockHTTPRequestHandler.m */; };
 		7DD89E8B20AB626600650227 /* AppStoreReview.m in Sources */ = {isa = PBXBuildFile; fileRef = 7DD89E8A20AB626600650227 /* AppStoreReview.m */; };
 		7DF5A776208AAB8000419AB9 /* CanvadocsAnnotationStateManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DF5A775208AAB8000419AB9 /* CanvadocsAnnotationStateManager.swift */; };
 		9F068D64207C082B0040EFFA /* registerSharedNativeViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F068D63207C082B0040EFFA /* registerSharedNativeViewControllers.swift */; };
@@ -1044,6 +1045,7 @@
 		7D349C7821430D2A004C1074 /* sv-instk12 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sv-instk12"; path = "sv-instk12.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		7D349C7B21430D2C004C1074 /* sv-instk12 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sv-instk12"; path = "sv-instk12.lproj/TimedQuizViewController.strings"; sourceTree = "<group>"; };
 		7D6410EB2280B74E008FA345 /* NativeLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeLoginManager.swift; sourceTree = "<group>"; };
+		7D6C8C7422F2335A00E5ADD8 /* MockHTTPRequestHandler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MockHTTPRequestHandler.m; sourceTree = "<group>"; };
 		7D9DF28B22BD7F4D003110B9 /* en-AU-unimelb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU-unimelb"; path = "en-AU-unimelb.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		7D9DF28C22BD7F4D003110B9 /* en-AU-unimelb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU-unimelb"; path = "en-AU-unimelb.lproj/TimedQuizViewController.strings"; sourceTree = "<group>"; };
 		7D9DF28D22BD7F4D003110B9 /* en-AU-unimelb */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-AU-unimelb"; path = "en-AU-unimelb.lproj/SubmissionConfirmationViewController.strings"; sourceTree = "<group>"; };
@@ -1673,6 +1675,7 @@
 				494AE08E1F843A01001A8F31 /* HapticFeedback.h */,
 				494AE0911F843A02001A8F31 /* HapticFeedback.m */,
 				9FD18B6A2052DE6800119927 /* LTITools.m */,
+				7D6C8C7422F2335A00E5ADD8 /* MockHTTPRequestHandler.m */,
 				B1C3407720D1AD3B00D0554D /* ModuleItemsProgress.m */,
 				494AE0971F843A04001A8F31 /* NativeAccessibility.h */,
 				494AE0921F843A02001A8F31 /* NativeAccessibility.m */,
@@ -2953,6 +2956,7 @@
 				4961F5A91F8FB2A90093EC86 /* HairlineView.swift in Sources */,
 				496C7D661F8C00250010DC03 /* TabBarBadgeCounts.m in Sources */,
 				B196F79B206AB60400DE640F /* CoreDataSync.m in Sources */,
+				7D6C8C7522F2335A00E5ADD8 /* MockHTTPRequestHandler.m in Sources */,
 				49CE97A41F900D0000121A43 /* BackdropServerHandling.swift in Sources */,
 				4930204E1F902364006BD777 /* Values.swift in Sources */,
 				49CE96A21F8FF4A700121A43 /* Dispatcher.swift in Sources */,

--- a/CanvasCore/CanvasCore/React Native Modules/MockHTTPRequestHandler.m
+++ b/CanvasCore/CanvasCore/React Native Modules/MockHTTPRequestHandler.m
@@ -1,0 +1,68 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2017-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#if DEBUG
+
+#import <Foundation/Foundation.h>
+#import <CanvasCore/CanvasCore-Swift.h>
+@import React;
+@import Core;
+
+@interface MockHTTPRequestHandler : NSObject <RCTURLRequestHandler>
+@end
+
+@implementation MockHTTPRequestHandler
+
+RCT_EXPORT_MODULE();
+
+- (float)handlerPriority { return 1.0; }
+
+#pragma mark - NSURLRequestHandler
+
+- (BOOL)canHandleRequest:(NSURLRequest *)request
+{
+    return (
+        [MockDistantURLSession isSetup] &&
+        [request.URL.scheme.lowercaseString hasPrefix:@"http"] &&
+        !request.URL.port // don't mock requests to bundler
+    );
+}
+
+- (NSObject *)sendRequest:(NSURLRequest *)request withDelegate:(id<RCTURLRequestDelegate>)delegate
+{
+    NSObject* token = [NSObject new];
+    NSURLSessionDataTask *task = [[NSURLSession getDefaultURLSession] dataTaskWithRequest:request completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+        if (response) {
+            [delegate URLRequest:token didReceiveResponse:response];
+        }
+        if (data) {
+            [delegate URLRequest:token didReceiveData:data];
+        }
+        [delegate URLRequest:token didCompleteWithError:error];
+    }];
+
+    dispatch_async([[[RCTBridge currentBridge] networking] methodQueue], ^{ [task resume]; });
+    return token;
+}
+
+- (dispatch_queue_t)methodQueue { return dispatch_get_main_queue(); }
++ (BOOL)requiresMainQueueSetup { return YES; }
+
+@end
+
+#endif

--- a/rn/Teacher/index.ios.js
+++ b/rn/Teacher/index.ios.js
@@ -123,13 +123,11 @@ const loginHandler = async ({
 
   setSession(session)
 
-  if (!NativeModules.SettingsManager.settings.IS_UI_TEST) {
-    try {
-      await getUser('self')
-    } catch (err) {
-      if (err.response && err.response.status === 401) {
-        return NativeLogin.logout()
-      }
+  try {
+    await getUser('self')
+  } catch (err) {
+    if (err.response && err.response.status === 401) {
+      return NativeLogin.logout()
     }
   }
 

--- a/rn/Teacher/src/common/login-verify.js
+++ b/rn/Teacher/src/common/login-verify.js
@@ -24,9 +24,6 @@ import canvas from '../canvas-api'
 // if the user has an invalid login, the promise will send `true`. Otherwise it will send `false`
 export default async function loginVerify (): Promise<boolean> {
   return new Promise((resolve, reject) => {
-    if (NativeModules.SettingsManager.settings.IS_UI_TEST) {
-      return resolve(false)
-    }
     canvas.getUserProfile('self')
       .then(() => resolve(false))
       .catch((e) => {


### PR DESCRIPTION
Adds another http(s) handler that will use mock data when it there is some in a DEBUG build.

refs: MBL-12943
affects: none
release note: none