### PR TITLE
Inbox polish

### DIFF
--- a/Parent/Parent/Conversations/ConversationCoursesActionSheet.swift
+++ b/Parent/Parent/Conversations/ConversationCoursesActionSheet.swift
@@ -50,6 +50,7 @@ class ConversationCoursesActionSheet: UITableViewController, ErrorViewController
         loadingIndicator.startAnimating()
         loadingIndicator.center.x = tableView.center.x
         loadingIndicator.center.y = tableView.center.y / 2 // the table view hasn't yet been shrunk to activity sheet size
+        loadingIndicator.center.y -= 48 // minus header height to get centered
         view.addSubview(loadingIndicator)
 
         enrollments.exhaust()

--- a/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
@@ -37,9 +37,16 @@ class ComposeViewControllerTests: ParentTestCase {
         controller.viewWillAppear(false)
     }
 
-    func testLayout() {
+    func testLayout() throws {
+        api.mock(
+            GetCourseRequest(courseID: "1", include: GetCourseRequest.defaultIncludes),
+            value: .make(id: "1", name: "Course 1")
+        )
         let navigation = UINavigationController(rootViewController: controller)
         loadView()
+        let titleView = try XCTUnwrap(controller.navigationItem.titleView as? TitleSubtitleView)
+        XCTAssertEqual(titleView.title, "New Message")
+        XCTAssertEqual(titleView.subtitle, "Course 1")
         XCTAssertEqual(navigation.navigationBar.barTintColor, .named(.backgroundLightest))
 
         XCTAssertEqual(controller.navigationItem.rightBarButtonItem?.isEnabled, true)


### PR DESCRIPTION
refs: MBL-13820
affects: parent
release note: none

* Added course name as subheader to Compose
* Centered spinner in Compose > course picker