### PR TITLE
Fix attaching to new conversation

### DIFF
--- a/Core/Core/Conversations/APIConversation.swift
+++ b/Core/Core/Conversations/APIConversation.swift
@@ -254,14 +254,14 @@ public struct PostConversationRequest: APIRequestable {
     // the response is an array
     public typealias Response = [APIConversation]
 
-    public struct Body: Encodable {
+    public struct Body: Encodable, Equatable {
         public let subject: String
         public let body: String
         public let recipients: [String]
         public let context_code: String?
-        public let media_comment_id: String? = nil
-        public let media_comment_type: MediaCommentType? = nil
-        public let attachment_ids: [String]? = nil
+        public let media_comment_id: String?
+        public let media_comment_type: MediaCommentType?
+        public let attachment_ids: [String]?
         public let group_conversation: Bool? = true
         public let force_new: Bool? = nil // Setting this seems to cause the api to ignore group_conversation
     }

--- a/Core/Core/Conversations/CreateConversation.swift
+++ b/Core/Core/Conversations/CreateConversation.swift
@@ -55,8 +55,11 @@ public class CreateConversation: APIUseCase {
             subject: subject,
             body: body,
             recipients: recipientIDs,
-            context_code: canvasContextID)
-        )
+            context_code: canvasContextID,
+            media_comment_id: mediaCommentID,
+            media_comment_type: mediaCommentType,
+            attachment_ids: attachmentIDs
+        ))
     }
 
     public var scope: Scope = Scope.all(orderBy: #keyPath(Conversation.lastMessageAt))

--- a/Core/CoreTests/Conversations/APIConversationTests.swift
+++ b/Core/CoreTests/Conversations/APIConversationTests.swift
@@ -72,13 +72,18 @@ class APIConversationTests: CoreTestCase {
     }
 
     func testPostConversationRequest() {
-        let request = PostConversationRequest(body: PostConversationRequest.Body(
+        let body = PostConversationRequest.Body(
             subject: "subject",
             body: "body",
             recipients: ["1"],
-            context_code: "course_5")
+            context_code: "course_5",
+            media_comment_id: "1",
+            media_comment_type: .audio,
+            attachment_ids: ["1"]
         )
+        let request = PostConversationRequest(body: body)
         XCTAssertEqual(request.path, "conversations")
         XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.body, body)
     }
 }

--- a/Core/CoreTests/Conversations/CreateConversationTests.swift
+++ b/Core/CoreTests/Conversations/CreateConversationTests.swift
@@ -20,6 +20,25 @@ import XCTest
 @testable import Core
 
 class CreateConversationTests: CoreTestCase {
+    func testUseCase() {
+        let useCase = CreateConversation(
+            subject: "subject",
+            body: "body",
+            recipientIDs: ["1"],
+            canvasContextID: "course_1",
+            mediaCommentID: "1",
+            mediaCommentType: .audio,
+            attachmentIDs: ["1"]
+        )
+        XCTAssertEqual(useCase.request.body?.subject, "subject")
+        XCTAssertEqual(useCase.request.body?.body, "body")
+        XCTAssertEqual(useCase.request.body?.recipients, ["1"])
+        XCTAssertEqual(useCase.request.body?.context_code, "course_1")
+        XCTAssertEqual(useCase.request.body?.media_comment_id, "1")
+        XCTAssertEqual(useCase.request.body?.media_comment_type, .audio)
+        XCTAssertEqual(useCase.request.body?.attachment_ids, ["1"])
+    }
+
     func testWritesData() {
         let useCase = CreateConversation(subject: "subject", body: "body", recipientIDs: ["1"])
         api.mock(useCase.request, value: [APIConversation.make(subject: "subject", context_name: nil, context_code: nil)])

--- a/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
@@ -90,7 +90,10 @@ class ComposeViewControllerTests: ParentTestCase {
             subject: "subject",
             body: controller.body(),
             recipients: [ APIConversationRecipient.make().id.value ],
-            context_code: controller.context!.canvasContextID)
+            context_code: controller.context!.canvasContextID,
+            media_comment_id: nil,
+            media_comment_type: nil,
+            attachment_ids: [])
             ), value: [ APIConversation.make() ]
         )
         task.paused = true
@@ -107,8 +110,11 @@ class ComposeViewControllerTests: ParentTestCase {
             subject: "subject",
             body: controller.body(),
             recipients: [ APIConversationRecipient.make().id.value ],
-            context_code: controller.context!.canvasContextID)
-            ), error: NSError.instructureError("Error")
+            context_code: controller.context!.canvasContextID,
+            media_comment_id: nil,
+            media_comment_type: nil,
+            attachment_ids: []
+        )), error: NSError.instructureError("Error")
         )
         let sendButton = controller.sendButton
         XCTAssertNoThrow(sendButton.target?.perform(sendButton.action))


### PR DESCRIPTION
refs: none
affects: parent
release note: none