### PR TITLE
Fix parent dashboard reverting to default student

### DIFF
--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -176,6 +176,7 @@ class DashboardViewController: UIViewController {
     }
 
     @objc func setup() throws {
+        guard studentCollection == nil else { return }
         viewState.isSiteAdmin = session.isSiteAdmin
         studentCollection = try Student.observedStudentsCollection(session)
         studentCountObserver = try Student.countOfObservedStudentsObserver(session) { [weak self] count in


### PR DESCRIPTION
Don't redo setup every time the view appears, since that goes to the first student courses

refs: MBL-13176
affects: Parent
release note: Fixed an issue that auto navigated to default student courses