### PR TITLE
Support submitting raw images in share extension

### DIFF
--- a/Core/Core/Models/UTI.swift
+++ b/Core/Core/Models/UTI.swift
@@ -62,6 +62,10 @@ public struct UTI: Equatable {
         return UTI(rawValue: kUTTypeURL as String)
     }
 
+    public static var fileURL: UTI {
+        return UTI(rawValue: kUTTypeFileURL as String)
+    }
+
     public var isVideo: Bool {
         return UTTypeConformsTo(rawValue as CFString, kUTTypeMovie)
     }

--- a/Core/CoreTests/Models/UTITests.swift
+++ b/Core/CoreTests/Models/UTITests.swift
@@ -67,4 +67,8 @@ class UTITests: XCTestCase {
     func testURL() {
         XCTAssertEqual(UTI.url.rawValue, "public.url")
     }
+
+    func testFileURL() {
+        XCTAssertEqual(UTI.fileURL.rawValue, "public.file-url")
+    }
 }

--- a/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
@@ -138,10 +138,43 @@ class SubmitAssignmentPresenterTests: SubmitAssignmentTests, SubmitAssignmentVie
                 expectation.fulfill()
             }
         }
-        let attachment = NSItemProvider(contentsOf: URL(string: "data:text/plain,abcde")!)!
+        let attachment = NSItemProvider(item: Data() as NSSecureCoding, typeIdentifier: UTI.any.rawValue)
         let item = TestExtensionItem(mockAttachments: [attachment])
         presenter.load(items: [item])
         wait(for: [expectation], timeout: 1)
+    }
+
+    func testLoadItemsImage() {
+        presenter.select(course: .make())
+        presenter.select(assignment: .make())
+        let expectation = XCTestExpectation(description: "content is valid")
+        onUpdate = {
+            if self.presenter.isContentValid {
+                expectation.fulfill()
+            }
+        }
+        let attachment = NSItemProvider(item: UIImage.icon(.addImageLine), typeIdentifier: UTI.image.rawValue)
+        let item = TestExtensionItem(mockAttachments: [attachment])
+        presenter.load(items: [item])
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testLoadItemsFileURL() throws {
+        let fileURL = URL.temporaryDirectory.appendingPathComponent("loadFileURL.txt", isDirectory: false)
+        try "test".write(to: fileURL, atomically: false, encoding: .utf8)
+        presenter.select(course: .make())
+        presenter.select(assignment: .make())
+        let expectation = XCTestExpectation(description: "content is valid")
+        onUpdate = {
+            if self.presenter.isContentValid {
+                expectation.fulfill()
+            }
+        }
+        let attachment = NSItemProvider(item: fileURL as NSSecureCoding, typeIdentifier: UTI.fileURL.rawValue)
+        let item = TestExtensionItem(mockAttachments: [attachment])
+        presenter.load(items: [item])
+        wait(for: [expectation], timeout: 1)
+        try FileManager.default.removeItem(at: fileURL)
     }
 
     func testSubmit() {
@@ -153,7 +186,7 @@ class SubmitAssignmentPresenterTests: SubmitAssignmentTests, SubmitAssignmentVie
                 expectation.fulfill()
             }
         }
-        let attachment = NSItemProvider(contentsOf: URL(string: "data:text/plain,abcde")!)!
+        let attachment = NSItemProvider(item: Data() as NSSecureCoding, typeIdentifier: UTI.any.rawValue)
         let item = TestExtensionItem(mockAttachments: [attachment])
         presenter.load(items: [item])
         wait(for: [expectation], timeout: 0.5)


### PR DESCRIPTION
refs: MBL-13354
affects: student
release note: Fixed submitting screenshots in iOS 13

**Test plan:**
- Take a screenshot and use the share menu to submit it to Student
- Submit a photo from Photos
- Submit a document from the Files app or one similar (Google drive, etc)