### PR TITLE
Fix module item selection

### DIFF
--- a/CanvasCore/CanvasCore/Persistence/Table View/TableViewDataSource.swift
+++ b/CanvasCore/CanvasCore/Persistence/Table View/TableViewDataSource.swift
@@ -43,13 +43,15 @@ extension TableViewDataSource {
 
     public func processUpdates<CollectedType>(_ updates: [CollectionUpdate<CollectedType>]) {
         guard let tableView = tableView else { return }
+        let selectedIndexPath = tableView.indexPathForSelectedRow
+        defer {
+            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
+        }
 
         if updates == [.reload] {
             tableView.reloadData()
             return
         }
-
-        let selectedIndexPath = tableView.indexPathForSelectedRow
 
         tableView.beginUpdates()
         for update in updates {
@@ -79,8 +81,6 @@ extension TableViewDataSource {
             }
         }
         tableView.endUpdates()
-        
-        tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
     }
 }
 

--- a/Core/Core/Extensions/NotificationCenterExtensions.swift
+++ b/Core/Core/Extensions/NotificationCenterExtensions.swift
@@ -21,7 +21,6 @@ import Foundation
 extension NSNotification.Name {
     public static var CompletedModuleItemRequirement = NSNotification.Name("com.instructure.core.notification.ModuleItemProgress")
     public static let SplitViewControllerWillChangeDisplayModeNotification = Notification.Name( "com.instructure.core.notification.splitview.willChangeDisplayMode")
-    public static let ModuleItemSelected = NSNotification.Name("com.instructure.core.notification.moduleItem.selected")
 }
 
 extension NotificationCenter {

--- a/Core/Core/Extensions/NotificationCenterExtensions.swift
+++ b/Core/Core/Extensions/NotificationCenterExtensions.swift
@@ -21,6 +21,7 @@ import Foundation
 extension NSNotification.Name {
     public static var CompletedModuleItemRequirement = NSNotification.Name("com.instructure.core.notification.ModuleItemProgress")
     public static let SplitViewControllerWillChangeDisplayModeNotification = Notification.Name( "com.instructure.core.notification.splitview.willChangeDisplayMode")
+    public static let ModuleItemSelected = NSNotification.Name("com.instructure.core.notification.moduleItem.selected")
 }
 
 extension NotificationCenter {

--- a/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
+++ b/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
@@ -188,7 +188,13 @@ class ModuleItemViewModel: NSObject {
         vm.titleTextColor <~ self.locked.producer.map { $0 && type != .assignment && type != .discussion ? .lightGray : .black }
         vm.indentationLevel <~ self.moduleItem.producer.map { $0?.indent ?? 0 }.map { Int($0) }
         vm.selectionEnabled <~ self.locked.producer.map { !$0 && type != .subHeader || type == .assignment || type == .discussion }
-        vm.setSelected <~ self.selected
+        let becameActive = NotificationCenter.default.reactive.notifications(forName: .moduleItemBecameActive).take(duringLifetimeOf: vm.setSelected)
+        vm.setSelected <~ self.moduleItem.producer.combineLatest(with: becameActive).map { moduleItem, notification in
+            if let moduleItem = moduleItem, let id = notification.userInfo?["moduleItemID"] as? String {
+                return moduleItem.id == id
+            }
+            return false
+        }
 
         let contentType = self.moduleItem.producer.map { $0?.contentType.accessibilityLabel }
         vm.accessibilityLabel <~ SignalProducer.combineLatest(vm.title.producer, vm.subtitle.producer, contentType, self.completed.producer, self.locked.producer)
@@ -297,7 +303,6 @@ class ModuleItemViewModel: NSObject {
 
         super.init()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(moduleItemBecameActive(_:)), name: .moduleItemBecameActive, object: nil)
         beginObservingLockedStatus()
     }
 
@@ -314,12 +319,6 @@ class ModuleItemViewModel: NSObject {
         let completed = moduleItem.producer.map { $0?.completed ?? false }
         let canFulfill = SignalProducer.combineLatest(sameCompletionRequirement.skipRepeats(==), completed.skipRepeats(==)).map { $0 && !$1 }
         return Property(initial: false, then: canFulfill)
-    }
-
-    @objc func moduleItemBecameActive(_ notification: NSNotification) {
-        if let moduleItem = moduleItem.value, let id = notification.userInfo?["moduleItemID"] as? String {
-            selected.value = moduleItem.id == id
-        }
     }
 
     @objc func moduleItemBecameActive() {

--- a/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
+++ b/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
@@ -188,13 +188,17 @@ class ModuleItemViewModel: NSObject {
         vm.titleTextColor <~ self.locked.producer.map { $0 && type != .assignment && type != .discussion ? .lightGray : .black }
         vm.indentationLevel <~ self.moduleItem.producer.map { $0?.indent ?? 0 }.map { Int($0) }
         vm.selectionEnabled <~ self.locked.producer.map { !$0 && type != .subHeader || type == .assignment || type == .discussion }
-        let becameActive = NotificationCenter.default.reactive.notifications(forName: .moduleItemBecameActive).take(duringLifetimeOf: vm.setSelected)
-        vm.setSelected <~ self.moduleItem.producer.combineLatest(with: becameActive).map { moduleItem, notification in
-            if let moduleItem = moduleItem, let id = notification.userInfo?["moduleItemID"] as? String {
-                return moduleItem.id == id
+        let becameActive = NotificationCenter.default.reactive
+            .notifications(forName: .moduleItemBecameActive)
+            .take(duringLifetimeOf: vm.setSelected)
+        vm.setSelected <~ self.moduleItem.producer
+            .combineLatest(with: becameActive)
+            .map { moduleItem, notification in
+                if let moduleItem = moduleItem, let id = notification.userInfo?["moduleItemID"] as? String {
+                    return moduleItem.id == id
+                }
+                return false
             }
-            return false
-        }
 
         let contentType = self.moduleItem.producer.map { $0?.contentType.accessibilityLabel }
         vm.accessibilityLabel <~ SignalProducer.combineLatest(vm.title.producer, vm.subtitle.producer, contentType, self.completed.producer, self.locked.producer)


### PR DESCRIPTION
refs: MBL-13316
affects: student
release note: Fixed showing which module item is active on iPad

Test plan:
* Install the Student app on an iPad
* View Modules > tap on an individual module
* Tap on a module item, the module item cell should stay selected
* Use the 'Next and 'Previous' buttons to navigate through the module
* The active module item's cell should become active as expected

You can use my test student (s) and modules in CS 1400.