### PR TITLE
Fix relative header image (default) in dashboard

### DIFF
--- a/Core/Core/AppEnvironment/Brand.swift
+++ b/Core/Core/AppEnvironment/Brand.swift
@@ -72,7 +72,7 @@ public struct Brand: Equatable {
         self.primary = primary ?? .named(.electric)
     }
 
-    public init(response: APIBrandVariables) {
+    public init(response: APIBrandVariables, baseURL: URL) {
         self.init(
             buttonPrimaryBackground: UIColor(hexString: response.button_primary_bgd),
             buttonPrimaryText: UIColor(hexString: response.button_primary_text),
@@ -80,7 +80,7 @@ public struct Brand: Equatable {
             buttonSecondaryText: UIColor(hexString: response.button_secondary_text),
             fontColorDark: UIColor(hexString: response.font_color_dark),
             headerImageBackground: UIColor(hexString: response.header_image_bgd),
-            headerImageUrl: response.header_image,
+            headerImageUrl: response.header_image.flatMap { URL(string: $0.absoluteString, relativeTo: baseURL) },
             linkColor: UIColor(hexString: response.link_color),
             navBackground: UIColor(hexString: response.nav_bgd),
             navBadgeBackground: UIColor(hexString: response.nav_badge_bgd),

--- a/Core/Core/Use Cases/GetBrandVariables.swift
+++ b/Core/Core/Use Cases/GetBrandVariables.swift
@@ -26,7 +26,7 @@ public class GetBrandVariables: APIUseCase {
     public init() {}
 
     public func write(response: APIBrandVariables?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
-        guard let response = response else { return }
-        Brand.shared = Brand(response: response)
+        guard let response = response, let url = urlResponse?.url else { return }
+        Brand.shared = Brand(response: response, baseURL: url)
     }
 }

--- a/Core/CoreTests/Extensions/UITabBarExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UITabBarExtensionsTests.swift
@@ -34,7 +34,7 @@ class UITabBarExtensionsTests: XCTestCase {
         let shiny = Brand(response: APIBrandVariables.make(
             nav_bgd: "#ffffff",
             nav_text_color: "#333"
-        ))
+        ), baseURL: URL(string: "https://canvas.instructure.com")!)
         tabBar.useGlobalNavStyle(brand: shiny)
         XCTAssertEqual(tabBar.tintColor, shiny.navTextColor)
     }

--- a/Core/CoreTests/Use Cases/GetBrandVariablesTests.swift
+++ b/Core/CoreTests/Use Cases/GetBrandVariablesTests.swift
@@ -23,12 +23,13 @@ import TestsFoundation
 
 class GetBrandVariablesTest: CoreTestCase {
     func testItUpdatesBrandVariables() {
+        let response = HTTPURLResponse(url: URL(string: "https://canvas.instructure.com/brand_variables")!, statusCode: 200, httpVersion: nil, headerFields: nil)
         let prev = Brand.shared
-        GetBrandVariables().write(response: nil, urlResponse: nil, to: databaseClient)
+        GetBrandVariables().write(response: nil, urlResponse: response, to: databaseClient)
         XCTAssertEqual(Brand.shared, prev)
 
         let brand = APIBrandVariables.make(primary: "#ffff00")
-        GetBrandVariables().write(response: brand, urlResponse: nil, to: databaseClient)
+        GetBrandVariables().write(response: brand, urlResponse: response, to: databaseClient)
         XCTAssertEqual(Brand.shared.primary.hexString, "#ffff00")
     }
 }


### PR DESCRIPTION
Most institutions likely have an absolute url to their school's logo, so this may be something only dev ever saw.

[ignore-commit-lint]