### PR TITLE
Fix linking to course details

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -448,13 +448,13 @@ open class HelmManager: NSObject {
 
 extension HelmManager {
     @objc func navigationControllerForSplitViewControllerPush(splitViewController: HelmSplitViewController?, sourceModule: ModuleName, destinationModule: ModuleName, props: [String: Any], options: [String: Any]) -> UINavigationController? {
-
-        if (splitViewController?.detailTopViewController as? HelmModule)?.moduleName == sourceModule {
+        let canBecomeMaster = options["canBecomeMaster"] as? Bool == true
+        if canBecomeMaster, let masterNav = splitViewController?.masterHelmNavigationController {
+            return masterNav
+        } else if (splitViewController?.detailTopViewController as? HelmModule)?.moduleName == sourceModule {
             return splitViewController?.detailHelmNavigationController ?? splitViewController?.detailNavigationController
         } else {
-            let canBecomeMaster = options["canBecomeMaster"] as? Bool ?? false
-
-            if canBecomeMaster || (splitViewController?.traitCollection.horizontalSizeClass ?? .compact) == .compact {
+            if (splitViewController?.traitCollection.horizontalSizeClass ?? .compact) == .compact {
                 return splitViewController?.masterHelmNavigationController as? HelmNavigationController
             }
 

--- a/rn/Teacher/src/modules/courses/CourseNavigation.js
+++ b/rn/Teacher/src/modules/courses/CourseNavigation.js
@@ -275,7 +275,7 @@ export let Refreshed: any = refresh(
     if (isTeacher()) {
       props.refreshLTITools(props.courseID)
     }
-    props.refreshCourses()
+    props.refreshCourse(props.courseID)
     props.refreshTabs(props.courseID)
     props.getUserSettings()
   },

--- a/rn/Teacher/src/modules/courses/__tests__/CourseNavigation.test.js
+++ b/rn/Teacher/src/modules/courses/__tests__/CourseNavigation.test.js
@@ -56,7 +56,7 @@ describe('CourseNavigation', () => {
   })
 
   it('refreshes courses and tabs', () => {
-    const refreshCourses = jest.fn()
+    const refreshCourse = jest.fn()
     const refreshTabs = jest.fn()
     const refreshLTITools = jest.fn()
     const getUserSettings = jest.fn()
@@ -64,7 +64,7 @@ describe('CourseNavigation', () => {
       navigator: template.navigator(),
       courseID: course.id,
       tabs: [],
-      refreshCourses,
+      refreshCourse,
       refreshTabs,
       refreshLTITools,
       getUserSettings,
@@ -72,13 +72,13 @@ describe('CourseNavigation', () => {
 
     const tree = shallow(<Refreshed {...refreshProps} />)
     expect(tree).toMatchSnapshot()
-    expect(refreshCourses).toHaveBeenCalled()
+    expect(refreshCourse).toHaveBeenCalledWith(course.id)
     expect(refreshTabs).toHaveBeenCalledWith(course.id)
     expect(getUserSettings).toHaveBeenCalled()
   })
 
   it('refreshes when props change', () => {
-    const refreshCourses = jest.fn()
+    const refreshCourse = jest.fn()
     const refreshTabs = jest.fn()
     const refreshLTITools = jest.fn()
     const getUserSettings = jest.fn()
@@ -87,7 +87,7 @@ describe('CourseNavigation', () => {
       courseID: course.id,
       course,
       tabs: [],
-      refreshCourses,
+      refreshCourse,
       refreshTabs,
       refreshLTITools,
       getUserSettings,
@@ -97,7 +97,7 @@ describe('CourseNavigation', () => {
     expect(tree).toMatchSnapshot()
     tree.instance().refresh()
     tree.setProps(refreshProps)
-    expect(refreshCourses).toHaveBeenCalled()
+    expect(refreshCourse).toHaveBeenCalled()
     expect(refreshTabs).toHaveBeenCalledWith(course.id)
     expect(getUserSettings).toHaveBeenCalled()
   })

--- a/rn/Teacher/src/modules/courses/__tests__/__snapshots__/CourseNavigation.test.js.snap
+++ b/rn/Teacher/src/modules/courses/__tests__/__snapshots__/CourseNavigation.test.js.snap
@@ -41,10 +41,12 @@ exports[`CourseNavigation refreshes courses and tabs 1`] = `
     }
   }
   refresh={[Function]}
-  refreshCourses={
+  refreshCourse={
     [MockFunction] {
       "calls": Array [
-        Array [],
+        Array [
+          "1",
+        ],
       ],
       "results": Array [
         Object {
@@ -165,10 +167,12 @@ exports[`CourseNavigation refreshes when props change 1`] = `
     }
   }
   refresh={[Function]}
-  refreshCourses={
+  refreshCourse={
     [MockFunction] {
       "calls": Array [
-        Array [],
+        Array [
+          "1",
+        ],
       ],
       "results": Array [
         Object {

--- a/rn/Teacher/src/modules/courses/__tests__/courses-reducer.test.js
+++ b/rn/Teacher/src/modules/courses/__tests__/courses-reducer.test.js
@@ -545,16 +545,20 @@ describe('refresh single course', () => {
     let action = {
       type: CoursesActions().refreshCourse.toString(),
       payload: {
-        result: {
-          data: {
-            id: '1',
-            permissions: {
-              create_announcement: true,
-              create_discussion_topic: true,
-            }
-            ,
+        result: [
+          {
+            data: {
+              id: '1',
+              permissions: {
+                create_announcement: true,
+                create_discussion_topic: true,
+              },
+            },
           },
-        },
+          {
+            data: templates.customColors(),
+          },
+        ],
         context: 'courses',
         courseID: '1',
       },
@@ -568,7 +572,7 @@ describe('refresh single course', () => {
           'announcements': { 'pending': 0, 'refs': [] },
           'assignmentGroups': { 'pending': 0, 'refs': [] },
           'attendanceTool': { 'pending': 0 },
-          'color': '#FFFFFF00',
+          'color': '#fff',
           'course': {
             'id': '1',
             'permissions': {
@@ -599,17 +603,19 @@ describe('refresh single course', () => {
     let action = {
       type: CoursesActions().refreshCourse.toString(),
       payload: {
-        result: {
-          data: {
-            id: '1',
-            name: 'Course 2',
-            permissions: {
-              create_announcement: false,
-              create_discussion_topic: true,
-            }
-            ,
+        result: [
+          {
+            data: {
+              id: '1',
+              name: 'Course 2',
+              permissions: {
+                create_announcement: false,
+                create_discussion_topic: true,
+              },
+            },
           },
-        },
+          { data: templates.customColors() },
+        ],
         context: 'courses',
         courseID: '1',
       },
@@ -650,7 +656,7 @@ describe('refresh single course', () => {
           'announcements': { 'pending': 0, 'refs': [] },
           'assignmentGroups': { 'pending': 0, 'refs': [] },
           'attendanceTool': { 'pending': 0 },
-          'color': '#FFFFFF00',
+          'color': '#fff',
           'course': {
             'id': '1',
             'name': 'Course 2',

--- a/rn/Teacher/src/modules/courses/actions.js
+++ b/rn/Teacher/src/modules/courses/actions.js
@@ -33,7 +33,10 @@ export let CoursesActions = (api: CanvasApi): * => ({
   })),
   refreshCourse: createAction('course.refresh', (courseID: string) => {
     return {
-      promise: api.getCourse(courseID),
+      promise: Promise.all([
+         api.getCourse(courseID),
+         api.getCustomColors(),
+       ]),
       courseID,
     }
   }),

--- a/rn/Teacher/src/modules/courses/actions.js
+++ b/rn/Teacher/src/modules/courses/actions.js
@@ -34,9 +34,9 @@ export let CoursesActions = (api: CanvasApi): * => ({
   refreshCourse: createAction('course.refresh', (courseID: string) => {
     return {
       promise: Promise.all([
-         api.getCourse(courseID),
-         api.getCustomColors(),
-       ]),
+        api.getCourse(courseID),
+        api.getCustomColors(),
+      ]),
       courseID,
     }
   }),

--- a/rn/Teacher/src/modules/courses/courses-reducer.js
+++ b/rn/Teacher/src/modules/courses/courses-reducer.js
@@ -332,16 +332,14 @@ const coursesData: Reducer<CoursesState, any> = handleActions({
     },
   }),
   [refreshCourse.toString()]: handleAsync({
-    resolved: (state, { result, courseID }) => {
+    resolved: (state, { result: [courseResponse, colorsResponse], courseID }) => {
+      let colors = groupCustomColors(colorsResponse.data).custom_colors.course
+      let course = normalizeCourse(courseResponse.data, colors, state[courseID])
       return {
         ...state,
         [courseID]: {
-          ...state[courseID],
-          course: {
-            ...(state[courseID] && state[courseID].course || {}),
-            ...result.data,
-          },
-          permissions: { ...(state[courseID] && state[courseID].permissions || {}), ...result.data.permissions },
+          ...course,
+          permissions: { ...(state[courseID] && state[courseID].permissions || {}), ...courseResponse.data.permissions },
         },
       }
     },

--- a/rn/Teacher/src/modules/courses/courses-reducer.js
+++ b/rn/Teacher/src/modules/courses/courses-reducer.js
@@ -99,7 +99,10 @@ export const normalizeCourse = (course: Course, colors: { [courseId: string]: st
   const color = colors[id] || '#aaa'
   return {
     ...prevState,
-    course,
+    course: {
+      ...prevState.course,
+      ...course,
+    },
     color,
     pending: 0,
   }


### PR DESCRIPTION
refs: MBL-13399
affects: student, teacher
release note: Fixed a bug with course links

Test plan:
* Link to a public course from a page and tap the link in the student and teacher apps
* Courses details should load in the master on iPad
* Course details should use the course color for nav bar and icons
* See ticket for example