### PR TITLE
Fix a crash in GradesViewController

### DIFF
--- a/Core/Core/Grades/Grades.swift
+++ b/Core/Core/Grades/Grades.swift
@@ -29,7 +29,7 @@ public class Grades {
     }
     var gradingPeriodID: String? = UnknownGradingPeriodID {
         didSet {
-            reload()
+            performUIUpdate { self.reload() }
         }
     }
     var callback: (() -> Void)?


### PR DESCRIPTION
[ignore-commit-lint]

There was timing issue where the main thread might access a Store that hasn't performed a fetch yet. This should make the operation synchronous so to avoid the crash.

Test plan:
View a course in Parent then immediately tap the Reply icon to compose a message. The app should not crash.