### PR TITLE
Do not show attachments for deleted replies

### DIFF
--- a/rn/Teacher/src/modules/discussions/details/Reply.js
+++ b/rn/Teacher/src/modules/discussions/details/Reply.js
@@ -185,7 +185,7 @@ export default class Reply extends Component<Props, State> {
                 heightCacheKey={reply.id}
               />
             }
-            {reply.attachment &&
+            {!reply.deleted && reply.attachment &&
               <TouchableOpacity testID={`discussion-reply.${reply.id}.attachment`} onPress={this.showAttachment}>
                 <View style={style.attachment}>
                   <Image source={Images.paperclip} style={style.attachmentIcon} />

--- a/rn/Teacher/src/modules/discussions/details/__tests__/Reply.test.js
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/Reply.test.js
@@ -76,6 +76,13 @@ describe('DiscussionReplies', () => {
     expect(webview.props().html.includes('Deleted this reply.')).toEqual(true)
   })
 
+  it('does not show attachments when deleted', () => {
+    props.reply.deleted = true
+    props.reply.attachment = {}
+    let tree = shallow(<Reply {...props} />)
+    expect(tree.find(`[testID="discussion-reply.${props.reply.id}.attachment"]`).length).toEqual(0)
+  })
+
   it('renders with no user', () => {
     props.reply.user_id = ''
     props.reply.editor_id = ''


### PR DESCRIPTION
refs: MBL-13175
affects: teacher, student
release note: Fixed to not show attachments for deleted discussion replies