### PR TITLE
fix calendar event button action from parent summary tab on grades view

### DIFF
--- a/Core/Core/Router/Route.swift
+++ b/Core/Core/Router/Route.swift
@@ -58,6 +58,10 @@ public struct Route: Equatable {
         return Route("/courses/\(courseID)/calendar_events/\(eventID)")
     }
 
+    public static func actionableItemCalendarEvent(eventID: String) -> Route {
+        return Route("/calendar_events/\(eventID)")
+    }
+
     public static func courseDiscussion(courseID: String, topicID: String) -> Route {
         return Route("/courses/\(courseID)/discussion_topics/\(topicID)")
     }

--- a/Parent/Parent/Details/CalendarEventDetailsViewController.swift
+++ b/Parent/Parent/Details/CalendarEventDetailsViewController.swift
@@ -58,7 +58,7 @@ class CalendarEventDetailsViewController: CalendarEventDetailViewController {
     var disposable: Disposable?
     @objc let studentID: String
 
-    @objc init(session: Session, studentID: String, courseID: String, calendarEventID: String) throws {
+    @objc init(session: Session, studentID: String, courseID: String? = nil, calendarEventID: String) throws {
         self.studentID = studentID
         super.init()
         let observer = try CalendarEvent.observer(session, studentID: studentID, calendarEventID: calendarEventID)
@@ -74,12 +74,16 @@ class CalendarEventDetailsViewController: CalendarEventDetailViewController {
             .observeValues { _ in
         }
 
-        session.enrollmentsDataSource(withScope: studentID)
-            .producer(ContextID(id: courseID, context: .course))
-            .observe(on: UIScheduler())
-            .startWithValues { next in
-            guard let course = next as? CanvasCore.Course else { return }
-            self.title = course.name
+        if let courseID = courseID {
+            session.enrollmentsDataSource(withScope: studentID)
+                .producer(ContextID(id: courseID, context: .course))
+                .observe(on: UIScheduler())
+                .startWithValues { next in
+                    guard let course = next as? CanvasCore.Course else { return }
+                    self.title = course.name
+            }
+        } else {
+            title = NSLocalizedString("Calendar Event", comment: "")
         }
     }
 

--- a/Parent/Parent/Routes.swift
+++ b/Parent/Parent/Routes.swift
@@ -65,6 +65,12 @@ let router = Router(routes: [
         return try? AnnouncementDetailsViewController(session: session, studentID: studentID, courseID: courseID, announcementID: topicID)
     },
 
+    RouteHandler(.actionableItemCalendarEvent(eventID: ":eventID")) { _, params in
+        guard  let eventID = params["eventID"] else { return nil }
+        guard let session = legacySession, let studentID = currentStudentID else { return nil }
+        return try? CalendarEventDetailsViewController(session: session, studentID: studentID, calendarEventID: eventID)
+    },
+
     RouteHandler(.profile) { _, _ in
         return ProfileViewController.create(enrollment: .observer)
     },


### PR DESCRIPTION
refs: MBL-13699
affects: Parent
release note: none

test plan
--------------
1. go to parent app
2. login with observer
3. go to student that has a syllabus and a summary with a calendar event
4. click on the calendar event.  make sure user is show a native detail view and not routed to some web page in core webview.