### PR TITLE
Mark discussion topics as read

### DIFF
--- a/rn/Teacher/src/canvas-api/apis/discussions.js
+++ b/rn/Teacher/src/canvas-api/apis/discussions.js
@@ -86,6 +86,11 @@ export function subscribeDiscussion (context: CanvasContext, contextID: string, 
   return httpClient[subscribed ? 'put' : 'delete'](url)
 }
 
+export function markTopicAsRead (context, contextID, discussionID) {
+  const url = `${context}/${contextID}/discussion_topics/${discussionID}/read`
+  return httpClient.put(url)
+}
+
 export function markEntryAsRead (context: CanvasContext, contextID: string, discussionID: string, entryID: string): ApiPromise<null> {
   const url = `${context}/${contextID}/discussion_topics/${discussionID}/entries/${entryID}/read`
   return httpClient.put(url)

--- a/rn/Teacher/src/modules/discussions/details/DiscussionDetails.js
+++ b/rn/Teacher/src/modules/discussions/details/DiscussionDetails.js
@@ -58,8 +58,10 @@ import { isRegularDisplayMode } from '../../../routing/utils'
 import { isTeacher, isStudent } from '../../app'
 import { alertError } from '../../../redux/middleware/error-handler'
 import { logEvent } from '../../../common/CanvasAnalytics'
+import * as canvas from '../../../canvas-api'
 
 const { NativeAccessibility, ModuleItemsProgress } = NativeModules
+const { markTopicAsRead } = canvas
 
 type EntryRatings = { [string]: number }
 
@@ -129,6 +131,10 @@ export type Props
 export class DiscussionDetails extends Component<Props, any> {
   hasReplaced: boolean = false
 
+  static defaultProps = {
+    markTopicAsRead,
+  }
+
   constructor (props: Props) {
     super(props)
     this.state = {
@@ -149,6 +155,7 @@ export class DiscussionDetails extends Component<Props, any> {
       if (isStudent) {
         ModuleItemsProgress.viewedDiscussion(props.contextID, props.discussionID)
       }
+      props.markTopicAsRead(props.context, props.contextID, props.discussionID)
     }
   }
 

--- a/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
@@ -769,7 +769,7 @@ describe('DiscussionDetails', () => {
     props.context = 'courses'
     props.contextID = '1'
     props.discussionID = '2'
-    let view = shallow(<DiscussionDetails {...props} />)
+    shallow(<DiscussionDetails {...props} />)
     expect(props.markTopicAsRead).toHaveBeenCalledWith('courses', '1', '2')
   })
 

--- a/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
@@ -88,6 +88,7 @@ describe('DiscussionDetails', () => {
       refreshSingleDiscussion: jest.fn(),
       markAllAsRead: jest.fn(),
       markEntryAsRead: jest.fn(),
+      markTopicAsRead: jest.fn(),
       unreadEntries: [],
       permissions: { post_to_forum: true },
     }
@@ -761,6 +762,15 @@ describe('DiscussionDetails', () => {
       ...props,
       permissions: { post_to_forum: false },
     })
+  })
+
+  it('marks topic as read', () => {
+    props.markTopicAsRead = jest.fn()
+    props.context = 'courses'
+    props.contextID = '1'
+    props.discussionID = '2'
+    let view = shallow(<DiscussionDetails {...props} />)
+    expect(props.markTopicAsRead).toHaveBeenCalledWith('courses', '1', '2')
   })
 
   describe('GroupTopicChildren', () => {


### PR DESCRIPTION
refs: MBL-7308
affects: student, teacher
release note: Fixed marking announcements and discussions as read

Test plan:
* Create a new course announcement
* View the course announcements as a student in web
* Notice the new announcement is unread
* View the new announcement as a student in the student app
* On the web, the announcement should be marked as read

You can use my account:
```
narmstrong > s > CS 1400 > Announcements > Push Notifications X
```