### PR TITLE
fetch course front page on course details load

### DIFF
--- a/Core/Core/Models/Course.swift
+++ b/Core/Core/Models/Course.swift
@@ -47,7 +47,7 @@ final public class Course: NSManagedObject, Context, WriteableModel {
         model.courseCode = item.course_code
         model.imageDownloadURL = URL(string: item.image_download_url ?? "")
         model.syllabusBody = item.syllabus_body
-
+        model.defaultViewRaw = item.default_view?.rawValue
         model.enrollments?.forEach { context.delete($0) }
         model.enrollments = nil
 

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -38,11 +38,11 @@ class CourseDetailsViewController: HorizontalMenuViewController {
     lazy var courses = env.subscribe(GetCourse(courseID: courseID, include: GetCourseRequest.defaultIncludes + [.observedUsers])) { [weak self] in
         self?.courseReady()
     }
-    
+
     lazy var frontPages = env.subscribe(GetFrontPage(context: ContextModel(.course, id: courseID))) { [weak self] in
         self?.courseReady()
     }
-    
+
     static func create(courseID: String, studentID: String, env: AppEnvironment = .shared) -> CourseDetailsViewController {
         let controller = CourseDetailsViewController(nibName: nil, bundle: nil)
         controller.env = env
@@ -83,7 +83,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
         summaryViewController = Core.SyllabusActionableItemsViewController(courseID: courseID, sort: GetAssignments.Sort.dueAt, colorDelegate: self)
         viewControllers.append(summaryViewController)
     }
-    
+
     func configureFrontPage() {
         let vc = CoreWebViewController()
         vc.webView.loadHTMLString(frontPages.first?.body ?? "", baseURL: nil)

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -143,7 +143,7 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
         case .syllabus:
             switch courses.first?.defaultView {
             case .wiki:
-                return NSLocalizedString("Homepage", comment: "")
+                return NSLocalizedString("Frontpage", comment: "")
             case .syllabus:
                 return NSLocalizedString("Syllabus", comment: "")
             default:

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -91,6 +91,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
     }
 
     func courseReady() {
+        title = courses.first?.name
         if !courses.pending && !frontPages.pending && readyToLayoutTabs, !didLayoutTabs, let course = courses.first {
             didLayoutTabs = true
             configureGrades()

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -104,7 +104,6 @@ class CourseDetailsViewController: HorizontalMenuViewController {
             case .wiki:
                 if let page = frontPages.first, !page.body.isEmpty {
                     configureFrontPage()
-                    configureSummary()
                 }
             default: break
             }
@@ -142,7 +141,13 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
         case .grades:
             return NSLocalizedString("Grades", comment: "")
         case .syllabus:
-            return NSLocalizedString("Syllabus", comment: "")
+            switch courses.first?.defaultView {
+            case .wiki:
+                return NSLocalizedString("Homepage", comment: "")
+            case .syllabus: fallthrough
+            default:
+                return NSLocalizedString("Syllabus", comment: "")
+            }
         case .summary:
             return NSLocalizedString("Summary", comment: "")
         }

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -144,7 +144,8 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
             switch courses.first?.defaultView {
             case .wiki:
                 return NSLocalizedString("Homepage", comment: "")
-            case .syllabus: fallthrough
+            case .syllabus:
+                return NSLocalizedString("Syllabus", comment: "")
             default:
                 return NSLocalizedString("Syllabus", comment: "")
             }


### PR DESCRIPTION
refs: MBL-13197
affects: Parent
release note: none

Test plan:
in course details:
1. go to a course with a front page set.  Make sure homepage tab is shown but not summary or syllabus.
2. go to a course with a syllabus set as front page.  Make sure syllabus tab and summary loads
3. go to a course with no front page set or syllabus and make sure syllabus or summary tab or homepage do not show.