### PR TITLE
Record the posted_at timestamp on grade

### DIFF
--- a/rn/Teacher/src/modules/submissions/list/__tests__/submission-entities-reducer.test.js
+++ b/rn/Teacher/src/modules/submissions/list/__tests__/submission-entities-reducer.test.js
@@ -267,12 +267,12 @@ describe('gradeSubmission', () => {
         error: null,
       },
     }
-
+    let postedAt = new Date().toISOString()
     const action = {
       type: gradeSubmission.toString(),
       payload: {
         result: {
-          data: templates.submission({ id: '1', grade: '1', score: 1 }),
+          data: templates.submission({ id: '1', grade: '1', score: 1, posted_at: postedAt }),
         },
         submissionID: '1',
       },
@@ -285,6 +285,7 @@ describe('gradeSubmission', () => {
         score: 1,
         excused: false,
         grade_matches_current_submission: true,
+        posted_at: postedAt,
       },
       pending: 0,
     })

--- a/rn/Teacher/src/modules/submissions/list/submission-entities-reducer.js
+++ b/rn/Teacher/src/modules/submissions/list/submission-entities-reducer.js
@@ -128,6 +128,7 @@ export const submissions: Reducer<SubmissionsState, any> = handleActions({
         grade_matches_current_submission,
         late,
         points_deducted,
+        posted_at,
       } = result.data
 
       return {
@@ -144,6 +145,7 @@ export const submissions: Reducer<SubmissionsState, any> = handleActions({
             late,
             points_deducted,
             excused: false,
+            posted_at,
           },
           pending: submissionState.pending - 1,
           lastGradedAt: Date.now(),


### PR DESCRIPTION
refs: MBL-13386
affects: teacher
release note: Fixed a bug where grading an assignment where automatic grade posting is set would show the grade as hidden.

Test Plan:
 - Create an assignment
 - Make sure new gradebook is turned on
 - go to the gradebook and turn on automatic grade posting
   (cog -> grade posting policy -> automatic)
 - Go into speedgrader for the assignment
 - Grade the student, when the grade saves it shouldnt
   show the red hidden eyeball