### PR TITLE
Fix infinite loop

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -210,7 +210,7 @@ open class HelmManager: NSObject {
                 let sideBySideViews = splitViewController.viewControllers.count > 1
                 let viewCanExpandCollapse = !canBecomeMaster && sideBySideViews
                 if (viewCanExpandCollapse) {
-                    viewController.navigationItem.leftBarButtonItem = splitViewController.prettyDisplayModeButtonItem
+                    viewController.navigationItem.leftBarButtonItem = splitViewController.prettyDisplayModeButtonItem(splitViewController.displayMode)
                     viewController.navigationItem.leftItemsSupplementBackButton = true
                 }
                 

--- a/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
@@ -91,19 +91,21 @@ extension NavigationSubtitleView {
 }
 
 extension HelmSplitViewController: UISplitViewControllerDelegate {
+    public func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
+        if svc.viewControllers.count == 2 {
+            let top = (svc.viewControllers.last as? UINavigationController)?.topViewController
+            top?.navigationItem.leftItemsSupplementBackButton = true
+            if top?.isKind(of: EmptyViewController.self) == false {
+                top?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem(displayMode)
+            }
+        }
+    }
+
     open func targetDisplayModeForAction(in svc: UISplitViewController) -> UISplitViewController.DisplayMode {
         if svc.displayMode == .primaryOverlay || svc.displayMode == .primaryHidden {
-            if let nav = svc.viewControllers.last as? UINavigationController {
-                nav.topViewController?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem
-                nav.topViewController?.navigationItem.leftItemsSupplementBackButton = true
-            }
-            return .allVisible;
+            return .allVisible
         } else {
-            if let nav = svc.viewControllers.last as? UINavigationController, let top = nav.topViewController, !top.isKind(of: EmptyViewController.self) {
-                nav.topViewController?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem
-                nav.topViewController?.navigationItem.leftItemsSupplementBackButton = true
-            }
-            return .primaryHidden;
+            return .primaryHidden
         }
     }
 

--- a/CanvasCore/CanvasCore/Views/SplitViewController.swift
+++ b/CanvasCore/CanvasCore/Views/SplitViewController.swift
@@ -51,17 +51,13 @@ open class SplitViewController: UISplitViewController {
 }
 
 extension SplitViewController: UISplitViewControllerDelegate {
-    public func targetDisplayModeForAction(in svc: UISplitViewController) -> UISplitViewController.DisplayMode {
-        if svc.displayMode == .primaryOverlay || svc.displayMode == .primaryHidden {
-            if let nav = svc.viewControllers.last as? UINavigationController {
-                nav.topViewController?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem
+    public func splitViewController(_ svc: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
+        if svc.viewControllers.count == 2 {
+            let top = (svc.viewControllers.last as? UINavigationController)?.topViewController
+            top?.navigationItem.leftItemsSupplementBackButton = true
+            if top?.isKind(of: EmptyViewController.self) == false {
+                top?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem(displayMode)
             }
-            return .allVisible;
-        } else {
-            if let nav = svc.viewControllers.last as? UINavigationController {
-                nav.topViewController?.navigationItem.leftBarButtonItem = prettyDisplayModeButtonItem
-            }
-            return .primaryHidden;
         }
     }
 
@@ -72,7 +68,7 @@ extension SplitViewController: UISplitViewControllerDelegate {
 }
 
 extension UISplitViewController {
-    @objc open var prettyDisplayModeButtonItem: UIBarButtonItem {
+    @objc open func prettyDisplayModeButtonItem(_ displayMode: DisplayMode) -> UIBarButtonItem {
         let defaultButton = self.displayModeButtonItem
         let collapse = displayMode == .primaryOverlay || displayMode == .primaryHidden
         let icon: UIImage = collapse ? .icon(.collapse) : .icon(.expand)


### PR DESCRIPTION
refs: MBL-13347
affects: student
release note: Fixed a bug that would cause the app to crash

**Test plan:**
* Please pull this down and tap around on iPad and iPhone and make sure we always show the correct left nav bar items
* Play around with side-by-side on iPad
* Make sure you can always go back from a screen and/or expand it on iPad if the split view changes

I gave it a pretty good run-through but another pair of eyes would be great.