### PR TITLE
Add pronouns to Parent

### DIFF
--- a/Core/Core/API/APISearchRecipient.swift
+++ b/Core/Core/API/APISearchRecipient.swift
@@ -23,6 +23,7 @@ public struct APISearchRecipient: Codable, Equatable {
     public let id: ID
     public let name: String
     public let full_name: String
+    public let pronouns: String?
     public let avatar_url: APIURL?
     public let type: APISearchRecipientContext?
     public let common_courses: [String: [String]]

--- a/Core/Core/Conversations/APIConversationRecipient.swift
+++ b/Core/Core/Conversations/APIConversationRecipient.swift
@@ -23,6 +23,7 @@ public struct APIConversationRecipient: Codable {
     public let name: String
     public let full_name: String?
     public let avatar_url: APIURL?
+    public let pronouns: String?
 }
 
 extension APIConversationRecipient: Hashable {
@@ -37,6 +38,7 @@ extension APIConversationRecipient {
         self.name = r.fullName
         self.full_name = r.fullName
         self.avatar_url = APIURL(rawValue: r.avatarURL)
+        self.pronouns = r.pronouns
     }
 
     public init(user: User) {
@@ -44,6 +46,7 @@ extension APIConversationRecipient {
         self.name = user.name
         self.full_name = user.name
         self.avatar_url = APIURL(rawValue: user.avatarURL)
+        self.pronouns = user.pronouns
     }
 }
 
@@ -53,13 +56,15 @@ extension APIConversationRecipient {
         id: ID = "1",
         name: String = "Homestar",
         full_name: String = "Homestar Runner",
-        avatar_url: APIURL? = .make(rawValue: URL(string: "https://homestarrunner.com/tempHomeImg/logo_200x200@2x.png")!)
+        avatar_url: APIURL? = .make(rawValue: URL(string: "https://homestarrunner.com/tempHomeImg/logo_200x200@2x.png")!),
+        pronouns: String? = nil
     ) -> APIConversationRecipient {
         return APIConversationRecipient(
             id: id,
             name: name,
             full_name: full_name,
-            avatar_url: avatar_url
+            avatar_url: avatar_url,
+            pronouns: pronouns
         )
     }
 }

--- a/Core/Core/Conversations/ConversationMessage.swift
+++ b/Core/Core/Conversations/ConversationMessage.swift
@@ -75,7 +75,7 @@ extension ConversationMessage {
         let containsMe = audience.contains(myID)
 
         if audience.count == 1 {
-            user =  containsMe ? NSLocalizedString("me", comment: "") : userMap[ audience[0] ]?.name
+            user =  containsMe ? NSLocalizedString("me", comment: "") : userMap[ audience[0] ]?.displayName
         } else if audience.count > 1 {
             let cnt = containsMe ? audience.count - 1 : audience.count
             let pluralFormat = NSLocalizedString("conversation_recipients_to", bundle: .core, comment: "")

--- a/Core/Core/Conversations/ConversationParticipant.swift
+++ b/Core/Core/Conversations/ConversationParticipant.swift
@@ -23,12 +23,18 @@ public final class ConversationParticipant: NSManagedObject, WriteableModel {
     @NSManaged public var avatarURL: URL?
     @NSManaged public var id: String
     @NSManaged public var name: String
+    @NSManaged public var pronouns: String?
+
+    public var displayName: String {
+        User.displayName(name, pronouns: pronouns)
+    }
 
     public static func save(_ item: APIConversationParticipant, in context: NSManagedObjectContext) -> ConversationParticipant {
         let model: ConversationParticipant = context.first(where: #keyPath(ConversationParticipant.id), equals: item.id.value) ?? context.insert()
         model.avatarURL = item.avatar_url?.rawValue
         model.id = item.id.value
         model.name = item.name
+        model.pronouns = item.pronouns
         return model
     }
 }

--- a/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -481,6 +481,7 @@
         <attribute name="filter" optional="YES" attributeType="String"/>
         <attribute name="fullName" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="pronouns" optional="YES" attributeType="String"/>
         <relationship name="commonCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CommonCourse" inverseName="searchRecipient" inverseEntity="CommonCourse"/>
     </entity>
     <entity name="Submission" representedClassName="Core.Submission" syncable="YES">
@@ -616,7 +617,7 @@
         <element name="Rubric" positionX="-540" positionY="-27" width="128" height="180"/>
         <element name="RubricAssessment" positionX="-540" positionY="-27" width="128" height="133"/>
         <element name="RubricRating" positionX="-531" positionY="-18" width="128" height="150"/>
-        <element name="SearchRecipient" positionX="-540" positionY="-27" width="128" height="118"/>
+        <element name="SearchRecipient" positionX="-540" positionY="-27" width="128" height="133"/>
         <element name="Submission" positionX="-312.484375" positionY="260.38671875" width="128" height="403"/>
         <element name="SubmissionComment" positionX="-369" positionY="-18" width="128" height="268"/>
         <element name="Syllabus" positionX="-540" positionY="-18" width="128" height="73"/>

--- a/Core/Core/Models/SearchRecipient.swift
+++ b/Core/Core/Models/SearchRecipient.swift
@@ -20,12 +20,16 @@ import Foundation
 import CoreData
 
 public final class SearchRecipient: NSManagedObject {
-
     @NSManaged public var id: String
     @NSManaged public var fullName: String
+    @NSManaged public var pronouns: String?
     @NSManaged public var avatarURL: URL?
     @NSManaged public var filter: String
     @NSManaged public var commonCourses: Set<CommonCourse>
+
+    public var displayName: String? {
+        User.displayName(fullName, pronouns: pronouns)
+    }
 
     @discardableResult
     public static func save(_ item: APISearchRecipient, filter: String, in context: NSManagedObjectContext) -> SearchRecipient {
@@ -34,6 +38,7 @@ public final class SearchRecipient: NSManagedObject {
 
         model.id = item.id.value
         model.fullName = item.full_name
+        model.pronouns = item.pronouns
         model.avatarURL = item.avatar_url?.rawValue
         model.filter = filter
         model.commonCourses = []

--- a/Parent/Parent/Airwolf/Model/Airwolf.xcdatamodeld/Airwolf.xcdatamodel/contents
+++ b/Parent/Parent/Airwolf/Model/Airwolf.xcdatamodeld/Airwolf.xcdatamodel/contents
@@ -1,15 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10171" systemVersion="15E65" minimumToolsVersion="Xcode 7.0">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="19C57" minimumToolsVersion="Xcode 7.0" sourceLanguage="Objective-C" userDefinedModelVersionIdentifier="">
     <entity name="Student" representedClassName=".Student" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="domain" optional="YES" attributeType="Transformable" syncable="YES"/>
         <attribute name="id" attributeType="String" indexed="YES" syncable="YES"/>
         <attribute name="name" attributeType="String" syncable="YES"/>
         <attribute name="parentID" attributeType="String" indexed="YES" syncable="YES"/>
+        <attribute name="pronouns" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="shortName" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="sortableName" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <elements>
-        <element name="Student" positionX="-63" positionY="-18" width="128" height="150"/>
+        <element name="Student" positionX="-63" positionY="-18" width="128" height="163"/>
     </elements>
 </model>

--- a/Parent/Parent/Airwolf/Model/Student/Student.swift
+++ b/Parent/Parent/Airwolf/Model/Student/Student.swift
@@ -30,6 +30,7 @@ public final class Student: NSManagedObject {
     @NSManaged fileprivate (set) public var sortableName: String
     @NSManaged fileprivate (set) public var avatarURL: URL?
     @NSManaged fileprivate (set) public var domain: URL
+    @NSManaged fileprivate (set) public var pronouns: String?
 }
 
 extension Student: SynchronizedModel {
@@ -46,5 +47,6 @@ extension Student: SynchronizedModel {
         sortableName    = (try json <| "sortable_name") ?? name
         avatarURL       = try json <| "avatar_url"
         domain          = try json <| "student_domain"
+        pronouns        = try json <| "pronouns"
     }
 }

--- a/Parent/Parent/Conversations/ComposeRecipientsView.swift
+++ b/Parent/Parent/Conversations/ComposeRecipientsView.swift
@@ -179,7 +179,7 @@ class ComposeRecipientView: UIView {
     func update(_ recipient: APIConversationRecipient) {
         avatarView.name = recipient.name
         avatarView.url = recipient.avatar_url?.rawValue
-        nameLabel.text = recipient.name
+        nameLabel.text = User.displayName(recipient.name, pronouns: recipient.pronouns)
         nameLabel.accessibilityIdentifier = "Compose.recipientName.\(recipient.id)"
     }
 }

--- a/Parent/Parent/Conversations/ComposeReplyViewController.swift
+++ b/Parent/Parent/Conversations/ComposeReplyViewController.swift
@@ -90,7 +90,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
             .reduce(into: [:]) { map, p in map[p.id] = p }
         messageLabel.text = message.body
         toLabel.text = message.localizedAudience(myID: myID, userMap: userMap)
-        fromLabel.text = userMap[message.authorID]?.name
+        fromLabel.text = userMap[message.authorID]?.displayName
         dateLabel.text = DateFormatter.localizedString(from: message.createdAt, dateStyle: .medium, timeStyle: .short)
         avatarView.url = userMap[message.authorID]?.avatarURL
         avatarView.name = userMap[message.authorID]?.name ?? ""

--- a/Parent/Parent/Conversations/ConversationCoursesActionSheet.swift
+++ b/Parent/Parent/Conversations/ConversationCoursesActionSheet.swift
@@ -82,7 +82,8 @@ class ConversationCoursesActionSheet: UITableViewController, ErrorViewController
         }
 
         cell.textLabel?.text = course.name
-        cell.detailTextLabel?.text = String.localizedStringWithFormat(NSLocalizedString("for %@", bundle: .parent, comment: ""), enrollment.observedUser?.name ?? "")
+        let userName = enrollment.observedUser.flatMap { User.displayName($0.name, pronouns: $0.pronouns) } ?? ""
+        cell.detailTextLabel?.text = String.localizedStringWithFormat(NSLocalizedString("for %@", bundle: .parent, comment: ""), userName)
         return cell
     }
 

--- a/Parent/Parent/Conversations/ConversationDetailCell.swift
+++ b/Parent/Parent/Conversations/ConversationDetailCell.swift
@@ -37,7 +37,7 @@ class ConversationDetailCell: UITableViewCell {
         self.parent = parent
         messageLabel.text = m.body
         toLabel.text = m.localizedAudience(myID: myID, userMap: userMap)
-        fromLabel.text = userMap[ m.authorID ]?.name
+        fromLabel.text = userMap[ m.authorID ]?.displayName
         dateLabel.text = DateFormatter.localizedString(from: m.createdAt, dateStyle: .medium, timeStyle: .short)
         avatar.url = userMap[ m.authorID ]?.avatarURL
         avatar.name = userMap[ m.authorID ]?.name ?? ""

--- a/Parent/Parent/Conversations/EditComposeRecipientsViewController.swift
+++ b/Parent/Parent/Conversations/EditComposeRecipientsViewController.swift
@@ -93,7 +93,7 @@ class EditComposeRecipientsViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeue(for: indexPath) as RecipientCell
         let person = recipients[indexPath.row]
-        cell.nameLabel.text = person.fullName
+        cell.nameLabel.text = person.displayName
         cell.roleLabel.text = person.commonCourses
             .filter { $0.courseID == context.id }
             .compactMap { Role(rawValue: $0.role)?.description() }

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -73,7 +73,8 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
                 currentStudentID = student.id
                 let color = ColorScheme.observee(student.id).color
                 alertsTabItem.badgeColor = color
-                navbarNameButton.setTitle(student.name, for: .normal)
+                let displayName = Core.User.displayName(student.name, pronouns: student.pronouns)
+                navbarNameButton.setTitle(displayName, for: .normal)
                 navigationItem.leftBarButtonItem?.addBadge(number: badgeCount, color: color)
                 navbarAvatar?.name = student.name
                 navbarAvatar?.url = student.avatarURL
@@ -369,7 +370,7 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
             item.addConstraintsWithVFL("V:[view(90)]")
             item.avatar.url = student.avatarURL
             item.avatar.name = student.name
-            item.label.text = student.shortName
+            item.label.text = Core.User.displayName(student.shortName, pronouns: student.pronouns)
         }
         navbarMenuStackView.leftAlignArrangedSubviews()
     }

--- a/Parent/Parent/Settings/SettingsObserveeCellViewModel.swift
+++ b/Parent/Parent/Settings/SettingsObserveeCellViewModel.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-
+import Core
 import CanvasCore
 
 struct SettingsObserveeCellViewModel: TableViewCellViewModel {
@@ -27,7 +27,7 @@ struct SettingsObserveeCellViewModel: TableViewCellViewModel {
     let highlightColor: UIColor
 
     init(student: Student, highlightColor: UIColor) {
-        name = student.name
+        name = Core.User.displayName(student.name, pronouns: student.pronouns)
         avatarURL = student.avatarURL
         studentID = student.id
         self.highlightColor = highlightColor

--- a/Parent/Parent/Thresholds/StudentSettingsViewController.swift
+++ b/Parent/Parent/Thresholds/StudentSettingsViewController.swift
@@ -287,7 +287,7 @@ extension StudentSettingsViewController: UITableViewDataSource, UITableViewDeleg
         if section == 0 {
             let header = tableView.dequeueReusableHeaderFooterView(withIdentifier: String(describing: StudentSettingsHeaderView.self)) as? StudentSettingsHeaderView
             let student = studentObserver?.object
-            header?.nameLabel.text = student?.name
+            header?.nameLabel.text = student.flatMap { Core.User.displayName($0.name, pronouns: $0.pronouns) }
             header?.avatarView.name = student?.name ?? ""
             header?.avatarView.url = student?.avatarURL
             return header

--- a/Parent/ParentUnitTests/Conversations/ComposeReplyViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeReplyViewControllerTests.swift
@@ -56,4 +56,20 @@ class ComposeReplyViewControllerTests: ParentTestCase {
         api.mock(AddMessage(conversationID: conversation.id, body: "").request, value: .make())
         XCTAssertNoThrow(sendButton?.target?.perform(sendButton?.action))
     }
+
+    func testPronouns() {
+        conversation = Conversation.make(from: .make(
+            participants: [
+                .make(id: "1", name: "user 1", pronouns: "He/Him"),
+                .make(id: "2", name: "user 2", pronouns: "She/Her"),
+            ],
+            messages: [
+                .make(id: "1", author_id: "1", participating_user_ids: ["1", "2"]),
+            ]
+        ))
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+        XCTAssertEqual(controller.toLabel.text, "to user 2 (She/Her)")
+        XCTAssertEqual(controller.fromLabel.text, "user 1 (He/Him)")
+    }
 }

--- a/Parent/ParentUnitTests/Conversations/ConversationCoursesActionSheetTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationCoursesActionSheetTests.swift
@@ -95,12 +95,33 @@ class ConversationCoursesActionSheetTests: ParentTestCase {
     }
 
     func testCellForRowAt() {
-        let enrollment = Enrollment.make(from: .make(course_id: "1", type: "ObserverEnrollment", observed_user: .make()), course: .make(from: .make(id: "1"), in: databaseClient), in: databaseClient)
+        let enrollment = Enrollment.make(
+            from: .make(
+                course_id: "1",
+                type: "ObserverEnrollment",
+                observed_user: .make(name: "Observed User")),
+            course: .make(from: .make(id: "1"))
+        )
         loadView()
 
         let cell = controller.tableView(controller.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
         XCTAssertEqual(cell.textLabel?.text, enrollment.course?.name)
-        XCTAssertEqual(cell.detailTextLabel?.text, "for \(enrollment.observedUser?.name ?? "")")
+        XCTAssertEqual(cell.detailTextLabel?.text, "for Observed User")
+    }
+
+    func testCellForRowAtPronouns() {
+        let enrollment = Enrollment.make(
+            from: .make(
+                course_id: "1",
+                type: "ObserverEnrollment",
+                observed_user: .make(name: "Eve", pronouns: "She/Her")),
+            course: .make(from: .make(id: "1"))
+        )
+        loadView()
+
+        let cell = controller.tableView(controller.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(cell.textLabel?.text, enrollment.course?.name)
+        XCTAssertEqual(cell.detailTextLabel?.text, "for Eve (She/Her)")
     }
 
     func testCellTapped() {

--- a/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ConversationDetailViewControllerTests.swift
@@ -33,6 +33,8 @@ class ConversationDetailViewControllerTests: ParentTestCase {
             participants: [
                 .make(id: "1", name: "user 1"),
                 .make(id: "2", name: "user 2"),
+                .make(id: "3", name: "user 3", pronouns: "Them/They"),
+                .make(id: "4", name: "user 4", pronouns: "He/Him"),
             ],
             messages: [
                 APIConversationMessage.make(
@@ -65,6 +67,13 @@ class ConversationDetailViewControllerTests: ParentTestCase {
                         .make(id: "9", url: URL(string: "data:text/plain,")!, mime_class: "audio"),
                     ],
                     participating_user_ids: [ "1", "2" ]
+                ),
+                APIConversationMessage.make(
+                    id: "4",
+                    created_at: Clock.now.addDays(-4),
+                    body: "foo bar",
+                    author_id: "3",
+                    participating_user_ids: [ "3", "4" ]
                 ),
             ]
         )
@@ -120,6 +129,10 @@ class ConversationDetailViewControllerTests: ParentTestCase {
         XCTAssertTrue(router.presented is AVPlayerViewController)
         (third?.attachmentStackView.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(router.presented is AVPlayerViewController)
+
+        let fourth = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 3)) as? ConversationDetailCell
+        XCTAssertEqual(fourth?.fromLabel.text, "user 3 (Them/They)")
+        XCTAssertEqual(fourth?.toLabel.text, "to user 4 (He/Him)")
     }
 
     func testReplyAll() {

--- a/Parent/ParentUnitTests/Conversations/EditComposeRecipientsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/EditComposeRecipientsViewControllerTests.swift
@@ -51,6 +51,7 @@ class EditComposeRecipientsViewControllerTests: ParentTestCase {
             id: "1",
             name: "A",
             full_name: "A",
+            pronouns: "He/Him",
             common_courses: [courseID: ["StudentEnrollment"]]
         )
         let ta = APISearchRecipient.make(
@@ -82,7 +83,7 @@ class EditComposeRecipientsViewControllerTests: ParentTestCase {
         XCTAssertTrue(taCell.selectedView.isHidden)
         let observeeCell = recipientCell(at: 3)
         XCTAssertEqual(observeeCell.avatarView.name, "A")
-        XCTAssertEqual(observeeCell.nameLabel.text, "A")
+        XCTAssertEqual(observeeCell.nameLabel.text, "A (He/Him)")
         XCTAssertEqual(observeeCell.roleLabel.text, "Student")
         XCTAssertTrue(observeeCell.selectedView.isHidden)
         controller.tableView?.delegate?.tableView?(controller.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))

--- a/Parent/ParentUnitTests/Conversations/EditComposeRecipientsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/EditComposeRecipientsViewControllerTests.swift
@@ -33,7 +33,7 @@ class EditComposeRecipientsViewControllerTests: ParentTestCase {
     var callbackController: EditComposeRecipientsViewController?
 
     func testLayout() {
-        selectedRecipients = [APIConversationRecipient(id: "2", name: "B", full_name: "B", avatar_url: nil)]
+        selectedRecipients = [.make(id: "2", name: "B", full_name: "B", avatar_url: nil)]
         controller.delegate = self
         let teacher = APISearchRecipient.make(
             id: "2",

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APISearchRecipientFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APISearchRecipientFixture.swift
@@ -24,6 +24,7 @@ extension APISearchRecipient {
         id: ID = "1",
         name: String = "John Doe",
         full_name: String? = nil,
+        pronouns: String? = nil,
         avatar_url: URL? = nil,
         type: APISearchRecipientContext? = .course,
         common_courses: [String: [String]] = [:]
@@ -32,6 +33,7 @@ extension APISearchRecipient {
             id: id,
             name: name,
             full_name: full_name ?? name,
+            pronouns: pronouns,
             avatar_url: APIURL(rawValue: avatar_url),
             type: type,
             common_courses: common_courses


### PR DESCRIPTION
refs: MBL-13764
affects: parent
release note: Added support for user pronouns

Test plan:
* Log in to Parent > narmstrong > o
* Pronouns should show for Student 1 in the following places:
  - Dashboard: Student Picker and Nav title
  - Manage Children > Children list
  - Manage Children > tap Student1 > Nav title
  - Inbox > Tap Conversation ("Test Push Notification") > to and from labels
  - Inbox > Compose > Course picker > Student name below course
  - Compose > Edit recipients > Should show in the picker > Select Student 1 > Should show in the recipient pills