### PR TITLE
fixed fix of PageListPresenterTests

### DIFF
--- a/Core/CoreTests/Pages/PageList/PageListPresenterTests.swift
+++ b/Core/CoreTests/Pages/PageList/PageListPresenterTests.swift
@@ -109,7 +109,9 @@ class PageListPresenterTests: CoreTestCase {
 extension PageListPresenterTests: PageListViewProtocol {
 
     func update(isLoading: Bool) {
-        update.fulfill()
+        if (updateExpectationPredicate()) {
+            update.fulfill()
+        }
     }
 
     func showError(_ error: Error) {


### PR DESCRIPTION
Somehow missed this in the last PR, and the tests just magically succeeded anyway.

[ignore-commit-lint]