### PR TITLE
Fix favoriting and unfavoriting courses for the dashboard

### DIFF
--- a/rn/Teacher/src/modules/courses/__tests__/courses-reducer.test.js
+++ b/rn/Teacher/src/modules/courses/__tests__/courses-reducer.test.js
@@ -818,6 +818,7 @@ describe('getDashboardCards', () => {
         dashboardPosition: 0,
       },
     })
+    expect(newState[1] === state[1]).toEqual(false)
   })
 
   it('still works when there are no courses yet', () => {

--- a/rn/Teacher/src/modules/courses/courses-reducer.js
+++ b/rn/Teacher/src/modules/courses/courses-reducer.js
@@ -371,7 +371,7 @@ const coursesData: Reducer<CoursesState, any> = handleActions({
         .reduce((newState, id) => {
           newState[id] = {
             ...newState[id],
-            dashboardPosition: undefined
+            dashboardPosition: undefined,
           }
           return newState
         }, { ...state })

--- a/rn/Teacher/src/modules/courses/courses-reducer.js
+++ b/rn/Teacher/src/modules/courses/courses-reducer.js
@@ -369,7 +369,10 @@ const coursesData: Reducer<CoursesState, any> = handleActions({
     resolved: (state, { result }) => {
       let clearedState = Object.keys(state)
         .reduce((newState, id) => {
-          newState[id].dashboardPosition = undefined
+          newState[id] = {
+            ...newState[id],
+            dashboardPosition: undefined
+          }
           return newState
         }, { ...state })
 


### PR DESCRIPTION
refs: MBL-13589
affects: student, teacher
release note: none

This issue did not affect production builds because redux state
in production is not frozen where as in debug it is