### PR TITLE
Show proper wording for graded unsubmitted assignments and quizzes

### DIFF
--- a/Core/Core/Models/Viewable/SubmissionViewable.swift
+++ b/Core/Core/Models/Viewable/SubmissionViewable.swift
@@ -40,7 +40,7 @@ extension SubmissionViewable {
     }
 
     public var isSubmitted: Bool {
-        return submission != nil && submission?.workflowState != .unsubmitted
+        return submission != nil && submission?.submittedAt != nil
     }
 
     public var submissionStatusIsHidden: Bool {

--- a/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
+++ b/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
@@ -55,8 +55,8 @@ class SubmissionViewableTests: XCTestCase {
 
     func testIsSubmitted() {
         XCTAssertFalse(Model(submission: nil).isSubmitted)
-        XCTAssertFalse(Model(submission: Submission.make(from: .make(workflow_state: .unsubmitted))).isSubmitted)
-        XCTAssertTrue(Model(submission: Submission.make(from: .make(workflow_state: .submitted))).isSubmitted)
+        XCTAssertFalse(Model(submission: Submission.make(from: .make(submitted_at: nil))).isSubmitted)
+        XCTAssertTrue(Model(submission: Submission.make(from: .make(submitted_at: Date()))).isSubmitted)
     }
 
     func testStatusIsHidden() {
@@ -67,19 +67,18 @@ class SubmissionViewableTests: XCTestCase {
 
     func testStatusColor() {
         XCTAssertEqual(Model(submission: nil).submissionStatusColor, UIColor.named(.ash))
-        XCTAssertEqual(Model(submission: Submission.make(from: .make(workflow_state: .submitted))).submissionStatusColor, UIColor.named(.shamrock))
+        XCTAssertEqual(Model(submission: Submission.make(from: .make(submitted_at: Date()))).submissionStatusColor, UIColor.named(.shamrock))
     }
 
     func testStatusIcon() {
         XCTAssertEqual(Model(submission: nil).submissionStatusIcon, UIImage.icon(.no, .solid))
-        XCTAssertEqual(Model(submission: Submission.make(from: .make(workflow_state: .submitted))).submissionStatusIcon, UIImage.icon(.complete, .solid))
+        XCTAssertEqual(Model(submission: Submission.make(from: .make(submitted_at: Date()))).submissionStatusIcon, UIImage.icon(.complete, .solid))
     }
 
     func testStatusText() {
         XCTAssertEqual(Model(submission: nil).submissionStatusText, "Not Submitted")
-        XCTAssertEqual(Model(submission: Submission.make(from: .make(submitted_at: nil, workflow_state: .submitted))).submissionStatusText, "Submitted")
         let submittedAt = DateComponents(calendar: Calendar.current, year: 2018, month: 10, day: 1).date!
-        XCTAssertEqual(Model(submission: Submission.make(from: .make(submitted_at: submittedAt, workflow_state: .submitted))).submissionStatusText, "Submitted Oct 1, 2018 at 12:00 AM")
+        XCTAssertEqual(Model(submission: Submission.make(from: .make(submitted_at: submittedAt))).submissionStatusText, "Submitted Oct 1, 2018 at 12:00 AM")
     }
 
     func testHasLatePenalty() {

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -72,7 +72,7 @@ class SubmissionButtonPresenter: NSObject {
         }
         if quiz?.submission?.attemptsLeft == 0 { return nil }
         if assignment.quizID != nil {
-            return assignment.submission?.workflowState == .unsubmitted
+            return assignment.submission?.submittedAt == nil
                 ? NSLocalizedString("Take Quiz", bundle: .student, comment: "")
                 : NSLocalizedString("Retake Quiz", bundle: .student, comment: "")
         }

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -113,8 +113,9 @@ class SubmissionButtonPresenterTests: PersistenceTestCase {
         quiz.submission = QuizSubmission.make(from: .make(attempts_left: 0))
         XCTAssertNil(presenter.buttonText(course: c, assignment: a, quiz: quiz, onlineUpload: nil))
         quiz.submission = nil
+        a.submission?.submittedAt = Date()
         XCTAssertEqual(presenter.buttonText(course: c, assignment: a, quiz: quiz, onlineUpload: nil), "Retake Quiz")
-        a.submission?.workflowState = .unsubmitted
+        a.submission?.submittedAt = nil
         XCTAssertEqual(presenter.buttonText(course: c, assignment: a, quiz: quiz, onlineUpload: nil), "Take Quiz")
 
         a.submissionTypes = [ .online_upload ]


### PR DESCRIPTION
refs: MBL-13139
affects: Student
release note: Fixed an issue where unsubmitted assignments and quizzes that were graded were saying they were submitted