### PR TITLE
Fix French web view resizing

### DIFF
--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -166,7 +166,7 @@ open class CoreWebView: WKWebView {
             document.querySelectorAll('iframe').forEach(iframe => {
                 const replace = iframe => {
                     const a = document.createElement('a')
-                    a.textContent = '\(buttonText)'
+                    a.textContent = \(CoreWebView.jsString(buttonText))
                     a.classList.add('canvas-ios-lti-launch-button')
                     a.href = iframe.src
                     iframe.parentNode.replaceChild(a, iframe)


### PR DESCRIPTION
properly encodes the localized launch text so translations can't break the js.

refs: MBL-13733
affects: Student
release note: Fixed an issue with assignment descriptions in French