### PR TITLE
Fix loading calendar events from syllabus

### DIFF
--- a/CanvasCore/CanvasCore/Session/Session.swift
+++ b/CanvasCore/CanvasCore/Session/Session.swift
@@ -30,7 +30,7 @@ open class Session: NSObject {
         case Default, AppGroup
     }
 
-    public let env: AppEnvironment
+    public private(set) var env: AppEnvironment
     public var api: API {
         return env.api
     }
@@ -39,8 +39,14 @@ open class Session: NSObject {
     public let URLSession: Foundation.URLSession
     public let localStoreDirectory: LocalStoreDirectory
 
+    private static var _current: Session?
     @objc public static var current: Session? {
-        return Session(environment: .shared)
+        if let current = _current {
+            current.env = AppEnvironment.shared
+            return current
+        }
+        _current = Session(environment: .shared)
+        return _current
     }
 
     private init?(environment: AppEnvironment = .shared) {

--- a/Student/Canvas/Calendar/UI/View Controller/CalendarEventDetailViewController.swift
+++ b/Student/Canvas/Calendar/UI/View Controller/CalendarEventDetailViewController.swift
@@ -135,7 +135,7 @@ class CalendarEventDetailViewController: UIViewController {
         locationAddressLabel.text = event?.locationAddress
         
         if let description = event?.htmlDescription {
-            details.load(html: description, title: event?.title, baseURL: nil) { [weak self] url in
+            details.load(html: description, title: nil, baseURL: nil) { [weak self] url in
                 guard let me = self else { return }
                 me.route(me, url)
             }
@@ -148,7 +148,7 @@ class CalendarEventDetailViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        refresher.refresh(false)
+        refresher.refresh(true)
     }
     
     override func viewDidLoad() {


### PR DESCRIPTION
refs: MBL-13301
affects: student
release note: none

I forgot that we store things on Session that need to stay alive so
we shouldn't be creating a new one each time we access `.shared`. This
makes it so that a Session is re-used but the AppEnvironment is always
up to date.

Test plan:
* View a calendar event from syllabus (you can use my student account)
* View a calendar event from calendar
* View other screens that rely on Session (Modules, Notifications, To Do) and make sure they load correctly