### PR TITLE
Use separate keychain for login session in tests

### DIFF
--- a/Core/Core/Login/LoginSession.swift
+++ b/Core/Core/Login/LoginSession.swift
@@ -117,7 +117,7 @@ public struct LoginSession: Codable, Hashable {
     // MARK: Persistence into keychain
 
     private static let key = "CanvasUsers"
-    private static let keychain = Keychain(serviceName: "com.instructure.shared-credentials", accessGroup: Bundle.main.appGroupID())
+    static var keychain = Keychain(serviceName: "com.instructure.shared-credentials", accessGroup: Bundle.main.appGroupID())
 
     public static var sessions: Set<LoginSession> {
         get { return keychain.getJSON(for: key) ?? [] }

--- a/Core/Core/UITestHelpers/UITestHelpers.swift
+++ b/Core/Core/UITestHelpers/UITestHelpers.swift
@@ -41,13 +41,13 @@ public class UITestHelpers {
     let decoder = JSONDecoder()
     let encoder = JSONEncoder()
     let pasteboardType = "com.instructure.ui-test-helper"
-    let sessionBackup = LoginSession.sessions
     let window: ActAsUserWindow?
 
     init(_ appDelegate: UIApplicationDelegate) {
         self.appDelegate = appDelegate
         self.window = appDelegate.window as? ActAsUserWindow
 
+        LoginSession.keychain = Keychain(serviceName: "com.instructure.shared-credentials.tests")
         CacheManager.clear()
         UserDefaults.standard.set(true, forKey: "IS_UI_TEST")
         ExperimentalFeature.allEnabled = true
@@ -135,7 +135,6 @@ public class UITestHelpers {
     func tearDown() {
         resetNavigationStack()
         LoginSession.clearAll()
-        LoginSession.sessions = sessionBackup
     }
 }
 

--- a/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
@@ -29,16 +29,11 @@ class CacheManagerTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
-        backupEntries = LoginSession.sessions
         backupManifest = try? Data(contentsOf: rnManifestURL)
     }
 
     override func tearDown() {
         super.tearDown()
-        LoginSession.clearAll()
-        for entry in backupEntries {
-            LoginSession.add(entry)
-        }
         try? backupManifest?.write(to: rnManifestURL, options: .atomic)
     }
 

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -34,7 +34,6 @@ class CoreTestCase: XCTestCase {
     var logger = TestLogger()
     var environment: AppEnvironment!
     var currentSession = LoginSession.make()
-    let entriesBackup = LoginSession.sessions
 
     let notificationCenter = MockUserNotificationCenter()
     var notificationManager: NotificationManager!
@@ -46,6 +45,7 @@ class CoreTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        LoginSession.useTestKeychain()
         api = MockAPI()
         router = TestRouter()
         logger = TestLogger()
@@ -65,7 +65,8 @@ class CoreTestCase: XCTestCase {
     }
 
     override func tearDown() {
-        LoginSession.sessions = entriesBackup
+        super.tearDown()
+        LoginSession.clearAll()
     }
 
     func waitForMainAsync() {

--- a/Core/CoreTests/Login/LoginSessionTests.swift
+++ b/Core/CoreTests/Login/LoginSessionTests.swift
@@ -20,11 +20,6 @@ import XCTest
 @testable import Core
 
 class LoginSessionTests: CoreTestCase {
-    override func setUp() {
-        super.setUp()
-        LoginSession.clearAll()
-    }
-
     func testAddEntry() {
         let entry = LoginSession.make()
         LoginSession.add(entry)

--- a/Core/CoreUITests/CoreUITestCase.swift
+++ b/Core/CoreUITests/CoreUITestCase.swift
@@ -49,6 +49,7 @@ open class CoreUITestCase: XCTestCase {
 
     open override func setUp() {
         super.setUp()
+        LoginSession.useTestKeychain()
         continueAfterFailure = false
         if CoreUITestCase.firstRun || app.state != .runningForeground {
             CoreUITestCase.firstRun = false
@@ -66,6 +67,7 @@ open class CoreUITestCase: XCTestCase {
 
     open override func tearDown() {
         super.tearDown()
+        LoginSession.clearAll()
         send(.tearDown)
     }
 

--- a/Student/StudentUnitTests/PersistenceTestCase.swift
+++ b/Student/StudentUnitTests/PersistenceTestCase.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import Core
+@testable import Core
 import TestsFoundation
 import CoreData
 @testable import Student
@@ -40,6 +40,7 @@ class PersistenceTestCase: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        LoginSession.useTestKeychain()
         queue = OperationQueue()
         router = TestRouter()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
@@ -53,5 +54,10 @@ class PersistenceTestCase: XCTestCase {
         MockURLSession.reset()
         UploadManager.shared = uploadManager
         MockUploadManager.reset()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        LoginSession.clearAll()
     }
 }

--- a/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
@@ -49,12 +49,14 @@ class SubmitAssignmentPresenterTests: SubmitAssignmentTests, SubmitAssignmentVie
     var presenter: SubmitAssignmentPresenter!
 
     override func setUp() {
-        LoginSession.clearAll()
+        super.setUp()
         LoginSession.add(.make())
-        env.userDefaults?.reset()
         presenter = SubmitAssignmentPresenter()
         presenter.view = self
-        super.setUp()
+        // SubmitAssignmentPresenter calls env.userDidLogin, so need to reset after
+        env.api = api
+        env.database = database
+        env.userDefaults?.reset()
     }
 
     func testInitNilWithoutRecentSession() {

--- a/Student/SubmitAssignmentTests/SubmitAssignmentTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentTests.swift
@@ -16,30 +16,31 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import Core
+@testable import Core
 import TestsFoundation
 import XCTest
 import CoreData
 
 class SubmitAssignmentTests: XCTestCase {
     let env = AppEnvironment.shared
+    let api = URLSessionAPI(accessToken: nil, actAsUserID: nil, baseURL: nil, urlSession: MockURLSession())
     var database: NSPersistentContainer {
         return TestsFoundation.singleSharedTestDatabase
     }
     let uploadManager = MockUploadManager()
-    let sessionsBackup = LoginSession.sessions
 
     override func setUp() {
         super.setUp()
-
+        LoginSession.useTestKeychain()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
         MockURLSession.reset()
         UploadManager.shared = uploadManager
+        env.api = api
         env.database = database
-        env.api = URLSessionAPI(accessToken: nil, actAsUserID: nil, baseURL: nil, urlSession: MockURLSession())
     }
 
     override func tearDown() {
-        LoginSession.sessions = sessionsBackup
+        super.tearDown()
+        LoginSession.clearAll()
     }
 }

--- a/TestsFoundation/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import Core
+@testable import Core
 
 extension LoginSession {
     public static func make(
@@ -43,5 +43,10 @@ extension LoginSession {
             userID: userID,
             userName: userName
         )
+    }
+
+    public static func useTestKeychain() {
+        keychain = Keychain(serviceName: "com.instructure.shared-credentials.tests")
+        clearAll()
     }
 }

--- a/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
+++ b/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import Core
+@testable import Core
 import TestsFoundation
 import CoreData
 
@@ -38,6 +38,7 @@ class TeacherTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
 
+        LoginSession.useTestKeychain()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
         environment.api = api
         environment.database = singleSharedTestDatabase
@@ -45,5 +46,10 @@ class TeacherTestCase: XCTestCase {
         environment.router = router
         environment.logger = logger
         environment.currentSession = LoginSession.make()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        LoginSession.clearAll()
     }
 }


### PR DESCRIPTION
This should prevent tests from messing with the keychain used by the apps.

[ignore-commit-lint]