### PR TITLE
Check for context when launching LTI tools

### DIFF
--- a/Core/Core/Models/Context.swift
+++ b/Core/Core/Models/Context.swift
@@ -21,6 +21,11 @@ import Foundation
 public enum ContextType: String, Codable {
     case account, course, group, user, section
 
+    public init?(pathComponent: String) {
+        guard pathComponent.last == "s" else { return nil }
+        self.init(rawValue: String(pathComponent.dropLast()))
+    }
+
     public var pathComponent: String {
         return "\(self)s"
     }

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -37,6 +37,20 @@ class LTIToolsTests: CoreTestCase {
         XCTAssertEqual(LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))?.url, URL(string: "/"))
     }
 
+    func testInitLinkContext() {
+        let defaultContext = LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        XCTAssertEqual(defaultContext?.context.contextType, .account)
+        XCTAssertEqual(defaultContext?.context.id, "self")
+
+        let course = LTITools(link: URL(string: "/courses/1/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        XCTAssertEqual(course?.context.contextType, .course)
+        XCTAssertEqual(course?.context.id, "1")
+
+        let account = LTITools(link: URL(string: "/accounts/2/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        XCTAssertEqual(account?.context.contextType, .account)
+        XCTAssertEqual(account?.context.id, "2")
+    }
+
     func testGetSessionlessLaunchURL() {
         let tools = LTITools(
             env: environment,

--- a/Core/CoreTests/Models/ContextTests.swift
+++ b/Core/CoreTests/Models/ContextTests.swift
@@ -28,6 +28,15 @@ class ContextTests: XCTestCase {
         XCTAssertEqual(ContextType.section.pathComponent, "sections")
     }
 
+    func testInitTypeWithPathComponent() {
+        XCTAssertEqual(ContextType(pathComponent: "accounts"), .account)
+        XCTAssertEqual(ContextType(pathComponent: "courses"), .course)
+        XCTAssertEqual(ContextType(pathComponent: "groups"), .group)
+        XCTAssertEqual(ContextType(pathComponent: "users"), .user)
+        XCTAssertEqual(ContextType(pathComponent: "sections"), .section)
+        XCTAssertNil(ContextType(pathComponent: "chums"))
+    }
+
     func testCanvasContextID() {
         XCTAssertEqual(ContextModel(.account, id: "1").canvasContextID, "account_1")
         XCTAssertEqual(ContextModel(.course, id: "2").canvasContextID, "course_2")


### PR DESCRIPTION
refs: MBL-13323
affects: student
release note: Fixed an issue with launching certain external tools

Test plan:
* Studio LTI launches should show comments section
* See ticket: https://instructure.atlassian.net/browse/MBL-13323

Look at the modules in that tickets
It has Studio embedded in a few different content types
Launch each of them and make sure they show the comments section