### PR TITLE
Push alert detail screens and not modal

### DIFF
--- a/Parent/Parent/Dashboard/Alerts/AlertsListViewController.swift
+++ b/Parent/Parent/Dashboard/Alerts/AlertsListViewController.swift
@@ -83,11 +83,11 @@ class AlertsListViewController: FetchedTableViewController<Alert> {
         self.tableView.reloadRows(at: [indexPath], with: UITableView.RowAnimation.automatic)
 
         if [.courseGradeLow, .courseGradeHigh].contains(alert.type) {
-            AppEnvironment.shared.router.route(to: .courseGrades(alert.courseID ?? alert.contextID ?? ""), from: self, options: .modal(embedInNav: true, addDoneButton: true))
+            AppEnvironment.shared.router.route(to: .courseGrades(alert.courseID ?? alert.contextID ?? ""), from: self)
         } else if let assetPath = alert.assetPath {
-            AppEnvironment.shared.router.route(to: assetPath, from: self, options: .modal(embedInNav: true, addDoneButton: true))
+            AppEnvironment.shared.router.route(to: assetPath, from: self)
         } else if alert.type == .institutionAnnouncement, let announcementID = alert.contextID {
-            AppEnvironment.shared.router.route(to: .accountNotification(announcementID), from: self, options: .modal(embedInNav: true, addDoneButton: true))
+            AppEnvironment.shared.router.route(to: .accountNotification(announcementID), from: self)
         }
     }
 }

--- a/Parent/Parent/Details/AccountNotificationViewController.swift
+++ b/Parent/Parent/Details/AccountNotificationViewController.swift
@@ -87,6 +87,7 @@ class AccountNotificationViewController: UITableViewController {
         tableView.dataSource = self
         AnnouncementDetailsCellViewModel.tableViewDidLoad(tableView)
         tableView.reloadData()
+        navigationController?.isNavigationBarHidden = false
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Parent/Parent/Details/AnnouncementDetailsViewController.swift
+++ b/Parent/Parent/Details/AnnouncementDetailsViewController.swift
@@ -111,4 +111,9 @@ class AnnouncementDetailsViewController: DiscussionTopic.DetailViewController {
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationController?.isNavigationBarHidden = false
+    }
 }

--- a/Parent/Parent/Details/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Details/AssignmentDetailsViewController.swift
@@ -96,6 +96,7 @@ class AssignmentDetailsViewController: AssignmentDetailViewController {
         student.refresh()
         teachers.refresh()
         assignment.refresh()
+        navigationController?.isNavigationBarHidden = false
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Parent/Parent/Details/CalendarEventDetailsViewController.swift
+++ b/Parent/Parent/Details/CalendarEventDetailsViewController.swift
@@ -91,6 +91,11 @@ class CalendarEventDetailsViewController: CalendarEventDetailViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationController?.isNavigationBarHidden = false
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         let scheme = ColorScheme.observee(studentID)


### PR DESCRIPTION
refs: MBL-13822
affects: Parent
release note: Better display details about alerts

test plan:
 - Go to the list of alerts for a student
 - Tap on alerts, they should all push instead of modal