### PR TITLE
[Parent] Fix refreshing total score on grades page

### DIFF
--- a/Core/Core/Models/Enrollment.swift
+++ b/Core/Core/Models/Enrollment.swift
@@ -124,8 +124,13 @@ extension Enrollment {
         }
 
         self.course = course
-        if course != nil {
-            // these only come back in the course endpoint
+
+        if let apiGrades = item.grades {
+            let grade = grades.first { $0.gradingPeriodID == gradingPeriodID } ?? client.insert()
+            grade.currentScore = apiGrades.current_score
+            grade.gradingPeriodID = gradingPeriodID
+            grades.insert(grade)
+        } else {
             multipleGradingPeriodsEnabled = item.multiple_grading_periods_enabled ?? false
             currentGradingPeriodID = item.current_grading_period_id
             totalsForAllGradingPeriodsOption = item.totals_for_all_grading_periods_option ?? false
@@ -147,13 +152,6 @@ extension Enrollment {
                 currentPeriodGrade.currentScore = item.current_period_computed_current_score
                 grades.insert(currentPeriodGrade)
             }
-        }
-
-        if let apiGrades = item.grades {
-            let grade = grades.first { $0.gradingPeriodID == gradingPeriodID } ?? client.insert()
-            grade.currentScore = apiGrades.current_score
-            grade.gradingPeriodID = gradingPeriodID
-            grades.insert(grade)
         }
     }
 }


### PR DESCRIPTION
refs: MBL-13698
affects: parent
release note: none

Test plan:
* View the grades list in the Parent app for a student with a visible total score
* Change the grade of an assignment so that the total score will change
* Pull to refresh the grades list
* The total score should update to the new value

See ticket for one user. You can also use

Account: narmstrong
Observer: o
Student: student8