### PR TITLE
disable testUnlockModuleItemWithPrerequisiteModule

### DIFF
--- a/Student/StudentUITests/Modules/ModulesTests.swift
+++ b/Student/StudentUITests/Modules/ModulesTests.swift
@@ -132,7 +132,7 @@ class MockedModulesTests: StudentUITestCase {
         mockBaseRequests()
     }
 
-    func testUnlockModuleItemWithPrerequisiteModule() {
+    func xtestUnlockModuleItemWithPrerequisiteModule() {
         let modules: [APIModule] = [
             .make(id: "1", name: "Module 1", position: 1, prerequisite_module_ids: [], state: .unlocked),
             .make(id: "2", name: "Module 2", position: 2, prerequisite_module_ids: ["1"], state: .locked),


### PR DESCRIPTION
Ticket to re-enable: MBL-13814

refs: none
affects: student
release note: none