### PR TITLE
Fix updating keychain entry

### DIFF
--- a/Core/Core/AppEnvironment/Keychain.swift
+++ b/Core/Core/AppEnvironment/Keychain.swift
@@ -37,6 +37,9 @@ class Keychain {
             kSecAttrService: serviceName,
             kSecAttrAccount: key,
         ]
+        if accessGroup?.isEmpty == false {
+            query[kSecAttrAccessGroup] = accessGroup
+        }
         let exists = SecItemCopyMatching(query as CFDictionary, nil) == noErr
         var status: OSStatus?
         if exists {
@@ -44,9 +47,6 @@ class Keychain {
         } else {
             query[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlocked
             query[kSecValueData] = data
-            if accessGroup?.isEmpty == false {
-                query[kSecAttrAccessGroup] = accessGroup
-            }
             status = SecItemAdd(query as CFDictionary, nil)
         }
         assert(status == errSecSuccess)

--- a/Core/Core/AppEnvironment/Keychain.swift
+++ b/Core/Core/AppEnvironment/Keychain.swift
@@ -30,33 +30,27 @@ class Keychain {
 
     @discardableResult
     func setData(_ data: Data, for key: String) -> Bool {
+        // Only query with class, service, and account
+        // https://forums.developer.apple.com/message/259602#259602
         var query: [CFString: Any] = [
             kSecClass: kSecClassGenericPassword,
             kSecAttrService: serviceName,
             kSecAttrAccount: key,
-            kSecValueData: data,
-            kSecAttrAccessible: kSecAttrAccessibleWhenUnlocked,
         ]
-
-        if accessGroup?.isEmpty == false {
-            query[kSecAttrAccessGroup] = accessGroup
+        let exists = SecItemCopyMatching(query as CFDictionary, nil) == noErr
+        var status: OSStatus?
+        if exists {
+            status = SecItemUpdate(query as CFDictionary, [kSecValueData: data] as CFDictionary)
+        } else {
+            query[kSecAttrAccessible] = kSecAttrAccessibleWhenUnlocked
+            query[kSecValueData] = data
+            if accessGroup?.isEmpty == false {
+                query[kSecAttrAccessGroup] = accessGroup
+            }
+            status = SecItemAdd(query as CFDictionary, nil)
         }
-
-        //  try add
-        var status: OSStatus = SecItemAdd(query as CFDictionary, nil)
-
-        if status == errSecSuccess {
-            return true
-        }
-        // try to update
-        else if status == errSecDuplicateItem {
-            query[kSecValueData] = nil
-            let updateQuery: [CFString: Any] = [kSecValueData: data]
-            status = SecItemUpdate(query as CFDictionary, updateQuery as CFDictionary)
-            return status == errSecSuccess
-        }
-
-        return false
+        assert(status == errSecSuccess)
+        return status == errSecSuccess
     }
 
     @discardableResult


### PR DESCRIPTION
[ignore-commit-lint]

I noticed that my login sessions were not persisting. Turns out I was getting `errSecItemNotFound` from `SecItemAdd` and then `errSecDuplicateItem` from `SecItemUpdate`, identitical to [this SO post](https://stackoverflow.com/questions/22403734/keychain-item-reported-as-errsecitemnotfound-but-receive-errsecduplicateitem-o).

Turns out that we should only query on `kSecClass`, `kSecAttrService` and `kSecAttrAccount` because additional fields (like `kAttrAccessible`) will _"exclude any existing item with the same unique key, but with different attributes."_

The new approach is taken from [this post](https://forums.developer.apple.com/message/259602#259602) from an Apple developer.