### PR TITLE
Improve accessibility in inbox

### DIFF
--- a/Core/Core/Conversations/APIConversationRecipient.swift
+++ b/Core/Core/Conversations/APIConversationRecipient.swift
@@ -47,6 +47,12 @@ extension APIConversationRecipient {
     }
 }
 
+extension Array where Element == APIConversationRecipient {
+    public func sortedByName() -> [APIConversationRecipient] {
+        return self.sorted(by: { $0.name < $1.name })
+    }
+}
+
 #if DEBUG
 extension APIConversationRecipient {
     public static func make(

--- a/Parent/Parent/Conversations/ComposeRecipientsView.swift
+++ b/Parent/Parent/Conversations/ComposeRecipientsView.swift
@@ -31,7 +31,7 @@ class ComposeRecipientsView: UIView {
     var editButton: UIButton!
     var placeholder: UILabel!
     var additionalRecipients: UILabel!
-    var isExpanded: Bool = false
+    var isExpanded: Bool = UIAccessibility.isVoiceOverRunning
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -47,7 +47,10 @@ class ComposeRecipientsView: UIView {
         addEditButton()
         addPlaceholder()
         addAdditionalRecipients()
-        addExpandCollapse()
+
+        if UIAccessibility.isVoiceOverRunning == false {
+            addExpandCollapse()
+        }
     }
 
     func addEditButton() {
@@ -55,6 +58,7 @@ class ComposeRecipientsView: UIView {
         editButton.setImage(.icon(.addressBook), for: .normal)
         editButton.tintColor = .named(.textDark)
         editButton.translatesAutoresizingMaskIntoConstraints = false
+        editButton.accessibilityLabel = NSLocalizedString("Edit Recipients", comment: "")
         addSubview(editButton)
         NSLayoutConstraint.activate([
             editButton.heightAnchor.constraint(equalToConstant: 24),
@@ -92,7 +96,7 @@ class ComposeRecipientsView: UIView {
 
     func addExpandCollapse() {
         let touch = UITapGestureRecognizer(target: self, action: #selector(toggleIsExpanded(sender:)))
-        self.addGestureRecognizer(touch)
+        addGestureRecognizer(touch)
     }
 
     @objc

--- a/Parent/Parent/Conversations/ComposeReplyViewController.swift
+++ b/Parent/Parent/Conversations/ComposeReplyViewController.swift
@@ -63,6 +63,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .named(.textDarkest)
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
+        bodyView.accessibilityLabel = NSLocalizedString("Message", comment: "")
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Parent/Parent/Conversations/ComposeViewController.storyboard
+++ b/Parent/Parent/Conversations/ComposeViewController.storyboard
@@ -16,19 +16,23 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mok-pg-KkL">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Mok-pg-KkL">
                                 <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                                 <subviews>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Ucz-Xk-VcY">
+                                    <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ucz-Xk-VcY">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="141.5"/>
                                         <subviews>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BVF-r0-wRL" customClass="ComposeRecipientsView" customModule="Parent" customModuleProvider="target">
+                                            <view contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BVF-r0-wRL" customClass="ComposeRecipientsView" customModule="Parent" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
+                                                <accessibility key="accessibilityConfiguration">
+                                                    <accessibilityTraits key="traits" notEnabled="YES"/>
+                                                    <bool key="isElement" value="NO"/>
+                                                </accessibility>
                                                 <constraints>
                                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="zMo-r5-fqc"/>
                                                 </constraints>
                                             </view>
-                                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="noy-Us-iAN" customClass="DividerView" customModule="Parent" customModuleProvider="target">
+                                            <view opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="noy-Us-iAN" customClass="DividerView" customModule="Parent" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="56" width="375" height="1"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="UF3-u8-IrB"/>
@@ -37,9 +41,11 @@
                                                     <userDefinedRuntimeAttribute type="string" keyPath="tintColorName" value="borderMedium"/>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Subject" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-0x-wXN" customClass="DynamicTextField" customModule="Parent" customModuleProvider="target">
+                                            <textField opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Subject" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="dz1-0x-wXN" customClass="DynamicTextField" customModule="Parent" customModuleProvider="target">
                                                 <rect key="frame" x="16" y="57" width="343" height="48"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="Compose.subject"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Compose.subject">
+                                                    <accessibilityTraits key="traits" header="YES"/>
+                                                </accessibility>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="48" id="VCI-fH-9f0"/>
                                                 </constraints>
@@ -53,7 +59,7 @@
                                                     <action selector="updateSendButton" destination="5LE-uY-8Ht" eventType="editingChanged" id="tUg-4O-qDV"/>
                                                 </connections>
                                             </textField>
-                                            <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="rhy-5d-51p" customClass="DividerView" customModule="Parent" customModuleProvider="target">
+                                            <view opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rhy-5d-51p" customClass="DividerView" customModule="Parent" customModuleProvider="target">
                                                 <rect key="frame" x="0.0" y="105" width="375" height="1"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="1" id="pYh-ox-LRj"/>
@@ -62,9 +68,11 @@
                                                     <userDefinedRuntimeAttribute type="string" keyPath="tintColorName" value="borderMedium"/>
                                                 </userDefinedRuntimeAttributes>
                                             </view>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="oQx-YB-DID">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="oQx-YB-DID">
                                                 <rect key="frame" x="0.0" y="106" width="375" height="35.5"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="Compose.body"/>
+                                                <accessibility key="accessibilityConfiguration" identifier="Compose.body">
+                                                    <accessibilityTraits key="traits" header="YES"/>
+                                                </accessibility>
                                                 <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>
                                                 <fontDescription key="fontDescription" type="system" weight="medium" pointSize="16"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>

--- a/Parent/Parent/Conversations/ComposeViewController.swift
+++ b/Parent/Parent/Conversations/ComposeViewController.swift
@@ -48,7 +48,7 @@ class ComposeViewController: UIViewController, ErrorViewController {
         controller.bodyView.text = body
         controller.context = context
         controller.observeeID = observeeID
-        controller.recipientsView.recipients = recipients
+        controller.recipientsView.recipients = recipients.sorted(by: { $0.name < $1.name })
         controller.subjectField.text = subject
         controller.textViewDidChange(controller.bodyView)
         controller.hiddenMessage = hiddenMessage
@@ -72,11 +72,13 @@ class ComposeViewController: UIViewController, ErrorViewController {
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .named(.textDarkest)
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
+        bodyView.accessibilityLabel = NSLocalizedString("Message", comment: "")
 
         subjectField.attributedPlaceholder = NSAttributedString(
             string: NSLocalizedString("Subject", comment: ""),
             attributes: [ .foregroundColor: UIColor.named(.textDark) ]
         )
+        subjectField.accessibilityLabel = NSLocalizedString("Subject", comment: "")
 
         recipientsView.editButton.addTarget(self, action: #selector(editRecipients), for: .primaryActionTriggered)
     }
@@ -150,7 +152,7 @@ class ComposeViewController: UIViewController, ErrorViewController {
         let request = GetConversationRecipientsRequest(search: "", context: searchContext, includeContexts: false)
         env.api.makeRequest(request) { [weak self] (recipients, _, _) in
             performUIUpdate {
-                self?.recipientsView.recipients = recipients ?? []
+                self?.recipientsView.recipients = recipients?.sorted(by: { $0.name < $1.name }) ?? []
             }
         }
     }
@@ -164,7 +166,8 @@ extension ComposeViewController: UITextViewDelegate {
 
 extension ComposeViewController: EditComposeRecipientsViewControllerDelegate {
     func editRecipientsControllerDidFinish(_ controller: EditComposeRecipientsViewController) {
-        recipientsView.recipients = Array(controller.selectedRecipients)
+        recipientsView.recipients = Array(controller.selectedRecipients).sorted(by: { $0.name < $1.name })
         updateSendButton()
+        UIAccessibility.post(notification: .screenChanged, argument: recipientsView.editButton)
     }
 }

--- a/Parent/Parent/Conversations/ComposeViewController.swift
+++ b/Parent/Parent/Conversations/ComposeViewController.swift
@@ -48,7 +48,7 @@ class ComposeViewController: UIViewController, ErrorViewController {
         controller.bodyView.text = body
         controller.context = context
         controller.observeeID = observeeID
-        controller.recipientsView.recipients = recipients.sorted(by: { $0.name < $1.name })
+        controller.recipientsView.recipients = recipients.sortedByName()
         controller.subjectField.text = subject
         controller.textViewDidChange(controller.bodyView)
         controller.hiddenMessage = hiddenMessage
@@ -152,7 +152,7 @@ class ComposeViewController: UIViewController, ErrorViewController {
         let request = GetConversationRecipientsRequest(search: "", context: searchContext, includeContexts: false)
         env.api.makeRequest(request) { [weak self] (recipients, _, _) in
             performUIUpdate {
-                self?.recipientsView.recipients = recipients?.sorted(by: { $0.name < $1.name }) ?? []
+                self?.recipientsView.recipients = recipients?.sortedByName() ?? []
             }
         }
     }
@@ -166,7 +166,7 @@ extension ComposeViewController: UITextViewDelegate {
 
 extension ComposeViewController: EditComposeRecipientsViewControllerDelegate {
     func editRecipientsControllerDidFinish(_ controller: EditComposeRecipientsViewController) {
-        recipientsView.recipients = Array(controller.selectedRecipients).sorted(by: { $0.name < $1.name })
+        recipientsView.recipients = Array(controller.selectedRecipients).sortedByName()
         updateSendButton()
         UIAccessibility.post(notification: .screenChanged, argument: recipientsView.editButton)
     }

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -43,6 +43,9 @@ class ConversationDetailCell: UITableViewCell {
         avatar.name = userMap[ m.authorID ]?.name ?? ""
 
         handleAttachments(m.attachments, media: m.mediaComment)
+
+        let template = NSLocalizedString("Message from %@, %@, on %@, %@", comment: "")
+        accessibilityLabel = String.localizedStringWithFormat(template, fromLabel.text ?? "", toLabel.text ?? "", dateLabel.text ?? "", m.body)
     }
 
     func handleAttachments(_ attachments: [File], media: MediaComment?) {

--- a/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
+++ b/Parent/Parent/Conversations/ConversationDetailViewController.storyboard
@@ -150,7 +150,9 @@
                             </tableView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rAw-lF-SAM" customClass="FloatingButton" customModule="Parent" customModuleProvider="target">
                                 <rect key="frame" x="342" y="790" width="56" height="56"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ConversationDetail.replyButton"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ConversationDetail.replyButton">
+                                    <accessibilityTraits key="traits" button="YES" header="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="56" id="GWW-b8-mwx"/>
                                     <constraint firstAttribute="width" constant="56" id="e9j-vX-RiZ"/>

--- a/Parent/Parent/Conversations/ConversationListCell.swift
+++ b/Parent/Parent/Conversations/ConversationListCell.swift
@@ -42,9 +42,9 @@ class ConversationListCell: UITableViewCell {
 
         accessibilityIdentifier = "ConversationListCell.\(conversation.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("%@, %@, last message %@ %@", comment: "label for conversation row with context, subject, & last message date & text"),
-            conversation.contextName ?? "",
+            NSLocalizedString("%@, in %@, the last message was on %@ %@", comment: "label for conversation row with context, subject, & last message date & text"),
             subject,
+            conversation.contextName ?? "",
             conversation.lastMessageAt.dateMediumString,
             conversation.lastMessage
         )

--- a/Parent/Parent/Conversations/ConversationListViewController.storyboard
+++ b/Parent/Parent/Conversations/ConversationListViewController.storyboard
@@ -211,7 +211,9 @@
                             </view>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Prk-n7-JjP" customClass="FloatingButton" customModule="Parent" customModuleProvider="target">
                                 <rect key="frame" x="303" y="551" width="56" height="56"/>
-                                <accessibility key="accessibilityConfiguration" identifier="ConversationList.composeButton"/>
+                                <accessibility key="accessibilityConfiguration" identifier="ConversationList.composeButton">
+                                    <accessibilityTraits key="traits" button="YES" header="YES"/>
+                                </accessibility>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="56" id="PdI-fv-6we"/>
                                     <constraint firstAttribute="height" constant="56" id="oM0-xE-QAd"/>

--- a/Parent/Parent/Conversations/ConversationListViewController.swift
+++ b/Parent/Parent/Conversations/ConversationListViewController.swift
@@ -93,7 +93,6 @@ class ConversationListViewController: UIViewController, ConversationCoursesActio
         }
     }
 
-    @objc
     @IBAction func createNewConversation() {
         let vc = ConversationCoursesActionSheet.create(delegate: self)
         let actionSheet = ActionSheetController(viewController: vc)

--- a/Parent/Parent/Conversations/ConversationListViewController.swift
+++ b/Parent/Parent/Conversations/ConversationListViewController.swift
@@ -93,6 +93,7 @@ class ConversationListViewController: UIViewController, ConversationCoursesActio
         }
     }
 
+    @objc
     @IBAction func createNewConversation() {
         let vc = ConversationCoursesActionSheet.create(delegate: self)
         let actionSheet = ActionSheetController(viewController: vc)

--- a/Parent/ParentUnitTests/Conversations/ConversationListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationListViewControllerTests.swift
@@ -54,11 +54,11 @@ class ConversationListViewControllerTests: ParentTestCase {
         XCTAssertEqual(first?.contextLabel.text, "Canvas 101")
         XCTAssertEqual(first?.subjectLabel.text, "Subject One")
         XCTAssertEqual(first?.unreadView.isHidden, false)
-        XCTAssertEqual(first?.accessibilityLabel, "Canvas 101, Subject One, last message Dec 25 Last Message One, unread")
+        XCTAssertEqual(first?.accessibilityLabel, "Subject One, in Canvas 101, the last message was on Dec 25 Last Message One, unread")
 
         let last = controller.tableView.cellForRow(at: IndexPath(row: 1, section: 0)) as? ConversationListCell
         XCTAssertEqual(last?.unreadView.isHidden, true)
-        XCTAssertEqual(last?.accessibilityLabel, "CTX, (No subject), last message Dec 25, 2018 last")
+        XCTAssertEqual(last?.accessibilityLabel, "(No subject), in CTX, the last message was on Dec 25, 2018 last")
 
         controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         XCTAssert(router.lastRoutedTo(.conversation("1")))


### PR DESCRIPTION
Make each text field a heading on compose to easily navigate
Text fields have proper a11y labels
Recipients field is auto expanded when VO is on
Close edit recipients focuses edit button
Made compose button a header for easier navigation
Made reply button a header for easier navigation
Made the message cells on a conversation have better a11y text

refs: MBL-13864
affects: parent
release note: none