### PR TITLE
Fix context cards from Inbox

### DIFF
--- a/rn/Teacher/src/modules/inbox/__tests__/reducer.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/reducer.test.js
@@ -26,6 +26,45 @@ import { testAsyncReducer } from '../../../../test/helpers/async'
 const { refreshInboxAll, updateInboxSelectedScope, markAsRead, deleteConversationMessage } = InboxActions()
 import * as templates from '../../../__templates__'
 
+describe('inbox', () => {
+  it('does not remove common_courses', () => {
+    let conversation = templates.conversation({
+      id: '1',
+      participants: [
+        {
+          id: '1',
+          name: 'participant 1',
+        },
+      ],
+    })
+    let data = [conversation]
+    const action = {
+      type: refreshInboxAll.toString(),
+      payload: { result: { data } },
+    }
+    let state = {
+      conversations: {
+        '1': {
+          data: {
+            id: '1',
+            participants: [
+              {
+                id: '1',
+                name: 'participant 1',
+                common_courses: {
+                  '2': ['StudentEnrollment'],
+                },
+              },
+            ],
+          },
+        },
+      },
+    }
+    let result = inbox(state, action)
+    expect(result.conversations['1'].data.participants[0].common_courses).not.toBeUndefined()
+  })
+})
+
 test('it handles the data', () => {
   const data = [
     templates.conversation({ id: '1' }),

--- a/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
+++ b/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
@@ -62,8 +62,15 @@ export default class ConversationMessageRow extends React.Component<Props, State
   }
 
   courseID () {
-    let contextCodeID = this.props.conversation.context_code?.split('_')[1]
-    return Object.keys(this.author().common_courses ?? {})[0] ?? contextCodeID
+    let { author_id } = this.props.message
+    let target = this.props.conversation.participants.find(({ id }) => {
+      if (author_id === getSession().user.id) {
+        // current user doesn't have common courses so take from any other participant
+        return id !== getSession().user.id
+      }
+      return id === author_id
+    })
+    return Object.keys(target?.common_courses ?? {})[0]
   }
 
   handleAvatarPress = () => {

--- a/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
+++ b/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
@@ -61,10 +61,13 @@ export default class ConversationMessageRow extends React.Component<Props, State
     this.props.onReply(this.props.message.id)
   }
 
+  courseID () {
+    return Object.keys(this.author().common_courses)[0]
+  }
+
   handleAvatarPress = () => {
-    let courseID = this.props.conversation.context_code.split('_')[1]
     this.props.navigator.show(
-      `/courses/${courseID}/users/${this.props.message.author_id}`,
+      `/courses/${this.courseID()}/users/${this.props.message.author_id}`,
       { modal: true, modalPresentationStyle: 'currentContext' }
     )
   }
@@ -91,7 +94,6 @@ export default class ConversationMessageRow extends React.Component<Props, State
   author (): ConversationParticipant {
     const convo = this.props.conversation
     const message = this.props.message
-    // $FlowFixMe we know the author will always be in participants
     return convo.participants.find(({ id }) => id === message.author_id)
   }
 

--- a/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
+++ b/rn/Teacher/src/modules/inbox/components/ConversationMessageRow.js
@@ -62,7 +62,8 @@ export default class ConversationMessageRow extends React.Component<Props, State
   }
 
   courseID () {
-    return Object.keys(this.author().common_courses)[0]
+    let contextCodeID = this.props.conversation.context_code?.split('_')[1]
+    return Object.keys(this.author().common_courses ?? {})[0] ?? contextCodeID
   }
 
   handleAvatarPress = () => {
@@ -146,7 +147,7 @@ export default class ConversationMessageRow extends React.Component<Props, State
               height={32}
               avatarURL={author.avatar_url}
               userName={author.name}
-              onPress={this.props.conversation.context_code ? this.handleAvatarPress : undefined}
+              onPress={this.courseID() != null ? this.handleAvatarPress : undefined}
             />
           </View>
           <View style={{ flex: 1 }}>

--- a/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
+++ b/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
@@ -28,6 +28,7 @@ import * as template from '../../../../__templates__'
 describe('ConversationMessageRow', () => {
   let props
   beforeEach(() => {
+    jest.clearAllMocks()
     props = {
       conversation: template.conversation(),
       message: template.conversationMessage(),
@@ -163,6 +164,45 @@ describe('ConversationMessageRow', () => {
       `/courses/2/users/5678`,
       { modal: true, modalPresentationStyle: 'currentContext' },
     )
+  })
+
+  it('navigates to own context card when avatar is pressed', () => {
+    props.conversation = template.conversation({
+      context_code: 'course_1',
+      participants: [
+        { id: '1234', name: 'participant 1' },
+        {
+          id: '5678',
+          name: 'participant 2',
+          common_courses: {},
+        },
+      ],
+    })
+    props.message.author_id = '5678'
+    const tree = shallow(<ConversationMessage {...props} />)
+    tree.find('Avatar').simulate('Press')
+    expect(props.navigator.show).toHaveBeenCalledWith(
+      `/courses/1/users/5678`,
+      { modal: true, modalPresentationStyle: 'currentContext' },
+    )
+  })
+
+  it('does not navigate to context card without a valid course ID', () => {
+    props.conversation = template.conversation({
+      context_code: null, // an anomoly
+      participants: [
+        { id: '1234', name: 'participant 1' },
+        {
+          id: '5678',
+          name: 'participant 2',
+          common_courses: {},
+        },
+      ],
+    })
+    props.message.author_id = '5678'
+    const tree = shallow(<ConversationMessage {...props} />)
+    tree.find('Avatar').simulate('Press')
+    expect(props.navigator.show).not.toHaveBeenCalled()
   })
 
   it('navigates to a link when pressed', () => {

--- a/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
+++ b/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
@@ -151,7 +151,7 @@ describe('ConversationMessageRow', () => {
           id: '5678',
           name: 'participant 2',
           common_courses: {
-            '2': ['StudentEnrollment']
+            '2': ['StudentEnrollment'],
           },
         },
       ],

--- a/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
+++ b/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
@@ -143,10 +143,24 @@ describe('ConversationMessageRow', () => {
   })
 
   it('navigates to context card when the avatar is pressed', () => {
+    props.conversation = template.conversation({
+      context_code: 'course_1',
+      participants: [
+        { id: '1234', name: 'participant 1' },
+        {
+          id: '5678',
+          name: 'participant 2',
+          common_courses: {
+            '2': ['StudentEnrollment']
+          },
+        },
+      ],
+    })
+    props.message.author_id = '5678'
     const tree = shallow(<ConversationMessage {...props} />)
     tree.find('Avatar').simulate('Press')
     expect(props.navigator.show).toHaveBeenCalledWith(
-      `/courses/1/users/1234`,
+      `/courses/2/users/5678`,
       { modal: true, modalPresentationStyle: 'currentContext' },
     )
   })

--- a/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
+++ b/rn/Teacher/src/modules/inbox/components/__tests__/ConversationMessageRow.test.js
@@ -167,22 +167,29 @@ describe('ConversationMessageRow', () => {
   })
 
   it('navigates to own context card when avatar is pressed', () => {
+    let session = getSession()
     props.conversation = template.conversation({
       context_code: 'course_1',
       participants: [
-        { id: '1234', name: 'participant 1' },
         {
-          id: '5678',
-          name: 'participant 2',
+          id: session.user.id,
+          name: 'me',
           common_courses: {},
+        },
+        {
+          id: 'not_the_current_user_id',
+          name: 'participant 2',
+          common_courses: {
+            '2': ['StudentEnrollment'],
+          },
         },
       ],
     })
-    props.message.author_id = '5678'
+    props.message.author_id = session.user.id
     const tree = shallow(<ConversationMessage {...props} />)
     tree.find('Avatar').simulate('Press')
     expect(props.navigator.show).toHaveBeenCalledWith(
-      `/courses/1/users/5678`,
+      `/courses/2/users/${session.user.id}`,
       { modal: true, modalPresentationStyle: 'currentContext' },
     )
   })

--- a/rn/Teacher/src/modules/inbox/reducer.js
+++ b/rn/Teacher/src/modules/inbox/reducer.js
@@ -90,10 +90,16 @@ export function entityExtractor (): { [string]: Function } {
     resolved: (state, { result }) => {
       const pairs = result.data.map((c) => {
         const current = (state[c.id] || { data: {} }).data
+        let participants = c.participants.map(participant => ({
+          ...participant,
+          common_courses: current?.participants?.find(({ id }) => id === participant.id)?.common_courses,
+        }))
+
         return [c.id, {
           data: {
             ...current,
             ...c,
+            participants,
           },
         }]
       })


### PR DESCRIPTION
refs: MBL-13754
affects: teacher
release note: Fixed a bug when tapping on user avatars in Inbox

Test plan: See [ticket](https://instructure.atlassian.net/browse/MBL-13754)

Apparently we can't trust the `context_code` in the conversation payload because in this case the ID was completely wrong.