### PR TITLE
Fix notifications tests

### DIFF
--- a/Core/Core/API/APIActivity.swift
+++ b/Core/Core/API/APIActivity.swift
@@ -44,14 +44,22 @@ public struct APIActivity: Codable {
 
 public struct GetActivitiesRequest: APIRequestable {
     public typealias Response = [APIActivity]
+    let perPage: Int?
+
+    public init(perPage: Int? = nil) {
+        self.perPage = perPage
+    }
 
     public var path: String {
-        return "users/self/activity_stream"
+        let context = ContextModel(.user, id: "self")
+        return "\(context.pathComponent)/activity_stream"
     }
 
     public var query: [APIQueryItem] {
-        return [
-            .value("per_page", "10"),
-        ]
+        var query: [APIQueryItem] = []
+        if let perPage = perPage {
+            query.append(.value("per_page", String(perPage)))
+        }
+        return query
     }
 }

--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -24,7 +24,7 @@ import Foundation
 /// that is not ready for all users to exercise. This is different from
 /// feature flags in Canvas, which represent optional functionality in
 /// production that should only apply to certain accounts, courses, or people.
-public enum ExperimentalFeature: String, CaseIterable {
+public enum ExperimentalFeature: String, CaseIterable, Codable {
     case parent3
     case conferences
     case favoriteGroups = "favorite_groups"

--- a/Core/Core/UITestHelpers/UITestHelpers.swift
+++ b/Core/Core/UITestHelpers/UITestHelpers.swift
@@ -33,9 +33,10 @@ public class UITestHelpers {
         case setAnimationsEnabled(Bool)
         case useMocksOnly
         case debug(Any?)
+        case enableExperimentalFeatures([String])
 
         private enum CodingKeys: String, CodingKey {
-            case reset, login, show, tearDown, currentSession, setAnimationsEnabled, useMocksOnly, debug, mockNow
+            case reset, login, show, tearDown, currentSession, setAnimationsEnabled, useMocksOnly, debug, mockNow, experimentalFeatures
         }
 
         public init(from decoder: Decoder) throws {
@@ -58,6 +59,8 @@ public class UITestHelpers {
                 self = .debug(try NSKeyedUnarchiver(forReadingFrom: data).decodeObject(forKey: "debug"))
             } else if let date = try container.decodeIfPresent(Date.self, forKey: .mockNow) {
                 self = .mockNow(date)
+            } else if let features = try container.decodeIfPresent([String].self, forKey: .experimentalFeatures) {
+                self = .enableExperimentalFeatures(features)
             } else {
                 throw DecodingError.typeMismatch(Helper.self, .init(codingPath: container.codingPath, debugDescription: "Couldn't decode \(Helper.self)"))
             }
@@ -85,6 +88,8 @@ public class UITestHelpers {
                 try container.encode(archiver.encodedData, forKey: .debug)
             case .mockNow(let date):
                 try container.encode(date, forKey: .mockNow)
+            case .enableExperimentalFeatures(let features):
+                try container.encode(features, forKey: .experimentalFeatures)
             }
         }
     }
@@ -147,6 +152,10 @@ public class UITestHelpers {
             ()
         case .mockNow(let date):
             Clock.mockNow(date)
+        case .enableExperimentalFeatures(let features):
+            for feature in features {
+                ExperimentalFeature(rawValue: feature)!.isEnabled = true
+            }
         }
         return nil
     }

--- a/Core/Core/UITestHelpers/UITestHelpers.swift
+++ b/Core/Core/UITestHelpers/UITestHelpers.swift
@@ -33,7 +33,7 @@ public class UITestHelpers {
         case setAnimationsEnabled(Bool)
         case useMocksOnly
         case debug(Any?)
-        case enableExperimentalFeatures([String])
+        case enableExperimentalFeatures([ExperimentalFeature])
 
         private enum CodingKeys: String, CodingKey {
             case reset, login, show, tearDown, currentSession, setAnimationsEnabled, useMocksOnly, debug, mockNow, experimentalFeatures
@@ -59,7 +59,7 @@ public class UITestHelpers {
                 self = .debug(try NSKeyedUnarchiver(forReadingFrom: data).decodeObject(forKey: "debug"))
             } else if let date = try container.decodeIfPresent(Date.self, forKey: .mockNow) {
                 self = .mockNow(date)
-            } else if let features = try container.decodeIfPresent([String].self, forKey: .experimentalFeatures) {
+            } else if let features = try container.decodeIfPresent([ExperimentalFeature].self, forKey: .experimentalFeatures) {
                 self = .enableExperimentalFeatures(features)
             } else {
                 throw DecodingError.typeMismatch(Helper.self, .init(codingPath: container.codingPath, debugDescription: "Couldn't decode \(Helper.self)"))
@@ -153,9 +153,8 @@ public class UITestHelpers {
         case .mockNow(let date):
             Clock.mockNow(date)
         case .enableExperimentalFeatures(let features):
-            for feature in features {
-                ExperimentalFeature(rawValue: feature)!.isEnabled = true
-            }
+            ExperimentalFeature.allEnabled = false
+            features.forEach { $0.isEnabled = true }
         }
         return nil
     }

--- a/Core/CoreTests/API/APIActivityTests.swift
+++ b/Core/CoreTests/API/APIActivityTests.swift
@@ -19,25 +19,11 @@
 import XCTest
 @testable import Core
 
-class GetActivitiesRequestTests: XCTestCase {
-    var req: GetActivitiesRequest!
-
-    override func setUp() {
-        super.setUp()
-        req = GetActivitiesRequest()
-    }
-
-    func testPath() {
-        XCTAssertEqual(req.path, "users/self/activity_stream")
-    }
-
-    func testQuery() {
-        let expected: [APIQueryItem] = [.value("per_page", "10")]
-        XCTAssertEqual(req.query, expected)
-    }
-
-    func testModel() {
-        let model = APIActivity.make()
-        XCTAssertNotNil(model)
+class APIActivityTests: XCTestCase {
+    func testGetActivitiesRequest() {
+        let request = GetActivitiesRequest()
+        XCTAssertEqual(request.path, "users/self/activity_stream")
+        XCTAssertEqual(request.queryItems, [])
+        XCTAssertEqual(GetActivitiesRequest(perPage: 99).queryItems, [URLQueryItem(name: "per_page", value: "99")])
     }
 }

--- a/Core/CoreUITests/CoreUITestCase.swift
+++ b/Core/CoreUITests/CoreUITestCase.swift
@@ -44,6 +44,8 @@ open class CoreUITestCase: XCTestCase {
         }
     }
 
+    open var experimentalFeatures: [ExperimentalFeature] { [] }
+
     // The class in this variable will not have tests run for it, only for subclasses
     open var abstractTestClass: CoreUITestCase.Type { CoreUITestCase.self }
 
@@ -83,6 +85,7 @@ open class CoreUITestCase: XCTestCase {
             }
         }
         reset()
+        send(.enableExperimentalFeatures(experimentalFeatures.map { $0.rawValue }))
         if let user = user {
             logInUser(user)
             homeScreen.waitToExist()

--- a/Core/CoreUITests/CoreUITestCase.swift
+++ b/Core/CoreUITests/CoreUITestCase.swift
@@ -85,7 +85,7 @@ open class CoreUITestCase: XCTestCase {
             }
         }
         reset()
-        send(.enableExperimentalFeatures(experimentalFeatures.map { $0.rawValue }))
+        send(.enableExperimentalFeatures(experimentalFeatures))
         if let user = user {
             logInUser(user)
             homeScreen.waitToExist()

--- a/Student/StudentUITests/Notifications/NotificationsListTests.swift
+++ b/Student/StudentUITests/Notifications/NotificationsListTests.swift
@@ -25,9 +25,32 @@ class NotificationsListTests: CoreUITestCase {
     override var user: UITestUser? { return nil }
 
     func testNotificationItemsDisplayed() {
+        ExperimentalFeature.notifications2.isEnabled = true
         mockBaseRequests()
-        mockEncodableRequest("users/self/activity_stream?per_page=99", value: [
-            APIActivity.make(),
+        mockData(GetActivitiesRequest(perPage: 99), value: [
+            APIActivity.make(id: "1", title: "Assignment Created"),
+            APIActivity.make(id: "2", title: "Another Notification"),
+        ])
+
+        logIn()
+        TabBar.notificationsTab.tap()
+
+        app.find(labelContaining: "Assignment Created").waitToExist()
+        app.find(labelContaining: "Another Notification").waitToExist()
+    }
+}
+
+class Notifications2ListTests: CoreUITestCase {
+    override var user: UITestUser? { nil }
+    override var experimentalFeatures: [ExperimentalFeature] {
+        return [.notifications2]
+    }
+
+    func testNotificationItemsDisplayed() {
+        mockBaseRequests()
+        mockData(GetCoursesRequest(enrollmentState: .active), value: [ baseCourse ])
+        mockData(GetActivitiesRequest(), value: [
+            APIActivity.make(id: "1", title: "Assignment Created"),
             APIActivity.make(id: "2", title: "Another Notification"),
         ])
 


### PR DESCRIPTION
refs: MBL-13632
affects: student
release note: none

Also adds a way to enable experimental features in UI tests.