### PR TITLE
Fix media attachments in RN rich content

### DIFF
--- a/rn/Teacher/rn-mods.sh
+++ b/rn/Teacher/rn-mods.sh
@@ -33,3 +33,7 @@ sed -i '' 's#<fishhook/fishhook.h>#\"fishhook.h\"#g' ./node_modules/react-native
 # https://github.com/facebook/react-native/issues/18079
 # set the warning condition true. (it warns if false)
 sed -i '' -e "s/flatStyles == null || flatStyles.flexWrap !== 'wrap'/true/g" ./node_modules/react-native/Libraries/Lists/VirtualizedList.js
+
+# react-native-image-picker is broken in iOS 13
+# https://github.com/react-native-community/react-native-image-picker/issues/1179
+sed -i '' -e "s/moveItemAtURL:videoURL/copyItemAtURL:videoURL/g" ./node_modules/react-native-image-picker/ios/ImagePickerManager.m


### PR DESCRIPTION
refs: MBL-13420
affects: student, teacher
release note: Fixed issues with media attachments

**Test plan**

Student app:
* Tap Reply on an announcement and/or discussion
* Tap the image icon in the editor toolbar to embed a media
* Tap 'Choose from Library'
* Select a video
* Verify that the video gets uploaded and embeded
* Post the reply and verify that you can play the video from the discussion thread

Teacher app:
* Repeats steps above to embed a video in a discussion reply
* Edit a discussion and embed a video in the description
* Edit an assignment and embed a video in the description
* Edit a page and embed a video in the description