### PR TITLE
Fix mismatch in recipients selected

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2147,7 +2147,6 @@
 				7DCF2037216D55E6003AF358 /* QuizType.swift */,
 				B109248B23CD2BC400796903 /* Role.swift */,
 				3B6386A82264FB17002DEE72 /* Rubric.swift */,
-				9F87D0782322EF5A00EDA363 /* SearchRecipient.swift */,
 				7DF4FFDE21713919007E5F81 /* Submission.swift */,
 				7DA5C48722385435003CDB4C /* SubmissionComment.swift */,
 				7DCF1E9F216BB731003AF358 /* SubmissionType.swift */,
@@ -2389,8 +2388,9 @@
 				7DFDB43523A4587B00B28DED /* Conversation.swift */,
 				7DFDB43723A45A4A00B28DED /* ConversationMessage.swift */,
 				7DFDB43923A45A5A00B28DED /* ConversationParticipant.swift */,
-				7D26B84223A7F24400262380 /* GetConversations.swift */,
 				9F73859D23C904D200A9C6FE /* CreateConversation.swift */,
+				7D26B84223A7F24400262380 /* GetConversations.swift */,
+				9F87D0782322EF5A00EDA363 /* SearchRecipient.swift */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";

--- a/Core/Core/Conversations/APIConversationRecipient.swift
+++ b/Core/Core/Conversations/APIConversationRecipient.swift
@@ -35,7 +35,7 @@ extension APIConversationRecipient: Hashable {
 extension APIConversationRecipient {
     public init(searchRecipient r: SearchRecipient) {
         self.id = ID(r.id)
-        self.name = r.fullName
+        self.name = r.name
         self.full_name = r.fullName
         self.avatar_url = APIURL(rawValue: r.avatarURL)
         self.pronouns = r.pronouns

--- a/Core/Core/Conversations/SearchRecipient.swift
+++ b/Core/Core/Conversations/SearchRecipient.swift
@@ -21,6 +21,7 @@ import CoreData
 
 public final class SearchRecipient: NSManagedObject {
     @NSManaged public var id: String
+    @NSManaged public var name: String
     @NSManaged public var fullName: String
     @NSManaged public var pronouns: String?
     @NSManaged public var avatarURL: URL?
@@ -28,7 +29,7 @@ public final class SearchRecipient: NSManagedObject {
     @NSManaged public var commonCourses: Set<CommonCourse>
 
     public var displayName: String? {
-        User.displayName(fullName, pronouns: pronouns)
+        User.displayName(name, pronouns: pronouns)
     }
 
     @discardableResult
@@ -37,6 +38,7 @@ public final class SearchRecipient: NSManagedObject {
         let model: SearchRecipient = context.fetch(predicate).first ?? context.insert()
 
         model.id = item.id.value
+        model.name = item.name
         model.fullName = item.full_name
         model.pronouns = item.pronouns
         model.avatarURL = item.avatar_url?.rawValue

--- a/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="19C57" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="15508" systemVersion="18G3020" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Activity" representedClassName=".Activity" syncable="YES">
         <attribute name="canvasContextIDRaw" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -481,6 +481,7 @@
         <attribute name="filter" optional="YES" attributeType="String"/>
         <attribute name="fullName" optional="YES" attributeType="String"/>
         <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String"/>
         <attribute name="pronouns" optional="YES" attributeType="String"/>
         <relationship name="commonCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CommonCourse" inverseName="searchRecipient" inverseEntity="CommonCourse"/>
     </entity>
@@ -618,7 +619,7 @@
         <element name="Rubric" positionX="-540" positionY="-27" width="128" height="180"/>
         <element name="RubricAssessment" positionX="-540" positionY="-27" width="128" height="133"/>
         <element name="RubricRating" positionX="-531" positionY="-18" width="128" height="150"/>
-        <element name="SearchRecipient" positionX="-540" positionY="-27" width="128" height="133"/>
+        <element name="SearchRecipient" positionX="-540" positionY="-27" width="128" height="148"/>
         <element name="Submission" positionX="-312.484375" positionY="260.38671875" width="128" height="403"/>
         <element name="SubmissionComment" positionX="-369" positionY="-18" width="128" height="268"/>
         <element name="Syllabus" positionX="-540" positionY="-18" width="128" height="73"/>


### PR DESCRIPTION
Since the whole API object equality/hashing was used, we needed both name & fullname to be persisted in CoreData. Also the display name should always be used rather than the full name.

refs: MBL-13942
affects: Parent
release note: none