### PR TITLE
Remove force unwraps

### DIFF
--- a/Student/Canvas/Calendar/UI/View/CalendarView.swift
+++ b/Student/Canvas/Calendar/UI/View/CalendarView.swift
@@ -433,8 +433,7 @@ open class CalendarView: UIView, UICollectionViewDelegate, UICollectionViewDataS
     }
     
     @objc func frameForItemAtIndexPath(_ indexPath: IndexPath) -> CGRect {
-        let attrs = collectionView!.layoutAttributesForItem(at: indexPath)!
-        return attrs.frame
+        return collectionView?.layoutAttributesForItem(at: indexPath)?.frame ?? .zero
     }
     
     // ---------------------------------------------


### PR DESCRIPTION
[ignore-commit-lint]

We're getting crash logs on this line. I haven't able to repro but I'm
guessing it's the force unwraps. I doubt `layoutAttributesForItem(at:)`
crashes since it has an optional return value.