### PR TITLE
Fix showing detail views on iPad

### DIFF
--- a/Core/Core/Pages/PageList/PageListPresenter.swift
+++ b/Core/Core/Pages/PageList/PageListPresenter.swift
@@ -84,7 +84,7 @@ class PageListPresenter: PageViewLoggerPresenterProtocol {
     }
 
     func select(_ page: Page, from view: UIViewController) {
-        env.router.route(to: page.htmlURL, from: view, options: nil)
+        env.router.route(to: page.htmlURL, from: view, options: [.detail, .embedInNav])
     }
 
     func newPage(from view: UIViewController) {

--- a/Core/Core/Pages/PageList/PageListViewController.swift
+++ b/Core/Core/Pages/PageList/PageListViewController.swift
@@ -57,7 +57,7 @@ public class PageListViewController: UIViewController, PageListViewProtocol {
 
         if !isLoading && !isEmpty && !selectedFirstPage {
             selectedFirstPage = true
-            if appTraitCollection?.horizontalSizeClass == .regular {
+            if appTraitCollection?.horizontalSizeClass == .regular && !isInSplitViewDetail {
                 if let frontPage = presenter?.frontPage.first {
                     presenter?.select(frontPage, from: self)
                 } else if let page = presenter?.pages.first {

--- a/Core/CoreTests/Pages/PageList/PageListPresenterTests.swift
+++ b/Core/CoreTests/Pages/PageList/PageListPresenterTests.swift
@@ -102,6 +102,7 @@ class PageListPresenterTests: CoreTestCase {
         let router = environment.router as? TestRouter
         XCTAssertNoThrow(coursePresenter.select(page, from: UIViewController()))
         XCTAssertEqual(router?.calls.last?.0, URLComponents.parse(page.htmlURL))
+        XCTAssertEqual(router?.calls.last?.2, [.detail, .embedInNav])
     }
 
     func testPageViewEventName() {

--- a/Student/Canvas/Notifications/ActivityStreamTableViewController.swift
+++ b/Student/Canvas/Notifications/ActivityStreamTableViewController.swift
@@ -70,10 +70,7 @@ private func colorfulActivity(session: Session) -> ((Activity) -> ColorfulViewMo
 }
 
 class ActivityStreamTableViewController: FetchedTableViewController<Activity> {
-    @objc let route: (UIViewController, URL)->()
-
-    init(session: Session, context: ContextID = .currentUser, route: @escaping (UIViewController, URL)->()) throws {
-        self.route = route
+    init(session: Session, context: ContextID = .currentUser) throws {
         super.init()
 
         tableView.rowHeight = UITableView.automaticDimension
@@ -89,6 +86,6 @@ class ActivityStreamTableViewController: FetchedTableViewController<Activity> {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         Analytics.shared.logEvent("notification_selected")
         let activity = collection[indexPath]
-        route(self, activity.url)
+        router.route(to: activity.url, from: self, options: [.detail, .embedInNav])
     }
 }

--- a/Student/Canvas/Notifications/NotificationsTab.swift
+++ b/Student/Canvas/Notifications/NotificationsTab.swift
@@ -24,9 +24,7 @@ import Core
 
 func NotificationsTab(session: Session) throws -> UIViewController {
     let title = NSLocalizedString("Notifications", comment: "Notifications tab title")
-    let activityStream = try ActivityStreamTableViewController(session: session, route: { viewController, url in
-        AppEnvironment.shared.router.route(to: url, from: viewController)
-    })
+    let activityStream = try ActivityStreamTableViewController(session: session)
     activityStream.title = title
     
     let split = SplitViewController()

--- a/Student/Canvas/To Do/ToDoListViewController.swift
+++ b/Student/Canvas/To Do/ToDoListViewController.swift
@@ -85,11 +85,9 @@ func colorfulToDoViewModel(session: Session, toDoItem: Todo) -> ColorfulViewMode
 class ToDoListViewController: FetchedTableViewController<Todo>, PageViewEventViewControllerLoggingProtocol {
 
     @objc let session: Session
-    @objc let route: (UIViewController, URL)->()
 
-    @objc init(session: Session, route: @escaping (UIViewController, URL)->()) throws {
+    @objc init(session: Session) throws {
         self.session = session
-        self.route = route
         super.init()
 
         tableView.rowHeight = UITableView.automaticDimension
@@ -132,7 +130,7 @@ class ToDoListViewController: FetchedTableViewController<Todo>, PageViewEventVie
         let todo = collection[indexPath]
         Analytics.shared.logEvent("todo_selected")
         if let url = URL(string: todo.routingURL) {
-            route(self, url)
+            router.route(to: url, from: self, options: [.detail, .embedInNav])
         }
     }
 }

--- a/Student/Canvas/To Do/ToDoTab.swift
+++ b/Student/Canvas/To Do/ToDoTab.swift
@@ -21,9 +21,9 @@ import TechDebt
 import CanvasCore
 import Core
 
-public func ToDoTabViewController(session: Session, route: @escaping (UIViewController, URL)->()) throws -> UIViewController {
+public func ToDoTabViewController(session: Session) throws -> UIViewController {
         
-    let list = try ToDoListViewController(session: session, route: route)
+    let list = try ToDoListViewController(session: session)
 
     let split = SplitViewController()
     split.preferredDisplayMode = .allVisible

--- a/Student/Student/People/PeopleListPresenter.swift
+++ b/Student/Student/People/PeopleListPresenter.swift
@@ -64,6 +64,6 @@ class PeopleListPresenter {
     }
 
     func select(recipient: SearchRecipient, from: UIViewController) {
-        env.router.route(to: "/\(context.pathComponent)/users/\(recipient.id)", from: from)
+        env.router.route(to: "/\(context.pathComponent)/users/\(recipient.id)", from: from, options: [.detail, .embedInNav])
     }
 }

--- a/Student/Student/Quizzes/QuizList/QuizListPresenter.swift
+++ b/Student/Student/Quizzes/QuizList/QuizListPresenter.swift
@@ -98,6 +98,6 @@ class QuizListPresenter: PageViewLoggerPresenterProtocol {
     }
 
     func select(_ quiz: Quiz, from view: UIViewController) {
-        env.router.route(to: quiz.htmlURL, from: view, options: nil)
+        env.router.route(to: quiz.htmlURL, from: view, options: [.detail, .embedInNav])
     }
 }

--- a/Student/Student/RootViewController.swift
+++ b/Student/Student/RootViewController.swift
@@ -33,9 +33,7 @@ func rootViewController(_ session: Session) -> UIViewController {
             UINavigationController(rootViewController: CalendarTabViewController(session: session) { vc, url in
                 AppEnvironment.shared.router.route(to: url, from: vc)
             }),
-            try ToDoTabViewController(session: session) { vc, url in
-                AppEnvironment.shared.router.route(to: url, from: vc)
-            },
+            try ToDoTabViewController(session: session),
             try NotificationsTab(session: session),
             inboxTab(),
         ]

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -60,7 +60,7 @@ let routeMap: [String: RouteHandler.ViewFactory?] = [
     "/:context/:contextID/activity_stream": { url, _ in
         guard let context = ContextID(path: url.path) else { return nil }
         guard let session = Session.current else { return nil }
-        return try? ActivityStreamTableViewController(session: session, context: context, route: route)
+        return try? ActivityStreamTableViewController(session: session, context: context)
     },
 
     "/:context/:contextID/announcements": nil,

--- a/Student/StudentUnitTests/People/PeopleListPresenterTests.swift
+++ b/Student/StudentUnitTests/People/PeopleListPresenterTests.swift
@@ -84,6 +84,7 @@ class PeopleListPresenterTests: PersistenceTestCase {
 
         let router = env.router as? TestRouter
         XCTAssertEqual(router?.calls.last?.0, .parse("/courses/1/users/1"))
+        XCTAssertEqual(router?.calls.last?.2, [.detail, .embedInNav])
     }
 }
 

--- a/Student/StudentUnitTests/Quizzes/QuizList/QuizListPresenterTests.swift
+++ b/Student/StudentUnitTests/Quizzes/QuizList/QuizListPresenterTests.swift
@@ -112,6 +112,7 @@ class QuizListPresenterTests: PersistenceTestCase {
         let router = env.router as? TestRouter
         XCTAssertNoThrow(presenter.select(quiz, from: UIViewController()))
         XCTAssertEqual(router?.calls.last?.0, URLComponents.parse(quiz.htmlURL))
+        XCTAssertEqual(router?.calls.last?.2, [.detail, .embedInNav])
     }
 }
 


### PR DESCRIPTION
refs: MBL-13274
affects: student
release note: none

Test plan:
- Course and group people lists > user context card
- Notifications Tab > tap notification
- To Do tab > tap to do item
- Quizzes list > tap quiz item
- Pages list > tap page

You can use my normal student user. It has a To Do item and some notifications and all the rest.