### PR TITLE
Update "safari" user agent to just match os version

### DIFF
--- a/CanvasCore/CanvasCore/WhizzyWig/CanvasWebView.swift
+++ b/CanvasCore/CanvasCore/WhizzyWig/CanvasWebView.swift
@@ -146,11 +146,9 @@ public class CanvasWebView: WKWebView {
     }
     
     @objc public init(config: WKWebViewConfiguration) {
-        // Make the user agent look like Safari as best we can to work around Google OAuth restrictions.
-        // Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.3 Mobile/15E217 Safari/605.1
-        config.applicationNameForUserAgent = "Version/\(UIDevice.current.systemVersion) Mobile/15E217 Safari/605.1"
         config.processPool = CoreWebView.processPool
         super.init(frame: .zero, configuration: config)
+        customUserAgent = UserAgent.safari.description
         translatesAutoresizingMaskIntoConstraints = false
         navigationDelegate = self
         uiDelegate = self

--- a/Core/Core/Constants/UserAgent.swift
+++ b/Core/Core/Constants/UserAgent.swift
@@ -42,8 +42,9 @@ public enum UserAgent: CustomStringConvertible {
             let bundleVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") ?? ""
             return "\(product)/\(shortVersion) (\(bundleVersion)) \(UIDevice.current.model)/\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)"
         case .safari:
-            let systemVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
-            return "Mozilla/5.0 (iPhone; CPU iPhone OS \(systemVersion) like Mac OS X) AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1"
+            let version = UIDevice.current.systemVersion
+            let os = version.replacingOccurrences(of: ".", with: "_")
+            return "Mozilla/5.0 (iPhone; CPU iPhone OS \(os) like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(version) Mobile/15E148 Safari/604.1"
         }
     }
 }

--- a/Core/CoreTests/Constants/UserAgentTests.swift
+++ b/Core/CoreTests/Constants/UserAgentTests.swift
@@ -30,8 +30,9 @@ class UserAgentTests: XCTestCase {
 
     func testDescription() {
         XCTAssertEqual(UserAgent.default.description, "iCanvas/1.0 (1) \(UIDevice.current.model)/\(UIDevice.current.systemName) \(UIDevice.current.systemVersion)")
-        let systemVersion = UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")
-        XCTAssertEqual(UserAgent.safari.description, "Mozilla/5.0 (iPhone; CPU iPhone OS \(systemVersion) like Mac OS X)"
-            + " AppleWebKit/603.1.23 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1")
+        let version = UIDevice.current.systemVersion
+        let os = version.replacingOccurrences(of: ".", with: "_")
+        XCTAssertEqual(UserAgent.safari.description, "Mozilla/5.0 (iPhone; CPU iPhone OS \(os) like Mac OS X)"
+            + " AppleWebKit/605.1.15 (KHTML, like Gecko) Version/\(version) Mobile/15E148 Safari/604.1")
     }
 }


### PR DESCRIPTION
It was essentially what CanvasWebView had been doing anyway. Instead of a hardcoded known user agent, generate one in which the Version matches the os version, since at least the major version has in iOS for a while now.

refs: MBL-13097
affects: Student
release note: Fixed outdated browser message on quiz results