### PR TITLE
Disable rotating text annotations in Teacher

### DIFF
--- a/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsPDFDocumentPresenter.swift
+++ b/CanvasCore/CanvasCore/Annotations/Canvadocs/CanvadocsPDFDocumentPresenter.swift
@@ -199,6 +199,7 @@ extension CanvadocsPDFDocumentPresenter: PSPDFViewControllerDelegate {
     }
 
     public func pdfViewController(_ pdfController: PSPDFViewController, shouldShow menuItems: [PSPDFMenuItem], atSuggestedTargetRect rect: CGRect, for annotations: [PSPDFAnnotation]?, in annotationRect: CGRect, on pageView: PSPDFPageView) -> [PSPDFMenuItem] {
+        annotations?.forEach { (pageView.annotationView(for: $0) as? PSPDFFreeTextAnnotationView)?.resizableView?.allowRotating = false }
         if annotations?.count == 1, let annotation = annotations?.first, let metadata = service.metadata?.annotationMetadata {
             var realMenuItems = [PSPDFMenuItem]()
             realMenuItems.append(PSPDFMenuItem(title: NSLocalizedString("Comments", tableName: "Localizable", bundle: Bundle(for: type(of: self)), value: "", comment: ""), block: {

--- a/Core/Core/DocViewer/DocViewerPresenter.swift
+++ b/Core/Core/DocViewer/DocViewerPresenter.swift
@@ -120,6 +120,7 @@ extension DocViewerPresenter: PSPDFViewControllerDelegate {
         in annotationRect: CGRect,
         on pageView: PSPDFPageView
     ) -> [PSPDFMenuItem] {
+        annotations?.forEach { (pageView.annotationView(for: $0) as? PSPDFFreeTextAnnotationView)?.resizableView?.allowRotating = false }
         if annotations?.count == 1, let annotation = annotations?.first, let document = pdfController.document, let metadata = metadata?.annotations {
             var realMenuItems = [PSPDFMenuItem]()
             realMenuItems.append(PSPDFMenuItem(title: NSLocalizedString("Comments", bundle: .core, comment: "")) { [weak self] in

--- a/Core/CoreTests/DocViewer/DocViewerPresenterTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerPresenterTests.swift
@@ -132,6 +132,13 @@ class DocViewerPresenterTests: CoreTestCase {
         }
     }
 
+    class MockPDFPageView: PSPDFPageView {
+        var annotationView: (UIView & PSPDFAnnotationPresenting)?
+        override func annotationView(for annotation: PSPDFAnnotation) -> (UIView & PSPDFAnnotationPresenting)? {
+            return annotationView
+        }
+    }
+
     func testShouldShowForNoAnnotations() {
         let menuItems = [
             PSPDFMenuItem(title: "test", block: {}),
@@ -176,6 +183,31 @@ class DocViewerPresenterTests: CoreTestCase {
 
         results[3].performBlock()
         XCTAssertEqual((viewController.document as? MockPDFDocument)?.removed, [annotation])
+    }
+
+    func testShouldShowForAnnotationsDontAllowRotating() {
+        let menuItems = [
+            PSPDFMenuItem(title: "test", block: {}),
+            PSPDFMenuItem(title: "opacity", block: {}, identifier: PSPDFTextMenu.annotationMenuOpacity.rawValue),
+            PSPDFMenuItem(title: "inspector", block: {}, identifier: PSPDFTextMenu.annotationMenuInspector.rawValue),
+        ]
+        presenter.metadata = APIDocViewerMetadata.make()
+        let viewController = MockPDFViewController(document: MockPDFDocument(url: url))
+        let annotation = PSPDFFreeTextAnnotation(contents: "text")
+        let pageView = MockPDFPageView(frame: .zero)
+        let annotationView = PSPDFFreeTextAnnotationView()
+        let resizableView = PSPDFResizableView()
+        annotationView.resizableView = resizableView
+        pageView.annotationView = annotationView
+        _ = presenter.pdfViewController(
+            viewController,
+            shouldShow: menuItems,
+            atSuggestedTargetRect: .zero,
+            for: [annotation],
+            in: .zero,
+            on: pageView
+        )
+        XCTAssertFalse(resizableView.allowRotating)
     }
 
     func testShouldShowController() {


### PR DESCRIPTION
refs: MBL-13463
affects: teacher
release note: none

Test plan:
* Add a text annotation to a document in Teacher SG
* Tap away from the text annotation
* Tap it again to show blue box
* Should not have option to rotate annotation