### PR TITLE
Fix Grades list icons

### DIFF
--- a/Core/Core/Grades/GradesCell.xib
+++ b/Core/Core/Grades/GradesCell.xib
@@ -24,10 +24,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="VpP-3m-wzd">
-                    <rect key="frame" x="18" y="14" width="20" height="20"/>
+                    <rect key="frame" x="16" y="12" width="24" height="24"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="20" id="Ut5-Ri-6UL"/>
-                        <constraint firstAttribute="width" constant="20" id="rVv-uV-xXs"/>
+                        <constraint firstAttribute="height" constant="24" id="Ut5-Ri-6UL"/>
+                        <constraint firstAttribute="width" constant="24" id="rVv-uV-xXs"/>
                     </constraints>
                 </imageView>
                 <stackView opaque="NO" contentMode="scaleToFill" distribution="equalSpacing" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="XIK-90-1NF">
@@ -89,12 +89,12 @@
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="XIK-90-1NF" secondAttribute="bottom" id="CBv-fd-gDq"/>
-                <constraint firstItem="XIK-90-1NF" firstAttribute="leading" secondItem="VpP-3m-wzd" secondAttribute="trailing" constant="18" id="Ky7-Cb-KVw"/>
+                <constraint firstItem="XIK-90-1NF" firstAttribute="leading" secondItem="VpP-3m-wzd" secondAttribute="trailing" constant="16" id="Ky7-Cb-KVw"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="XIK-90-1NF" secondAttribute="bottom" priority="750" constant="12" id="QTh-EC-6Mh"/>
-                <constraint firstItem="VpP-3m-wzd" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="900" constant="14" id="bs1-dx-lan"/>
+                <constraint firstItem="VpP-3m-wzd" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" priority="900" constant="12" id="bs1-dx-lan"/>
                 <constraint firstItem="XIK-90-1NF" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" priority="750" constant="12" id="o4r-fs-udo"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="XIK-90-1NF" secondAttribute="trailing" constant="16" id="uzs-4P-R6X"/>
-                <constraint firstItem="VpP-3m-wzd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="18" id="vyZ-1B-2Ie"/>
+                <constraint firstItem="VpP-3m-wzd" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="16" id="vyZ-1B-2Ie"/>
             </constraints>
             <nil key="simulatedTopBarMetrics"/>
             <nil key="simulatedBottomBarMetrics"/>


### PR DESCRIPTION
refs: MBL-13713
affects: parent
release note: none

Test plan:
Tap on a course in the Parent app to view the Grades list.
The icons and space around the icons should be the correct size.