### PR TITLE
Fix parent calendar event details

### DIFF
--- a/CanvasCore/CanvasCore/WhizzyWig/WhizzyWigTableViewCell.swift
+++ b/CanvasCore/CanvasCore/WhizzyWig/WhizzyWigTableViewCell.swift
@@ -124,6 +124,7 @@ open class WhizzyWigTableViewCell: UITableViewCell {
     }
     
     open override func prepareForReuse() {
+        super.prepareForReuse()
         indexPath = IndexPath(row: 0, section: 0)
         cellSizeUpdated = {_ in }
         readMore = nil

--- a/Parent/Parent/Details/DetailsDescriptionCell.swift
+++ b/Parent/Parent/Details/DetailsDescriptionCell.swift
@@ -57,4 +57,10 @@ class DetailsDescriptionCell: WhizzyWigTableViewCell {
         contentView.addConstraints(horizontalConstraints)
     }
 
+    override func prepareForReuse() {
+        // don't call super because this tableView is broken
+        indexPath = IndexPath(row: 0, section: 0)
+        cellSizeUpdated = {_ in }
+        readMore = nil
+    }
 }


### PR DESCRIPTION
refs: MBL-13376
affects: parent
release note: none

**Test plan:**
- Log in as narmstrong > o
- View CS 1400 > Week of Sept 1 > New Event!!
- Details should load, scrolling should be smooth