### PR TITLE
Fix attaching from My Files

### DIFF
--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -138,10 +138,7 @@ let routeMap: [String: RouteHandler.ViewFactory?] = [
     "/files/folder/:folderID": { _, params in
         return fileListController(params: params)
     },
-    "/:context/:contextID/files": { url, params in
-        if let preview = previewFileViewController(url: url, params: params) { return preview }
-        return fileListController(params: params)
-    },
+    "/:context/:contextID/files": nil,
 
     "/files/folder/*subFolder": { url, params in
         if let preview = previewFileViewController(url: url, params: params) { return preview }
@@ -150,15 +147,8 @@ let routeMap: [String: RouteHandler.ViewFactory?] = [
         props["contextID"] = "self"
         return HelmViewController(moduleName: "/:context/:contextID/files/folder/*subFolder", props: makeProps(url, params: props))
     },
-    "/:context/:contextID/files/folder/*subFolder": { url, params in
-        if let preview = previewFileViewController(url: url, params: params) { return preview }
-        return HelmViewController(moduleName: "/:context/:contextID/files/folder/*subFolder", props: makeProps(url, params: params))
-    },
-
-    "/:context/:contextID/files/folders/:folderID": { _, params in
-        // We don't support routing to a specific folderID yet, that's to come later
-        return fileListController(params: params)
-    },
+    "/:context/:contextID/files/folder/*subFolder": nil,
+    "/:context/:contextID/files/folders/*subFolder": nil,
 
     "/files/:fileID": fileViewController,
     "/files/:fileID/download": fileViewController,


### PR DESCRIPTION
The native route handler lost the function props passed by the attachment picker. When there are props passed to an RN route from an RN screen, it has to be handled all in Helm to get the props passed through.

refs: MBL-13309
affects: Student
release note: Fixed an issue with attaching a file from My Files