### PR TITLE
Make Google LTIs full screen on iPadOS

### DIFF
--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -88,7 +88,7 @@ public class LTITools {
             let url = response.url
             if response.name == "Google Apps" {
                 let controller = GoogleCloudAssignmentViewController(url: url)
-                self.env.router.show(controller, from: view, options: .modal(embedInNav: true, addDoneButton: true)) {
+                self.env.router.show(controller, from: view, options: .modal(.overFullScreen, embedInNav: true, addDoneButton: true)) {
                     completionHandler(true)
                 }
             } else if self.openInSafari {
@@ -96,8 +96,7 @@ public class LTITools {
                     completionHandler(true)
             } else {
                 let safari = SFSafariViewController(url: url)
-                safari.modalPresentationStyle = .overFullScreen
-                self.env.router.show(safari, from: view, options: .modal()) {
+                self.env.router.show(safari, from: view, options: .modal(.overFullScreen)) {
                     completionHandler(true)
                 }
             }

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -100,7 +100,7 @@ class LTIToolsTests: CoreTestCase {
         XCTAssertEqual(url, actualURL)
     }
 
-    func testPresentTool() {
+    func testPresentTool() throws {
         let tools = LTITools(
             env: environment,
             context: ContextModel(.course, id: "1"),
@@ -142,11 +142,8 @@ class LTIToolsTests: CoreTestCase {
         }
         wait(for: [doneValue], timeout: 1)
         XCTAssertTrue(success)
-        XCTAssert(router.presented is SFSafariViewController)
-        XCTAssertEqual(router.presented?.modalPresentationStyle, .overFullScreen)
-
-        UserDefaults.standard.set(true, forKey: "open_lti_safari")
-        tools.presentTool(from: mockView, animated: true)
+        let sfSafari = try XCTUnwrap(router.presented as? SFSafariViewController)
+        XCTAssert(router.lastRoutedTo(viewController: sfSafari, from: mockView, withOptions: .modal(.overFullScreen)))
     }
 
     func testPresentToolInSafariProper() {
@@ -167,7 +164,7 @@ class LTIToolsTests: CoreTestCase {
         api.mock(request, value: .make(name: "Google Apps", url: url))
         tools.presentTool(from: mockView, animated: true)
         let controller = try XCTUnwrap(router.presented as? GoogleCloudAssignmentViewController)
-        XCTAssertEqual(controller.url, url)
+        XCTAssertTrue(router.lastRoutedTo(viewController: controller, from: mockView, withOptions: .modal(.overFullScreen, embedInNav: true, addDoneButton: true)))
     }
 
     func testMarksModuleItemAsRead() {

--- a/TestsFoundation/TestsFoundation/Router/TestRouter.swift
+++ b/TestsFoundation/TestsFoundation/Router/TestRouter.swift
@@ -21,7 +21,7 @@ import Core
 
 public class TestRouter: RouterProtocol {
     public init() {}
-    public var calls = [(URLComponents, UIViewController, RouteOptions)]()
+    public var calls = [(URLComponents?, UIViewController, RouteOptions)]()
     public var viewControllerCalls = [(UIViewController, UIViewController, RouteOptions)]()
     public var presented: UIViewController? {
         if viewControllerCalls.last?.2.isModal == true {
@@ -70,12 +70,17 @@ public class TestRouter: RouterProtocol {
         return calls.last?.0 == URLComponents.parse(url)
     }
 
-    public func lastRoutedTo(_ url: URLComponents) -> Bool {
+    public func lastRoutedTo(_ url: URLComponents?) -> Bool {
         return calls.last?.0 == url
     }
 
     public func lastRoutedTo(_ url: URL, withOptions options: RouteOptions) -> Bool {
         return lastRoutedTo(url) && calls.last?.2 == options
+    }
+
+    public func lastRoutedTo(viewController: UIViewController, from: UIViewController, withOptions options: RouteOptions) -> Bool {
+        guard let last = viewControllerCalls.last else { return false }
+        return last == (viewController, from, options)
     }
 
     public func resetExpectations() {


### PR DESCRIPTION
refs: none
affects: student
release note: none

Test plan:
* On an iPad running iOS 13
* narmstrong : s
* Dashboard > CS 1400 > Assignments > Clear filter > Google Cloud Assignment
* Launch External Tool
* Should be full screen