### PR TITLE
Fix page view events background task management

### DIFF
--- a/Core/Core/PageViewAnalytics/AppBackgroundHelperProtocol.swift
+++ b/Core/Core/PageViewAnalytics/AppBackgroundHelperProtocol.swift
@@ -20,5 +20,5 @@ import Foundation
 
 public protocol AppBackgroundHelperProtocol {
     func startBackgroundTask(taskName: String)
-    func endBackgroundTask()
+    func endBackgroundTask(taskName: String)
 }

--- a/Core/CoreTests/PageViewAnalytics/PageViewEventRequestManagerTests.swift
+++ b/Core/CoreTests/PageViewAnalytics/PageViewEventRequestManagerTests.swift
@@ -27,6 +27,7 @@ class PageViewEventRequestManagerTests: CoreTestCase {
     var expectation = XCTestExpectation(description: "expectation")
     var writeWait1 = XCTestExpectation(description: "expectation")
     var requestManager: PageViewEventRequestManager!
+    let backgroundHelper = TestAppBackgroundHelper()
 
     override func setUp() {
         super.setUp()
@@ -40,6 +41,7 @@ class PageViewEventRequestManagerTests: CoreTestCase {
         Clock.mockNow(date)
 
         requestManager = PageViewEventRequestManager(persistence: p, env: environment)
+        requestManager.backgroundAppHelper = backgroundHelper
     }
 
     override func tearDown() {
@@ -83,6 +85,8 @@ class PageViewEventRequestManagerTests: CoreTestCase {
         wait(for: [expectation], timeout: 5)
 
         XCTAssertEqual(p.queueCount, 0)
+        XCTAssertEqual(["start", "end"], backgroundHelper.tasks["fetch pandata token"])
+        XCTAssertEqual(["start", "end"], backgroundHelper.tasks["send pageview events"])
     }
 
     func testCleanup() {

--- a/Core/CoreTests/PageViewAnalytics/PageViewEventViewControllerLoggingProtocolTests.swift
+++ b/Core/CoreTests/PageViewAnalytics/PageViewEventViewControllerLoggingProtocolTests.swift
@@ -83,11 +83,18 @@ class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
 extension PageViewEventViewControllerLoggingProtocolTests: PageViewEventViewControllerLoggingProtocol {}
 
 class TestAppBackgroundHelper: AppBackgroundHelperProtocol {
+    var tasks: [String: [String]] = [:]
     func startBackgroundTask(taskName: String) {
-
+        append("start", to: taskName)
     }
 
-    func endBackgroundTask() {
+    func endBackgroundTask(taskName: String) {
+        append("end", to: taskName)
+    }
 
+    private func append(_ event: String, to taskName: String) {
+        var events = tasks[taskName] ?? []
+        events.append(event)
+        tasks[taskName] = events
     }
 }

--- a/Student/Student/CanvasAppDelegate.swift
+++ b/Student/Student/CanvasAppDelegate.swift
@@ -286,16 +286,15 @@ extension AppDelegate {
 extension AppDelegate {
     func setupPageViewLogging() {
         class BackgroundAppHelper: AppBackgroundHelperProtocol {
-            var task: UIBackgroundTaskIdentifier?
+            var tasks: [String: UIBackgroundTaskIdentifier] = [:]
             func startBackgroundTask(taskName: String) {
-                task = UIBackgroundTaskIdentifier.invalid
-                task = UIApplication.shared.beginBackgroundTask(withName: taskName) { [weak self] in
-                    self?.task = UIBackgroundTaskIdentifier.invalid
+                tasks[taskName] = UIApplication.shared.beginBackgroundTask(withName: taskName) { [weak self] in
+                    self?.tasks[taskName] = .invalid
                 }
             }
 
-            func endBackgroundTask() {
-                if let task = task {
+            func endBackgroundTask(taskName: String) {
+                if let task = tasks[taskName] {
                     UIApplication.shared.endBackgroundTask(task)
                 }
             }


### PR DESCRIPTION
refs: MBL-13350
affects: student
release note: Fixed a bug that would cause the app to restart when in the background

Every time we send page view events from the background we create two
background tasks: 1 to get a token and 1 to send the events.

The problem was that we weren't calling `endBackgroundTask` for the
token task because the task was getting replaced with the second task
before we had a chance. And the system terminates apps that don't call
`endBackgroundTask`.

So instead of holding on to one task at a time we can hold on to as many
as we need.

**Test plan:**
- Launch the Student app and tap into a course
- Background the app for 30 seconds
  - No need to launch other apps. Just let your phone sit for at least 30 seconds
- Bring the Student app to the foreground by launching it
- You should be where you left off (ie the app didn't restart)