### PR TITLE
Polish badge colors in Parent

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2772,9 +2772,9 @@
 				7DBED03523344EDE00392F3C /* ExternalToolLaunchPlacementTests.swift */,
 				7DBED016232FDDB700392F3C /* GetAccountHelpLinksTests.swift */,
 				7DBED0302333EC3B00392F3C /* ProfilePresenterTests.swift */,
+				97A486C32397826300084499 /* ProfileViewControllerTests.swift */,
 				7DBED01C2330332800392F3C /* UploadAvatarTests.swift */,
 				7D71807A233FCD0A0053FC7A /* UserProfileTests.swift */,
-				97A486C32397826300084499 /* ProfileViewControllerTests.swift */,
 			);
 			path = Profile;
 			sourceTree = "<group>";

--- a/Core/Core/Profile/ProfilePresenter.swift
+++ b/Core/Core/Profile/ProfilePresenter.swift
@@ -21,7 +21,7 @@ import UIKit
 
 public class ProfilePresenter {
     var unreadCount: UInt = 0
-    let env: AppEnvironment
+    let env = AppEnvironment.shared
     weak var view: ProfileViewProtocol?
 
     #if DEBUG
@@ -158,8 +158,7 @@ public class ProfilePresenter {
         return cells
     }
 
-    init(env: AppEnvironment = .shared, enrollment: HelpLinkEnrollment, view: ProfileViewProtocol?) {
-        self.env = env
+    init(enrollment: HelpLinkEnrollment, view: ProfileViewProtocol?) {
         self.enrollment = enrollment
         self.view = view
     }

--- a/Core/Core/Profile/ProfileViewController.swift
+++ b/Core/Core/Profile/ProfileViewController.swift
@@ -68,7 +68,7 @@ public class ProfileViewController: UIViewController, ProfileViewProtocol {
     @IBOutlet weak var emailLabel: UILabel?
     @IBOutlet weak var versionLabel: UILabel?
 
-    var env = AppEnvironment.shared
+    let env = AppEnvironment.shared
     var presenter: ProfilePresenter?
     var dashboard: UIViewController {
         var dashboard = presentingViewController ?? self
@@ -81,12 +81,11 @@ public class ProfileViewController: UIViewController, ProfileViewProtocol {
         return dashboard
     }
 
-    public static func create(env: AppEnvironment = .shared, enrollment: HelpLinkEnrollment) -> ProfileViewController {
+    public static func create(enrollment: HelpLinkEnrollment) -> ProfileViewController {
         let controller = loadFromStoryboard()
         controller.modalPresentationStyle = .custom
         controller.transitioningDelegate = DrawerTransitioningDelegate.shared
-        controller.env = env
-        controller.presenter = ProfilePresenter(env: env, enrollment: enrollment, view: controller)
+        controller.presenter = ProfilePresenter(enrollment: enrollment, view: controller)
         return controller
     }
 
@@ -177,6 +176,8 @@ extension ProfileViewController: UITableViewDataSource, UITableViewDelegate {
         case .badge(let count):
             cell.accessoryView = nil
             cell.badgeLabel.text = NumberFormatter.localizedString(from: NSNumber(value: count), number: .none)
+            cell.badgeLabel.textColor = Brand.shared.navBadgeText
+            cell.badgeView.backgroundColor = Brand.shared.navBadgeBackground
             cell.badgeView.isHidden = count == 0
         case .none:
             cell.accessoryView = nil

--- a/Core/CoreTests/Profile/ProfileViewControllerTests.swift
+++ b/Core/CoreTests/Profile/ProfileViewControllerTests.swift
@@ -30,7 +30,7 @@ class ProfileViewControllerTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
-        vc = ProfileViewController.create(env: environment, enrollment: .student)
+        vc = ProfileViewController.create(enrollment: .student)
         notificationPayload = nil
         didChangeUser = false
         didLogout = false

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -65,6 +65,7 @@ class DashboardViewController: UIViewController {
             if let student = currentStudent {
                 currentStudentID = student.id
                 let color = ColorScheme.observee(student.id).color
+                alertsTabItem.badgeColor = color
                 headerContainerView.backgroundColor = color
                 badgeLabel.textColor = color
                 badgeView.layer.borderColor = color.cgColor
@@ -118,10 +119,8 @@ class DashboardViewController: UIViewController {
         let tap = UITapGestureRecognizer(target: self, action: #selector(studentInfoTapped))
         studentInfoContainer.addGestureRecognizer(tap)
 
-        // Set the tab navigation background and the base view to be the same
-        // This will make color below the safe area to be the same as the tab nav
-        tabBar.barTintColor = UIColor.init(r: 254, g: 254, b: 254)
-        view.backgroundColor = tabBar.barTintColor
+        tabBar.barTintColor = .named(.backgroundLightest)
+        view.backgroundColor = .named(.backgroundLightest)
 
         let color = ColorScheme.observer.color
         headerContainerView.backgroundColor = color
@@ -272,6 +271,8 @@ class DashboardViewController: UIViewController {
         alertsTabItem.selectedImage = UIImage.icon(.notification)
         alertsTabItem.accessibilityLabel = String.localizedStringWithFormat(tabViewFormatString, alertsTitle, 3, 3)
         alertsTabItem.accessibilityIdentifier = "TabBar.alertsTab"
+        alertsTabItem.badgeColor = .named(.backgroundInfo)
+        alertsTabItem.setBadgeTextAttributes([.foregroundColor: UIColor.named(.white)], for: .normal)
 
         selectCoursesTab()
     }
@@ -331,7 +332,7 @@ class DashboardViewController: UIViewController {
             alertsTabItem.badgeValue = nil
             let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [Alert.unreadPredicate(), Alert.undismissedPredicate(), Alert.observeePredicate(observeeID)])
             alertTabBadgeCountCoordinator = AlertCountCoordinator(session: session, studentID: observeeID, predicate: predicate) { [weak self] count in
-                self?.alertsTabItem.badgeValue = count > 0 ? "\(count)" : nil
+                self?.alertsTabItem.badgeValue = count > 0 ? NumberFormatter.localizedString(from: NSNumber(value: count), number: .none) : nil
             }
         } else {
             alertTabBadgeCountCoordinator = nil


### PR DESCRIPTION
Ensured badge in profile drawer is electric
- if it were used in Teacher or Student it would match branding
Set alert tab bar item to use context badge color
Menu icon badge was already correct

refs: MBL-13801
affects: Parent
release note: none