### PR TITLE
Fix Parent grades

### DIFF
--- a/Core/Core/API/APICourseRequestable.swift
+++ b/Core/Core/API/APICourseRequestable.swift
@@ -90,6 +90,7 @@ public struct GetCourseRequest: APIRequestable {
         .syllabusBody,
         .term,
         .totalScores,
+        .observedUsers,
     ]
 
     var include: [Include] = defaultIncludes

--- a/Core/CoreTests/API/APICourseRequestableTests.swift
+++ b/Core/CoreTests/API/APICourseRequestableTests.swift
@@ -60,6 +60,7 @@ class APICourseRequestableTests: XCTestCase {
             URLQueryItem(name: "include[]", value: "syllabus_body"),
             URLQueryItem(name: "include[]", value: "term"),
             URLQueryItem(name: "include[]", value: "total_scores"),
+            URLQueryItem(name: "include[]", value: "observed_users"),
         ])
     }
 

--- a/Core/CoreUITests/CoreUITestCase.swift
+++ b/Core/CoreUITests/CoreUITestCase.swift
@@ -305,6 +305,16 @@ open class CoreUITestCase: XCTestCase {
     @discardableResult
     open func mock(course: APICourse) -> APICourse {
         mockData(GetCourseRequest(courseID: course.id), value: course)
+        mockData(GetCourseRequest(courseID: course.id, include: [
+            .courseImage,
+            .currentGradingPeriodScores,
+            .favorites,
+            .permissions,
+            .sections,
+            .syllabusBody,
+            .term,
+            .totalScores,
+        ]), value: course)
         mockData(GetEnabledFeatureFlagsRequest(context: ContextModel(.course, id: course.id)), value: ["rce_enhancements"])
         mockEncodableRequest("courses/\(course.id)/external_tools?per_page=99&include_parents=true", value: [String]())
         return course


### PR DESCRIPTION
refs: MBl-13641
affects: parent
release note: none

I would prefer to always include observed_users so I mocked in in the base class helper so that UI tests still pass.

**Test plan:**
* Log in as narmstrong > `o` in Parent app
* Enable parent3 in experimental features
* Tap a course to view grades
* Assignment and total grades should load