### PR TITLE
Fix selecting mastery path

### DIFF
--- a/Student/Canvas/Modules/Mastery Paths/MasteryPathSelectOptionViewController.swift
+++ b/Student/Canvas/Modules/Mastery Paths/MasteryPathSelectOptionViewController.swift
@@ -101,15 +101,13 @@ class MasteryPathSelectOptionViewController: UIViewController {
         navigationItem.title = NSLocalizedString("Select Option", comment: "")
 
         let toolbar = UIToolbar()
-        toolbar.barTintColor = Brand.current.navBgColor
-        toolbar.tintColor = Brand.current.navButtonColor
         let item = UIBarButtonItem(customView: optionSegmentedControl)
         toolbar.setItems([UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil), item, UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)], animated: false)
         toolbar.delegate = self
         view.addSubview(toolbar)
 
         toolbar.translatesAutoresizingMaskIntoConstraints = false
-        toolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
+        toolbar.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
         toolbar.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
         toolbar.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
 
@@ -142,7 +140,7 @@ class MasteryPathSelectOptionViewController: UIViewController {
             selectOptionButton.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
             selectOptionButton.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
             selectOptionButton.heightAnchor.constraint(equalToConstant: 50.0).isActive = true
-            selectOptionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+            selectOptionButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
 
             selectOptionActivityIndicator.hidesWhenStopped = true
             view.insertSubview(selectOptionActivityIndicator, aboveSubview: selectOptionButton)
@@ -150,7 +148,7 @@ class MasteryPathSelectOptionViewController: UIViewController {
             selectOptionActivityIndicator.centerXAnchor.constraint(equalTo: selectOptionButton.centerXAnchor).isActive = true
             selectOptionActivityIndicator.centerYAnchor.constraint(equalTo: selectOptionButton.centerYAnchor).isActive = true
         } else {
-            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+            tableView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         }
     }
 
@@ -174,15 +172,15 @@ class MasteryPathSelectOptionViewController: UIViewController {
         selectOptionActivityIndicator.startAnimating()
         do {
             try itemWithMasteryPaths.selectMasteryPath(session: session, assignmentSetID: assignmentSet.id).startWithResult { [weak self] result in
-                self?.selectOptionActivityIndicator.stopAnimating()
-                switch result {
-                case .success:
-                    DispatchQueue.main.async {
-                        self?.navigationController?.popViewController(animated: true)
+                DispatchQueue.main.async {
+                    self?.selectOptionActivityIndicator.stopAnimating()
+                    switch result {
+                    case .success:
+                        self?.dismiss(animated: true, completion: nil)
+                    case .failure(let error):
+                        self?.selectOptionButton.setTitle(String(format: NSLocalizedString("Select Option %d", comment: "Button title to select a certain assignment set option"), (self?.optionSegmentedControl.selectedSegmentIndex ?? 0)+1), for: .normal)
+                        ErrorReporter.reportError(error, from: self)
                     }
-                case .failure(let error):
-                    self?.selectOptionButton.setTitle(String(format: NSLocalizedString("Select Option %d", comment: "Button title to select a certain assignment set option"), (self?.optionSegmentedControl.selectedSegmentIndex ?? 0)+1), for: .normal)
-                    ErrorReporter.reportError(error, from: self)
                 }
             }
         } catch let error as NSError {

--- a/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
+++ b/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
@@ -70,10 +70,6 @@ class ModuleItemViewModel: NSObject {
                         return nil
                     }
                     return LTIViewController(toolName: "", courseID: courseID, launchURL: url, in: self.session, fallbackURL: htmlURL.flatMap(URL.init))
-                case .masteryPaths:
-                    if let moduleItemID = moduleItemID, let moduleID = moduleID {
-                        return try! MasteryPathSelectOptionViewController(session: self.session, moduleID: moduleID, itemIDWithMasteryPaths: moduleItemID)
-                    }
                 default: break
                 }
             }

--- a/Student/Canvas/Modules/ModuleDetailsViewController.swift
+++ b/Student/Canvas/Modules/ModuleDetailsViewController.swift
@@ -92,6 +92,11 @@ class ModuleDetailsViewController: CanvasCore.TableViewController, PageViewEvent
             guard let content = moduleItem.content, content != .subHeader else { return }
             let analyticsParams = ["contentType": moduleItem.contentType.rawValue]
             Analytics.shared.logEvent("module_item_content_selected", parameters: analyticsParams)
+            if content == .masteryPaths, let item = moduleItem as? MasteryPathsItem {
+                showMasteryPathOptions(for: item)
+                tableView.deselectRow(at: indexPath, animated: true)
+                return
+            }
             router.route(to: Route.moduleItem(forCourse: courseID, moduleID: moduleItem.moduleID, itemID: moduleItem.id), from: self, options: [.detail, .embedInNav])
         default:
             return
@@ -100,5 +105,17 @@ class ModuleDetailsViewController: CanvasCore.TableViewController, PageViewEvent
 
     @objc func requirementCompleted() {
         refresher?.refresh(true)
+    }
+
+    func showMasteryPathOptions(for item: MasteryPathsItem) {
+        do {
+            let selection = try MasteryPathSelectOptionViewController(session: session, moduleID: item.moduleID, itemIDWithMasteryPaths: item.moduleItemID)
+            let nav = UINavigationController(rootViewController: selection)
+            selection.addCancelButton()
+            nav.modalPresentationStyle = .formSheet
+            present(nav, animated: true, completion: nil)
+        } catch let error as NSError {
+            handleError(error)
+        }
     }
 }


### PR DESCRIPTION
refs: MBL-13287
affects: student
release note: Fixed a crash when selecting a mastery path

Test plan:
- Log in as `student10` on `narmstrong`
- Dashboard > CS 1400 > Modules > Mastery Paths > Choose option
- App should not crash
- Should have option to dismiss with Cancel button
- Selection view should be in a formsheet on iPad
- Selecting an option should dismiss the modal and make the selection available