### PR TITLE
Use a different background session for share

### DIFF
--- a/Core/Core/Use Cases/UploadManager.swift
+++ b/Core/Core/Use Cases/UploadManager.swift
@@ -30,8 +30,9 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
     public static let AssignmentSubmittedNotification = NSNotification.Name(rawValue: "com.instructure.core.assignment-submitted")
     public typealias Store = Core.Store<LocalUseCase<File>>
 
-    public static var shared = UploadManager()
+    public static var shared = UploadManager(identifier: "com.instructure.core.file-uploads")
 
+    public let identifier: String
     var notificationManager: NotificationManager = .shared
     var process: ProcessManager = ProcessInfo.processInfo
     private var validSession: URLSession?
@@ -60,9 +61,14 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
         return decoder
     }()
 
+    public init(identifier: String) {
+        self.identifier = identifier
+        super.init()
+    }
+
     @discardableResult
     public func createSession() -> URLSession {
-        let configuration = URLSessionConfiguration.background(withIdentifier: "com.instructure.core.file-uploads")
+        let configuration = URLSessionConfiguration.background(withIdentifier: identifier)
         configuration.sharedContainerIdentifier = Bundle.main.appGroupID()
         return URLSessionAPI.delegateURLSession(configuration, self, nil)
     }

--- a/Core/CoreTests/Use Cases/UploadManagerTests.swift
+++ b/Core/CoreTests/Use Cases/UploadManagerTests.swift
@@ -31,7 +31,7 @@ class UploadManagerTests: CoreTestCase {
 
     let uploadContext: FileUploadContext = .course("1")
     let backgroundSession = MockURLSession()
-    let manager = UploadManager()
+    let manager = UploadManager(identifier: "upload-manager-tests")
     var context: NSManagedObjectContext {
         return NSPersistentContainer.shared.viewContext
     }

--- a/Student/Student/CanvasAppDelegate.swift
+++ b/Student/Student/CanvasAppDelegate.swift
@@ -138,7 +138,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
 
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
         Logger.shared.log()
-        let manager = UploadManager.shared
+        let manager = UploadManager(identifier: identifier)
         manager.completionHandler = {
             DispatchQueue.main.async {
                 completionHandler()

--- a/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
@@ -53,6 +53,7 @@ class SubmitAssignmentPresenterTests: SubmitAssignmentTests, SubmitAssignmentVie
         LoginSession.add(.make())
         presenter = SubmitAssignmentPresenter()
         presenter.view = self
+        presenter.uploadManager = uploadManager
         // SubmitAssignmentPresenter calls env.userDidLogin, so need to reset after
         env.api = api
         env.database = database

--- a/TestsFoundation/TestsFoundation/Files/MockUploadManager.swift
+++ b/TestsFoundation/TestsFoundation/Files/MockUploadManager.swift
@@ -28,7 +28,9 @@ public class MockUploadManager: UploadManager {
     public var addWasCalled = false
     public var cancelWasCalled = false
 
-   public override init() {}
+   public init() {
+        super.init(identifier: "mock")
+    }
 
     open override func upload(environment: AppEnvironment = .shared, batch batchID: String, to uploadContext: FileUploadContext, callback: (() -> Void)? = nil) {
         uploadWasCalled = true


### PR DESCRIPTION
[ignore-commit-lint]

I'm getting an error uploading from the share extension using the Test Flight build. Based on the logs and error message, I'm guessing that it has to do with the app and the share extension using the same identifier.

I was going off of [this post](https://forums.developer.apple.com/message/225659#225659) by an Apple Staff member:

> The app and the share extension must use the same NSURLSession background session identifier

However, the [official docs](https://developer.apple.com/library/archive/documentation/General/Conceptual/ExtensibilityPG/ExtensionScenarios.html) say this:

> Because only one process can use a background session at a time, you need to create a different background session for the containing app and each of its app extensions. 

I wasn't sure which one to trust so I went with 1 since it seemed to work. But something is wrong so I'll try this (and the docs seem like a safer bet anyway).

