### PR TITLE
code gen for new API entities to fit in our new arch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ scripts/coverage/**/
 scripts/coverage/*.xcresult
 scripts/translations/source
 scripts/translations/imports
+scripts/apiModelCodegen/output
 
 # Secrets
 **/*.xcassets/Secrets/*.dataset

--- a/scripts/apiModelCodegen/Cartfile
+++ b/scripts/apiModelCodegen/Cartfile
@@ -1,0 +1,1 @@
+github "groue/GRMustache.swift" == 4.0.1

--- a/scripts/apiModelCodegen/Cartfile.resolved
+++ b/scripts/apiModelCodegen/Cartfile.resolved
@@ -1,0 +1,1 @@
+github "groue/GRMustache.swift" "4.0.1"

--- a/scripts/apiModelCodegen/CodeGen.swift
+++ b/scripts/apiModelCodegen/CodeGen.swift
@@ -1,0 +1,85 @@
+#!/usr/bin/swift -F Carthage/Build/Mac/
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Mustache
+
+struct Input: Codable {
+    let entity: String
+    let properties: [[String: String]]
+
+    func toDictionary() -> [String: Any] {
+        return ["entity": entity, "properties": properties]
+    }
+}
+
+enum TemplateType: String {
+    case APIModel, APIModelFixture, GetApiRequestable, GetApiRequestableTests, GetUseCase, GetUseCaseTests
+
+    var fullpath: String {
+        return "templates/\(self.rawValue).mustache"
+    }
+
+    func filename(_ params: Input) -> String {
+        switch self {
+        case .APIModel: return "API\(params.entity)"
+        case .APIModelFixture: return "API\(params.entity)Fixture"
+        case .GetApiRequestable: return "Get\(params.entity)Requestable"
+        case .GetApiRequestableTests: return "Get\(params.entity)RequestableTests"
+        case .GetUseCase: return "Get\(params.entity)UseCase"
+        case .GetUseCaseTests: return "Get\(params.entity)UseCaseTests"
+        }
+    }
+}
+
+func writeTemplateToFile(_ templateType: TemplateType, params: Input) {
+    do {
+        let mustacheTemplate = try Template(path: templateType.fullpath)
+        let output = try mustacheTemplate.render(params.toDictionary())
+        let outputDir = "./output"
+        var url = URL(fileURLWithPath: outputDir, isDirectory: true)
+
+        url.appendPathComponent("\(templateType.filename(params)).swift")
+        try output.write(to: url, atomically: true, encoding: .utf8)
+    }
+    catch let error as MustacheError {
+        print("[mustache error]: \(error)")
+    }
+    catch {
+        print("[error]: \(error)")
+    }
+}
+
+do {
+    let inputFile = URL(fileURLWithPath: "./input.json", isDirectory: false)
+    let data = try Data(contentsOf: inputFile)
+    let decoder = JSONDecoder()
+    let input: Input = try decoder.decode(Input.self, from: data)
+
+    writeTemplateToFile(.APIModel, params: input)
+    writeTemplateToFile(.APIModelFixture, params: input)
+    writeTemplateToFile(.GetApiRequestable, params: input)
+    writeTemplateToFile(.GetApiRequestableTests, params: input)
+    writeTemplateToFile(.GetUseCase, params: input)
+    writeTemplateToFile(.GetUseCaseTests, params: input)
+}
+catch {
+    print("[I/O error]: \(error)")
+    exit(EXIT_FAILURE);
+}

--- a/scripts/apiModelCodegen/input.json
+++ b/scripts/apiModelCodegen/input.json
@@ -1,0 +1,21 @@
+{
+    "entity": "AlertThreshold",
+    "properties": [
+        {
+            "name": "id",
+            "type": "String"
+        },
+        {
+            "name": "user_id",
+            "type": "String"
+        },
+        {
+            "name": "studentID",
+            "type": "String"
+        },
+        {
+            "name": "threshold",
+            "type": "String?"
+        }
+    ]
+}

--- a/scripts/apiModelCodegen/setup.sh
+++ b/scripts/apiModelCodegen/setup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# This file is part of Canvas.
+# Copyright (C) 2019-present  Instructure, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+# fail if any commands fails
+set -e
+
+mkdir -p output
+carthage bootstrap --platform mac

--- a/scripts/apiModelCodegen/templates/APIModel.mustache
+++ b/scripts/apiModelCodegen/templates/APIModel.mustache
@@ -1,0 +1,25 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2018-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public struct API{{entity}}: Codable, Equatable {
+  {{# properties }}
+    let {{ name }}: {{type}}
+  {{/ properties }}
+}

--- a/scripts/apiModelCodegen/templates/APIModelFixture.mustache
+++ b/scripts/apiModelCodegen/templates/APIModelFixture.mustache
@@ -1,0 +1,16 @@
+import Foundation
+@testable import Core
+
+extension API{{entity}} {
+    public static func make(
+    {{# properties }}
+    	{{ name }}: {{type}} = "<{{name}}>",
+    {{/ properties }}        
+    ) -> API{{entity}} {
+        return API{{entity}}(
+	    {{# properties }}
+			{{name}}: {{name}},  
+	    {{/ properties }}        
+        )
+    }
+}

--- a/scripts/apiModelCodegen/templates/GetApiRequestable.mustache
+++ b/scripts/apiModelCodegen/templates/GetApiRequestable.mustache
@@ -1,0 +1,33 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2018-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+
+public struct Get{{entity}}Request: APIRequestable {
+    public typealias Response = API{{entity}}
+	
+	public var path: String {
+		return "/custom_path"
+	}
+	
+	public var query: [APIQueryItem] {
+        return [
+            .value("per_page", "99"),
+        ]
+    }
+}

--- a/scripts/apiModelCodegen/templates/GetApiRequestableTests.mustache
+++ b/scripts/apiModelCodegen/templates/GetApiRequestableTests.mustache
@@ -1,0 +1,43 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2018-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+class Get{{entity}}RequestTests: XCTestCase {
+    var req: Get{{entity}}Request!
+
+    override func setUp() {
+        super.setUp()
+        req = Get{{entity}}Request()
+    }
+
+    func testPath() {
+        XCTAssertEqual(req.path, "/custom_path_here")
+    }
+
+	func testQuery() {
+		let expected: [APIQueryItem] = [.value("per_page", "100")]
+		XCTAssertEqual(req.query, expected)
+	}
+
+	func testModel() {
+		let model = API{{entity}}.make()
+		XCTAssertNotNil(model)
+	}
+}

--- a/scripts/apiModelCodegen/templates/GetUseCase.mustache
+++ b/scripts/apiModelCodegen/templates/GetUseCase.mustache
@@ -1,0 +1,46 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2018-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import CoreData
+
+public class Get{{entity}}: APIUseCase {
+    public typealias Model = {{entity}}
+
+    public let someID: String
+
+    public init(someID: String) {
+        self.someID = someID
+    }
+
+    public var cacheKey: String? {
+        return "get-{{entity}}-\(someID)"
+    }
+
+    public var scope: Scope {
+        return .where(#keyPath({{entity}}.id), equals: someID)
+    }
+
+    public var request: Get{{entity}}Request {
+        return Get{{entity}}Request(someID: someID)
+    }
+	
+    public func write(response: {{entity}}?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        assertionFailure("implement me")
+    }
+}

--- a/scripts/apiModelCodegen/templates/GetUseCaseTests.mustache
+++ b/scripts/apiModelCodegen/templates/GetUseCaseTests.mustache
@@ -1,0 +1,23 @@
+class Get{{entity}}UseCaseTests: XCTestCase {
+
+    var useCase: Get{{entity}}!
+    let studentID: String = "1"
+
+    override func setUp() {
+        super.setUp()
+        useCase = Get{{entity}}(studentID: studentID)
+    }
+
+    func testCacheKey() {
+        XCTAssertEqual(useCase.cacheKey, "get-{{entity}}-\(studentID)")
+
+    }
+
+    func testScope() {
+        XCTAssertEqual(useCase.scope, Scope.where(#keyPath({{entity}}.id), equals: studentID))
+    }
+
+    func testRequest() {
+        XCTAssertEqual(useCase.request.studentID, studentID)
+    }
+}


### PR DESCRIPTION
refs: none
affects: none
release note: none

Not sure if anyone is interested in this.  I've made new entities for our API so many times that hopefully this will speed up that process.   this will generate the API model, fixture, Requestables, use case and unit tests.

1. Run the `./setup` script which configures dependencies.  
2. You define the entity name and the properties to your API model in `input.json`.  
3. Then run `./GenCode.swift` from the command line. 
   The code is generated in an `output` folder and you can add them to the project.  It isn't perfect but it's a faster start than writing it again from scratch or copying files.
4. Add files to project
5. Edit the files as you see fit.
6. sit back and relax

![goldblum](https://user-images.githubusercontent.com/928783/64578771-a5d24f00-d33d-11e9-81bf-93d984c3f5ee.gif)

