### PR TITLE
Changed drainMainQueue to be dumber, but less random

### DIFF
--- a/Core/CoreTests/MetaTests/XCTestCaseTests.swift
+++ b/Core/CoreTests/MetaTests/XCTestCaseTests.swift
@@ -21,19 +21,20 @@ import XCTest
 class XCTestCaseTests: XCTestCase {
 
     func testDrainMainQueueDrainsNestedAsyncs() {
-        var allNestsCalled = false
-        DispatchQueue.main.async {
-            usleep(100)
+        for _ in 0..<10 {
+            var allNestsCalled = false
             DispatchQueue.main.async {
-                usleep(100)
+                usleep(10)
                 DispatchQueue.main.async {
-                    usleep(100)
-                    allNestsCalled = true
+                    usleep(10)
+                    DispatchQueue.main.async {
+                        usleep(10)
+                        allNestsCalled = true
+                    }
                 }
             }
+            drainMainQueue()
+            XCTAssertTrue(allNestsCalled)
         }
-
-        drainMainQueue()
-        XCTAssertTrue(allNestsCalled)
     }
 }

--- a/TestsFoundation/TestsFoundation/Extensions/XCTestCaseExtensions.swift
+++ b/TestsFoundation/TestsFoundation/Extensions/XCTestCaseExtensions.swift
@@ -21,9 +21,14 @@ import XCTest
 
 public extension XCTestCase {
     // make sure anything sitting on the main queue is run before returning
-    func drainMainQueue() {
-        XCTAssertTrue(Thread.current.isMainThread)
-        while (CFRunLoopRunInMode(.defaultMode, 0, true) == .handledSource) {
+    func drainMainQueue(thoroughness: UInt = 10) {
+        assert(Thread.current.isMainThread)
+        for _ in 0..<thoroughness {
+            let expectation = XCTestExpectation()
+            DispatchQueue.main.async {
+                expectation.fulfill()
+            }
+            wait(for: [expectation], timeout: 30)
         }
     }
 }


### PR DESCRIPTION
There just doesn't seem to be a reliable way to tell if a runloop/dispatch queue is drained. So instead just do the dumb thing.

[ignore-commit-lint]