### PR TITLE
exclude TabBar.swift files from code coverage

### DIFF
--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -6,6 +6,7 @@
     "Transitioning.\\w+$",
     "View.\\w+$",
     "Window.\\w+$",
+    "TabBar.\\w+$",
     "\\/Views\\/",
     "CanvasCore\/",
     "CanvasKit1\/",


### PR DESCRIPTION
refs: none
affects: none
release note: none