### PR TITLE
Resume activity indicator animations after page change

### DIFF
--- a/Core/Core/Grades/GradesViewController.storyboard
+++ b/Core/Core/Grades/GradesViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j3n-Ay-Z48">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j3n-Ay-Z48">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -125,6 +125,7 @@
                         <viewLayoutGuide key="safeArea" id="cOb-sB-t27"/>
                     </view>
                     <connections>
+                        <outlet property="activityIndicator" destination="bvs-mD-dxP" id="VDM-r0-44o"/>
                         <outlet property="filterButton" destination="Gaj-1W-VFV" id="s2a-4B-MWm"/>
                         <outlet property="gradingPeriodLabel" destination="SHp-y7-PBa" id="4MQ-du-Vp0"/>
                         <outlet property="gradingPeriodView" destination="22T-dU-m0c" id="zxn-3b-84t"/>

--- a/Core/Core/Grades/GradesViewController.swift
+++ b/Core/Core/Grades/GradesViewController.swift
@@ -23,7 +23,7 @@ public protocol ColorDelegate: class {
     var iconColor: UIColor? { get }
 }
 
-public class GradesViewController: UIViewController, HorizontalPagedMenuItem {
+public class GradesViewController: UIViewController {
     @IBOutlet weak var filterButton: DynamicButton!
     @IBOutlet weak var totalGradeLabel: DynamicLabel!
     @IBOutlet weak var gradingPeriodLabel: DynamicLabel!
@@ -136,17 +136,6 @@ public class GradesViewController: UIViewController, HorizontalPagedMenuItem {
             view.setNeedsLayout()
         }
     }
-
-    public func itemWillBeDisplayed() {
-        if grades.isPending == true && tableView.refreshControl?.isRefreshing == false {
-            activityIndicator.startAnimating()
-        } else if grades.isPending == true && tableView.refreshControl?.isRefreshing == true {
-            let offset = tableView.contentOffset
-            tableView.refreshControl?.endRefreshing()
-            tableView.refreshControl?.beginRefreshing()
-            tableView.contentOffset = offset
-        }
-    }
 }
 
 extension GradesViewController: UITableViewDataSource, UITableViewDelegate {
@@ -185,6 +174,19 @@ extension GradesViewController: UITableViewDataSource, UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, estimatedHeightForHeaderInSection section: Int) -> CGFloat {
         return 22
+    }
+}
+
+extension GradesViewController: HorizontalPagedMenuItem {
+    public func menuItemWillBeDisplayed() {
+        if grades.isPending == true && tableView.refreshControl?.isRefreshing == false {
+            activityIndicator.startAnimating()
+        } else if grades.isPending == true && tableView.refreshControl?.isRefreshing == true {
+            let offset = tableView.contentOffset
+            tableView.refreshControl?.endRefreshing()
+            tableView.refreshControl?.beginRefreshing()
+            tableView.contentOffset = offset
+        }
     }
 }
 

--- a/Core/Core/Grades/GradesViewController.swift
+++ b/Core/Core/Grades/GradesViewController.swift
@@ -57,6 +57,7 @@ public class GradesViewController: UIViewController {
         grades.refresh()
         if grades.isPending {
             loadingView.isHidden = false
+            activityIndicator.startAnimating()
         }
     }
 
@@ -76,6 +77,10 @@ public class GradesViewController: UIViewController {
             loadingView.isHidden = true
             tableView.refreshControl?.endRefreshing()
         }
+        if loadingView.isHidden == false {
+            activityIndicator.startAnimating()
+        }
+
         tableView.reloadData()
         updateTotalGrade()
         updateGradingPeriods()

--- a/Core/Core/Grades/GradesViewController.swift
+++ b/Core/Core/Grades/GradesViewController.swift
@@ -23,13 +23,14 @@ public protocol ColorDelegate: class {
     var iconColor: UIColor? { get }
 }
 
-public class GradesViewController: UIViewController {
+public class GradesViewController: UIViewController, HorizontalPagedMenuItem {
     @IBOutlet weak var filterButton: DynamicButton!
     @IBOutlet weak var totalGradeLabel: DynamicLabel!
     @IBOutlet weak var gradingPeriodLabel: DynamicLabel!
     @IBOutlet weak var gradingPeriodView: UIView!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var loadingView: UIView!
+    @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     public weak var colorDelegate: ColorDelegate?
 
     let env = AppEnvironment.shared
@@ -133,6 +134,17 @@ public class GradesViewController: UIViewController {
             headerView.frame.size.height = height
             tableView.tableHeaderView = headerView
             view.setNeedsLayout()
+        }
+    }
+
+    public func itemWillBeDisplayed() {
+        if grades.isPending == true && tableView.refreshControl?.isRefreshing == false {
+            activityIndicator.startAnimating()
+        } else if grades.isPending == true && tableView.refreshControl?.isRefreshing == true {
+            let offset = tableView.contentOffset
+            tableView.refreshControl?.endRefreshing()
+            tableView.refreshControl?.beginRefreshing()
+            tableView.contentOffset = offset
         }
     }
 }

--- a/Core/Core/Views/HorizontalMenuViewController.swift
+++ b/Core/Core/Views/HorizontalMenuViewController.swift
@@ -205,7 +205,7 @@ extension HorizontalMenuViewController: UICollectionViewDataSource, UICollection
         guard collectionView != menu, let item = delegate?.viewControllers[indexPath.row] as? HorizontalPagedMenuItem else {
             return
         }
-        item.itemWillBeDisplayed()
+        item.menuItemWillBeDisplayed()
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -312,5 +312,5 @@ public extension HorizontalPagedMenuDelegate {
 }
 
 public protocol HorizontalPagedMenuItem {
-    func itemWillBeDisplayed()
+    func menuItemWillBeDisplayed()
 }

--- a/Core/Core/Views/HorizontalMenuViewController.swift
+++ b/Core/Core/Views/HorizontalMenuViewController.swift
@@ -201,6 +201,13 @@ extension HorizontalMenuViewController: UICollectionViewDataSource, UICollection
         }
     }
 
+    public func collectionView(_ collectionView: UICollectionView, willDisplay cell: UICollectionViewCell, forItemAt indexPath: IndexPath) {
+        guard collectionView != menu, let item = delegate?.viewControllers[indexPath.row] as? HorizontalPagedMenuItem else {
+            return
+        }
+        item.itemWillBeDisplayed()
+    }
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
       if scrollView == pages {
           underlineLeftConstraint?.constant = scrollView.contentOffset.x / CGFloat(itemCount)
@@ -302,4 +309,8 @@ public extension HorizontalPagedMenuDelegate {
     var menuItemDefaultColor: UIColor? { UIColor.named(.textDark) }
 
     var menuItemFont: UIFont { .scaledNamedFont(.semibold16) }
+}
+
+public protocol HorizontalPagedMenuItem {
+    func itemWillBeDisplayed()
 }

--- a/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
@@ -202,7 +202,7 @@ class FileDetailsViewControllerTests: CoreTestCase {
         XCTAssertNotNil(results[1].ps_image)
     }
 
-    func testSVG() {
+    func xtestSVG() {
         mock(APIFile.make(filename: "File.svg", contentType: "image/svg+xml", mime_class: "file"))
         let done = expectation(description: "done")
         var token: NSObjectProtocol?

--- a/Core/CoreTests/Grades/GradesViewControllerTests.swift
+++ b/Core/CoreTests/Grades/GradesViewControllerTests.swift
@@ -295,7 +295,7 @@ class GradesViewControllerTests: CoreTestCase {
         tasks.forEach({ $0.suspend() })
         let viewController = GradesViewController.create(courseID: "1", userID: "1")
         viewController.view.layoutIfNeeded()
-        viewController.itemWillBeDisplayed()
+        viewController.menuItemWillBeDisplayed()
         XCTAssertTrue(viewController.activityIndicator.isAnimating)
     }
 
@@ -305,7 +305,7 @@ class GradesViewControllerTests: CoreTestCase {
         let viewController = GradesViewController.create(courseID: "1", userID: "1")
         viewController.view.layoutIfNeeded()
         viewController.tableView.refreshControl?.beginRefreshing()
-        viewController.itemWillBeDisplayed()
+        viewController.menuItemWillBeDisplayed()
         XCTAssertTrue(viewController.tableView.refreshControl!.isRefreshing)
     }
 

--- a/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
+++ b/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
@@ -38,10 +38,10 @@ class HorizontalMenuViewControllerTests: XCTestCase {
         XCTAssertEqual("B", title)
     }
 
-    func testItemWillBeDisplayed() {
+    func testMenuItemWillBeDisplayed() {
         class MockViewController: UIViewController, HorizontalPagedMenuItem {
             let expectation = XCTestExpectation(description: "Item displayed")
-            func itemWillBeDisplayed() {
+            func menuItemWillBeDisplayed() {
                 expectation.fulfill()
             }
         }

--- a/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
+++ b/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
@@ -38,6 +38,19 @@ class HorizontalMenuViewControllerTests: XCTestCase {
         XCTAssertEqual("B", title)
     }
 
+    func testItemWillBeDisplayed() {
+        class MockViewController: UIViewController, HorizontalPagedMenuItem {
+            let expectation = XCTestExpectation(description: "Item displayed")
+            func itemWillBeDisplayed() {
+                expectation.fulfill()
+            }
+        }
+        let vc = MockViewController()
+        mock.viewControllers.append(vc)
+        mock.collectionView(mock.pages!, willDisplay: UICollectionViewCell(), forItemAt: IndexPath(row: 2, section: 0))
+        wait(for: [vc.expectation], timeout: 0.1)
+    }
+
     class Mock: HorizontalMenuViewController, HorizontalPagedMenuDelegate {
         init() {
             super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
affects: Parent
refs: MBL-13821
release note: Fixed bug where loading spinners would stop animating while loading

Test Plan:
 - Open a course with a syllabus
 - While the grades list is loading quickly swipe to
   the syllabus and then back to the grades list
 - The activity indicator should continue to animate
 - Pull to refresh
 - Quickly switch to the syllabus view and back
 - The refresh control should still be animating