### PR TITLE
Remove react-native-sfsafariviewcontroller

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.m
+++ b/CanvasCore/CanvasCore/Helm/Helm.m
@@ -39,6 +39,12 @@ RCT_EXPORT_METHOD(setDefaultScreenConfig:(NSDictionary *)config forModule:(NSStr
     [[HelmManager shared] setDefaultScreenConfig:config forModule:module];
 }
 
+RCT_REMAP_METHOD(openInSafariViewController, openInSafariViewControllerURL:(NSURL *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    [[HelmManager shared] openInSafariViewController:url completion:^() {
+        resolve(nil);
+    }];
+}
+
 RCT_REMAP_METHOD(pushFrom, pushModule:(NSString *)sourceModule destinationModule:(NSString*)module withProps:(NSDictionary *)props options:(NSDictionary *)options resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     [[HelmManager shared] pushFrom:sourceModule destinationModule:module withProps:props options:options callback:^() {
         resolve(nil);

--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import SafariServices
 import CanvasKeymaster
 import React
 import Core
@@ -120,6 +121,17 @@ open class HelmManager: NSObject {
     }
 
     //  MARK: - Navigation
+
+    public class ResetTransitionDelegate: NSObject, UIViewControllerTransitioningDelegate {
+        public static let shared = ResetTransitionDelegate()
+    }
+
+    @objc public func openInSafariViewController(_ url : URL, completion: @escaping () -> Void) {
+        guard let topViewController = topMostViewController() else { return completion() }
+        let safari = SFSafariViewController(url: url)
+        safari.transitioningDelegate = ResetTransitionDelegate.shared
+        topViewController.present(safari, animated: true, completion: completion)
+    }
 
     @objc public func pushFrom(_ sourceModule: ModuleName, destinationModule: ModuleName, withProps props: [String: Any], options: [String: Any], callback: (() -> Void)? = nil) {
         guard let topViewController = topMostViewController() else { return }

--- a/Podfile
+++ b/Podfile
@@ -43,7 +43,6 @@ abstract_target 'defaults' do
   pod 'Interactable', :path => nm_path + 'react-native-interactable'
   pod 'BVLinearGradient', :path => nm_path + 'react-native-linear-gradient'
   pod 'ReactNativeSearchBar', :path => nm_path + 'react-native-search-bar'
-  pod 'RCTSFSafariViewController', :path => nm_path + 'react-native-sfsafariviewcontroller'
   pod 'react-native-document-picker', :path => nm_path + 'react-native-document-picker'
   pod 'RNAudio', :path => nm_path + 'react-native-audio'
   pod 'RNSound', :path => nm_path + 'react-native-sound'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -85,8 +85,6 @@ PODS:
     - nanopb/encode (= 0.3.901)
   - nanopb/decode (0.3.901)
   - nanopb/encode (0.3.901)
-  - RCTSFSafariViewController (0.2.6):
-    - React
   - React (0.59.9):
     - React/Core (= 0.59.9)
   - react-native-camera (0.10.0):
@@ -184,7 +182,6 @@ DEPENDENCIES:
   - Kingfisher (~> 4.10)
   - Mantle (~> 1.5.5)
   - Marshal (~> 1.2.7)
-  - RCTSFSafariViewController (from `./rn/Teacher/node_modules/react-native-sfsafariviewcontroller`)
   - react-native-camera (from `./rn/Teacher/node_modules/react-native-camera`)
   - react-native-document-picker (from `./rn/Teacher/node_modules/react-native-document-picker`)
   - react-native-image-picker (from `./rn/Teacher/node_modules/react-native-image-picker`)
@@ -245,8 +242,6 @@ EXTERNAL SOURCES:
     :podspec: "./rn/Teacher/node_modules/react-native/third-party-podspecs/glog.podspec"
   Interactable:
     :path: "./rn/Teacher/node_modules/react-native-interactable"
-  RCTSFSafariViewController:
-    :path: "./rn/Teacher/node_modules/react-native-sfsafariviewcontroller"
   React:
     :path: "./rn/Teacher/node_modules/react-native/"
   react-native-camera:
@@ -292,7 +287,6 @@ SPEC CHECKSUMS:
   Mantle: f03b2b606c3f0cabd80214ad8a2fed6b464a7359
   Marshal: ef480864a6af10a63f67be7e55bb5d8fe67a16d9
   nanopb: 2901f78ea1b7b4015c860c2fdd1ea2fee1a18d48
-  RCTSFSafariViewController: 709bddbde953cd94f373827b02d36224a9ad8293
   React: a86b92f00edbe1873a63e4a212c29b7a7ad5224f
   react-native-camera: a4446f056fb28a9aa7acb3e14af595216aac0a8d
   react-native-document-picker: e3516aff0dcf65ee0785d9bcf190eb10e2261154
@@ -307,6 +301,6 @@ SPEC CHECKSUMS:
   TBBModal: 376820c480cac24b262c2e10c0178c67bb288390
   yoga: 03ff42a6f223fb88deeaed60249020d80c3091ee
 
-PODFILE CHECKSUM: 1318f20bc1a412ba1995045ac5502586e58906df
+PODFILE CHECKSUM: e75fc1e22eb9dbbaaf685b9a080183000f4d3dde
 
 COCOAPODS: 1.7.1

--- a/rn/Teacher/.flowconfig
+++ b/rn/Teacher/.flowconfig
@@ -24,7 +24,6 @@
 
 [untyped]
 .*/node_modules/react-native/Libraries/.*\(StyleSheetValidation\|Share\|List.*\|Easing\|Inspector\|InteractionManager\|ScrollResponder\|CameraRoll\)\.js
-.*/node_modules/react-native-sfsafariviewcontroller/.*
 .*/node_modules/react-native-keyboard-aware-scroll-view/.*
 .*/node_modules/react-native-image-picker/.*
 ./generate-release-notes.js

--- a/rn/Teacher/package.json
+++ b/rn/Teacher/package.json
@@ -62,7 +62,6 @@
     "react-native-on-layout": "^2.0.2",
     "react-native-progress": "^3.5.0",
     "react-native-search-bar": "^3.4.0",
-    "react-native-sfsafariviewcontroller": "skycocker/react-native-sfsafariviewcontroller",
     "react-native-sound": "^0.10.4",
     "react-native-status-bar-size": "^0.3.3",
     "react-native-test-utils": "^1.0.6",

--- a/rn/Teacher/src/__templates__/helm.js
+++ b/rn/Teacher/src/__templates__/helm.js
@@ -22,6 +22,7 @@ import template, { type Template } from '../utils/template'
 
 export const navigator: Template<any> = template({
   show: jest.fn(() => Promise.resolve()),
+  showWebView: jest.fn(() => Promise.resolve()),
   dismiss: jest.fn(() => Promise.resolve()),
   dismissAllModals: jest.fn(() => Promise.resolve()),
   traitCollection: jest.fn(),

--- a/rn/Teacher/src/common/components/CanvasWebView.js
+++ b/rn/Teacher/src/common/components/CanvasWebView.js
@@ -26,9 +26,7 @@ import {
   View,
   Image,
 } from 'react-native'
-import SFSafariViewController from 'react-native-sfsafariviewcontroller'
 import { getSession } from '../../canvas-api/session'
-import canvas from '../../canvas-api'
 
 import isEqual from 'lodash/isEqual'
 
@@ -82,15 +80,14 @@ export default class CanvasWebView extends Component<Props, State> {
     this.props.onFinishedLoading && this.props.onFinishedLoading()
   }
 
-  onNavigation = async (event: { nativeEvent: { url: string } }) => {
+  onNavigation = (event: { nativeEvent: { url: string } }) => {
     let url = event.nativeEvent.url
     if (this.props.onNavigation) {
       this.props.onNavigation(url)
       return
     }
     if (this.props.openLinksInSafari) {
-      let result = await canvas.getAuthenticatedSessionURL(url)
-      SFSafariViewController.open(result.data.session_url)
+      this.props.navigator.showWebView(url)
     } else {
       this.props.navigator.show(url, {
         deepLink: true,

--- a/rn/Teacher/src/common/components/__tests__/CanvasWebView.test.js
+++ b/rn/Teacher/src/common/components/__tests__/CanvasWebView.test.js
@@ -23,21 +23,11 @@ import { NativeModules } from 'react-native'
 import { shallow } from 'enzyme'
 import CanvasWebView, { type Props, heightCache } from '../CanvasWebView'
 import { setSession } from '../../../canvas-api/session'
-import SFSafariViewController from 'react-native-sfsafariviewcontroller'
-import canvas from '../../../canvas-api'
 
 const template = {
   ...require('../../../__templates__/helm'),
   ...require('../../../__templates__/session'),
 }
-
-jest
-  .mock('react-native-sfsafariviewcontroller', () => ({
-    open: jest.fn(),
-  }))
-  .mock('../../../canvas-api', () => ({
-    getAuthenticatedSessionURL: jest.fn(),
-  }))
 
 describe('CanvasWebView', () => {
   let props: Props
@@ -94,23 +84,13 @@ describe('CanvasWebView', () => {
     })
   })
 
-  it('handles navigation by opening in SFSafariViewController when openLinksInSafari is provided', async () => {
-    let authedURL = 'https://google.com'
-    let promise = Promise.resolve({
-      data: {
-        session_url: authedURL,
-      },
-    })
-    canvas.getAuthenticatedSessionURL.mockReturnValueOnce(promise)
-
+  it('handles navigation when openLinksInSafari is provided', async () => {
     const navigator = template.navigator({ show: jest.fn() })
     const tree = shallow(<CanvasWebView {...props} navigator={navigator} openLinksInSafari />)
     const webView = tree.find('WebView')
     const url = 'https://canvas.instructure.com/courses/1/assignments/1'
     webView.simulate('Navigation', { nativeEvent: { url } })
-    await promise
-
-    expect(SFSafariViewController.open).toHaveBeenCalledWith(authedURL)
+    expect(navigator.showWebView).toHaveBeenCalledWith(url)
   })
 
   it('handles navigation callback', () => {

--- a/rn/Teacher/src/common/components/rich-text-editor/__tests__/__snapshots__/RichTextEditor.test.js.snap
+++ b/rn/Teacher/src/common/components/rich-text-editor/__tests__/__snapshots__/RichTextEditor.test.js.snap
@@ -21,6 +21,7 @@ exports[`RichTextEditor can be keyboard aware 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -64,6 +65,7 @@ exports[`RichTextEditor hides toolbar when editor blurs 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -100,6 +102,7 @@ exports[`RichTextEditor hides toolbar when showToolbar is false 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -136,6 +139,7 @@ exports[`RichTextEditor renders 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -172,6 +176,7 @@ exports[`RichTextEditor renders toolbar when editor focused 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -221,6 +226,7 @@ exports[`RichTextEditor should update active editor items in toolbar 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -274,6 +280,7 @@ exports[`RichTextEditor should update active editor items in toolbar 2`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }

--- a/rn/Teacher/src/modules/announcements/edit/__tests__/__snapshots__/AnnouncementEdit.test.js.snap
+++ b/rn/Teacher/src/modules/announcements/edit/__tests__/__snapshots__/AnnouncementEdit.test.js.snap
@@ -298,6 +298,7 @@ exports[`AnnouncementEdit renders 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }
@@ -803,6 +804,7 @@ exports[`AnnouncementEdit updates with new props 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }

--- a/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetails.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetails.test.js.snap
@@ -829,6 +829,7 @@ exports[`renders 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -1621,6 +1622,7 @@ exports[`renders as a designer 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -2411,6 +2413,7 @@ exports[`renders loading 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -3205,6 +3208,7 @@ exports[`renders with no submission types 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -3995,6 +3999,7 @@ exports[`renders with not_graded submission type 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }

--- a/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetailsEdit.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetailsEdit.test.js.snap
@@ -830,6 +830,7 @@ exports[`error occurs when done pressed 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -1669,6 +1670,7 @@ exports[`modal saving is shown on assignment update 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -2508,6 +2510,7 @@ exports[`renders 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -3351,6 +3354,7 @@ exports[`saving invalid dates displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -4224,6 +4228,7 @@ exports[`saving invalid name displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -5097,6 +5102,7 @@ exports[`saving invalid points possible displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -5970,6 +5976,7 @@ exports[`saving negative points possible displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetailsStudent.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-details/__tests__/__snapshots__/AssignmentDetailsStudent.test.js.snap
@@ -131,6 +131,7 @@ exports[`renders a single file type 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -270,6 +271,7 @@ exports[`renders even if there is fake data 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -409,6 +411,7 @@ exports[`renders for a student 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -556,6 +559,7 @@ exports[`renders multiple file types 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -695,6 +699,7 @@ exports[`renders without a due date 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/attachments/__tests__/__snapshots__/Attachments.test.js.snap
+++ b/rn/Teacher/src/modules/attachments/__tests__/__snapshots__/Attachments.test.js.snap
@@ -125,6 +125,7 @@ exports[`Attachments renders attachments 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }
@@ -203,6 +204,7 @@ exports[`Attachments renders empty state 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }

--- a/rn/Teacher/src/modules/courses/__tests__/__snapshots__/CourseNavigation.test.js.snap
+++ b/rn/Teacher/src/modules/courses/__tests__/__snapshots__/CourseNavigation.test.js.snap
@@ -24,6 +24,7 @@ exports[`CourseNavigation refreshes courses and tabs 1`] = `
       "pop": [MockFunction],
       "replace": [MockFunction],
       "show": [MockFunction],
+      "showWebView": [MockFunction],
       "traitCollection": [MockFunction] {
         "calls": Array [
           Array [
@@ -147,6 +148,7 @@ exports[`CourseNavigation refreshes when props change 1`] = `
       "pop": [MockFunction],
       "replace": [MockFunction],
       "show": [MockFunction],
+      "showWebView": [MockFunction],
       "traitCollection": [MockFunction] {
         "calls": Array [
           Array [

--- a/rn/Teacher/src/modules/dashboard/__tests__/__snapshots__/GlobalAnnouncementRow.test.js.snap
+++ b/rn/Teacher/src/modules/dashboard/__tests__/__snapshots__/GlobalAnnouncementRow.test.js.snap
@@ -107,6 +107,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -230,6 +231,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -353,6 +355,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -476,6 +479,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -599,6 +603,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -722,6 +727,7 @@ Don’t forget your permission slips this Wednesday."
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/DiscussionDetails.test.js.snap
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/DiscussionDetails.test.js.snap
@@ -224,6 +224,7 @@ exports[`DiscussionDetails doesnt render the reply button when the permission is
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -1079,6 +1080,7 @@ exports[`DiscussionDetails doesnt render the reply button when the permission is
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -1564,6 +1566,7 @@ exports[`DiscussionDetails renders a non-assignment discussion 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -2464,6 +2467,7 @@ exports[`DiscussionDetails renders a non-assignment discussion 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -3110,6 +3114,7 @@ exports[`DiscussionDetails renders closed discussion as student 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -3432,6 +3437,7 @@ exports[`DiscussionDetails renders closed discussion as student 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -3830,6 +3836,7 @@ exports[`DiscussionDetails renders in student app 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -4220,6 +4227,7 @@ exports[`DiscussionDetails renders in student app 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -4861,6 +4869,7 @@ exports[`DiscussionDetails renders no replies 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -5752,6 +5761,7 @@ exports[`DiscussionDetails renders no replies 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -6088,6 +6098,7 @@ exports[`DiscussionDetails renders properly in rtl 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -7011,6 +7022,7 @@ exports[`DiscussionDetails renders properly in rtl 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -7740,6 +7752,7 @@ exports[`DiscussionDetails renders with nested replies selected 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -8735,6 +8748,7 @@ exports[`DiscussionDetails renders with nested replies selected 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }
@@ -9919,6 +9933,7 @@ exports[`DiscussionDetails renders with replies 1`] = `
                     "pop": [MockFunction],
                     "replace": [MockFunction],
                     "show": [MockFunction],
+                    "showWebView": [MockFunction],
                     "traitCollection": [MockFunction],
                   }
                 }
@@ -10842,6 +10857,7 @@ exports[`DiscussionDetails renders with replies 1`] = `
                         "pop": [MockFunction],
                         "replace": [MockFunction],
                         "show": [MockFunction],
+                        "showWebView": [MockFunction],
                         "traitCollection": [MockFunction],
                       }
                     }

--- a/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/EditReply.test.js.snap
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/EditReply.test.js.snap
@@ -147,6 +147,7 @@ exports[`EditReply dismisses modal activity upon save error 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }
@@ -306,6 +307,7 @@ exports[`EditReply renders 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }
@@ -465,6 +467,7 @@ exports[`EditReply renders title correctly when editing 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }

--- a/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/Reply.test.js.snap
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/__snapshots__/Reply.test.js.snap
@@ -126,6 +126,7 @@ exports[`DiscussionReplies renders 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -349,6 +350,7 @@ exports[`DiscussionReplies renders without the reply button when the user cant r
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/discussions/edit/__tests__/__snapshots__/DiscussionEdit.test.js.snap
+++ b/rn/Teacher/src/modules/discussions/edit/__tests__/__snapshots__/DiscussionEdit.test.js.snap
@@ -106,6 +106,7 @@ exports[`DiscussionEdit renders 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }
@@ -283,6 +284,7 @@ exports[`DiscussionEdit renders new form 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }
@@ -453,6 +455,7 @@ exports[`DiscussionEdit updates from props 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }
@@ -645,6 +648,7 @@ exports[`DiscussionEdit updates with new props 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }

--- a/rn/Teacher/src/modules/files/__tests__/__snapshots__/FilesList.test.js.snap
+++ b/rn/Teacher/src/modules/files/__tests__/__snapshots__/FilesList.test.js.snap
@@ -706,6 +706,7 @@ exports[`FilesList progress function should update the UI correctly 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -1567,6 +1568,7 @@ exports[`FilesList progress function should update the UI correctly 2`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -2428,6 +2430,7 @@ exports[`FilesList progress function should update the UI correctly 3`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -3289,6 +3292,7 @@ exports[`FilesList sending weird data into the progress update function should n
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -4157,6 +4161,7 @@ exports[`FilesList should render 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -4892,6 +4897,7 @@ exports[`FilesList should render for course files 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -5634,6 +5640,7 @@ exports[`FilesList should render for user files 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -6383,6 +6390,7 @@ exports[`FilesList should render with folders 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [
@@ -6482,6 +6490,7 @@ exports[`FilesList should render with no data at all 1`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction] {
             "calls": Array [
               Array [

--- a/rn/Teacher/src/modules/inbox/detail/__tests__/__snapshots__/ConversationDetails.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/detail/__tests__/__snapshots__/ConversationDetails.test.js.snap
@@ -418,6 +418,7 @@ exports[`ConversationDetails renders correctly with some messages 2`] = `
           "pop": [MockFunction],
           "replace": [MockFunction],
           "show": [MockFunction],
+          "showWebView": [MockFunction],
           "traitCollection": [MockFunction],
         }
       }

--- a/rn/Teacher/src/modules/pages/details/__tests__/__snapshots__/PageDetails.test.js.snap
+++ b/rn/Teacher/src/modules/pages/details/__tests__/__snapshots__/PageDetails.test.js.snap
@@ -30,6 +30,7 @@ exports[`PageDetails renders 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }
@@ -80,6 +81,7 @@ exports[`PageDetails renders while loading 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }

--- a/rn/Teacher/src/modules/pages/edit/__tests__/__snapshots__/PageEdit.test.js.snap
+++ b/rn/Teacher/src/modules/pages/edit/__tests__/__snapshots__/PageEdit.test.js.snap
@@ -78,6 +78,7 @@ exports[`PageEdit renders 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }
@@ -185,6 +186,7 @@ exports[`PageEdit renders when the student app 1`] = `
               "pop": [MockFunction],
               "replace": [MockFunction],
               "show": [MockFunction],
+              "showWebView": [MockFunction],
               "traitCollection": [MockFunction],
             }
           }

--- a/rn/Teacher/src/modules/quizzes/details/__tests__/__snapshots__/QuizDetails.test.js.snap
+++ b/rn/Teacher/src/modules/quizzes/details/__tests__/__snapshots__/QuizDetails.test.js.snap
@@ -740,6 +740,7 @@ exports[`QuizDetails displays "Lock Questions After Answering" 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -2043,6 +2044,7 @@ exports[`QuizDetails displays access code 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -3346,6 +3348,7 @@ exports[`QuizDetails does not render Show Correct Answers when hide_results is n
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -4545,6 +4548,7 @@ exports[`QuizDetails renders 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -5796,6 +5800,7 @@ exports[`QuizDetails renders One Question At A Time: 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -7099,6 +7104,7 @@ exports[`QuizDetails renders One Question At A Time: 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -8350,6 +8356,7 @@ exports[`QuizDetails renders Show Correct Answers dates 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -9601,6 +9608,7 @@ exports[`QuizDetails renders Show Correct Answers dates 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -10852,6 +10860,7 @@ exports[`QuizDetails renders Show Correct Answers dates 3`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -12103,6 +12112,7 @@ exports[`QuizDetails renders Show Correct Answers: After Last Attempt 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -13354,6 +13364,7 @@ exports[`QuizDetails renders Show Correct Answers: After Last Attempt 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -14553,6 +14564,7 @@ exports[`QuizDetails renders allowed attempts 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -15804,6 +15816,7 @@ exports[`QuizDetails renders allowed attempts 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -17089,6 +17102,7 @@ exports[`QuizDetails renders assignment due dates 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -18340,6 +18354,7 @@ exports[`QuizDetails renders assignment group 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -19643,6 +19658,7 @@ exports[`QuizDetails renders published state 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -20894,6 +20910,7 @@ exports[`QuizDetails renders published state 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -22145,6 +22162,7 @@ exports[`QuizDetails renders quiz type 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -23396,6 +23414,7 @@ exports[`QuizDetails renders quiz type 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -24647,6 +24666,7 @@ exports[`QuizDetails renders scoring policy 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -25898,6 +25918,7 @@ exports[`QuizDetails renders scoring policy 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -27149,6 +27170,7 @@ exports[`QuizDetails renders scoring policy 3`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -28400,6 +28422,7 @@ exports[`QuizDetails renders show correct answers 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -29651,6 +29674,7 @@ exports[`QuizDetails renders show correct answers 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -30902,6 +30926,7 @@ exports[`QuizDetails renders shuffle answers 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -32153,6 +32178,7 @@ exports[`QuizDetails renders shuffle answers 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -33404,6 +33430,7 @@ exports[`QuizDetails renders time limit 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -34655,6 +34682,7 @@ exports[`QuizDetails renders time limit 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -35906,6 +35934,7 @@ exports[`QuizDetails renders view responses 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -37157,6 +37186,7 @@ exports[`QuizDetails renders view responses 2`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -38356,6 +38386,7 @@ exports[`QuizDetails renders view responses 3`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }

--- a/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
+++ b/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
@@ -2011,6 +2011,7 @@ exports[`QuizEdit changes assignment group 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -4037,6 +4038,7 @@ exports[`QuizEdit changes quiz type 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -6298,6 +6300,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -8559,6 +8562,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -10601,6 +10605,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -12603,6 +12608,7 @@ exports[`QuizEdit renders 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -14642,6 +14648,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -16715,6 +16722,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -19125,6 +19133,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -21322,6 +21331,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -23336,6 +23346,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -25378,6 +25389,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -27404,6 +27416,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -29517,6 +29530,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -31629,6 +31643,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -33741,6 +33756,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -35743,6 +35759,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -37869,6 +37886,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -39871,6 +39889,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -42178,6 +42197,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -44478,6 +44498,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -46480,6 +46501,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -48592,6 +48614,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -50595,6 +50618,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -52597,6 +52621,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -54904,6 +54929,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -57204,6 +57230,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -59206,6 +59233,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -61208,6 +61236,7 @@ exports[`QuizEdit toggles publish 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -63209,6 +63238,7 @@ exports[`QuizEdit toggles publish 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -65212,6 +65242,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -67214,6 +67245,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -69342,6 +69374,7 @@ exports[`QuizEdit toggles time limit 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -71345,6 +71378,7 @@ exports[`QuizEdit toggles time limit 2`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -73652,6 +73686,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }
@@ -75959,6 +75994,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/rich-text-editor/__tests__/__snapshots__/RichTextEditor.test.js.snap
+++ b/rn/Teacher/src/modules/rich-text-editor/__tests__/__snapshots__/RichTextEditor.test.js.snap
@@ -25,6 +25,7 @@ exports[`RichTextEditor renders 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }

--- a/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/GradeTab.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/GradeTab.test.js.snap
@@ -105,6 +105,7 @@ exports[`Rubric renders a rubric 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -694,6 +695,7 @@ exports[`Rubric renders the comment input when openCommentKeyboard is called 1`]
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -1205,6 +1207,7 @@ exports[`Rubric renders the grade picker when there is no rubric 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }
@@ -1347,6 +1350,7 @@ exports[`Rubric shows the activity indicator when saving a rubric score 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               }
             }

--- a/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/RubricDescription.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/RubricDescription.test.js.snap
@@ -32,6 +32,7 @@ exports[`RubricDescription renders 1`] = `
             "pop": [MockFunction],
             "replace": [MockFunction],
             "show": [MockFunction],
+            "showWebView": [MockFunction],
             "traitCollection": [MockFunction],
           }
         }

--- a/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SpeedGrader.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SpeedGrader.test.js.snap
@@ -289,6 +289,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -357,6 +358,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -458,6 +460,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -528,6 +531,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -629,6 +633,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -699,6 +704,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -799,6 +805,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -895,6 +902,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1029,6 +1037,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -1116,6 +1125,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1242,6 +1252,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -1329,6 +1340,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1455,6 +1467,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -1523,6 +1536,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1622,6 +1636,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -1690,6 +1705,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1789,6 +1805,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                 "pop": [MockFunction],
                 "replace": [MockFunction],
                 "show": [MockFunction],
+                "showWebView": [MockFunction],
                 "traitCollection": [MockFunction],
               },
               "onDismiss": [Function],
@@ -1876,6 +1893,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
                       "pop": [MockFunction],
                       "replace": [MockFunction],
                       "show": [MockFunction],
+                      "showWebView": [MockFunction],
                       "traitCollection": [MockFunction],
                     }
                   }
@@ -1994,6 +2012,7 @@ exports[`SpeedGrader renders submissions if there are some 1`] = `
         "pop": [MockFunction],
         "replace": [MockFunction],
         "show": [MockFunction],
+        "showWebView": [MockFunction],
         "traitCollection": [MockFunction],
       }
     }

--- a/rn/Teacher/src/routing/Navigator.js
+++ b/rn/Teacher/src/routing/Navigator.js
@@ -19,7 +19,6 @@
 // @flow
 import { NativeModules, type PushNotificationIOS, Linking } from 'react-native'
 import { route } from './index'
-import SFSafariViewController from 'react-native-sfsafariviewcontroller'
 import { getAuthenticatedSessionURL } from '../canvas-api'
 import { recordRoute } from '../modules/developer-menu/DeveloperMenu'
 import { logEvent } from '@common/CanvasAnalytics'
@@ -77,9 +76,9 @@ export default class Navigator {
       logEvent('webview_content_selected', { url })
       try {
         let { data: { session_url: authenticatedURL } } = await getAuthenticatedSessionURL(url)
-        SFSafariViewController.open(authenticatedURL)
+        NativeModules.Helm.openInSafariViewController(authenticatedURL)
       } catch (err) {
-        SFSafariViewController.open(url)
+        NativeModules.Helm.openInSafariViewController(url)
       }
     } else {
       Linking.openURL(url)

--- a/rn/Teacher/src/routing/__tests__/Navigator.test.js
+++ b/rn/Teacher/src/routing/__tests__/Navigator.test.js
@@ -26,7 +26,6 @@ import {
 import { registerScreens } from '../register-screens'
 import Navigator from '../Navigator'
 import canvas from '../../canvas-api'
-import SFSafariViewController from 'react-native-sfsafariviewcontroller'
 
 jest.mock('../../canvas-api', () => ({
   getAuthenticatedSessionURL: jest.fn(),
@@ -43,10 +42,6 @@ jest.mock('../../canvas-api', () => ({
   }),
 }))
 
-jest.mock('react-native-sfsafariviewcontroller', () => ({
-  open: jest.fn(),
-}))
-
 jest.mock('Linking', () => ({ openURL: jest.fn() }))
 
 registerScreens({})
@@ -54,15 +49,6 @@ registerScreens({})
 describe('Navigator', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-
-    NativeModules.Helm = {
-      pushFrom: jest.fn(() => Promise.resolve()),
-      popFrom: jest.fn(() => Promise.resolve()),
-      present: jest.fn(() => Promise.resolve()),
-      dismiss: jest.fn(() => Promise.resolve()),
-      dismissAllModals: jest.fn(() => Promise.resolve()),
-      traitCollection: jest.fn(),
-    }
   })
 
   it('forwards show as a push', () => {
@@ -183,7 +169,7 @@ describe('Navigator', () => {
 
     await promise
 
-    expect(SFSafariViewController.open).toHaveBeenCalledWith('https://google.com')
+    expect(NativeModules.Helm.openInSafariViewController).toHaveBeenCalledWith('https://google.com')
   })
 
   it('linking should  be called if something is unsupported and it is not http or https', () => {
@@ -200,7 +186,7 @@ describe('Navigator', () => {
     new Navigator('push').show('https://google.com')
 
     await promise
-    expect(SFSafariViewController.open).toHaveBeenCalledWith('https://google.com')
+    expect(NativeModules.Helm.openInSafariViewController).toHaveBeenCalledWith('https://google.com')
   })
 
   it('opens a webview with the https url if we dont route some canvas protocol', async () => {
@@ -211,7 +197,7 @@ describe('Navigator', () => {
 
     expect(canvas.getAuthenticatedSessionURL).toHaveBeenCalledWith(httpsUrl)
     await promise
-    expect(SFSafariViewController.open).toHaveBeenCalledWith(httpsUrl + '?auth')
+    expect(NativeModules.Helm.openInSafariViewController).toHaveBeenCalledWith(httpsUrl + '?auth')
   })
 
   it('opens the original url if getting the authenticated session url errors', async () => {
@@ -222,7 +208,7 @@ describe('Navigator', () => {
     try {
       await promise
     } catch (err) {
-      expect(SFSafariViewController.open).toHaveBeenCalledWith('https://google.com')
+      expect(NativeModules.Helm.openInSafariViewController).toHaveBeenCalledWith('https://google.com')
     }
   })
 

--- a/rn/Teacher/test/scripts/jestSetup.js
+++ b/rn/Teacher/test/scripts/jestSetup.js
@@ -149,6 +149,7 @@ NativeModules.SettingsManager = {
 
 NativeModules.Helm = {
   setScreenConfig: jest.fn(),
+  openInSafariViewController: jest.fn(() => Promise.resolve()),
   pushFrom: jest.fn(() => Promise.resolve()),
   popFrom: jest.fn(() => Promise.resolve()),
   present: jest.fn(() => Promise.resolve()),

--- a/rn/Teacher/yarn.lock
+++ b/rn/Teacher/yarn.lock
@@ -6902,10 +6902,6 @@ react-native-search-bar@^3.4.0:
   dependencies:
     prop-types "^15.5.10"
 
-react-native-sfsafariviewcontroller@skycocker/react-native-sfsafariviewcontroller:
-  version "0.2.6"
-  resolved "https://codeload.github.com/skycocker/react-native-sfsafariviewcontroller/tar.gz/65b56448709b15999f7b0fec2d543cda6612eb48"
-
 react-native-sound@^0.10.4:
   version "0.10.12"
   resolved "https://registry.yarnpkg.com/react-native-sound/-/react-native-sound-0.10.12.tgz#f912d6f9d6e9e2b42b391e0226787628d940f01a"


### PR DESCRIPTION
This module doesn't declare it's methods need to run on the main thread and can cause crashes in our UI tests, luckily we aren't using it much and it was easy to swap out.

[ignore-commit-lint]