### PR TITLE
Made nightly runner more robust to xcode errors

### DIFF
--- a/Core/CoreTests/DocViewer/DocViewerPresenterTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerPresenterTests.swift
@@ -26,7 +26,7 @@ class DocViewerPresenterTests: CoreTestCase {
     var error: Error?
     var resetted = false
 
-    let url = Bundle(for: DocViewerPresenterTests.self).url(forResource: "instructure", withExtension: "pdf")!
+    lazy var url = Bundle(for: DocViewerPresenterTests.self).url(forResource: "instructure", withExtension: "pdf")!
 
     class MockSession: DocViewerSession {
         var requested: URL?

--- a/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
+++ b/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
@@ -164,7 +164,12 @@ class RichContentEditorViewControllerTests: CoreTestCase, RichContentEditorDeleg
     }
 
     func testMediaRetry() {
-        let url = Bundle(for: type(of: self)).url(forResource: "instructure", withExtension: "pdf")!
+        let originalUrl = Bundle(for: type(of: self)).url(forResource: "instructure", withExtension: "pdf")!
+        // File will get deleted after upload, so use a copy instead
+        let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            .appendingPathComponent("instructure.pdf", isDirectory: false)
+        try? FileManager.default.copyItem(at: originalUrl, to: url)
+
         api.mock(GetMediaServiceRequest(), error: NSError.internalError())
         controller.imagePickerController(MockPicker(), didFinishPickingMediaWithInfo: [ .mediaURL: url ])
         XCTAssertTrue((self.databaseClient.fetch() as [File]).isEmpty)

--- a/Core/CoreUITests/CoreUITestCase.swift
+++ b/Core/CoreUITests/CoreUITestCase.swift
@@ -83,10 +83,10 @@ open class CoreUITestCase: XCTestCase {
         }
         // re-install the existing mocks
         for message in dataMocks {
-            try! send(.mockData(message))
+            send(.mockData(message))
         }
         for message in downloadMocks {
-            try! send(.mockDownload(message))
+            send(.mockDownload(message))
         }
     }
 

--- a/Core/CoreUITests/UITestUser.swift
+++ b/Core/CoreUITests/UITestUser.swift
@@ -66,7 +66,7 @@ public class UITestUser: NSObject, XCTestObservation {
         XCTestObservationCenter.shared.addTestObserver(self)
     }
 
-    public func testBundleDidFinish(_ testBundle: Bundle) {
+    public func testSuiteWillStart(_ testSuite: XCTestSuite) {
         session = nil // ensure sessions get cleaned up
     }
 }

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -1,3 +1,12 @@
+---
+app:
+  envs:
+  - BITRISE_PROJECT_PATH: "./Canvas.xcworkspace"
+    opts:
+      is_expand: false
+  - BITRISE_SCHEME: NightlyTests
+    opts:
+      is_expand: false
 default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 format_version: '4'
 project_type: other

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -194,20 +194,20 @@ workflows:
 
   nightly:
     steps:
-    # - slack:
-    #     title: "Send build start message to slack"
-    #     inputs:
-    #     - webhook_url: $SLACK_URL
-    #     - channel: '#ios'
-    #     - pretext: ""
-    #     - author_name: ""
-    #     - message: ""
-    #     - title: 'Nightly build started... ${BITRISE_BUILD_URL}'
-    #     - fields: ""
-    #     - color: warning
-    #     - footer: ""
-    #     - buttons: ""
-    #     - timestamp: "no"
+    - slack:
+        title: "Send build start message to slack"
+        inputs:
+        - webhook_url: $SLACK_URL
+        - channel: '#ios'
+        - pretext: ""
+        - author_name: ""
+        - message: ""
+        - title: 'Nightly build started... ${BITRISE_BUILD_URL}'
+        - fields: ""
+        - color: warning
+        - footer: ""
+        - buttons: ""
+        - timestamp: "no"
     - git::git@github.com:instructure/steps-canvas-ios-secrets.git@master:
         title: Canvas iOS Secrets
     - script:
@@ -326,12 +326,12 @@ workflows:
             $BITRISE_SOURCE_DIR/rn/Teacher/node_modules/
             ~/Library/Developer/Xcode/DerivedData
     - deploy-to-bitrise-io: {}
-    # - slack:
-    #     inputs:
-    #     - pretext_on_error: "*Nightly Build Failed!*"
-    #     - webhook_url: "$SLACK_URL"
-    #     - channel: "#ios"
-    #     - author_name: ''
-    #     - title: ''
-    #     - message: ''
-    #     - pretext: "*Nightly Build Succeeded!*"
+    - slack:
+        inputs:
+        - pretext_on_error: "*Nightly Build Failed!*"
+        - webhook_url: "$SLACK_URL"
+        - channel: "#ios"
+        - author_name: ''
+        - title: ''
+        - message: ''
+        - pretext: "*Nightly Build Succeeded!*"

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -217,7 +217,7 @@ workflows:
 
             # Set all changed files to now
             git checkout -
-    # - cache-pull: {}
+    - cache-pull: {}
     - script:
         title: brew tap
         run_if: .IsCI

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -185,20 +185,20 @@ workflows:
 
   nightly:
     steps:
-    - slack:
-        title: "Send build start message to slack"
-        inputs:
-        - webhook_url: $SLACK_URL
-        - channel: '#ios'
-        - pretext: ""
-        - author_name: ""
-        - message: ""
-        - title: 'Nightly build started... ${BITRISE_BUILD_URL}'
-        - fields: ""
-        - color: warning
-        - footer: ""
-        - buttons: ""
-        - timestamp: "no"
+    # - slack:
+    #     title: "Send build start message to slack"
+    #     inputs:
+    #     - webhook_url: $SLACK_URL
+    #     - channel: '#ios'
+    #     - pretext: ""
+    #     - author_name: ""
+    #     - message: ""
+    #     - title: 'Nightly build started... ${BITRISE_BUILD_URL}'
+    #     - fields: ""
+    #     - color: warning
+    #     - footer: ""
+    #     - buttons: ""
+    #     - timestamp: "no"
     - git::git@github.com:instructure/steps-canvas-ios-secrets.git@master:
         title: Canvas iOS Secrets
     - script:
@@ -317,12 +317,12 @@ workflows:
             $BITRISE_SOURCE_DIR/rn/Teacher/node_modules/
             ~/Library/Developer/Xcode/DerivedData
     - deploy-to-bitrise-io: {}
-    - slack:
-        inputs:
-        - pretext_on_error: "*Nightly Build Failed!*"
-        - webhook_url: "$SLACK_URL"
-        - channel: "#ios"
-        - author_name: ''
-        - title: ''
-        - message: ''
-        - pretext: "*Nightly Build Succeeded!*"
+    # - slack:
+    #     inputs:
+    #     - pretext_on_error: "*Nightly Build Failed!*"
+    #     - webhook_url: "$SLACK_URL"
+    #     - channel: "#ios"
+    #     - author_name: ''
+    #     - title: ''
+    #     - message: ''
+    #     - pretext: "*Nightly Build Succeeded!*"

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -217,7 +217,7 @@ workflows:
 
             # Set all changed files to now
             git checkout -
-    - cache-pull: {}
+    # - cache-pull: {}
     - script:
         title: brew tap
         run_if: .IsCI

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -51,7 +51,7 @@ function setEnv {
     done
     if [[ i -eq 0 ]]; then
         echo "failed to set any environment variables!"
-        exit 1
+        return 1
     fi
 }
 
@@ -84,7 +84,7 @@ function getTestResults {
     if (( ${#tests_passed_this_run} + ${#tests_failed_this_run} == 0 )); then
         echo "Couldn't find any test results... probably a bug!"
         jq -C . <$all_results_path
-        exit 1
+        return 1
     fi
 
     all_passing_tests+=($tests_passed_this_run)

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -128,7 +128,7 @@ function doTest {
     local flags=($destination_flag)
     flags+=(-resultBundlePath $result_path)
     flags+=(-xctestrun $xctestrun)
-    if (( try < 1 )); then
+    if (( try < 2 )); then
         flags+=(-parallel-testing-enabled YES -parallel-testing-worker-count 3)
     fi
     for skip in $all_passing_tests; do
@@ -141,7 +141,7 @@ function doTest {
     mkfifo $pipe_file
 
     < $pipe_file NSUnbufferedIO=YES xcbeautify &
-    xcodebuild test-without-building $flags > $pipe_file 2> $pipe_file || ret=$?
+    NSUnbufferedIO=YES xcodebuild test-without-building $flags > $pipe_file 2> $pipe_file || ret=$?
     wait
     rm -rf $pipe_file
 

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -124,18 +124,18 @@ function doTest {
     local result_path=$results_directory/$try.xcresult
     local ret=0
 
-
     local flags=($destination_flag)
     flags+=(-resultBundlePath $result_path)
     flags+=(-xctestrun $xctestrun)
-    if (( try < 0 )); then
+
+    if (( false )); then
         flags+=(-parallel-testing-enabled YES -parallel-testing-worker-count 3)
     fi
     for skip in $all_passing_tests; do
         flags+=(-skip-testing:$skip)
     done
 
-    # Do this the long way to make sure we notice failures
+    # Do this the long way to make sure we get the correct exit code
     pipe_file=tmp/formatter-fifo
     rm -rf $pipe_file
     mkfifo $pipe_file

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -113,7 +113,7 @@ function doTest {
     NSUnbufferedIO=YES xcodebuild test-without-building $flags 2>&1 | $formatter ||
         ret=$?
 
-    getTestResults || return $?
+    getTestResults || echo "couldn't parse test results!"
     banner "${#tests_passed_this_run} tests passed"
     banner "${#tests_failed_this_run} tests failed"
     print ${(F)tests_failed_this_run}
@@ -125,8 +125,8 @@ function retry {
     (( try += 1 ))
     banner "Retrying"
 
-    setEnv $xctestrun CANVAS_TEST_IS_RETRY YES || return $?
-    doTest || return $?
+    setEnv $xctestrun CANVAS_TEST_IS_RETRY YES
+    doTest
 }
 
 xcrun simctl boot 'iPhone 8' || true

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -47,7 +47,7 @@ function setEnv {
     for (( i = 0; ; i++ )); do
         name=$(/usr/libexec/PlistBuddy $1 -c "print :TestConfigurations:0:TestTargets:$i:BlueprintName" 2>/dev/null) || break
         echo "Setting $2=$3 in $1 $name"
-        /usr/libexec/PlistBuddy $1 -c "add :TestConfigurations:0:TestTargets:$i:EnvironmentVariables:$2 string $3" || exit $?
+        /usr/libexec/PlistBuddy $1 -c "add :TestConfigurations:0:TestTargets:$i:EnvironmentVariables:$2 string $3" || true
     done
     if [[ i -eq 0 ]]; then
         echo "failed to set any environment variables!"

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -28,6 +28,8 @@ function banner() (
     TERM=xterm-color tput sgr0
 )
 
+mkdir -p tmp
+
 destination_flag=(-destination 'platform=iOS Simulator,name=iPhone 8')
 
 banner "Building NightlyTests"
@@ -65,7 +67,14 @@ rm -rf $results_directory
 mkdir -p $results_directory
 
 function getTestResults {
+    tests_passed_this_run=0
+    tests_failed_this_run=0
+
     local result_path=$results_directory/$try.xcresult
+    if [[ ! -d $result_path ]]; then
+        echo "couldn't find test results!!"
+        exit 1
+    fi
     local test_result_id=($(xcrun xcresulttool get --format json --path $result_path |
                                  jq -r '.actions._values[].actionResult.testsRef.id._value'))
     local all_results_path=$results_directory/$try.json
@@ -82,11 +91,22 @@ function getTestResults {
     tests_failed_this_run=($(jq -r '.[] | select(.status == "Failure").id' $all_results_path)) || return $?
 
     if (( ${#tests_passed_this_run} + ${#tests_failed_this_run} == 0 )); then
-        echo "Couldn't find any test results... probably a bug!"
-        jq -C . <$all_results_path
-        return 1
+        echo "Couldn't find any test results... possibly a test class crashed in init somewhere?"
+        crash_logs=($result_path/Staging/**/*.crash)
+        banner "found ${#crash_logs} crash logs"
+        for crash_log in $crash_logs; do
+            banner $crash_log
+            cat $crash_log
+        done
+
+        # Something more than flakiness is going on, fail immediately
+        exit 1
     fi
 
+    banner "${#tests_passed_this_run} tests passed"
+    banner "${#tests_failed_this_run} tests failed"
+    print ${(F)tests_failed_this_run}
+    (( total_failures += ${#tests_failed_this_run} ))
     all_passing_tests+=($tests_passed_this_run)
 }
 
@@ -105,19 +125,23 @@ function doTest {
     flags+=(-xctestrun $xctestrun)
     if (( try < 1 )); then
         flags+=(-parallel-testing-enabled YES -parallel-testing-worker-count 3)
-        formatter=(env NSUnbufferedIO=YES xcbeautify)
+        formatter=(xcbeautify)
     fi
     for skip in $all_passing_tests; do
         flags+=(-skip-testing:$skip)
     done
-    NSUnbufferedIO=YES xcodebuild test-without-building $flags 2>&1 | $formatter ||
-        ret=$?
 
-    getTestResults || echo "couldn't parse test results!"
-    banner "${#tests_passed_this_run} tests passed"
-    banner "${#tests_failed_this_run} tests failed"
-    print ${(F)tests_failed_this_run}
-    (( total_failures += ${#tests_failed_this_run} ))
+    # Do this the long way to make sure we notice failures
+    pipe_file=tmp/formatter-fifo
+    rm -rf $pipe_file
+    mkfifo $pipe_file
+
+    < $pipe_file NSUnbufferedIO=YES $formatter  &
+    xcodebuild test-without-building $flags > $pipe_file 2> $pipe_file || ret=$?
+    wait
+    rm -rf $pipe_file
+
+    getTestResults
     return $ret
 }
 
@@ -130,7 +154,7 @@ function retry {
 }
 
 xcrun simctl boot 'iPhone 8' || true
-open -a /Applications/Xcode.app/Contents/Developer/Applications/Simulator.app
+open -a $(xcode-select -p)/Applications/Simulator.app
 
 ret=0
 doTest $base_xctestrun ||

--- a/scripts/run-nightly-tests.sh
+++ b/scripts/run-nightly-tests.sh
@@ -128,7 +128,7 @@ function doTest {
     local flags=($destination_flag)
     flags+=(-resultBundlePath $result_path)
     flags+=(-xctestrun $xctestrun)
-    if (( try < 2 )); then
+    if (( try < 0 )); then
         flags+=(-parallel-testing-enabled YES -parallel-testing-worker-count 3)
     fi
     for skip in $all_passing_tests; do


### PR DESCRIPTION
Apparently the "set -e" flag does less than I thought (it doesn't cause functions to return)

Test plan: this build shouldn't time out:
https://app.bitrise.io/build/45f517fba25b08fc

refs: MBL-13510
affects: none
release note: none