### PR TITLE
Fix Calendar a11y

### DIFF
--- a/Student/Canvas/Calendar/UI/View/CalendarDaysOfWeekView.swift
+++ b/Student/Canvas/Calendar/UI/View/CalendarDaysOfWeekView.swift
@@ -32,6 +32,10 @@ class CalendarDaysOfWeekView : UIView {
     fileprivate lazy var symbols: [String] = {
         return dateFormatter.shortStandaloneWeekdaySymbols
     }()
+
+    lazy var a11ySymbols: [String] = {
+        return dateFormatter.standaloneWeekdaySymbols
+    }()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -78,6 +82,7 @@ class CalendarDaysOfWeekView : UIView {
             weekdayLabel.backgroundColor = UIColor.clear
             weekdayLabel.font = UIFont.preferredFont(forTextStyle: .title3).noLargerThan(32.0)
             weekdayLabel.text = weekdaySymbol
+            weekdayLabel.accessibilityLabel = a11ySymbols[index]
             weekdayLabel.adjustsFontSizeToFitWidth = true
             if index != 0 && index != 6 {
                 weekdayLabel.textColor = UIColor.black

--- a/Student/Canvas/Calendar/UI/View/CalendarView.swift
+++ b/Student/Canvas/Calendar/UI/View/CalendarView.swift
@@ -71,7 +71,13 @@ open class CalendarView: UIView, UICollectionViewDelegate, UICollectionViewDataS
         dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "MMMM yyyy", options: 0, locale: Locale.current)
         return dateFormatter
     }()
-    
+
+    private static let a11yMonthFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        // Parentheses prevent VO from pronouncing year 2020 as twentieth-twenty
+        dateFormatter.dateFormat = "MMMM (yyyy)"
+        return dateFormatter
+    }()
     
     // ---------------------------------------------
     // MARK: - LifeCycle
@@ -221,6 +227,7 @@ open class CalendarView: UIView, UICollectionViewDelegate, UICollectionViewDataS
                 monthHeader.date = date
 
                 monthHeader.dateLabel.text = CalendarView.dateFormatter.string(from: formattedDate).uppercased()
+                monthHeader.dateLabel.accessibilityLabel = CalendarView.a11yMonthFormatter.string(from: formattedDate)
                 monthHeader.dateLabel.accessibilityTraits = [.header]
                 
                 var todayCalDate = CalendarDate()

--- a/Student/Canvas/Calendar/UI/View/CalendarView.swift
+++ b/Student/Canvas/Calendar/UI/View/CalendarView.swift
@@ -68,7 +68,7 @@ open class CalendarView: UIView, UICollectionViewDelegate, UICollectionViewDataS
 
     private static let dateFormatter: DateFormatter = {
         let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "MMMM YYYY", options: 0, locale: Locale.current)
+        dateFormatter.dateFormat = DateFormatter.dateFormat(fromTemplate: "MMMM yyyy", options: 0, locale: Locale.current)
         return dateFormatter
     }()
     
@@ -219,7 +219,9 @@ open class CalendarView: UIView, UICollectionViewDelegate, UICollectionViewDataS
                 date.populate(formattedDate, calendar: calendar)
                 
                 monthHeader.date = date
+
                 monthHeader.dateLabel.text = CalendarView.dateFormatter.string(from: formattedDate).uppercased()
+                monthHeader.dateLabel.accessibilityTraits = [.header]
                 
                 var todayCalDate = CalendarDate()
                 todayCalDate.populate(today, calendar: calendar)

--- a/Student/StudentUnitTests/Calendar/CalendarMonthViewControllerTests.swift
+++ b/Student/StudentUnitTests/Calendar/CalendarMonthViewControllerTests.swift
@@ -74,6 +74,32 @@ class CalendarMonthViewControllerTests: StudentTestCase {
         XCTAssertNil(jan3.dateLabel.accessibilityValue)
     }
 
+    func testMonthHeaders() {
+        Clock.mockNow(jan(1, 2019))
+        calendar.view.layoutIfNeeded()
+        let header = monthHeader(at: IndexPath(item: 0, section: 0))
+        XCTAssertEqual(header.dateLabel.text, "JANUARY 2018")
+        XCTAssertTrue(header.dateLabel.accessibilityTraits.contains(.header))
+    }
+
+    func testDaysOfWeek() {
+        calendar.view.layoutIfNeeded()
+        let labels = calendar.calendarView.daysOfWeekView.stack.arrangedSubviews as! [UILabel]
+        let values = [
+            ("Sun", "Sunday"),
+            ("Mon", "Monday"),
+            ("Tue", "Tuesday"),
+            ("Wed", "Wednesday"),
+            ("Thu", "Thursday"),
+            ("Fri", "Friday"),
+            ("Sat", "Saturday"),
+        ]
+        for (index, value) in values.enumerated() {
+            XCTAssertEqual(labels[index].text, value.0)
+            XCTAssertEqual(labels[index].accessibilityLabel, value.1)
+        }
+    }
+
     // MARK: - Helpers
 
     func jan(_ day: Int, _ year: Int) -> Date {
@@ -82,6 +108,10 @@ class CalendarMonthViewControllerTests: StudentTestCase {
 
     func dayCell(at indexPath: IndexPath) -> CalendarDayCell {
         return collectionView.dataSource!.collectionView(collectionView, cellForItemAt: indexPath) as! CalendarDayCell
+    }
+
+    func monthHeader(at indexPath: IndexPath) -> CalendarMonthHeaderView {
+        return collectionView.dataSource!.collectionView?(collectionView, viewForSupplementaryElementOfKind: UICollectionView.elementKindSectionHeader, at: indexPath) as! CalendarMonthHeaderView
     }
 
     func mockRange(_ startDate: Date, _ endDate: Date) {

--- a/Student/StudentUnitTests/Calendar/CalendarMonthViewControllerTests.swift
+++ b/Student/StudentUnitTests/Calendar/CalendarMonthViewControllerTests.swift
@@ -79,6 +79,7 @@ class CalendarMonthViewControllerTests: StudentTestCase {
         calendar.view.layoutIfNeeded()
         let header = monthHeader(at: IndexPath(item: 0, section: 0))
         XCTAssertEqual(header.dateLabel.text, "JANUARY 2018")
+        XCTAssertEqual(header.dateLabel.accessibilityLabel, "January (2018)")
         XCTAssertTrue(header.dateLabel.accessibilityTraits.contains(.header))
     }
 


### PR DESCRIPTION
refs: MBL-12428
affects: student
release note: Accessibility improvements

Test plan:
* Navigate the student calendar with Voice Over on
* Use header navigation to swipe up and down between months (note you have to scroll with three fingers once to get more calendars to load. I don't know why. Might be a collection view optimization or something)
* Week day symbols at the top should read the full week day
* The year 2020 should not read "twentieth twenty"