### PR TITLE
Attach contextName on conversation creation

### DIFF
--- a/Core/Core/Conversations/APIConversation.swift
+++ b/Core/Core/Conversations/APIConversation.swift
@@ -88,8 +88,8 @@ extension APIConversation {
         audience: [String]? = [ "1" ],
         avatar_url: URL = URL(string: "https://canvas.instructure.com/avatar/1")!,
         visible: Bool = true,
-        context_name: String = "Canvas 101",
-        context_code: String = "course_1",
+        context_name: String? = "Canvas 101",
+        context_code: String? = "course_1",
         messages: [APIConversationMessage]? = nil
     ) -> APIConversation {
         return APIConversation(

--- a/Core/Core/Conversations/CreateConversation.swift
+++ b/Core/Core/Conversations/CreateConversation.swift
@@ -66,7 +66,18 @@ public class CreateConversation: APIUseCase {
             return
         }
         for conversation in response {
-            Conversation.save(conversation, in: client)
+            let conversation = Conversation.save(conversation, in: client)
+
+            // attach the context name since it is not part of the api response
+            // a ticket has been created to include the context_name in the api response
+            guard conversation.contextName == nil,
+                  let canvasContextID = canvasContextID,
+                  let context = ContextModel(canvasContextID: canvasContextID),
+                  let course: Course = client.fetch(scope: .where("id", equals: context.id)).first
+            else {
+                continue
+            }
+            conversation.contextName = course.name
         }
     }
 }

--- a/Core/Core/Conversations/CreateConversation.swift
+++ b/Core/Core/Conversations/CreateConversation.swift
@@ -70,6 +70,7 @@ public class CreateConversation: APIUseCase {
 
             // attach the context name since it is not part of the api response
             // a ticket has been created to include the context_name in the api response
+            // https://instructure.atlassian.net/browse/KNO-239
             guard conversation.contextName == nil,
                   let canvasContextID = canvasContextID,
                   let context = ContextModel(canvasContextID: canvasContextID),

--- a/Core/CoreTests/Conversations/CreateConversationTests.swift
+++ b/Core/CoreTests/Conversations/CreateConversationTests.swift
@@ -22,11 +22,24 @@ import XCTest
 class CreateConversationTests: CoreTestCase {
     func testWritesData() {
         let useCase = CreateConversation(subject: "subject", body: "body", recipientIDs: ["1"])
-        api.mock(useCase.request, value: [APIConversation.make(subject: "subject")])
+        api.mock(useCase.request, value: [APIConversation.make(subject: "subject", context_name: nil, context_code: nil)])
 
         useCase.fetch()
         let conversation: Conversation = databaseClient.fetch().first!
         XCTAssertNotNil(conversation)
         XCTAssertEqual(conversation.subject, "subject")
+        XCTAssertNil(conversation.contextCode)
+        XCTAssertNil(conversation.contextName)
+    }
+
+    func testWritesContextName() {
+        let course = Course.make()
+        let useCase = CreateConversation(subject: "subject", body: "body", recipientIDs: ["1"], canvasContextID: course.canvasContextID)
+        api.mock(useCase.request, value: [APIConversation.make(context_name: nil)])
+
+        useCase.fetch()
+        let conversation: Conversation = databaseClient.fetch().first!
+        XCTAssertEqual(conversation.contextCode, course.canvasContextID)
+        XCTAssertEqual(conversation.contextName, course.name)
     }
 }


### PR DESCRIPTION
affects: parent
refs: MBL-13862
release note: none

test plan:
 - When you compose a new message from the conversation
   list
 - when you land back on the conversation list with the
   new message, that message should have the course name
   in the cell as the gray secondary text in the cell