### PR TITLE
Fix NTLMS and HTTP Basic auth challenges

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -569,6 +569,7 @@
 		B1CA33462339434A0015CBB4 /* GetContextUsersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CA33452339434A0015CBB4 /* GetContextUsersTests.swift */; };
 		B1CA3348233948870015CBB4 /* UserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CA3347233948870015CBB4 /* UserTests.swift */; };
 		B1D5EF5E2357907F00B3ACD3 /* AlertAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D5EF5D2357907F00B3ACD3 /* AlertAction.swift */; };
+		B1D5EF602358D93100B3ACD3 /* LoginWebViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D5EF5F2358D93100B3ACD3 /* LoginWebViewControllerTests.swift */; };
 		B1E789A421B0EC1A0087FE4A /* LogEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789A321B0EC1A0087FE4A /* LogEvent.swift */; };
 		B1E789A721B0ED490087FE4A /* LogEventListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789A621B0ED490087FE4A /* LogEventListViewController.swift */; };
 		B1E789AB21B0EF130087FE4A /* LogEventListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B1E789AA21B0EF130087FE4A /* LogEventListViewController.storyboard */; };
@@ -1411,6 +1412,7 @@
 		B1CA33452339434A0015CBB4 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		B1CA3347233948870015CBB4 /* UserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserTests.swift; sourceTree = "<group>"; };
 		B1D5EF5D2357907F00B3ACD3 /* AlertAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertAction.swift; sourceTree = "<group>"; };
+		B1D5EF5F2358D93100B3ACD3 /* LoginWebViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginWebViewControllerTests.swift; sourceTree = "<group>"; };
 		B1E789A321B0EC1A0087FE4A /* LogEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEvent.swift; sourceTree = "<group>"; };
 		B1E789A621B0ED490087FE4A /* LogEventListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventListViewController.swift; sourceTree = "<group>"; };
 		B1E789AA21B0EF130087FE4A /* LogEventListViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LogEventListViewController.storyboard; sourceTree = "<group>"; };
@@ -1759,6 +1761,7 @@
 				DFE1FF1F212F5E41003F27AA /* LoginSessionTests.swift */,
 				7DB0A1B921BF1904009ABB40 /* LoginStartPresenterTests.swift */,
 				3B3467C821349EC000F9BC2E /* LoginWebPresenterTests.swift */,
+				B1D5EF5F2358D93100B3ACD3 /* LoginWebViewControllerTests.swift */,
 			);
 			path = Login;
 			sourceTree = "<group>";
@@ -3680,6 +3683,7 @@
 				7D70DEA2233EADBB00F5C3D4 /* CommunicationChannelTests.swift in Sources */,
 				7DBED017232FDDB700392F3C /* GetAccountHelpLinksTests.swift in Sources */,
 				7DDC450F215BF4AA003F3209 /* UIFontExtensionsTests.swift in Sources */,
+				B1D5EF602358D93100B3ACD3 /* LoginWebViewControllerTests.swift in Sources */,
 				7D2DC2F62199F27B008FE29A /* DocViewerPointAnnotationTests.swift in Sources */,
 				9F62EDD82326D1E500EA9F79 /* GetSearchRecipientsTests.swift in Sources */,
 				3B635B2F225CD7B3001F353D /* APICalendarEventsRequestableTests.swift in Sources */,

--- a/Core/CoreTests/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginWebViewControllerTests.swift
@@ -1,0 +1,107 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import Core
+import TestsFoundation
+
+class LoginWebViewControllerTests: CoreTestCase {
+    var viewController: LoginWebViewController!
+
+    override func setUp() {
+        super.setUp()
+        viewController = LoginWebViewController.create(host: "mhowe", loginDelegate: nil, method: .normalLogin)
+    }
+
+    func load() {
+        XCTAssertNotNil(viewController.view)
+    }
+
+    func testWebViewDidReceiveChallengeNTLM() throws {
+        load()
+        try handleUsernameAndPasswordChallenge(NSURLAuthenticationMethodNTLM)
+    }
+
+    func testWebViewDidReceiveChallengeHTTPBasic() throws {
+        load()
+        try handleUsernameAndPasswordChallenge(NSURLAuthenticationMethodHTTPBasic)
+    }
+
+    func testWebViewDidReceiveUsernameAndPasswordChallengeCancel() throws {
+        load()
+        let challenge = URLAuthenticationChallenge.make(authenticationMethod: NSURLAuthenticationMethodHTTPBasic)
+        let expectation = XCTestExpectation(description: "challenge completion handler")
+        var disposition: URLSession.AuthChallengeDisposition?
+        var credential: URLCredential?
+        viewController.webView(viewController.webView, didReceive: challenge) {
+            disposition = $0
+            credential = $1
+            expectation.fulfill()
+        }
+        drainMainQueue()
+        let alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Login")
+        let cancel = try XCTUnwrap(alert.actions.first { $0.title == "Cancel" } as? AlertAction)
+        XCTAssertNotNil(cancel.handler)
+        cancel.handler?(cancel)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func testWebViewDidReceiveChallengeServerTrust() throws {
+        load()
+        let challenge = URLAuthenticationChallenge.make(authenticationMethod: NSURLAuthenticationMethodServerTrust)
+        let expectation = XCTestExpectation(description: "challenge completion handler")
+        var disposition: URLSession.AuthChallengeDisposition?
+        var credential: URLCredential?
+        viewController.webView(viewController.webView, didReceive: challenge) {
+            disposition = $0
+            credential = $1
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(disposition, .performDefaultHandling)
+        XCTAssertNil(credential)
+    }
+
+    func handleUsernameAndPasswordChallenge(_ authenticationMethod: String) throws {
+        let challenge = URLAuthenticationChallenge.make(authenticationMethod: authenticationMethod)
+        let expectation = XCTestExpectation(description: "challenge completion handler")
+        var disposition: URLSession.AuthChallengeDisposition?
+        var credential: URLCredential?
+        viewController.webView(viewController.webView, didReceive: challenge) {
+            disposition = $0
+            credential = $1
+            expectation.fulfill()
+        }
+        drainMainQueue()
+        let alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Login")
+        XCTAssertEqual(alert.textFields?.count, 2)
+        alert.textFields?.first?.text = "user1"
+        alert.textFields?.last?.text = "password123"
+        let submit = try XCTUnwrap(alert.actions.first { $0.title == "OK" } as? AlertAction)
+        XCTAssertNotNil(submit.handler)
+        submit.handler?(submit)
+        wait(for: [expectation], timeout: 1)
+        XCTAssertEqual(disposition, .useCredential)
+        XCTAssertEqual(credential?.user, "user1")
+        XCTAssertEqual(credential?.password, "password123")
+    }
+}

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		B1B42C1822404AB20087399A /* FileUploadTargetFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B42C1722404AB20087399A /* FileUploadTargetFixture.swift */; };
 		B1C6BF6521BF2C2B00C8C585 /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C6BF6421BF2C2B00C8C585 /* UIBarButtonItemExtensions.swift */; };
 		B1CA334423393FEC0015CBB4 /* UserFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1CA334323393FEC0015CBB4 /* UserFixture.swift */; };
+		B1D5EF622358E01200B3ACD3 /* URLAuthenticationChallengeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D5EF612358E01200B3ACD3 /* URLAuthenticationChallengeExtensions.swift */; };
 		B1E789B821B1B06F0087FE4A /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789B721B1B06F0087FE4A /* TestLogger.swift */; };
 		B1E789BA21B1D0D30087FE4A /* LogEventFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789B921B1D0D30087FE4A /* LogEventFixture.swift */; };
 		B1F13296224BFE03002C0555 /* ModuleItemFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F13295224BFE03002C0555 /* ModuleItemFixture.swift */; };
@@ -178,6 +179,7 @@
 		B1B42C1722404AB20087399A /* FileUploadTargetFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadTargetFixture.swift; sourceTree = "<group>"; };
 		B1C6BF6421BF2C2B00C8C585 /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		B1CA334323393FEC0015CBB4 /* UserFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFixture.swift; sourceTree = "<group>"; };
+		B1D5EF612358E01200B3ACD3 /* URLAuthenticationChallengeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLAuthenticationChallengeExtensions.swift; sourceTree = "<group>"; };
 		B1E789B721B1B06F0087FE4A /* TestLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		B1E789B921B1D0D30087FE4A /* LogEventFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventFixture.swift; sourceTree = "<group>"; };
 		B1F13295224BFE03002C0555 /* ModuleItemFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemFixture.swift; sourceTree = "<group>"; };
@@ -344,6 +346,7 @@
 			children = (
 				3B84C391218BB102005946BA /* DateExtensions.swift */,
 				B1C6BF6421BF2C2B00C8C585 /* UIBarButtonItemExtensions.swift */,
+				B1D5EF612358E01200B3ACD3 /* URLAuthenticationChallengeExtensions.swift */,
 				7DAC287F22B1A3F900C0B692 /* XCUIApplicationExtensions.swift */,
 				E8BE4F5B233E73E100DC399A /* XCUIElementQueryExtensions.swift */,
 				E818EF20234652A20035613A /* XCTestCaseExtensions.swift */,
@@ -581,6 +584,7 @@
 				7DB0A1D421C1C90D009ABB40 /* APIAccountResultsFixture.swift in Sources */,
 				B1F428DC228B5C3C00EC8C37 /* MockURLSession.swift in Sources */,
 				9F62EDD62326C9E800EA9F79 /* APISearchRecipientFixture.swift in Sources */,
+				B1D5EF622358E01200B3ACD3 /* URLAuthenticationChallengeExtensions.swift in Sources */,
 				3BAA4177218A361100701E03 /* EnrollmentFixture.swift in Sources */,
 				3B0CEB732150406400D07CFA /* GroupFixture.swift in Sources */,
 				3B0CEBA421504C2500D07CFA /* APIGroupFixture.swift in Sources */,

--- a/TestsFoundation/TestsFoundation/Extensions/URLAuthenticationChallengeExtensions.swift
+++ b/TestsFoundation/TestsFoundation/Extensions/URLAuthenticationChallengeExtensions.swift
@@ -1,0 +1,44 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public class MockURLAuthenticationChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    public func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {}
+    public func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {}
+    public func cancel(_ challenge: URLAuthenticationChallenge) {}
+}
+
+extension URLAuthenticationChallenge {
+    public static func make(authenticationMethod: String = NSURLAuthenticationMethodServerTrust) -> URLAuthenticationChallenge {
+        return URLAuthenticationChallenge(
+            protectionSpace: URLProtectionSpace(
+                host: "",
+                port: 1,
+                protocol: nil,
+                realm: nil,
+                authenticationMethod: authenticationMethod
+            ),
+            proposedCredential: nil,
+            previousFailureCount: 0,
+            failureResponse: nil,
+            error: nil,
+            sender: MockURLAuthenticationChallengeSender()
+        )
+    }
+}

--- a/rn/Teacher/src/modules/dashboard/GroupRow.js
+++ b/rn/Teacher/src/modules/dashboard/GroupRow.js
@@ -67,7 +67,7 @@ export default class GroupRow extends React.Component<GroupRowProps & { onPress:
             <View style={styles.groupDetails}>
               <Text style={styles.title}>{name}</Text>
               <SubTitle style={[{ color }, styles.context]}>{contextName}</SubTitle>
-              {term && <SubTitle style={styles.term}>{term.toUpperCase()}</SubTitle>}
+              {Boolean(term) && <SubTitle style={styles.term}>{term.toUpperCase()}</SubTitle>}
             </View>
           </DashboardContent>
         </View>


### PR DESCRIPTION
refs: MBL-13370
affects: student, teacher, parent
release note: Fixed login for some institutions

Test plan:
* Launch student app and log out or change user
* Find My School > mhowe > Go
* Should load a discovery page. Tap ADFS
* Should be shown an alert with username and password fields. Use credentials from jira ticket
* Tap OK you should get logged in
* Tapping cancel should continue the request and show an error
* Make sure regular log in works (twilson, narmstrong, etc)