### PR TITLE
Enforce title color in iOS 13

### DIFF
--- a/Core/Core/Extensions/UINavigationBarExtensions.swift
+++ b/Core/Core/Extensions/UINavigationBarExtensions.swift
@@ -22,6 +22,7 @@ extension UINavigationBar {
     public func useContextColor(_ color: UIColor?) {
         let foreground = UIColor.named(.textLightest)
         let background = color?.ensureContrast(against: foreground)
+        titleTextAttributes = [.foregroundColor: foreground]
         tintColor = foreground
         barTintColor = background
         barStyle = .black
@@ -31,6 +32,7 @@ extension UINavigationBar {
     public func useGlobalNavStyle(brand: Brand = Brand.shared) {
         let background = brand.navBackground
         let foreground = brand.navTextColor.ensureContrast(against: background)
+        titleTextAttributes = [.foregroundColor: foreground]
         tintColor = foreground
         barTintColor = background
         barStyle = background.luminance < 0.5 ? .black : .default
@@ -38,7 +40,9 @@ extension UINavigationBar {
     }
 
     public func useModalStyle(brand: Brand = Brand.shared) {
-        tintColor = brand.linkColor.ensureContrast(against: .named(.backgroundLightest))
+        let foreground = brand.linkColor.ensureContrast(against: .named(.backgroundLightest))
+        titleTextAttributes = [.foregroundColor: foreground]
+        tintColor = foreground
         barTintColor = .named(.backgroundLightest)
         barStyle = .default
         isTranslucent = true

--- a/Core/CoreTests/Extensions/UINavigationBarExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UINavigationBarExtensionsTests.swift
@@ -24,6 +24,7 @@ class UINavigationBarExtensionsTests: XCTestCase {
     func testUseContextColor() {
         let bar = UINavigationBar(frame: .zero)
         bar.useContextColor(.named(.backgroundDarkest))
+        XCTAssertEqual(bar.titleTextAttributes?[.foregroundColor] as? UIColor, .named(.textLightest))
         XCTAssertEqual(bar.tintColor, .named(.textLightest))
         XCTAssertEqual(bar.barTintColor, .named(.backgroundDarkest))
         XCTAssertEqual(bar.barStyle, .black)
@@ -33,6 +34,7 @@ class UINavigationBarExtensionsTests: XCTestCase {
     func testUseGlobalNavStyle() {
         let bar = UINavigationBar(frame: .zero)
         bar.useGlobalNavStyle()
+        XCTAssertEqual(bar.titleTextAttributes?[.foregroundColor] as? UIColor, Brand.shared.navTextColor)
         XCTAssertEqual(bar.tintColor, Brand.shared.navTextColor)
         XCTAssertEqual(bar.barTintColor, Brand.shared.navBackground)
         XCTAssertEqual(bar.barStyle, .black)
@@ -63,6 +65,7 @@ class UINavigationBarExtensionsTests: XCTestCase {
     func testUseModalStyle() {
         let bar = UINavigationBar(frame: .zero)
         bar.useModalStyle()
+        XCTAssertEqual(bar.titleTextAttributes?[.foregroundColor] as? UIColor, Brand.shared.linkColor)
         XCTAssertEqual(bar.tintColor, Brand.shared.linkColor)
         XCTAssertEqual(bar.barTintColor, .named(.backgroundLightest))
         XCTAssertEqual(bar.barStyle, .default)


### PR DESCRIPTION
refs: MBL-13293
affects: Student
release note: Fixed calendar title contrast in iOS 13