### PR TITLE
Improved retry mechanism for NightlyTests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ video.mp4
 # Generated data
 fastlane/1
 bluepill/
+nightly-xcresults/
 
 # rn
 package-lock.json

--- a/Core/Core/UITestHelpers/MockDistantURLSession.swift
+++ b/Core/Core/UITestHelpers/MockDistantURLSession.swift
@@ -122,7 +122,7 @@ public class MockDistantURLSession: URLSession {
             self.session = nil
             let mock = MockDistantURLSession.dataMocks[url]
             if mock == nil {
-                var failReason = "data mock not found for url:\n\(url.absoluteString)\n"
+                var failReason = "data mock not found for url: \(url.absoluteString)\n"
                 for key in MockDistantURLSession.dataMocks.keys {
                     failReason += "  \(key.absoluteString)\n"
                 }
@@ -210,7 +210,7 @@ public class MockDistantURLSession: URLSession {
             self.session = nil
             let mock = MockDistantURLSession.downloadMocks[url]
             if mock == nil {
-                var failReason = "download mock not found for url:\n\(url.absoluteString)\n"
+                var failReason = "download mock not found for url: \(url.absoluteString)\n"
                 for key in MockDistantURLSession.downloadMocks.keys {
                     failReason += "  \(key.absoluteString)\n"
                 }
@@ -282,7 +282,7 @@ public class MockDistantURLSession: URLSession {
             self.session = nil
             let mock = MockDistantURLSession.dataMocks[request.url!]
             if mock == nil {
-                var failReason = "upload mock not found for url:\n\(request.url!.absoluteString)\n"
+                var failReason = "upload mock not found for url: \(request.url!.absoluteString)\n"
                 for key in MockDistantURLSession.dataMocks.keys {
                     failReason += "  \(key.absoluteString)\n"
                 }

--- a/NightlyTests.xctestplan
+++ b/NightlyTests.xctestplan
@@ -2,7 +2,7 @@
   "configurations" : [
     {
       "id" : "F519CF9A-DB0C-4080-B45A-F11438B81749",
-      "name" : "Configuration 1",
+      "name" : "Default",
       "options" : {
 
       }
@@ -68,7 +68,9 @@
       "containerPath" : "container:Student.xcodeproj",
       "identifier" : "492704721CF4AF7100C631C6",
       "name" : "Student"
-    }
+    },
+    "uiTestingScreenshotsLifetime" : "keepNever",
+    "userAttachmentLifetime" : "keepNever"
   },
   "testTargets" : [
     {

--- a/scripts/report-failing-tests.sh
+++ b/scripts/report-failing-tests.sh
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
+
 set -euo pipefail
 # set -x
 

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -1,0 +1,140 @@
+#!/bin/zsh
+#
+# This file is part of Canvas.
+# Copyright (C) 2019-present  Instructure, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+set -euo pipefail
+
+function banner() {
+    local greenbold=$(export TERM=xterm-color; tput bold; tput setaf 2)
+    printf "%s" $greenbold; echo " $@ " | tr -c $'\n' '='
+    printf "%s" $greenbold; echo " $@ "
+    printf "%s" $greenbold; echo " $@ " | tr -c $'\n' '='
+    TERM=xterm-color tput sgr0
+}
+
+destination_flag=(-destination 'platform=iOS Simulator,name=iPhone 8')
+
+banner "Building NightlyTests"
+
+NSUnbufferedIO=YES xcodebuild -workspace Canvas.xcworkspace -scheme NightlyTests $destination_flag build-for-testing 2>&1 | xcpretty --color
+
+BUILD_DIR=$(xcodebuild -workspace Canvas.xcworkspace -scheme NightlyTests -showBuildSettings build-for-testing -json |
+                jq -r '.[] | select(.target == "CoreTests").buildSettings.BUILD_DIR')
+base_xctestrun=($BUILD_DIR/NightlyTests_NightlyTests_*.xctestrun)
+
+# usage: setEnv testrun.xctestrun VAR value
+function setEnv {
+    local i name
+    for (( i = 0; ; i++ )); do
+        name=$(/usr/libexec/PlistBuddy $1 -c "print :TestConfigurations:0:TestTargets:$i:BlueprintName" 2>/dev/null) || break
+        echo "Setting $2=$3 in $1 $name"
+        /usr/libexec/PlistBuddy $1 -c "add :TestConfigurations:0:TestTargets:$i:EnvironmentVariables:$2 string $3"
+    done
+    if [[ i -eq 0 ]]; then
+        echo "failed to set any environment variables!"
+        exit 1
+    fi
+}
+
+try=0
+failures=()
+total_failures=0
+results_directory=nightly-xcresults
+rm -rf $results_directory
+mkdir -p $results_directory
+
+# usage: doTest testrun.xctestrun [options ...]
+function doTest {
+    local testrun=$1
+    shift
+    banner "Running test run $(basename $testrun) (retry $try)"
+    local result_path=$results_directory/$try.xcresult
+    local ret=0
+
+    local formatter=(xcpretty --color)
+
+    local flags=($destination_flag)
+    flags+=(-resultBundlePath $result_path)
+    flags+=(-xctestrun $testrun)
+    # flags+=(-only-testing StudentUITests)
+    if (( $try < 0 )); then
+        flags+=(-parallel-testing-enabled YES -parallel-testing-worker-count 4)
+        formatter=(xcbeautify)
+    fi
+    NSUnbufferedIO=YES xcodebuild test-without-building $flags $@ 2>&1 | $formatter ||
+        ret=$?
+
+    if [[ $ret -eq 0 ]]; then
+        failures=()
+    else
+        failures=($(getFailures))
+    fi
+    banner "${#failures} tests failed"
+    print ${(F)failures}
+    (( total_failures += ${#failures} ))
+    return $ret
+}
+
+function getFailures {
+    local result_path=$results_directory/$try.xcresult
+    xcrun xcresulttool get --format json --path $result_path |
+          jq -r '.issues.testFailureSummaries?._values[]? |
+                 .producingTarget._value + "." + .testCaseName._value' |
+          tr '.' '/' | tr -d '()'
+}
+
+function retry {
+    (( try += 1 ))
+    banner "Retrying"
+
+    local retry_run=$base_xctestrun.retry
+
+    cp $base_xctestrun $retry_run
+    setEnv $retry_run CANVAS_TEST_IS_RETRY YES
+    doTest $retry_run ${${:--only-testing}:^^failures}
+}
+
+ret=0
+doTest $base_xctestrun ||
+    retry ||
+    retry ||
+    retry ||
+    retry ||
+    ret=$?
+
+if [[ $ret -eq 0 ]]; then
+    if [[ $try -eq 0 ]]; then
+        banner "\U1F389 All tests passed ON THE FIRST TRY! \U1F389"
+    else
+        banner "All tests passed after $try retries! ($total_failures flaky failures)"
+    fi
+else
+    banner "${#failures} Tests still failing after $try retries"
+    echo "failing tests:"
+    print ${(F)failures}
+fi
+
+results=($results_directory/*.xcresult)
+merged_result_path=$results_directory/merged.xcresult
+if [[ ${#results} -gt 1 ]]; then
+    xcrun xcresulttool merge $results --output-path $merged_result_path
+else
+    cp -r $results $merged_result_path
+fi
+
+exit $ret


### PR DESCRIPTION
Removes the old in-XCTestCase retry mechanism in favor of a script wrapper that essential re-calls `xcodebuild test` with all the failed tests.

This should be more reliable and flexible. Expect lots of UI test failures, but the failing ones can now be worked on with confidence.

Relevant build:
https://app.bitrise.io/build/78244fed7fc067e1

refs: MBL-13427
affects: none
release note: none