### PR TITLE
Fix and enhance Modules UI test

### DIFF
--- a/CanvasCore/CanvasCore/Persistence/Table View/ColorfulTableViewCell.swift
+++ b/CanvasCore/CanvasCore/Persistence/Table View/ColorfulTableViewCell.swift
@@ -239,6 +239,11 @@ public class ColorfulTableViewCell: UITableViewCell {
             .startWithValues { [weak self] selectionEnabled in
                 self?.selectionStyle = selectionEnabled ? .default : .none
                 self?.isUserInteractionEnabled = selectionEnabled
+                if selectionEnabled {
+                    self?.accessibilityTraits.remove(.notEnabled)
+                } else {
+                    self?.accessibilityTraits.insert(.notEnabled)
+                }
             }
 
         titleLabel.lineBreakMode = viewModel.value?.titleLineBreakMode ?? .byTruncatingTail

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -110,9 +110,13 @@ public extension RouterProtocol {
                 (nav ?? view).isModalInPresentation = true
             }
             from.present(nav ?? view, animated: true, completion: completion)
-        case .detail where from.splitViewController != nil  && !from.isInSplitViewDetail:
+        case .detail where from.splitViewController != nil && !from.isInSplitViewDetail:
             from.showDetailViewController(nav ?? view, sender: from)
-        case .detail, .push:
+        case .detail:
+            // not in a split view so we can ignore `embedInNav`
+            // and must not `show` `nav` otherwise it will modal
+            from.show(view, sender: nil)
+        case .push:
             from.show(nav ?? view, sender: nil)
         }
     }

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -155,6 +155,7 @@ class RouterTests: XCTestCase {
         router.route(to: URLComponents(string: "/detail")!, from: mockView, options: .detail(embedInNav: true))
         XCTAssertNotNil(mockView.shown)
         XCTAssert(mockView.shown?.isKind(of: UIViewController.self) == true)
+        XCTAssert(mockView.shown?.isKind(of: UINavigationController.self) == false)
     }
 
     func testRouteDetailFromDetailDoesAShow() {

--- a/Student/StudentUITests/Modules/ModulesTests.swift
+++ b/Student/StudentUITests/Modules/ModulesTests.swift
@@ -132,12 +132,11 @@ class MockedModulesTests: StudentUITestCase {
         mockBaseRequests()
     }
 
-    func xtestUnlockModuleItemWithPrerequisiteModule() {
-        let modules: [APIModule] = [
+    func testUnlockModuleItemWithPrerequisiteModule() {
+        mockData(GetModulesRequest(courseID: "1", include: [.items], perPage: 99), value: [
             .make(id: "1", name: "Module 1", position: 1, prerequisite_module_ids: [], state: .unlocked),
             .make(id: "2", name: "Module 2", position: 2, prerequisite_module_ids: ["1"], state: .locked),
-        ]
-        mockData(GetModulesRequest(courseID: "1", include: [.items], perPage: 99), value: modules)
+        ])
         mockData(GetModuleItemsRequest(courseID: "1", moduleID: "1", include: [.content_details, .mastery_paths], perPage: 99), value: [
             .make(
                 id: "1",
@@ -174,9 +173,7 @@ class MockedModulesTests: StudentUITestCase {
         app.find(labelContaining: "PREREQUISITE MODULES").waitToExist()
         XCTAssertEqual(app.find(id: "module_cell_0_0").label(), "Module 1")
         XCTAssertEqual(ModulesDetail.moduleItem(index: 0).label(), "Page 2. Type: Page. Status: Locked")
-        ModulesDetail.module(index: 0).tap()
-        ModulesDetail.moduleItem(index: 0).tap()
-        NavBar.backButton(label: "Module 1").waitToExist(60)
+        XCTAssertFalse(ModulesDetail.moduleItem(index: 0).isEnabled)
         mockData(GetModuleItemsRequest(courseID: "1", moduleID: "2", include: [.content_details, .mastery_paths], perPage: 99), value: [
             .make(
                 id: "2",
@@ -187,8 +184,17 @@ class MockedModulesTests: StudentUITestCase {
                 content_details: .make(locked_for_user: false)
             ),
         ])
+        mockData(GetModulesRequest(courseID: "1", include: [.items], perPage: 99), value: [
+            .make(id: "1", name: "Module 1", position: 1, prerequisite_module_ids: [], state: .unlocked),
+            .make(id: "2", name: "Module 2", position: 2, prerequisite_module_ids: ["1"], state: .unlocked),
+        ])
+        ModulesDetail.module(index: 0).tap()
+        ModulesDetail.moduleItem(index: 0).tap()
+        NavBar.backButton(label: "Module 1").waitToExist(60)
         NavBar.backButton(label: "Module 1").tap()
         NavBar.backButton(label: "Module 2").tap()
+        app.find(label: "Page 2. Type: Page").waitToExist()
         XCTAssertEqual(ModulesDetail.moduleItem(index: 0).label(), "Page 2. Type: Page")
+        XCTAssertTrue(ModulesDetail.moduleItem(index: 0).isEnabled)
     }
 }


### PR DESCRIPTION
refs: MBL-13783, MBL-13814
affects: student
release note: none

[run-nightly]

Adds a check for accessing locked module items to cover case C3647962.
```swift
XCTAssertFalse(ModulesDetail.moduleItem(index: 0).isEnabled)
```

Also fixes the flakiness by mocking `GetModulesRequest` after tapping
into the module item. This is necessary because the item locked status
will depend on the `state` of the parent module.