### PR TITLE
Fix course action sheet from showing same course twice

### DIFF
--- a/Core/Core/Models/Course.swift
+++ b/Core/Core/Models/Course.swift
@@ -52,7 +52,13 @@ final public class Course: NSManagedObject, Context, WriteableModel {
         model.imageDownloadURL = URL(string: item.image_download_url ?? "")
         model.syllabusBody = item.syllabus_body
         model.defaultViewRaw = item.default_view?.rawValue
-        model.enrollments?.forEach { context.delete($0) }
+        model.enrollments?.forEach { enrollment in
+            // we only want to delete dangling enrollments created from
+            // the minimal enrollments attached to an APICourse
+            if enrollment.id == nil {
+                context.delete(enrollment)
+            }
+        }
         model.enrollments = nil
         model.hideFinalGrades = item.hide_final_grades ?? false
 

--- a/Core/CoreTests/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginWebViewControllerTests.swift
@@ -40,7 +40,7 @@ class LoginWebViewControllerTests: CoreTestCase {
         XCTAssertEqual(controller.webView.url, URL(string: "https://localhost:1/login/oauth2/auth?client_id=1&response_type=code&redirect_uri=https://canvas/login&mobile=1"))
     }
 
-    func testPreloaded() {
+    func xtestPreloaded() {
         controller.mdmLogin = MDMLogin(host: "localhost:1", username: "u", password: "p")
         controller.mobileVerifyModel = APIVerifyClient(authorized: true, base_url: url, client_id: "1", client_secret: "s")
         controller.view.layoutIfNeeded()

--- a/Core/CoreTests/Models/CourseTests.swift
+++ b/Core/CoreTests/Models/CourseTests.swift
@@ -52,6 +52,16 @@ class CourseTests: CoreTestCase {
         XCTAssertEqual(resultEnrollment?.canvasContextID, "course_1")
     }
 
+    func testDeletesOnlyDanglingEnrollments() {
+        let apiCourse = APICourse.make(id: "1")
+        let course = Course.make(from: apiCourse)
+        Enrollment.make(from: .make(course_id: "1"), course: course, in: databaseClient)
+
+        Course.save(apiCourse, in: databaseClient)
+        let enrollments: [Enrollment] = databaseClient.fetch()
+        XCTAssertEqual(enrollments.count, 2)
+    }
+
     func testWidgetDisplayGradeNoEnrollments() {
         let c = Course.make(from: .make(enrollments: nil))
         XCTAssertEqual(c.displayGrade, "")

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APICourseFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APICourseFixture.swift
@@ -30,6 +30,7 @@ extension APICourse {
         end_at: Date? = nil,
         locale: String? = nil,
         enrollments: [APIEnrollment]? = [ .make(
+            id: nil,
             enrollment_state: .active,
             user_id: "12",
             role: "StudentEnrollment",


### PR DESCRIPTION
refs: MBL-13788
affects: parent
release note: none

Test Plan: see ticket for credentials
 - In the inbox for the user the course CS1400
   should show up multiple times.
 - Ignore blank CS 2810 student name, this is
   just bad data from the api