### PR TITLE
Fix file upload size

### DIFF
--- a/Core/Core/Use Cases/UploadManager.swift
+++ b/Core/Core/Use Cases/UploadManager.swift
@@ -100,9 +100,10 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
     @discardableResult
     public func add(environment: AppEnvironment = .shared, url: URL, batchID: String? = nil) throws -> File {
         let file: File = viewContext.insert()
-        file.localFileURL = try uploadURL(url)
+        let uploadURL = try self.uploadURL(url)
+        file.localFileURL = uploadURL
         file.batchID = batchID
-        file.size = url.lookupFileSize()
+        file.size = uploadURL.lookupFileSize()
         if let session = environment.currentSession {
             file.user = File.User(id: session.userID, baseURL: session.baseURL, masquerader: session.masquerader)
         }

--- a/Core/CoreTests/Use Cases/UploadManagerTests.swift
+++ b/Core/CoreTests/Use Cases/UploadManagerTests.swift
@@ -88,6 +88,8 @@ class UploadManagerTests: CoreTestCase {
         try manager.add(url: url, batchID: "1")
         wait(for: [expectation], timeout: 1)
         XCTAssertEqual(store.count, 1)
+        let file = try XCTUnwrap(store.first)
+        XCTAssertGreaterThan(file.size, 0)
     }
 
     func testSubscribeScopedToBatchAndUser() {


### PR DESCRIPTION
refs: MBL-13351
affects: student
release note: Fixed a bug that caused file sizes to incorrectly show as 0 KB

Test plan:
* Submit to an assignment that allows file uploads
* Choose from Library and pick a video
* Before submitting, verify that the size in the file picker displays a non-zero value

https://instructure.atlassian.net/browse/MBL-13351