### PR TITLE
fix split view bug with horizontal menu

### DIFF
--- a/Core/Core/Views/HorizontalMenuViewController.swift
+++ b/Core/Core/Views/HorizontalMenuViewController.swift
@@ -43,6 +43,7 @@ open class HorizontalMenuViewController: UIViewController {
         super.viewDidLoad()
         edgesForExtendedLayout = []
         view.backgroundColor = UIColor.named(.backgroundLightest)
+        NotificationCenter.default.addObserver(self, selector: #selector(splitViewControllerWillChangeDisplayModes), name: Notification.Name.SplitViewControllerWillChangeDisplayModeNotification, object: nil)
     }
 
     override open func viewWillLayoutSubviews() {
@@ -96,7 +97,6 @@ open class HorizontalMenuViewController: UIViewController {
         menu.pinToLeftAndRightOfSuperview()
         menuHeightConstraint = menu.addConstraintsWithVFL("V:[view(height)]", metrics: ["height": menuCellHeight])?.first
         menu.addConstraintsWithVFL("V:|[view]")
-
     }
 
     func setupPages() {


### PR DESCRIPTION
[ignore-commit-lint]

student
1. on ipad navigate to syllabus with assignments and syllabus tabs
2. click to go to assignments tab
2. expand ipad to just show details
3. de-expand, it should still be on assignments and display correctly after expansion