### PR TITLE
MBL-12974 fix parent not seeing future-enrolled student

### DIFF
--- a/Parent/Parent/Airwolf/Model/Student/Student+Network.swift
+++ b/Parent/Parent/Airwolf/Model/Student/Student+Network.swift
@@ -43,7 +43,7 @@ extension Student {
     }
 
     private static func getEnrollments(session: Session) throws -> SignalProducer<[JSONObject], NSError> {
-        let params = ["state": ["creation_pending", "active", "invited"], "include": ["observed_users", "avatar_url"], "role": ["ObserverEnrollment"]]
+        let params = ["state": ["creation_pending", "active", "invited", "current_and_future", "completed"], "include": ["observed_users", "avatar_url"], "role": ["ObserverEnrollment"]]
         let request = try session.GET("/api/v1/users/self/enrollments", parameters: params)
         return session.paginatedJSONSignalProducer(request)
     }


### PR DESCRIPTION
Observers should now see the "courses may not be published yet" page in
circumstances where a course isn't visible, namely unpublished and concluded.

refs: MBL-12974
affects: Parent
release note: none