### PR TITLE
MBL-12897 - show empty screen for locked assignments

### DIFF
--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -265,9 +265,13 @@ class SubmissionDetailsPresenter: PageViewLoggerPresenterProtocol {
     }
 
     func lockedEmptyViewIsHidden() -> Bool {
-        if let assignment = assignment.first, assignment.quizID != nil {
+        if let assignment = assignment.first {
             return assignment.lockExplanation == nil && !(assignment.lockedForUser)
         }
         return true
+    }
+
+    func lockedEmptyViewHeader() -> String {
+        return assignment.first?.quizID != nil ? NSLocalizedString("Quiz Locked", comment: "") : NSLocalizedString("Assignment Locked", comment: "")
     }
 }

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -99,6 +99,7 @@ class SubmissionDetailsViewController: UIViewController, SubmissionDetailsViewPr
         }
 
         lockedEmptyView?.isHidden = presenter.lockedEmptyViewIsHidden()
+        lockedEmptyView?.headerLabel.text = presenter.lockedEmptyViewHeader()
     }
 
     func reloadNavBar() {

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
@@ -298,8 +298,7 @@ class SubmissionDetailsPresenterTests: PersistenceTestCase {
     }
 
     func testLockedEmptyViewIsNotHidden() {
-        Assignment.make(from: .make(quiz_id: "1",
-                                    submission_types: [ .online_upload ],
+        Assignment.make(from: .make(submission_types: [ .online_upload ],
                                     allowed_extensions: ["png"],
                                     unlock_at: Date().addYears(1),
                                     locked_for_user: true,
@@ -310,5 +309,26 @@ class SubmissionDetailsPresenterTests: PersistenceTestCase {
     func testLockedEmptyViewIsHidden() {
         Submission.make(from: .make(assignment_id: "1", user_id: "1", attempt: 1))
         XCTAssertTrue( presenter.lockedEmptyViewIsHidden() )
+    }
+
+    func testLockedEmptyViewHeaderWithQuiz() {
+        Assignment.make(from: .make(quiz_id: "1",
+                                    submission_types: [ .online_upload ],
+                                    allowed_extensions: ["png"],
+                                    unlock_at: Date().addYears(1),
+                                    locked_for_user: true,
+                                    lock_explanation: "this is locked"))
+
+        XCTAssertEqual( presenter.lockedEmptyViewHeader(), "Quiz Locked" )
+    }
+
+    func testLockedEmptyViewHeaderWithAssignment() {
+        Assignment.make(from: .make(submission_types: [ .online_upload ],
+                                    allowed_extensions: ["png"],
+                                    unlock_at: Date().addYears(1),
+                                    locked_for_user: true,
+                                    lock_explanation: "this is locked"))
+
+        XCTAssertEqual( presenter.lockedEmptyViewHeader(), "Assignment Locked" )
     }
 }


### PR DESCRIPTION
refs: MBL-12897
affects: Student
release note: none