### PR TITLE
Revert "Disable adding comments while assignment is locked (#684)"

### DIFF
--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -84,14 +84,9 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
     }
 
     func setInsets() {
-        guard let view = addCommentView, !view.isHidden else {
-            tableView?.contentInset = .zero
-            tableView?.scrollIndicatorInsets = .zero
-            return
-        }
         // Remember top & bottom are flipped by the transform.
-        tableView?.contentInset = UIEdgeInsets(top: view.frame.height, left: 0, bottom: 0, right: 0)
-        tableView?.scrollIndicatorInsets = UIEdgeInsets(top: view.frame.height, left: 0, bottom: 0, right: 0)
+        tableView?.contentInset = UIEdgeInsets(top: addCommentView?.frame.height ?? 0, left: 0, bottom: 0, right: 0)
+        tableView?.scrollIndicatorInsets = UIEdgeInsets(top: addCommentView?.frame.height ?? 0, left: 0, bottom: 0, right: 0)
     }
 
     @IBAction func addCommentButtonPressed(_ sender: UIButton) {
@@ -195,10 +190,6 @@ extension SubmissionCommentsViewController: UIImagePickerControllerDelegate, UIN
 
 extension SubmissionCommentsViewController: SubmissionCommentsViewProtocol {
     func reload() {
-        if let assignment = presenter?.assignment.first {
-            addCommentView?.isHidden = !assignment.isOpenForSubmissions()
-            setInsets()
-        }
         emptyContainer?.isHidden = presenter?.comments.isEmpty == false
         guard let changes = presenter?.comments.changes, changes.count == 1 else {
             tableView?.reloadData()


### PR DESCRIPTION
This reverts commit 191391c5b673ba8a4c79019eeeaaf46c8d130bc1.

refs: MBL-13394
affects: Student
release note: Fixed allowing comments on locked assignments