### PR TITLE
Expand and collapse recipients view

### DIFF
--- a/Core/Core/Profile/ProfileViewController.swift
+++ b/Core/Core/Profile/ProfileViewController.swift
@@ -104,7 +104,9 @@ public class ProfileViewController: UIViewController, ProfileViewProtocol {
         }
 
         env.api.makeRequest(GetUserRequest(userID: "self")) { [weak self] user, _, _ in
-            self?.avatarButton?.isHidden = user?.permissions?.can_update_avatar == false
+            performUIUpdate {
+                self?.avatarButton?.isHidden = user?.permissions?.can_update_avatar == false
+            }
         }
     }
 

--- a/Parent/Parent/Conversations/ComposeRecipientsView.swift
+++ b/Parent/Parent/Conversations/ComposeRecipientsView.swift
@@ -86,7 +86,7 @@ class ComposeRecipientsView: UIView {
         addSubview(additionalRecipients)
         NSLayoutConstraint.activate([
             additionalRecipients.topAnchor.constraint(equalTo: topAnchor, constant: 19),
-            additionalRecipients.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18)
+            additionalRecipients.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18),
         ])
     }
 
@@ -107,13 +107,14 @@ class ComposeRecipientsView: UIView {
 
         pills.forEach { $0.removeFromSuperview() }
 
-        for recipient in recipients.dropLast(isExpanded ? 0 : max(recipients.count - 1, 1)) {
+        for recipient in recipients.dropLast(isExpanded ? 0 : max(recipients.count - 1, 0)) {
             let pill = ComposeRecipientView()
             addSubview(pill)
             pill.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, constant: -32).isActive = true
             pill.update(recipient)
             setNeedsLayout()
         }
+
         for pill in pills.dropFirst(recipients.count) {
             pill.removeFromSuperview()
             setNeedsLayout()

--- a/Parent/Parent/Conversations/ComposeRecipientsView.swift
+++ b/Parent/Parent/Conversations/ComposeRecipientsView.swift
@@ -30,6 +30,8 @@ class ComposeRecipientsView: UIView {
 
     var editButton: UIButton!
     var placeholder: UILabel!
+    var additionalRecipients: UILabel!
+    var isExpanded: Bool = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -44,6 +46,8 @@ class ComposeRecipientsView: UIView {
     func initialize() {
         addEditButton()
         addPlaceholder()
+        addAdditionalRecipients()
+        addExpandCollapse()
     }
 
     func addEditButton() {
@@ -74,9 +78,36 @@ class ComposeRecipientsView: UIView {
         ])
     }
 
+    func addAdditionalRecipients() {
+        additionalRecipients = UILabel()
+        additionalRecipients.translatesAutoresizingMaskIntoConstraints = false
+        additionalRecipients.textColor = .named(.textDarkest)
+        additionalRecipients.font = .scaledNamedFont(.semibold16)
+        addSubview(additionalRecipients)
+        NSLayoutConstraint.activate([
+            additionalRecipients.topAnchor.constraint(equalTo: topAnchor, constant: 19),
+            additionalRecipients.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -18)
+        ])
+    }
+
+    func addExpandCollapse() {
+        let touch = UITapGestureRecognizer(target: self, action: #selector(toggleIsExpanded(sender:)))
+        self.addGestureRecognizer(touch)
+    }
+
+    @objc
+    func toggleIsExpanded(sender: UITapGestureRecognizer) {
+        isExpanded = !isExpanded
+        updatePills()
+    }
+
     func updatePills() {
+        additionalRecipients.text = String.localizedStringWithFormat(NSLocalizedString("+%d", bundle: .parent, comment: ""), recipients.count - 1)
+        additionalRecipients.isHidden = recipients.count <= 1 || isExpanded
+
         pills.forEach { $0.removeFromSuperview() }
-        for recipient in recipients {
+
+        for recipient in recipients.dropLast(isExpanded ? 0 : max(recipients.count - 1, 1)) {
             let pill = ComposeRecipientView()
             addSubview(pill)
             pill.widthAnchor.constraint(lessThanOrEqualTo: widthAnchor, constant: -32).isActive = true
@@ -94,7 +125,7 @@ class ComposeRecipientsView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
         let xPad: CGFloat = 16
-        let yPad: CGFloat = 12
+        let yPad: CGFloat = 8
         let space: CGFloat = 8
         var next = CGPoint(x: xPad, y: yPad)
         let lineHeight = pills.first?.frame.height ?? 0
@@ -112,6 +143,8 @@ class ComposeRecipientsView: UIView {
         }
         let height = constraints.first { $0.firstAnchor == heightAnchor }
         height?.constant = max(next.y + lineHeight + yPad, placeholder.intrinsicContentSize.height)
+
+        additionalRecipients.frame.origin.x = next.x
     }
 }
 

--- a/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
@@ -57,19 +57,6 @@ class ComposeViewControllerTests: ParentTestCase {
         controller.subjectField.sendActions(for: .editingChanged)
         XCTAssertEqual(controller.navigationItem.rightBarButtonItem?.isEnabled, true)
 
-        let task = api.mock(PostConversationRequest(body: PostConversationRequest.Body(
-            subject: "subject",
-            body: controller.body(),
-            recipients: [ APIConversationRecipient.make().id.value ],
-            context_code: controller.context!.canvasContextID)
-            ), value: [ APIConversation.make() ]
-        )
-        task.paused = true
-        let sendButton = controller.navigationItem.rightBarButtonItem
-        XCTAssertNoThrow(sendButton?.target?.perform(sendButton?.action))
-        XCTAssert(controller.navigationItem.rightBarButtonItem?.customView is UIActivityIndicatorView)
-        task.resume()
-
         XCTAssertNotNil(controller.recipientsView.editButton)
         XCTAssertTrue(controller.recipientsView.placeholder.isHidden)
         controller.recipientsView.editButton.sendActions(for: .primaryActionTriggered)
@@ -93,6 +80,19 @@ class ComposeViewControllerTests: ParentTestCase {
         XCTAssertEqual(controller.recipientsView.recipients.count, 1)
         XCTAssertEqual(controller.recipientsView.recipients.first?.id.value, "123")
         XCTAssertTrue(controller.recipientsView.placeholder.isHidden)
+
+        let task = api.mock(PostConversationRequest(body: PostConversationRequest.Body(
+            subject: "subject",
+            body: controller.body(),
+            recipients: [ APIConversationRecipient.make().id.value ],
+            context_code: controller.context!.canvasContextID)
+            ), value: [ APIConversation.make() ]
+        )
+        task.paused = true
+        let sendButton = controller.navigationItem.rightBarButtonItem
+        XCTAssertNoThrow(sendButton?.target?.perform(sendButton?.action))
+        XCTAssert(controller.navigationItem.rightBarButtonItem?.customView is UIActivityIndicatorView)
+        task.resume()
     }
 
     func testCreateConversationError() {

--- a/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
@@ -17,6 +17,7 @@
 //
 
 import XCTest
+import UIKit
 @testable import Core
 @testable import Parent
 import TestsFoundation
@@ -117,5 +118,19 @@ class ComposeViewControllerTests: ParentTestCase {
         loadView()
         drainMainQueue()
         XCTAssertEqual(controller.recipientsView.recipients.count, 1)
+    }
+
+    func testAdditionalRecipients() {
+        loadView()
+
+        XCTAssertTrue(controller.recipientsView.additionalRecipients.isHidden)
+
+        controller.recipientsView.recipients = [.make(), .make()]
+        XCTAssertFalse(controller.recipientsView.additionalRecipients.isHidden)
+        XCTAssertEqual(controller.recipientsView.pills.count, 1)
+
+        controller.recipientsView.toggleIsExpanded(sender: UITapGestureRecognizer())
+        XCTAssertTrue(controller.recipientsView.additionalRecipients.isHidden)
+        XCTAssertEqual(controller.recipientsView.pills.count, 2)
     }
 }


### PR DESCRIPTION
refs: MBL-13787
affects: parent
release note: none

test plan:
 - tapping in the recipients view should expand and collapse it
 - If there are more than one recipients and the view is collapsed
   it will show the additional number of recipients label