### PR TITLE
Show attachment for online_upload LTI submissions

### DIFF
--- a/Core/Core/Models/Assignment.swift
+++ b/Core/Core/Models/Assignment.swift
@@ -307,6 +307,13 @@ extension Assignment {
         guard let number = number else { return nil }
         return NumberFormatter.localizedString(from: NSNumber(value: (number * 100) / 100), number: .decimal)
     }
+
+    public func requiresLTILaunch(toViewSubmission submission: Submission) -> Bool {
+        // If it's an online_upload with an attachment
+        // we would rather show the attachment than launch the LTI (ex: Google Cloud Assignments)
+        let onlineUploadWithAttachment = submission.type == .online_upload && submission.attachments?.isEmpty == false
+        return submissionTypes.contains(.external_tool) && !onlineUploadWithAttachment
+    }
 }
 
 extension Assignment: DueViewable, GradeViewable, SubmissionViewable {

--- a/Core/CoreTests/Models/AssignmentTests.swift
+++ b/Core/CoreTests/Models/AssignmentTests.swift
@@ -491,4 +491,16 @@ class AssignmentTests: CoreTestCase {
         XCTAssertEqual(submissions?.first?.id, "1")
         XCTAssertEqual(submissions?.last?.id, "2")
     }
+
+    func testRequiresLTILaunchToViewSubmission() {
+        let onPaper = Assignment.make(from: .make(id: "1", submission_types: [.on_paper]))
+        let externalTool = Assignment.make(from: .make(id: "2", submission_types: [.external_tool]))
+        let onlineUploadWithAttachment = Submission.make(from: .make(submission_type: .online_upload, attempt: 1, attachments: [.make(id: "1")]))
+        let onlineUploadWithoutAttachment = Submission.make(from: .make(submission_type: .online_upload, attempt: 2, attachments: []))
+        let onlineQuizWithAttachment = Submission.make(from: .make(submission_type: .online_quiz, attempt: 3, attachments: [.make(id: "2")]))
+        XCTAssertFalse(onPaper.requiresLTILaunch(toViewSubmission: onlineUploadWithAttachment))
+        XCTAssertFalse(externalTool.requiresLTILaunch(toViewSubmission: onlineUploadWithAttachment))
+        XCTAssertTrue(externalTool.requiresLTILaunch(toViewSubmission: onlineUploadWithoutAttachment))
+        XCTAssertTrue(externalTool.requiresLTILaunch(toViewSubmission: onlineQuizWithAttachment))
+    }
 }

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -162,7 +162,7 @@ class SubmissionDetailsPresenter: PageViewLoggerPresenterProtocol {
 
         // external tools submission may be unsubmitted and the type nil but there could
         // still be a submission inside the tool
-        if assignment.submissionTypes.contains(.external_tool) {
+        if assignment.requiresLTILaunch(toViewSubmission: submission) {
             return ExternalToolSubmissionContentViewController.create(env: self.env, assignment: assignment)
         }
 

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
@@ -163,6 +163,17 @@ class SubmissionDetailsPresenterTests: PersistenceTestCase {
         XCTAssert(view.embedded is ExternalToolSubmissionContentViewController)
     }
 
+    func testEmbedExternalToolOnlineUploadWithAttachment() {
+        Assignment.make(from: .make(submission_types: [ .external_tool ]))
+        Submission.make(from: .make(
+            submission_type: .online_upload,
+            attachments: [ .make(mime_class: "doc") ]
+        ))
+        presenter.update()
+
+        XCTAssert(view.embedded is DocViewerViewController)
+    }
+
     func testEmbedQuiz() {
         Assignment.make(from: .make(quiz_id: "1"))
         Submission.make(from: .make(submission_type: .online_quiz, attempt: 2))


### PR DESCRIPTION
refs: MBL-13326, MBL-13392
affects: student
release note: Fixed an issue that would prevent users from viewing feedback on submissions

Test plan:
* External tool submissions that have an associated file should show the file in the submission viewer instead of showing the `Open External Tool` button
* External tool submissions that do not have a linked file should show the `Open External Tool` button
* Use test plan from linked tickets (MBL-13326 and MBL-13392)
* Make sure regular LTI assignments still work
  * twilson > student1 > Quizzes Next 2 > Assignments > Planets > Submission & Rubric > Open External Tool