### PR TITLE
fix filter by grading period

### DIFF
--- a/Core/Core/Grades/GradesViewController.swift
+++ b/Core/Core/Grades/GradesViewController.swift
@@ -85,11 +85,12 @@ public class GradesViewController: UIViewController {
     }
 
     @IBAction func actionUserDidClickFilter(_ sender: Any) {
-        if grades.gradingPeriod != nil {
+        if grades.gradingPeriodID != nil {
             grades.gradingPeriodID = nil
         } else {
             let alert = UIAlertController(title: nil, message: NSLocalizedString("Filter by:", comment: ""), preferredStyle: .actionSheet)
             for gp in grades.gradingPeriods {
+                if gp.title?.isEmpty ?? true { continue }
                 let action = UIAlertAction(title: gp.title, style: .default) { [weak self] _ in
                     self?.grades.gradingPeriodID = gp.id
                 }


### PR DESCRIPTION
refs: MBL-13612
affects: Parent
release note: none

getting an empty / faulted core data grading period

```
po print(gp)
<Core.GradingPeriod: 0x600000a30910> (entity: GradingPeriod; id: 0xeffeeed6f1635c1f <x-coredata://B326FF37-AE35-494C-85BF-6738F22883B1/GradingPeriod/p30>; data: {
    assignments = "<relationship fault: 0x6000028b3020 'assignments'>";
    courseID = 1;
    id = nil;
    title = nil;
})t``

Test plan:

1. go to grades
2. clear filter
3. filter by a different grading period
4. make sure there are results that can be seen and that it does not crash