### PR TITLE
Fix selecting assignment in SubmitAssignment

### DIFF
--- a/Student/Student.xcodeproj/project.pbxproj
+++ b/Student/Student.xcodeproj/project.pbxproj
@@ -484,6 +484,10 @@
 		B1CA093822C424E6008AA352 /* SubmitAssignmentPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A61422BD8ADA00963E56 /* SubmitAssignmentPresenter.swift */; };
 		B1CA093922C42520008AA352 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B1BB7A9022BADAC1006CA068 /* Core.framework */; };
 		B1CA093A22C425C8008AA352 /* TestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D864FFF22B2A432006B0127 /* TestsFoundation.framework */; };
+		B1D5EF6423590A0400B3ACD3 /* SubmitAssignmentViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D5EF6323590A0400B3ACD3 /* SubmitAssignmentViewControllerTests.swift */; };
+		B1D5EF652359182B00B3ACD3 /* SubmitAssignmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BB7A8422BAC820006CA068 /* SubmitAssignmentViewController.swift */; };
+		B1D5EF662359184500B3ACD3 /* CoursesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BB7A9522BAE3AD006CA068 /* CoursesViewController.swift */; };
+		B1D5EF672359184F00B3ACD3 /* AssignmentsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B157A61022BD790200963E56 /* AssignmentsViewController.swift */; };
 		B1D766A122C5049B0097561E /* SubmitAssignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D766A022C5049A0097561E /* SubmitAssignmentTests.swift */; };
 		B1D766A422C505770097561E /* CoursesPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1D766A322C505770097561E /* CoursesPresenterTests.swift */; };
 		B1D766A522C505B90097561E /* CoursesPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BB7A9722BAE3B9006CA068 /* CoursesPresenter.swift */; };
@@ -1396,6 +1400,7 @@
 		B1CA092E22C4237C008AA352 /* SubmitAssignmentTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SubmitAssignmentTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B1CA093022C4237C008AA352 /* SubmitAssignmentPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAssignmentPresenterTests.swift; sourceTree = "<group>"; };
 		B1CA093222C4237C008AA352 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B1D5EF6323590A0400B3ACD3 /* SubmitAssignmentViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAssignmentViewControllerTests.swift; sourceTree = "<group>"; };
 		B1D766A022C5049A0097561E /* SubmitAssignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAssignmentTests.swift; sourceTree = "<group>"; };
 		B1D766A322C505770097561E /* CoursesPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursesPresenterTests.swift; sourceTree = "<group>"; };
 		B1D766A722C509260097561E /* AssignmentsPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentsPresenterTests.swift; sourceTree = "<group>"; };
@@ -3042,8 +3047,9 @@
 				B1D766A622C509100097561E /* Assignments */,
 				B1D766A222C5055E0097561E /* Courses */,
 				B1CA093022C4237C008AA352 /* SubmitAssignmentPresenterTests.swift */,
-				B1CA093222C4237C008AA352 /* Info.plist */,
 				B1D766A022C5049A0097561E /* SubmitAssignmentTests.swift */,
+				B1D5EF6323590A0400B3ACD3 /* SubmitAssignmentViewControllerTests.swift */,
+				B1CA093222C4237C008AA352 /* Info.plist */,
 			);
 			path = SubmitAssignmentTests;
 			sourceTree = "<group>";
@@ -4211,13 +4217,17 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B1D5EF672359184F00B3ACD3 /* AssignmentsViewController.swift in Sources */,
 				B1D766A122C5049B0097561E /* SubmitAssignmentTests.swift in Sources */,
 				B1D766A922C509780097561E /* AssignmentsPresenter.swift in Sources */,
 				B1D766A822C509260097561E /* AssignmentsPresenterTests.swift in Sources */,
+				B1D5EF6423590A0400B3ACD3 /* SubmitAssignmentViewControllerTests.swift in Sources */,
 				B1D766A522C505B90097561E /* CoursesPresenter.swift in Sources */,
 				B1D766A422C505770097561E /* CoursesPresenterTests.swift in Sources */,
 				B1CA093122C4237C008AA352 /* SubmitAssignmentPresenterTests.swift in Sources */,
 				B1CA093822C424E6008AA352 /* SubmitAssignmentPresenter.swift in Sources */,
+				B1D5EF652359182B00B3ACD3 /* SubmitAssignmentViewController.swift in Sources */,
+				B1D5EF662359184500B3ACD3 /* CoursesViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Student/Student.xcodeproj/xcshareddata/xcschemes/SubmitAssignment.xcscheme
+++ b/Student/Student.xcodeproj/xcshareddata/xcschemes/SubmitAssignment.xcscheme
@@ -41,9 +41,18 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "492704721CF4AF7100C631C6"
+            BuildableName = "Student.app"
+            BlueprintName = "Student"
+            ReferencedContainer = "container:Student.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -85,23 +94,13 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "492704721CF4AF7100C631C6"
-            BuildableName = "Student.app"
-            BlueprintName = "Student"
-            ReferencedContainer = "container:Student.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = ""
       selectedLauncherIdentifier = "Xcode.IDEFoundation.Launcher.PosixSpawn"
       launchStyle = "0"
+      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
@@ -122,8 +121,6 @@
             ReferencedContainer = "container:Student.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Student/SubmitAssignment/SubmitAssignmentPresenter.swift
+++ b/Student/SubmitAssignment/SubmitAssignmentPresenter.swift
@@ -43,7 +43,7 @@ class SubmitAssignmentPresenter {
 
     var assignments: Store<GetAssignments>?
     lazy var courses: Store<GetCourses> = env.subscribe(GetCourses()) { [weak self] in
-        if let course = self?.courses.first {
+        if self?.course == nil, let course = self?.courses.first {
             self?.select(course: course)
         }
     }
@@ -90,12 +90,12 @@ class SubmitAssignmentPresenter {
     func loadDefaults() {
         if let courseID = env.userDefaults?.submitAssignmentCourseID {
             defaultCourses = env.subscribe(GetCourse(courseID: courseID)) { [weak self] in
-                if let course = self?.defaultCourses?.first {
+                if self?.course == nil, let course = self?.defaultCourses?.first {
                     self?.selectCourse(course, autoSelectAssignment: false)
                 }
                 if let assignmentID = self?.env.userDefaults?.submitAssignmentID {
                     self?.defaultAssignments = self?.env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID)) { [weak self] in
-                        self?.assignment = self?.defaultAssignments?.first
+                        self?.assignment = self?.assignment ?? self?.defaultAssignments?.first
                     }
                     self?.defaultAssignments?.refresh(force: true)
                 }

--- a/Student/SubmitAssignment/SubmitAssignmentViewController.swift
+++ b/Student/SubmitAssignment/SubmitAssignmentViewController.swift
@@ -25,16 +25,15 @@ class SubmitAssignmentViewController: SLComposeServiceViewController, SubmitAssi
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        presenter = SubmitAssignmentPresenter()
+        presenter?.view = self
         placeholder = NSLocalizedString("Comments...", bundle: .core, comment: "")
         navigationController?.navigationBar.topItem?.rightBarButtonItem?.title = NSLocalizedString("Submit", bundle: .core, comment: "")
     }
 
     override func presentationAnimationDidFinish() {
         super.presentationAnimationDidFinish()
-        presenter = SubmitAssignmentPresenter()
-        presenter?.view = self
         presenter?.viewIsReady()
-
         let items = extensionContext?.inputItems as? [NSExtensionItem] ?? []
         presenter?.load(items: items)
     }
@@ -55,10 +54,11 @@ class SubmitAssignmentViewController: SLComposeServiceViewController, SubmitAssi
         guard let environment = presenter?.env else { return items }
         if let course = SLComposeSheetConfigurationItem() {
             course.title = NSLocalizedString("Course", bundle: .core, comment: "")
-            let pending = presenter?.courses.pending == true
+            let pending = presenter?.courses.pending == true || presenter?.defaultCourses?.pending == true
             course.value = pending ? nil : presenter?.course?.name
             course.valuePending = pending
-            course.tapHandler = {
+            course.tapHandler = { [weak self] in
+                guard let self = self else { return }
                 let courses = CoursesViewController.create(environment: environment, selectedCourseID: self.presenter?.course?.id) { course in
                     self.presenter?.select(course: course)
                     self.navigationController?.popViewController(animated: true)
@@ -70,10 +70,11 @@ class SubmitAssignmentViewController: SLComposeServiceViewController, SubmitAssi
 
         if let course = presenter?.course, let assignment = SLComposeSheetConfigurationItem() {
             assignment.title = NSLocalizedString("Assignment", bundle: .core, comment: "")
-            let pending = presenter?.assignments?.pending == true
+            let pending = presenter?.assignments?.pending == true || presenter?.defaultAssignments?.pending == true
             assignment.value = pending ? nil : presenter?.assignment?.name
             assignment.valuePending = pending
-            assignment.tapHandler = {
+            assignment.tapHandler = { [weak self] in
+                guard let self = self else { return }
                 let assignments = AssignmentsViewController.create(environment: environment, courseID: course.id, selectedAssignmentID: self.presenter?.assignment?.id) { assignment in
                     self.presenter?.select(assignment: assignment)
                     self.navigationController?.popViewController(animated: true)

--- a/Student/SubmitAssignmentTests/SubmitAssignmentViewControllerTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentViewControllerTests.swift
@@ -1,0 +1,92 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import XCTest
+import Core
+import Social
+
+class SubmitAssignmentViewControllerTests: SubmitAssignmentTests {
+    var viewController: SubmitAssignmentViewController!
+
+    var configurationItems: [SLComposeSheetConfigurationItem]? {
+        return viewController.configurationItems() as? [SLComposeSheetConfigurationItem]
+    }
+
+    override func setUp() {
+        super.setUp()
+        LoginSession.add(.make())
+        viewController = SubmitAssignmentViewController()
+        load()
+    }
+
+    func load() {
+        XCTAssertNotNil(viewController.view)
+        env.api = URLSessionAPI()
+        env.database = database
+        env.userDefaults?.reset()
+    }
+
+    func testSelectsFirstCourseAndAssignmentByDefault() throws {
+        let presenter = try XCTUnwrap(viewController.presenter)
+        api.mock(presenter.courses, value: [.make(name: "Course 1")])
+        api.mock(GetSubmittableAssignments(courseID: "1"), value: [.make(name: "Assignment 1")])
+        viewController.presentationAnimationDidFinish()
+        drainMainQueue()
+        XCTAssertEqual(configurationItems?.count, 2)
+        XCTAssertEqual(configurationItems?.first?.title, "Course")
+        XCTAssertEqual(configurationItems?.first?.value, "Course 1")
+        XCTAssertEqual(configurationItems?.last?.title, "Assignment")
+        XCTAssertEqual(configurationItems?.last?.value, "Assignment 1")
+    }
+
+    func testDefaultCourseDoesNotOverrideSelected() throws {
+        env.userDefaults?.submitAssignmentCourseID = "1"
+        env.userDefaults?.submitAssignmentID = "2"
+        let task = api.mock(GetCourse(courseID: "1"), value: .make(id: "1", name: "Default"))
+        task.paused = true
+        viewController.presentationAnimationDidFinish()
+        drainMainQueue()
+        viewController.presenter?.select(course: Course.make(from: .make(id: "2", name: "Selected")))
+        drainMainQueue()
+        task.paused = false
+        drainMainQueue()
+        let course = try XCTUnwrap(configurationItems?.first)
+        XCTAssertEqual(course.value, "Selected")
+    }
+
+    func testDefaultAssignmentDoesNotOverrideSelected() throws {
+        env.userDefaults?.submitAssignmentCourseID = "1"
+        env.userDefaults?.submitAssignmentID = "2"
+        api.mock(GetCourse(courseID: "1"), value: .make(id: "1"))
+        let task = api.mock(GetAssignment(courseID: "1", assignmentID: "2"), value: .make(id: "2", name: "Default"))
+        task.paused = true
+        viewController.presentationAnimationDidFinish()
+        drainMainQueue()
+        XCTAssertEqual(configurationItems?.count, 2)
+        var assignment = try XCTUnwrap(configurationItems?.last)
+        XCTAssertTrue(assignment.valuePending)
+        viewController.presenter?.select(assignment: Assignment.make(from: .make(id: "3", name: "Selected")))
+        drainMainQueue()
+        task.paused = false
+        drainMainQueue()
+        XCTAssertEqual(configurationItems?.count, 2)
+        assignment = try XCTUnwrap(configurationItems?.last)
+        XCTAssertEqual(assignment.value, "Selected")
+    }
+}


### PR DESCRIPTION
refs: MBL-13312
affects: student
release note: Fixed a bug where selecting an assignment in the share menu would get reset

Test plan:
* Delete the student app
* Install this build
* Log in as my student (s)
* Dashboard > CS 1400 > Annotate This
* Tap the link `Agenda for UCF Visit.pdf`
* Okay you have to be quick for this next part so read ahead first:
* Tap Share > Student > Tap the assignment row and before the assignments list finishes loading, quickly tap an assignment from the list
* Were you quick enough? You won't know (if it worked)
* The selected assignment should be the one you chose, not the default
* See the video in the ticket for an example of what it used to do