### PR TITLE
Fix crash in speedgrader

### DIFF
--- a/CanvasCore/CanvasCore/Annotations/Canvadocs/Comments/UITextView+Placeholder.m
+++ b/CanvasCore/CanvasCore/Annotations/Canvadocs/Comments/UITextView+Placeholder.m
@@ -55,12 +55,17 @@
 
 + (UIColor *)defaultPlaceholderColor {
     static UIColor *color = nil;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        UITextField *textField = [[UITextField alloc] init];
-        textField.placeholder = @" ";
-        color = [textField valueForKeyPath:@"_placeholderLabel.textColor"];
-    });
+    if (@available(iOS 13.0, *)) {
+        color = [UIColor placeholderTextColor];
+    } else {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            UITextField *textField = [[UITextField alloc] init];
+            textField.placeholder = @" ";
+            // this private api has changed in ios 13 but continues to work in ios 12
+            color = [textField valueForKeyPath:@"_placeholderLabel.textColor"];
+        });
+    }
     return color;
 }
 


### PR DESCRIPTION
refs: MBL-13359
affects: Teacher
release note: Fixed a bug when adding comment to pin annotations

Test Plan:
 - Have a student submit a pdf to an assignment
 - In teacher app create a pin annotation and try to
   create a comment. It should work.
 - Because the fix for this issue depends on ios13
   should try in ios12 as well just to make sure it
   still works there as well.