### PR TITLE
Fix showing pages and module items on iPad

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -136,6 +136,7 @@ open class HelmManager: NSObject {
         let pushOntoNav: (UINavigationController) -> Void
         let replaceInNav: (UINavigationController) -> Void
         let pushToReplace = options["replace"] as? Bool ?? false
+        let detail = options["detail"] as? Bool == true
 
         // The views need to know when they are shown modaly and potentially other options
         // Doing it here instead of in JS so that native routing will also work
@@ -241,7 +242,7 @@ open class HelmManager: NSObject {
                 // because there is no other view controller to navigate back to. pushOnToNav will be called if
                 // a VC can be master or this navigation event was initiated from a non-empty detail view. A Back
                 // button will be shown after pushOnToNav is called...as long as the nav.viewControllers.count > 1.
-                let resetDetailNavStack = sideBySideViews && !canBecomeMaster && (clickedFromMaster || onlyDetailVCWasEmptyVC)
+                let resetDetailNavStack = sideBySideViews && !canBecomeMaster && (clickedFromMaster || onlyDetailVCWasEmptyVC || detail)
                 if (resetDetailNavStack) {
                     replaceInNav(nav)
                     callback?()

--- a/TestsFoundation/TestsFoundation/Router/TestRouter.swift
+++ b/TestsFoundation/TestsFoundation/Router/TestRouter.swift
@@ -56,6 +56,10 @@ public class TestRouter: RouterProtocol {
         return lastRoutedTo(route.url)
     }
 
+    public func lastRoutedTo(_ route: Route, withOptions options: RouteOptions?) -> Bool {
+        return lastRoutedTo(route) && calls.last?.2 == options
+    }
+
     public func lastRoutedTo(_ url: URL) -> Bool {
         return calls.last?.0 == URLComponents.parse(url)
     }

--- a/rn/Teacher/index.ios.js
+++ b/rn/Teacher/index.ios.js
@@ -180,7 +180,7 @@ notificationCenter.addListener('route', (notification) => {
     const navigator = new Navigator('')
     navigator.show(userInfo.url, {
       modal: userInfo.modal === true,
-      detail: userInfo.detail == true,
+      detail: userInfo.detail === true,
     })
   }
 })

--- a/rn/Teacher/index.ios.js
+++ b/rn/Teacher/index.ios.js
@@ -178,6 +178,9 @@ notificationCenter.addListener('route', (notification) => {
   const userInfo = notification.userInfo
   if (userInfo && userInfo.url) {
     const navigator = new Navigator('')
-    navigator.show(userInfo.url, { modal: userInfo.modal === true })
+    navigator.show(userInfo.url, {
+      modal: userInfo.modal === true,
+      detail: userInfo.detail == true,
+    })
   }
 })

--- a/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListPresenter.swift
+++ b/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListPresenter.swift
@@ -115,6 +115,6 @@ class ModuleListPresenter {
 
     func showItem(_ item: Core.ModuleItem, from viewController: UIViewController) {
         guard let url = item.url else { return }
-        env.router.route(to: url, from: viewController, options: nil)
+        env.router.route(to: url, from: viewController, options: [.detail])
     }
 }

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -31,6 +31,7 @@ class Router: RouterProtocol {
         let userInfo: [AnyHashable: Any] = [
             "url": url.absoluteString,
             "modal": options?.contains(.modal) == true,
+            "detail": options?.contains(.detail) == true,
         ]
         NotificationCenter.default.post(name: name, object: nil, userInfo: userInfo)
     }

--- a/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Modules/ModuleListPresenterTests.swift
@@ -296,6 +296,6 @@ class ModuleListPresenterTests: TeacherTestCase {
         let url = URL(string: "/courses/1/assignments/2")!
         let item = ModuleItem.make(from: .make(url: url))
         presenter.showItem(item, from: MockViewController())
-        XCTAssertTrue(router.lastRoutedTo(.course("1", assignment: "2")))
+        XCTAssertTrue(router.lastRoutedTo(.course("1", assignment: "2"), withOptions: [.detail]))
     }
 }

--- a/rn/Teacher/ios/TeacherTests/RoutesTests.swift
+++ b/rn/Teacher/ios/TeacherTests/RoutesTests.swift
@@ -34,6 +34,26 @@ class RoutesTests: XCTestCase {
         wait(for: [expectation], timeout: 0.5)
         XCTAssertNotNil(userInfo)
         XCTAssertEqual(userInfo?["url"] as? String, route.url!.absoluteString)
+        XCTAssertEqual(userInfo?["modal"] as? Bool, false)
+        XCTAssertEqual(userInfo?["detail"] as? Bool, false)
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    func testOptions() {
+        let route = URLComponents(string: "https://canvas.instructure.com/api/v1/courses/1")!
+        let expectation = self.expectation(description: "route notification")
+        let name = NSNotification.Name("route")
+        var userInfo: [AnyHashable: Any]?
+        let observer = NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil) { note in
+            userInfo = note.userInfo
+            expectation.fulfill()
+        }
+        router.route(to: route, from: UIViewController(), options: [.modal, .detail])
+        wait(for: [expectation], timeout: 0.5)
+        XCTAssertNotNil(userInfo)
+        XCTAssertEqual(userInfo?["url"] as? String, route.url!.absoluteString)
+        XCTAssertEqual(userInfo?["modal"] as? Bool, true)
+        XCTAssertEqual(userInfo?["detail"] as? Bool, true)
         NotificationCenter.default.removeObserver(observer)
     }
 }

--- a/rn/Teacher/src/routing/Navigator.js
+++ b/rn/Teacher/src/routing/Navigator.js
@@ -51,7 +51,7 @@ export default class Navigator {
     this.isModal = options.modal
   }
 
-  show (url: string, options: Object = { modal: false, modalPresentationStyle: 'formsheet', deepLink: false }, additionalProps: Object = {}) {
+  show (url: string, options: Object = { modal: false, modalPresentationStyle: 'formsheet', deepLink: false, detail: false }, additionalProps: Object = {}) {
     recordRoute(url, options, additionalProps)
     const r = route(url, additionalProps)
     if (!r) {
@@ -69,7 +69,7 @@ export default class Navigator {
       const embedInNavigationController = options.embedInNavigationController == null || options.embedInNavigationController
       return this.present(r, { modal: options.modal, modalPresentationStyle: options.modalPresentationStyle || 'formsheet', embedInNavigationController, canBecomeMaster: canBecomeMaster, modalTransitionStyle: options.modalTransitionStyle })
     } else {
-      return this.push(r)
+      return this.push(r, { detail: options.detail })
     }
   }
 
@@ -94,8 +94,9 @@ export default class Navigator {
     if (r) NativeModules.Helm.pushFrom(this.moduleName, r.screen, r.passProps, { ...r.config, replace: true })
   }
 
-  push (route: RouteOptions) {
-    return NativeModules.Helm.pushFrom(this.moduleName, route.screen, route.passProps, route.config)
+  push (route: RouteOptions, options) {
+    const opts = { ...route.config, ...options }
+    return NativeModules.Helm.pushFrom(this.moduleName, route.screen, route.passProps, opts)
   }
 
   pop () {

--- a/rn/Teacher/src/routing/__tests__/Navigator.test.js
+++ b/rn/Teacher/src/routing/__tests__/Navigator.test.js
@@ -59,7 +59,17 @@ describe('Navigator', () => {
       'push',
       '/courses/:courseID',
       { courseID: '1', screenInstanceID: expect.any(String), location: expect.any(Object) },
-      { canBecomeMaster: true, deepLink: true }
+      { canBecomeMaster: true, deepLink: true, detail: false }
+    )
+  })
+
+  it('passes detail option from show to push', () => {
+    new Navigator('detail').show('/courses/1', { detail: true })
+    expect(NativeModules.Helm.pushFrom).toHaveBeenCalledWith(
+      'detail',
+      '/courses/:courseID',
+      expect.any(Object),
+      { canBecomeMaster: true, deepLink: true, detail: true },
     )
   })
 


### PR DESCRIPTION
refs: MBL-13381
affects: teacher
release note: Fixed a navigation issue when viewing pages and module items on iPad

Test plan:
* Page and module item details should replace the split view details, not do a push
* On iPad in Teacher app, tap into a course and view Page
* Tap several pages, the split view details should get replaced with the page
* Repeat for Modules > tap on module items
* Use my student (s) in course CS 1400 for content