### PR TITLE
Show media comments in conversation messages

### DIFF
--- a/Core/Core/AudioVideo/AudioPlayerViewController.swift
+++ b/Core/Core/AudioVideo/AudioPlayerViewController.swift
@@ -31,6 +31,7 @@ public class AudioPlayerViewController: UIViewController {
     @IBOutlet weak var trackFill: UIView?
     @IBOutlet weak var trackFillWidth: NSLayoutConstraint?
 
+    var currentURL: URL?
     lazy var formatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
@@ -92,6 +93,8 @@ public class AudioPlayerViewController: UIViewController {
     }
 
     public func load(url: URL?) {
+        guard currentURL != url else { return }
+        currentURL = url
         currentTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
         remainingTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
         loadingView?.startAnimating()

--- a/Core/Core/AudioVideo/AudioPlayerViewController.swift
+++ b/Core/Core/AudioVideo/AudioPlayerViewController.swift
@@ -31,7 +31,6 @@ public class AudioPlayerViewController: UIViewController {
     @IBOutlet weak var trackFill: UIView?
     @IBOutlet weak var trackFillWidth: NSLayoutConstraint?
 
-    var currentURL: URL?
     lazy var formatter: DateComponentsFormatter = {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.minute, .second]
@@ -93,8 +92,6 @@ public class AudioPlayerViewController: UIViewController {
     }
 
     public func load(url: URL?) {
-        guard currentURL != url else { return }
-        currentURL = url
         currentTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
         remainingTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
         loadingView?.startAnimating()

--- a/Core/Core/Files/File.swift
+++ b/Core/Core/Files/File.swift
@@ -167,19 +167,17 @@ extension File: WriteableModel {
     }
 
     public var icon: UIImage? {
-        switch mimeClass {
-        case "audio":
+        if mimeClass == "audio" || contentType?.hasPrefix("audio/") == true {
             return UIImage.icon(.audio)
-        case "doc":
+        } else if mimeClass == "doc" {
             return UIImage.icon(.document)
-        case "image":
+        } else if mimeClass == "image" || contentType?.hasPrefix("image/") == true {
             return UIImage.icon(.image)
-        case "pdf":
+        } else if mimeClass == "pdf" {
             return UIImage.icon(.pdf)
-        case "video":
+        } else if mimeClass == "video" || contentType?.hasPrefix("video/") == true {
             return UIImage.icon(.video)
-        default:
-            return UIImage.icon(.document)
         }
+        return UIImage.icon(.document)
     }
 }

--- a/Core/Core/Files/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/FileDetails/FileDetailsViewController.swift
@@ -217,6 +217,8 @@ extension FileDetailsViewController: URLSessionDownloadDelegate {
         switch (file.mimeClass, file.contentType) {
         case ("audio", _):
             embedAudioView(for: localURL)
+        case (_, let type) where type?.hasPrefix("audio/") == true:
+            embedAudioView(for: localURL)
         case ("image", _), (_, "image/heic"):
             embedImageView(for: localURL)
         case (_, "model/vnd.usdz+zip"):

--- a/Core/CoreTests/Models/FileTests.swift
+++ b/Core/CoreTests/Models/FileTests.swift
@@ -31,12 +31,15 @@ class FileTests: CoreTestCase {
     }
 
     func testIcon() {
-        XCTAssertEqual(File.make(from: .make(mime_class: "audio")).icon, UIImage.icon(.audio))
-        XCTAssertEqual(File.make(from: .make(mime_class: "doc")).icon, UIImage.icon(.document))
-        XCTAssertEqual(File.make(from: .make(mime_class: "image")).icon, UIImage.icon(.image))
-        XCTAssertEqual(File.make(from: .make(mime_class: "pdf")).icon, UIImage.icon(.pdf))
-        XCTAssertEqual(File.make(from: .make(mime_class: "video")).icon, UIImage.icon(.video))
-        XCTAssertEqual(File.make(from: .make(mime_class: "bogus")).icon, UIImage.icon(.document))
+        XCTAssertEqual(File.make(from: .make(contentType: "audio/x-m4a", mime_class: "audio")).icon, UIImage.icon(.audio))
+        XCTAssertEqual(File.make(from: .make(contentType: "audio/x-m4a", mime_class: "file")).icon, UIImage.icon(.audio))
+        XCTAssertEqual(File.make(from: .make(contentType: "application/word", mime_class: "doc")).icon, UIImage.icon(.document))
+        XCTAssertEqual(File.make(from: .make(contentType: "image/jpeg", mime_class: "image")).icon, UIImage.icon(.image))
+        XCTAssertEqual(File.make(from: .make(contentType: "image/heic", mime_class: "file")).icon, UIImage.icon(.image))
+        XCTAssertEqual(File.make(from: .make(contentType: "application/pdf", mime_class: "pdf")).icon, UIImage.icon(.pdf))
+        XCTAssertEqual(File.make(from: .make(contentType: "video/x-m4v", mime_class: "video")).icon, UIImage.icon(.video))
+        XCTAssertEqual(File.make(from: .make(contentType: "video/x-m4v", mime_class: "file")).icon, UIImage.icon(.video))
+        XCTAssertEqual(File.make(from: .make(contentType: "bogus", mime_class: "bogus")).icon, UIImage.icon(.document))
     }
 
     func testIsUploading() {

--- a/Core/CoreTests/Models/SubmissionTests.swift
+++ b/Core/CoreTests/Models/SubmissionTests.swift
@@ -93,7 +93,7 @@ class SubmissionTests: CoreTestCase {
         XCTAssertEqual(submission.icon, UIImage.icon(.video))
 
         submission.type = .online_upload
-        submission.attachments = Set([ File.make(from: .make(mime_class: "pdf")) ])
+        submission.attachments = Set([ File.make(from: .make(contentType: "application/pdf", mime_class: "pdf")) ])
         XCTAssertEqual(submission.icon, UIImage.icon(.pdf))
 
         submission.type = .on_paper

--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -1371,21 +1371,21 @@
 		7D111CFD23A2DDAD00C912C0 /* Conversations */ = {
 			isa = PBXGroup;
 			children = (
+				9FB8FC4223C3B46A00E69E6A /* ActionSheetController.swift */,
 				7D1591BB23AD79B100ED0106 /* ComposeRecipientsView.swift */,
 				7D6F4CE823C676CE001C957D /* ComposeReplyViewController.storyboard */,
 				7D6F4CE623C66738001C957D /* ComposeReplyViewController.swift */,
 				7D57D3CD23AADAAC00EB2CC5 /* ComposeViewController.storyboard */,
 				7D57D3CB23AADA0F00EB2CC5 /* ComposeViewController.swift */,
+				9F520B8C23BFC3D200CE3672 /* ConversationCoursesActionSheet.swift */,
+				3B432E2C23D7A5EA00253849 /* ConversationDetailCell.swift */,
 				974BA7F823A89C5C00E09D5A /* ConversationDetailViewController.storyboard */,
 				974BA7F623A89BE200E09D5A /* ConversationDetailViewController.swift */,
 				7DFDB43323A4393D00B28DED /* ConversationListCell.swift */,
 				7D111D0023A2DDDF00C912C0 /* ConversationListViewController.storyboard */,
 				7D111CFE23A2DDD100C912C0 /* ConversationListViewController.swift */,
-				9F520B8C23BFC3D200CE3672 /* ConversationCoursesActionSheet.swift */,
-				B109249123CE7FC900796903 /* EditComposeRecipientsViewController.swift */,
 				B109248D23CE160400796903 /* EditComposeRecipientsViewController.storyboard */,
-				9FB8FC4223C3B46A00E69E6A /* ActionSheetController.swift */,
-				3B432E2C23D7A5EA00253849 /* ConversationDetailCell.swift */,
+				B109249123CE7FC900796903 /* EditComposeRecipientsViewController.swift */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";

--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -1411,9 +1411,9 @@
 			children = (
 				7D6F4CEA23C69F7F001C957D /* ComposeReplyViewControllerTests.swift */,
 				7D231BE023AC1E0A005BA31D /* ComposeViewControllerTests.swift */,
+				9F397F8423C8D54600A3E2AF /* ConversationCoursesActionSheetTests.swift */,
 				97D477C823AA738300A6BC78 /* ConversationDetailViewControllerTests.swift */,
 				7DFDB43123A3EDFB00B28DED /* ConversationListViewControllerTests.swift */,
-				9F397F8423C8D54600A3E2AF /* ConversationCoursesActionSheetTests.swift */,
 				B109248F23CE7F9500796903 /* EditComposeRecipientsViewControllerTests.swift */,
 			);
 			path = Conversations;

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -50,7 +50,7 @@ class ConversationDetailCell: UITableViewCell {
         attachmentStackView.arrangedSubviews.forEach { v in v.removeFromSuperview() }
 
         audioPlayerContainer.isHidden = true
-        if media?.mediaType == .video, let url = media?.url {
+        if /*media?.mediaType == .video,*/ let url = media?.url {
             addVideoAttachment(url: url, parent: parent)
         } else if media?.mediaType == .audio {
             addAudioPlayer(url: media?.url, parent: parent)

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -137,6 +137,7 @@ class ConversationDetailCell: UITableViewCell {
         let controller = AVPlayerViewController()
         controller.entersFullScreenWhenPlaybackBegins = true
         controller.player = AVPlayer(url: url)
+        controller.videoGravity = .resizeAspectFill
         parent?.embed(controller, in: container)
     }
 

--- a/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
@@ -21,14 +21,14 @@
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConversationDetailCell" id="Ggl-J4-YjR" customClass="ConversationDetailCell" customModule="Parent" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="283.5"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="235.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ggl-J4-YjR" id="WaV-UU-eyg">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="283.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="235.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yoK-vu-7JQ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="283.5"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="235.5"/>
                                                     <subviews>
                                                         <view clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ydl-fI-jzy" customClass="AvatarView" customModule="Parent" customModuleProvider="target">
                                                             <rect key="frame" x="16" y="12" width="40" height="40"/>
@@ -92,16 +92,10 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k6R-4f-fZa">
-                                                            <rect key="frame" x="16" y="115.5" width="382" height="152"/>
+                                                            <rect key="frame" x="16" y="115.5" width="382" height="104"/>
                                                             <subviews>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZNn-VI-tWH">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="32"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="32" id="9PG-to-NBM"/>
-                                                                    </constraints>
-                                                                </view>
                                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WAv-i1-qFc" customClass="HorizontalScrollingStackview" customModule="Core">
-                                                                    <rect key="frame" x="0.0" y="48" width="382" height="104"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="104"/>
                                                                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="104" id="AWb-1p-UhV"/>
@@ -141,7 +135,6 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="attachmentStackView" destination="WAv-i1-qFc" id="pOx-Rt-bjj"/>
-                                            <outlet property="audioPlayerContainer" destination="ZNn-VI-tWH" id="mcj-S4-SNi"/>
                                             <outlet property="avatar" destination="ydl-fI-jzy" id="ExW-58-iAJ"/>
                                             <outlet property="dateLabel" destination="lGq-Od-o8W" id="v4L-Qb-q2c"/>
                                             <outlet property="fromLabel" destination="rmq-tE-xSD" id="lIE-ZW-DTp"/>

--- a/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
@@ -21,14 +21,14 @@
                                 <color key="backgroundColor" red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="ConversationDetailCell" id="Ggl-J4-YjR" customClass="ConversationDetailCell" customModule="Parent" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="414" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="414" height="283.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ggl-J4-YjR" id="WaV-UU-eyg">
-                                            <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="283.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yoK-vu-7JQ">
-                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="414" height="283.5"/>
                                                     <subviews>
                                                         <view clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ydl-fI-jzy" customClass="AvatarView" customModule="Parent" customModuleProvider="target">
                                                             <rect key="frame" x="16" y="12" width="40" height="40"/>
@@ -37,40 +37,14 @@
                                                                 <constraint firstAttribute="height" constant="40" id="mwW-uG-LTV"/>
                                                             </constraints>
                                                         </view>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k6R-4f-fZa">
-                                                            <rect key="frame" x="16" y="68" width="382" height="120"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LyF-dE-u9U" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="0.0"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                                    <nil key="textColor"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium14"/>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </label>
-                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WAv-i1-qFc" customClass="HorizontalScrollingStackview" customModule="Core">
-                                                                    <rect key="frame" x="0.0" y="16" width="382" height="104"/>
-                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="104" id="AWb-1p-UhV"/>
-                                                                    </constraints>
-                                                                </view>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="WAv-i1-qFc" secondAttribute="trailing" constant="-16" id="RaP-Y9-vy0"/>
-                                                                <constraint firstItem="WAv-i1-qFc" firstAttribute="leading" secondItem="k6R-4f-fZa" secondAttribute="leading" id="ZSt-3Q-43n"/>
-                                                            </constraints>
-                                                        </stackView>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="aOx-Ck-kOT">
-                                                            <rect key="frame" x="68" y="16" width="330" height="32"/>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="aOx-Ck-kOT">
+                                                            <rect key="frame" x="68" y="16" width="330" height="43"/>
                                                             <subviews>
                                                                 <stackView opaque="NO" contentMode="scaleToFill" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="dpv-IS-zOx" userLabel="H Stack View">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="330" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="330" height="20.5"/>
                                                                     <subviews>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="1000" verticalHuggingPriority="251" text="Me" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rmq-tE-xSD" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
-                                                                            <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
+                                                                            <rect key="frame" x="0.0" y="0.0" width="24" height="20.5"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -80,7 +54,7 @@
                                                                             </userDefinedRuntimeAttributes>
                                                                         </label>
                                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="To john doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ub6-rx-Qcj" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
-                                                                            <rect key="frame" x="25" y="0.0" width="305" height="17"/>
+                                                                            <rect key="frame" x="28" y="0.0" width="302" height="20.5"/>
                                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                             <nil key="textColor"/>
                                                                             <nil key="highlightedColor"/>
@@ -91,8 +65,8 @@
                                                                         </label>
                                                                     </subviews>
                                                                 </stackView>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="Date here" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGq-Od-o8W" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="19" width="330" height="13"/>
+                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date here" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lGq-Od-o8W" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
+                                                                    <rect key="frame" x="0.0" y="22.5" width="330" height="20.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -107,18 +81,53 @@
                                                                 <constraint firstAttribute="trailing" secondItem="dpv-IS-zOx" secondAttribute="trailing" id="uGE-Zq-IYc"/>
                                                             </constraints>
                                                         </stackView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="message" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LyF-dE-u9U" customClass="DynamicLabel" customModule="Parent" customModuleProvider="target">
+                                                            <rect key="frame" x="16" y="79" width="382" height="20.5"/>
+                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium14"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </label>
+                                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="k6R-4f-fZa">
+                                                            <rect key="frame" x="16" y="115.5" width="382" height="152"/>
+                                                            <subviews>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZNn-VI-tWH">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="382" height="32"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="32" id="9PG-to-NBM"/>
+                                                                    </constraints>
+                                                                </view>
+                                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WAv-i1-qFc" customClass="HorizontalScrollingStackview" customModule="Core">
+                                                                    <rect key="frame" x="0.0" y="48" width="382" height="104"/>
+                                                                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="104" id="AWb-1p-UhV"/>
+                                                                    </constraints>
+                                                                </view>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstAttribute="trailing" secondItem="WAv-i1-qFc" secondAttribute="trailing" constant="-16" id="RaP-Y9-vy0"/>
+                                                                <constraint firstItem="WAv-i1-qFc" firstAttribute="leading" secondItem="k6R-4f-fZa" secondAttribute="leading" id="ZSt-3Q-43n"/>
+                                                            </constraints>
+                                                        </stackView>
                                                     </subviews>
                                                     <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                     <constraints>
+                                                        <constraint firstItem="LyF-dE-u9U" firstAttribute="top" secondItem="aOx-Ck-kOT" secondAttribute="bottom" constant="20" id="2s8-KA-m3l"/>
                                                         <constraint firstItem="aOx-Ck-kOT" firstAttribute="leading" secondItem="ydl-fI-jzy" secondAttribute="trailing" constant="12" id="73h-5S-WD0"/>
                                                         <constraint firstAttribute="trailing" secondItem="k6R-4f-fZa" secondAttribute="trailing" constant="16" id="Jy3-xY-aj5"/>
                                                         <constraint firstAttribute="bottom" secondItem="k6R-4f-fZa" secondAttribute="bottom" constant="16" id="Mk5-3U-2PK"/>
+                                                        <constraint firstItem="k6R-4f-fZa" firstAttribute="top" secondItem="LyF-dE-u9U" secondAttribute="bottom" constant="16" id="NXd-tH-wYx"/>
+                                                        <constraint firstItem="LyF-dE-u9U" firstAttribute="leading" secondItem="yoK-vu-7JQ" secondAttribute="leading" constant="16" id="PIu-ov-kGb"/>
+                                                        <constraint firstItem="LyF-dE-u9U" firstAttribute="top" relation="greaterThanOrEqual" secondItem="ydl-fI-jzy" secondAttribute="bottom" constant="16" id="Qa4-kH-Ajf"/>
                                                         <constraint firstItem="aOx-Ck-kOT" firstAttribute="top" secondItem="yoK-vu-7JQ" secondAttribute="top" constant="16" id="SEN-MO-cIK"/>
                                                         <constraint firstItem="ydl-fI-jzy" firstAttribute="top" secondItem="yoK-vu-7JQ" secondAttribute="top" constant="12" id="URq-w1-me9"/>
                                                         <constraint firstItem="k6R-4f-fZa" firstAttribute="leading" secondItem="yoK-vu-7JQ" secondAttribute="leading" constant="16" id="WdC-i2-jhV"/>
-                                                        <constraint firstItem="k6R-4f-fZa" firstAttribute="top" secondItem="aOx-Ck-kOT" secondAttribute="bottom" constant="20" id="bhW-Lo-RGG"/>
+                                                        <constraint firstAttribute="trailing" secondItem="LyF-dE-u9U" secondAttribute="trailing" constant="16" id="Wh7-5Y-c3Z"/>
                                                         <constraint firstAttribute="trailing" secondItem="aOx-Ck-kOT" secondAttribute="trailing" constant="16" id="vvF-Sq-Sw6"/>
-                                                        <constraint firstItem="k6R-4f-fZa" firstAttribute="top" secondItem="ydl-fI-jzy" secondAttribute="bottom" priority="750" constant="16" id="wmk-0e-Ype"/>
                                                         <constraint firstItem="ydl-fI-jzy" firstAttribute="leading" secondItem="yoK-vu-7JQ" secondAttribute="leading" constant="16" id="ysc-MJ-UcA"/>
                                                     </constraints>
                                                 </view>
@@ -132,11 +141,11 @@
                                         </tableViewCellContentView>
                                         <connections>
                                             <outlet property="attachmentStackView" destination="WAv-i1-qFc" id="pOx-Rt-bjj"/>
+                                            <outlet property="audioPlayerContainer" destination="ZNn-VI-tWH" id="mcj-S4-SNi"/>
                                             <outlet property="avatar" destination="ydl-fI-jzy" id="ExW-58-iAJ"/>
                                             <outlet property="dateLabel" destination="lGq-Od-o8W" id="v4L-Qb-q2c"/>
                                             <outlet property="fromLabel" destination="rmq-tE-xSD" id="lIE-ZW-DTp"/>
                                             <outlet property="messageLabel" destination="LyF-dE-u9U" id="gAk-JA-ziX"/>
-                                            <outlet property="stackview" destination="k6R-4f-fZa" id="Qjo-Tl-FEf"/>
                                             <outlet property="toLabel" destination="Ub6-rx-Qcj" id="V3S-PV-8Pz"/>
                                         </connections>
                                     </tableViewCell>

--- a/Parent/Parent/Conversations/ConversationDetailViewController.swift
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.swift
@@ -88,8 +88,7 @@ class ConversationDetailViewController: UIViewController {
         showReplyFor(IndexPath(row: 0, section: 0), all: message.participantIDs.count > 2)
     }
 
-    func showAttachment(_ attachment: File) {
-        guard let url = attachment.url else { return }
+    func showAttachment(_ url: URL) {
         env.router.route(to: url, from: self, options: .modal(embedInNav: true, addDoneButton: true))
     }
 }
@@ -106,7 +105,7 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: ConversationDetailCell = tableView.dequeue(for: indexPath)
         let msg = conversations.first?.messages[indexPath.section]
-        cell.update(msg, myID: myID, userMap: userMap)
+        cell.update(msg, myID: myID, userMap: userMap, parent: self)
         cell.onTapAttachment = { [weak self] file in self?.showAttachment(file) }
         return cell
     }

--- a/Parent/Parent/Conversations/ConversationDetailViewController.swift
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.swift
@@ -87,10 +87,6 @@ class ConversationDetailViewController: UIViewController {
         guard let message = conversations.first?.messages.first else { return }
         showReplyFor(IndexPath(row: 0, section: 0), all: message.participantIDs.count > 2)
     }
-
-    func showAttachment(_ url: URL) {
-        env.router.route(to: url, from: self, options: .modal(embedInNav: true, addDoneButton: true))
-    }
 }
 
 extension ConversationDetailViewController: UITableViewDataSource, UITableViewDelegate {
@@ -106,7 +102,6 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
         let cell: ConversationDetailCell = tableView.dequeue(for: indexPath)
         let msg = conversations.first?.messages[indexPath.section]
         cell.update(msg, myID: myID, userMap: userMap, parent: self)
-        cell.onTapAttachment = { [weak self] file in self?.showAttachment(file) }
         return cell
     }
 

--- a/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
@@ -39,7 +39,7 @@ class ConversationDetailViewControllerTests: ParentTestCase {
                   created_at: Clock.now.addDays(-1),
                   body: "hello world",
                   author_id: "1",
-                  attachments: [.make(id: "1", mime_class: "doc"), .make(id: "2", mime_class: "image")],
+                  attachments: [.make(id: "1", mime_class: "doc"), .make(id: "2", display_name: "Image", mime_class: "image")],
                   participating_user_ids: [ "1", "2" ]
                 ),
                 APIConversationMessage.make(
@@ -75,10 +75,10 @@ class ConversationDetailViewControllerTests: ParentTestCase {
 
         XCTAssertEqual(first?.attachmentStackView.arrangedSubviews.count, 3)
         XCTAssertTrue(first?.attachmentStackView.isHidden == false)
-        XCTAssertTrue(first?.attachmentStackView.arrangedSubviews.first is ConversationDetailCell.NonPhotoAttachment)
-        XCTAssertTrue(first?.attachmentStackView.arrangedSubviews[1] is ConversationDetailCell.PhotoAttachment)
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[0].accessibilityLabel, "File")
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[1].accessibilityLabel, "Image")
 
-        (first?.attachmentStackView.arrangedSubviews.first as? ConversationDetailCell.NonPhotoAttachment)?.button.sendActions(for: .primaryActionTriggered)
+        (first?.attachmentStackView.arrangedSubviews.first as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(router.lastRoutedTo(.parse("https://canvas.instructure.com/files/1/download")))
 
         let actions = controller.tableView.delegate?.tableView?(

--- a/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import XCTest
 @testable import Core
 @testable import Parent
@@ -36,18 +37,34 @@ class ConversationDetailViewControllerTests: ParentTestCase {
             messages: [
                 APIConversationMessage.make(
                     id: "1",
-                  created_at: Clock.now.addDays(-1),
-                  body: "hello world",
-                  author_id: "1",
-                  attachments: [.make(id: "1", mime_class: "doc"), .make(id: "2", display_name: "Image", mime_class: "image")],
-                  participating_user_ids: [ "1", "2" ]
+                    created_at: Clock.now.addDays(-1),
+                    body: "hello world",
+                    author_id: "1",
+                    media_comment: .make(url: URL(string: "data:text/plain,")!),
+                    attachments: [
+                        .make(id: "1", mime_class: "doc"),
+                        .make(id: "2", display_name: "Image", mime_class: "image"),
+                        .make(id: "3", url: URL(string: "data:text/plain,")!, mime_class: "video"),
+                    ],
+                    participating_user_ids: [ "1", "2" ]
                 ),
                 APIConversationMessage.make(
                     id: "2",
-                  created_at: Clock.now.addDays(-2),
-                  body: "foo bar",
-                  author_id: "1",
-                  participating_user_ids: [ "1", "2" ]
+                    created_at: Clock.now.addDays(-2),
+                    body: "foo bar",
+                    author_id: "1",
+                    participating_user_ids: [ "1", "2" ]
+                ),
+                APIConversationMessage.make(
+                    id: "3",
+                    created_at: Clock.now.addDays(-3),
+                    body: "audio",
+                    author_id: "1",
+                    media_comment: .make(media_type: .audio, url: URL(string: "data:text/plain,")!),
+                    attachments: [
+                        .make(id: "9", url: URL(string: "data:text/plain,")!, mime_class: "audio"),
+                    ],
+                    participating_user_ids: [ "1", "2" ]
                 ),
             ]
         )
@@ -73,12 +90,12 @@ class ConversationDetailViewControllerTests: ParentTestCase {
         XCTAssertEqual(first?.messageLabel.text, "hello world")
         XCTAssertEqual(first?.dateLabel.text, DateFormatter.localizedString(from: Clock.now.addDays(-1), dateStyle: .medium, timeStyle: .short))
 
-        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews.count, 3)
-        XCTAssertTrue(first?.attachmentStackView.isHidden == false)
-        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[0].accessibilityLabel, "File")
-        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[1].accessibilityLabel, "Image")
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews.count, 5)
+        XCTAssertEqual(first?.attachmentStackView.isHidden, false)
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[1].accessibilityLabel, "File")
+        XCTAssertEqual(first?.attachmentStackView.arrangedSubviews[2].accessibilityLabel, "Image")
 
-        (first?.attachmentStackView.arrangedSubviews.first as? UIButton)?.sendActions(for: .primaryActionTriggered)
+        (first?.attachmentStackView.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(router.lastRoutedTo(.parse("https://canvas.instructure.com/files/1/download")))
 
         let actions = controller.tableView.delegate?.tableView?(
@@ -93,7 +110,16 @@ class ConversationDetailViewControllerTests: ParentTestCase {
 
         let second = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? ConversationDetailCell
         XCTAssertEqual(second?.attachmentStackView.arrangedSubviews.count, 0)
-        XCTAssertTrue(second?.attachmentStackView.isHidden == true)
+        XCTAssertEqual(second?.attachmentStackView.isHidden, true)
+
+        let third = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 2)) as? ConversationDetailCell
+        XCTAssertEqual(third?.attachmentStackView.arrangedSubviews.count, 3)
+        XCTAssertEqual(third?.attachmentStackView.isHidden, false)
+
+        (third?.attachmentStackView.arrangedSubviews[0] as? UIButton)?.sendActions(for: .primaryActionTriggered)
+        XCTAssertTrue(router.presented is AVPlayerViewController)
+        (third?.attachmentStackView.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
+        XCTAssertTrue(router.presented is AVPlayerViewController)
     }
 
     func testReplyAll() {

--- a/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
+++ b/Student/SubmitAssignmentTests/SubmitAssignmentPresenterTests.swift
@@ -141,7 +141,7 @@ class SubmitAssignmentPresenterTests: SubmitAssignmentTests, SubmitAssignmentVie
         let attachment = NSItemProvider(item: Data() as NSSecureCoding, typeIdentifier: UTI.any.rawValue)
         let item = TestExtensionItem(mockAttachments: [attachment])
         presenter.load(items: [item])
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 5)
     }
 
     func testLoadItemsImage() {


### PR DESCRIPTION
Audio comments & attachments look like other files, but open a fullscreen AVPlayer when you tap.
Video comments & attachments get an inline AVPlayer that automatically goes fullscreen when you tap to play.

refs: MBL-13773
affects: Parent
release note: none