### PR TITLE
remove no dark mode from plist for parent and teacher

### DIFF
--- a/Parent/Parent/Info.plist
+++ b/Parent/Parent/Info.plist
@@ -83,7 +83,5 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
-    <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
 </dict>
 </plist>

--- a/rn/Teacher/ios/Teacher/Info.plist
+++ b/rn/Teacher/ios/Teacher/Info.plist
@@ -101,7 +101,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-    <key>UIUserInterfaceStyle</key>
-    <string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
refs: none
affects: Parent
release note: none