### PR TITLE
Workaround CourseNavigation header issue

### DIFF
--- a/rn/Teacher/src/modules/tabs/TabsList.js
+++ b/rn/Teacher/src/modules/tabs/TabsList.js
@@ -117,11 +117,7 @@ export default class TabsList extends Component<TabsListProps, any> {
     }
 
     return (
-      <View
-        style={styles.container}
-        refreshing={this.props.refreshing}
-        onRefresh={this.props.onRefresh}
-      >
+      <View style={styles.container}>
         <OnLayout style={styles.tabContainer}>
           {({ height }) => (
             <Animated.ScrollView
@@ -131,7 +127,7 @@ export default class TabsList extends Component<TabsListProps, any> {
               onScroll={this.onScroll}
               refreshControl={
                 <RefreshControl
-                  refreshing={this.props.refreshing}
+                  refreshing={false /* this.props.refreshing MBL-13034 */}
                   onRefresh={this.props.onRefresh}
                   style={{ position: 'absolute', top: headerHeight }}
                 />


### PR DESCRIPTION
The bad scrolling happens when the initial refresh flashes. By not reporting to be refreshing, the bad scroll never happens.
This does mean however that the spinner won't be accurately shown for the whole time it is refreshing.

refs: MBL-13034
affects: Student, Teacher
release note: Fixed an issue with Course navigation scrolling