### PR TITLE
Hide syllabus if it's not Home and disabled

### DIFF
--- a/Parent/ParentUnitTests/.swiftlint.yml
+++ b/Parent/ParentUnitTests/.swiftlint.yml
@@ -1,0 +1,26 @@
+disabled_rules: # rule identifiers to exclude from running
+  - control_statement
+  - class_delegate_protocol
+  - todo
+  - identifier_name
+  - force_try
+  - nesting
+  - force_cast
+  - xctfail_message
+  - type_body_length
+  - file_length
+opt_in_rules: # some rules are only opt-in
+  - yoda_condition
+included: # paths to include during linting. `--path` is ignored if present.
+excluded: # paths to ignore during linting. Takes precedence over `included`.
+  - Pods
+
+line_length: 200
+
+identifier_name:
+  min_length: 1 # only min_length
+  max_length: 50
+  excluded: # excluded via string array
+    - access_token
+trailing_comma:
+  mandatory_comma: true

--- a/Parent/ParentUnitTests/Course/CourseDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Course/CourseDetailsViewControllerTests.swift
@@ -38,7 +38,7 @@ class CourseDetailsViewControllerTests: ParentTestCase {
         api.mock(GetFrontPageRequest(context: ContextModel(.course, id: courseID)), value: APIPage.make())
         api.mock(
             GetTabsRequest(context: ContextModel(.course, id: courseID)),
-            value: [.make(id: "syllabus", html_url: URL(string:  "/tabs")!)]
+            value: [.make(id: "syllabus", html_url: URL(string: "/tabs")!)]
         )
     }
 

--- a/Parent/ParentUnitTests/Course/CourseDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Course/CourseDetailsViewControllerTests.swift
@@ -27,41 +27,100 @@ class CourseDetailsViewControllerTests: ParentTestCase {
     let courseID = "1"
     let studentID = "1"
 
+    var isSyllabusShown: Bool {
+        return vc.viewControllers.first { $0 is SyllabusViewController } != nil &&
+            vc.viewControllers.first { $0 is SyllabusActionableItemsViewController } != nil
+    }
+
     override func setUp() {
         super.setUp()
         vc = CourseDetailsViewController.create(courseID: courseID, studentID: studentID)
+        api.mock(GetFrontPageRequest(context: ContextModel(.course, id: courseID)), value: APIPage.make())
+        api.mock(
+            GetTabsRequest(context: ContextModel(.course, id: courseID)),
+            value: [.make(id: "syllabus", html_url: URL(string:  "/tabs")!)]
+        )
     }
 
-    func testRender() {
-        //  Most of the other features of this view controller are tested in the individual tabs
-
-        ExperimentalFeature.parentInbox.isEnabled = true
-
-        api.mock( GetCourseRequest(courseID: courseID), value: .make() )
-        api.mock(GetFrontPageRequest(context: ContextModel(.course, id: courseID)), value: APIPage.make())
-
+    func render() {
         vc.view.layoutIfNeeded()
-        vc.viewDidLoad()
         vc.viewWillAppear(false)
         vc.viewDidAppear(false)
+    }
+
+    func testInboxReplyButton() {
+        ExperimentalFeature.parentInbox.isEnabled = true
+        api.mock(GetCourseRequest(courseID: courseID), value: .make())
+
+        render()
 
         XCTAssertNotNil(vc.replyButton)
         vc.replyButton?.sendActions(for: .primaryActionTriggered)
-
         XCTAssertTrue(router.lastRoutedTo(.compose()))
     }
 
-    func testRenderWithExperimentalFeaturesOff() {
+    func testInboxReplyWithExperimentalFeaturesOff() {
         ExperimentalFeature.parentInbox.isEnabled = false
+        api.mock(GetCourseRequest(courseID: courseID), value: .make())
 
-        api.mock( GetCourseRequest(courseID: courseID), value: .make() )
-        api.mock(GetFrontPageRequest(context: ContextModel(.course, id: courseID)), value: APIPage.make())
-
-        vc.view.layoutIfNeeded()
-        vc.viewDidLoad()
-        vc.viewWillAppear(false)
-        vc.viewDidAppear(false)
+        render()
 
         XCTAssertNil(vc.replyButton)
+    }
+
+    func testHomeIsFrontPage() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .wiki))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsSyllabus() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .syllabus, syllabus_body: "body"))
+        render()
+        XCTAssertTrue(isSyllabusShown)
+    }
+
+    func testHomeIsNilSyllabus() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .syllabus, syllabus_body: nil))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsEmptySyllabus() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .syllabus, syllabus_body: ""))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsHiddenSyllabus() {
+        api.mock(GetTabsRequest(context: ContextModel(.course, id: courseID)), value: [])
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .syllabus, syllabus_body: "body"))
+        render()
+        XCTAssertTrue(isSyllabusShown)
+    }
+
+    func testHomeIsUnsupportedAndSyllabusPresentButNotInTabs() {
+        api.mock(GetTabsRequest(context: ContextModel(.course, id: courseID)), value: [])
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .modules, syllabus_body: "body"))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsUnsupportedAndSyllabusIsEmpty() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .modules, syllabus_body: ""))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsUnsupportedAndSyllabusIsNil() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .modules, syllabus_body: nil))
+        render()
+        XCTAssertFalse(isSyllabusShown)
+    }
+
+    func testHomeIsUnsupportedAndSyllabusIsPresent() {
+        api.mock(GetCourseRequest(courseID: courseID), value: .make(id: ID(courseID), default_view: .modules, syllabus_body: "body"))
+        render()
+        XCTAssertTrue(isSyllabusShown)
     }
 }

--- a/Parent/ParentUnitTests/ParentTestCase.swift
+++ b/Parent/ParentUnitTests/ParentTestCase.swift
@@ -33,23 +33,18 @@ class ParentTestCase: XCTestCase {
 
     var api = MockURLSession.self
     var queue = OperationQueue()
-    var router = TestRouter()
-    var env = AppEnvironment.shared
-    var logger = TestLogger()
-    var currentSession = LoginSession.make()
+    var router: TestRouter { env.router as! TestRouter }
+    var env = TestEnvironment()
+    var logger: TestLogger { env.logger as! TestLogger }
+    var currentSession: LoginSession? { env.currentSession }
 
     override func setUp() {
         super.setUp()
         queue = OperationQueue()
-        router = TestRouter()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
-        env = AppEnvironment.shared
-        env.api = URLSessionAPI(loginSession: nil, urlSession: MockURLSession())
-        env.database = database
-        env.globalDatabase = database
-        env.router = router
-        env.logger = logger
-        env.currentSession = currentSession
+        env = TestEnvironment()
+        env.mockStore = false
+        AppEnvironment.shared = env
         MockURLSession.reset()
         MockUploadManager.reset()
         ExperimentalFeature.allEnabled = false

--- a/Student/StudentUnitTests/StudentTestCase.swift
+++ b/Student/StudentUnitTests/StudentTestCase.swift
@@ -35,10 +35,7 @@ class StudentTestCase: XCTestCase {
     var queue = OperationQueue()
     var env = TestEnvironment()
     var logger: TestLogger!
-    var router: TestRouter! {
-        guard let r = env.router as? TestRouter else { return nil }
-        return r
-    }
+    var router: TestRouter { env.router as! TestRouter }
     var uploadManager = MockUploadManager()
     var currentSession: LoginSession!
 


### PR DESCRIPTION
refs: MBl-13778
affects: parent
release note: Fixed a bug that would cause the syllabus to show when it should not be shown

Test plan:
* Log in to Parent app as `o` on narmstrong
* Select Student Two
* _Fight Club_ should not show syllabus
* _Modules_ course should show the Syllabus
* _CS 1400_ should not show the syllabus but should show Front Page