### PR TITLE
Update the muted label when muted is toggled

### DIFF
--- a/rn/Teacher/src/canvas-api-v2/__tests__/client.test.js
+++ b/rn/Teacher/src/canvas-api-v2/__tests__/client.test.js
@@ -1,0 +1,15 @@
+import getClient, { getURI, clearClient } from '../client'
+
+describe('getClient', () => {
+  beforeEach(() => clearClient())
+
+  it('creates the correct uri', () => {
+    expect(getURI()).toEqual('http://mobiledev.instructure.com/api/graphql')
+  })
+
+  it('only creates one client', () => {
+    let client = getClient()
+    let client2 = getClient()
+    expect(client2).toEqual(client)
+  })
+})

--- a/rn/Teacher/src/canvas-api-v2/client.js
+++ b/rn/Teacher/src/canvas-api-v2/client.js
@@ -1,0 +1,37 @@
+import { getSession } from '../canvas-api/session'
+import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
+import { ApolloClient } from 'apollo-client'
+import { HttpLink } from 'apollo-link-http'
+import graphqlSchema from './schema.json'
+
+let client
+
+export function getURI () {
+  const session = getSession()
+  return `${session.baseURL.replace(/\/?$/, '')}/api/graphql`
+}
+
+export default function getClient () {
+  if (client != null) return client
+
+  const uri = getURI()
+  const headers = {
+    'GraphQL-Metrics': true,
+  }
+
+  let fragmentMatcher = new IntrospectionFragmentMatcher({
+    introspectionQueryResultData: graphqlSchema,
+  })
+
+  client = new ApolloClient({
+    link: new HttpLink({ uri, headers }),
+    cache: new InMemoryCache({ fragmentMatcher }),
+  })
+
+  return client
+}
+
+// for testing purposes
+export function clearClient () {
+  client = null
+}

--- a/rn/Teacher/src/canvas-api-v2/queries/SubmissionList.js
+++ b/rn/Teacher/src/canvas-api-v2/queries/SubmissionList.js
@@ -21,6 +21,7 @@ import gql from 'graphql-tag'
 
 export default gql`query SubmissionList($assignmentID: ID!, $states: [SubmissionState!], $late: Boolean, $scoredMoreThan: Float, $scoredLessThan: Float, $sectionIDs: [ID!], $gradingStatus: SubmissionGradingStatus) {
   assignment(id: $assignmentID) {
+    id
     name
     pointsPossible
     gradeGroupStudentsIndividually

--- a/rn/Teacher/src/canvas-api/httpClient.js
+++ b/rn/Teacher/src/canvas-api/httpClient.js
@@ -118,7 +118,6 @@ function xhr (method: Method, url: string, data: Body, config: ApiConfig = {}) {
             }
 
             if (!request.status || request.status >= 400) {
-              console.log(request)
               throw new TypeError('Network request failed')
             }
             if (config.transform) {

--- a/rn/Teacher/src/modules/submissions/list/SubmissionSettings.js
+++ b/rn/Teacher/src/modules/submissions/list/SubmissionSettings.js
@@ -27,9 +27,9 @@ import Screen from '../../../routing/Screen'
 import i18n from 'format-message'
 import RowWithSwitch from '../../../common/components/rows/RowWithSwitch'
 import RowSeparator from '../../../common/components/rows/RowSeparator'
-import { connect } from 'react-redux'
-import AssignmentActions from '../../assignments/actions'
 import { colors } from '../../../common/stylesheet'
+import { graphql } from 'react-apollo'
+import gql from 'graphql-tag'
 
 type SubmissionSettingsOwnProps = {
   courseID: string,
@@ -53,14 +53,22 @@ export class SubmissionSettings extends PureComponent<SubmissionSettingsProps> {
   props: SubmissionSettingsProps
 
   toggleMutedGrading = (value: boolean) => {
-    this.props.updateAssignment(
-      this.props.courseID,
-      {
-        ...this.props.assignment,
+    this.props.mutate({
+      variables: {
+        id: this.props.assignmentID,
         muted: value,
       },
-      this.props.assignment
-    )
+      optimisticResponse: {
+        updateAssignment: {
+          assignment: {
+            id: this.props.id,
+            muted: value,
+            __typename: 'Assignment',
+          },
+          __typename: 'UpdateAssignmentPayload',
+        },
+      },
+    })
   }
 
   render () {
@@ -83,15 +91,35 @@ export class SubmissionSettings extends PureComponent<SubmissionSettingsProps> {
   }
 }
 
-export function mapStateToProps (state: AppState, ownProps: SubmissionSettingsOwnProps) {
-  const { assignmentID } = ownProps
-  let assignment = state.entities.assignments[assignmentID].data
-  let muted = assignment.muted
-
-  return { muted, assignment }
+const SubmissionSettingsWithMutation = graphql(gql`
+mutation ($id: ID!, $muted: Boolean!) {
+  updateAssignment(input: { id: $id, muted: $muted }) {
+    assignment {
+      id
+      muted
+    }
+  }
 }
-const Connect = connect(mapStateToProps, AssignmentActions)(SubmissionSettings)
-export default (Connect: any)
+`)(SubmissionSettings)
+
+export default graphql(gql`
+query ($id: ID!) {
+  assignment(id: $id) {
+    id
+    muted
+  }
+}
+`, {
+  options: (props) => ({
+    variables: {
+      id: props.assignmentID,
+    },
+  }),
+  props: (props) => ({
+    muted: props.data.assignment?.muted ?? false,
+    id: props.data.assignment?.id,
+  }),
+})(SubmissionSettingsWithMutation)
 
 const style = StyleSheet.create({
   container: {

--- a/rn/Teacher/src/routing/index.js
+++ b/rn/Teacher/src/routing/index.js
@@ -31,10 +31,7 @@ import ErrorScreen from './ErrorScreen'
 import app from '../modules/app'
 
 import { ApolloProvider } from 'react-apollo'
-import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
-import { InMemoryCache, IntrospectionFragmentMatcher } from 'apollo-cache-inmemory'
-import graphqlSchema from '../canvas-api-v2/schema.json'
+import getClient from '../canvas-api-v2/client'
 
 export const routes: Map<RouteHandler, RouteConfig> = new Map()
 export const routeProps: Map<string, ?Object> = new Map()
@@ -111,19 +108,8 @@ export function wrapComponentInProviders (moduleName: string, generator: (props:
 
       const ScreenComponent = generator(props)
       const session = getSession()
-      const uri = `${session.baseURL.replace(/\/?$/, '')}/api/graphql`
-      const headers = {
-        'GraphQL-Metrics': true,
-      }
 
-      let fragmentMatcher = new IntrospectionFragmentMatcher({
-        introspectionQueryResultData: graphqlSchema,
-      })
-
-      const client = new ApolloClient({
-        link: new HttpLink({ uri, headers }),
-        cache: new InMemoryCache({ fragmentMatcher }),
-      })
+      let client = getClient()
 
       return (
         <ApolloProvider client={client}>


### PR DESCRIPTION
affects: Teacher
refs: MBL-13432
release note: Fixed an issue where toggling the mute property of an assignment wouldn't update the label on the submissions list

Test Plan:
 - Make sure that new gradebook is turned off
 - Go to an assignment
 - Go to the submissions list
 - Open the settings and toggle the muted switch
 - Close the settings and notice that the muted label is now there
 - Open the settings and toggle the muted switch off
 - Close the settings and notice that the muted label is now gone