### PR TITLE
Fix attachments layout on message details when there are 1 or 2 attachments

### DIFF
--- a/Core/Core/Views/HorizontalScrollingStackview.swift
+++ b/Core/Core/Views/HorizontalScrollingStackview.swift
@@ -41,7 +41,7 @@ public class HorizontalScrollingStackview: UIView {
         stackView = {
             let s = UIStackView()
             s.axis = .horizontal
-            s.distribution = .equalCentering
+            s.distribution = .fill
             s.alignment = .fill
             s.spacing = 12
             return s

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -56,11 +56,9 @@ class ConversationDetailCell: UITableViewCell {
                     view.heightAnchor.constraint(equalToConstant: 104),
                 ])
             }
-            if attachments.count == 1 {
-                let leftAlignViewsSpacer = UIView()
-                leftAlignViewsSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
-                attachmentStackView.addArrangedSubview(leftAlignViewsSpacer)
-            }
+            let leftAlignViewsSpacer = UIView()
+            leftAlignViewsSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+            attachmentStackView.addArrangedSubview(leftAlignViewsSpacer)
         }
     }
 

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -80,8 +80,8 @@ class ConversationDetailCell: UITableViewCell {
     }
 
     @objc func tapAttachment(sender: UIButton) {
-        guard message?.attachments.count ?? 0 > sender.tag,
-            let attachment = message?.attachments[sender.tag] else { return }
+        guard message?.attachments.count ?? 0 > sender.tag else { return }
+        guard let attachment = message?.attachments.sorted(by: File.idCompare)[sender.tag] else { return }
         onTapAttachment?(attachment)
     }
 

--- a/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
@@ -59,7 +59,7 @@
                                                                 </view>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="WAv-i1-qFc" secondAttribute="trailing" id="RaP-Y9-vy0"/>
+                                                                <constraint firstAttribute="trailing" secondItem="WAv-i1-qFc" secondAttribute="trailing" constant="-16" id="RaP-Y9-vy0"/>
                                                                 <constraint firstItem="WAv-i1-qFc" firstAttribute="leading" secondItem="k6R-4f-fZa" secondAttribute="leading" id="ZSt-3Q-43n"/>
                                                             </constraints>
                                                         </stackView>

--- a/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
@@ -73,10 +73,10 @@ class ConversationDetailViewControllerTests: ParentTestCase {
         XCTAssertEqual(first?.messageLabel.text, "hello world")
         XCTAssertEqual(first?.dateLabel.text, DateFormatter.localizedString(from: Clock.now.addDays(-1), dateStyle: .medium, timeStyle: .short))
 
-        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews.count, 2)
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews.count, 3)
         XCTAssertTrue(first?.attachmentStackView.isHidden == false)
         XCTAssertTrue(first?.attachmentStackView.arrangedSubviews.first is ConversationDetailCell.NonPhotoAttachment)
-        XCTAssertTrue(first?.attachmentStackView.arrangedSubviews.last is ConversationDetailCell.PhotoAttachment)
+        XCTAssertTrue(first?.attachmentStackView.arrangedSubviews[1] is ConversationDetailCell.PhotoAttachment)
 
         (first?.attachmentStackView.arrangedSubviews.first as? ConversationDetailCell.NonPhotoAttachment)?.button.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(router.lastRoutedTo(.parse("https://canvas.instructure.com/files/1/download")))


### PR DESCRIPTION
refs: MBL-13774
affects: Parent
release note: none

Test plan
---------------
Messages with 1 or 2 attachments should layout correctly.  Before this fix, if there was 2 attachments, there was a big space in between attachments.  No longer! 