### PR TITLE
Order courses by name and ID

### DIFF
--- a/Core/Core/Extensions/NSPredicateExtensions.swift
+++ b/Core/Core/Extensions/NSPredicateExtensions.swift
@@ -29,7 +29,7 @@ extension NSPredicate {
 
     public convenience init(key: String, equals value: CVarArg?) {
         if let value = value {
-            self.init(format: "%K == %@", key, value)
+            self.init(format: "%K == %@", argumentArray: [key, value])
         } else {
             self.init(format: "%K == nil", key)
         }

--- a/Core/Core/Store/Scope.swift
+++ b/Core/Core/Store/Scope.swift
@@ -30,7 +30,7 @@ public struct Scope: Equatable {
     }
 
     public init(predicate: NSPredicate, orderBy order: String, ascending: Bool = true, naturally: Bool = false, sectionNameKeyPath: String? = nil) {
-        let sort = NSSortDescriptor(key: order, ascending: ascending, selector: naturally ? #selector(NSString.localizedStandardCompare(_:)) : nil)
+        let sort = NSSortDescriptor(key: order, ascending: ascending, naturally: naturally)
         self.init(predicate: predicate, order: [sort], sectionNameKeyPath: sectionNameKeyPath)
     }
 
@@ -38,12 +38,18 @@ public struct Scope: Equatable {
     /// Adds a default `order` using the `key` ascending
     public static func `where`(_ key: String, equals value: Any, orderBy order: String? = nil, ascending: Bool = true, naturally: Bool = false) -> Scope {
         let predicate = NSPredicate(format: "%K == %@", argumentArray: [key, value])
-        let sort = NSSortDescriptor(key: order ?? key, ascending: ascending, selector: naturally ? #selector(NSString.localizedStandardCompare(_:)) : nil)
+        let sort = NSSortDescriptor(key: order ?? key, ascending: ascending, naturally: naturally)
         return Scope(predicate: predicate, order: [sort])
     }
 
     public static func all(orderBy order: String, ascending: Bool = true, naturally: Bool = false) -> Scope {
-        let sort = NSSortDescriptor(key: order, ascending: ascending, selector: naturally ? #selector(NSString.localizedStandardCompare(_:)) : nil)
+        let sort = NSSortDescriptor(key: order, ascending: ascending, naturally: naturally)
         return Scope(predicate: .all, order: [sort])
+    }
+}
+
+extension NSSortDescriptor {
+    convenience init(key: String?, ascending: Bool, naturally: Bool) {
+        self.init(key: key, ascending: ascending, selector: naturally ? #selector(NSString.localizedStandardCompare(_:)) : nil)
     }
 }

--- a/Core/Core/Use Cases/GetCourses.swift
+++ b/Core/Core/Use Cases/GetCourses.swift
@@ -26,14 +26,19 @@ public class GetCourses: CollectionUseCase {
     let perPage: Int
 
     public var scope: Scope {
+        let order = [
+            NSSortDescriptor(key: #keyPath(Course.name), ascending: true, naturally: true),
+            NSSortDescriptor(key: #keyPath(Course.id), ascending: true),
+        ]
+        let predicate: NSPredicate
         if showFavorites {
-            return Scope.where(#keyPath(Course.isFavorite), equals: true, orderBy: #keyPath(Course.name), ascending: true, naturally: true)
+            predicate = NSPredicate(key: #keyPath(Course.isFavorite), equals: true)
+        } else if let enrollmentState = enrollmentState {
+            predicate = NSPredicate(format: "ANY %K == %@", #keyPath(Course.enrollments.stateRaw), enrollmentState.rawValue)
+        } else {
+            predicate = .all
         }
-        if let enrollmentState = enrollmentState {
-            let predicate = NSPredicate(format: "ANY %K == %@", #keyPath(Course.enrollments.stateRaw), enrollmentState.rawValue)
-            return Scope(predicate: predicate, orderBy: #keyPath(Course.name), ascending: true, naturally: true)
-        }
-        return Scope.all(orderBy: #keyPath(Course.name), ascending: true, naturally: true)
+        return Scope(predicate: predicate, order: order)
     }
 
     public var request: GetCoursesRequest {

--- a/Core/CoreTests/Use Cases/GetCoursesTest.swift
+++ b/Core/CoreTests/Use Cases/GetCoursesTest.swift
@@ -93,4 +93,18 @@ class GetCoursesTest: CoreTestCase {
         XCTAssertEqual(courses.first, a)
         XCTAssertEqual(courses.last, c)
     }
+
+    func testScopeOrder() {
+        let one = Course.make(from: .make(id: "1", name: "A"))
+        let two = Course.make(from: .make(id: "2", name: "B"))
+        let three = Course.make(from: .make(id: "3", name: "B"))
+
+        let useCase = GetCourses(enrollmentState: nil)
+        let courses: [Course] = databaseClient.fetch(useCase.scope.predicate, sortDescriptors: useCase.scope.order)
+
+        XCTAssertEqual(courses.count, 3)
+        XCTAssertEqual(courses[0], one)
+        XCTAssertEqual(courses[1], two)
+        XCTAssertEqual(courses[2], three)
+    }
 }


### PR DESCRIPTION
Ordering only by name caused the course picker in the share extension to
appear to switch courses randomly.

refs: MBL-13933
affects: student
release note: Fixed a bug that would cause the course selection to change in the share extension

Test plan: See [ticket](https://instructure.atlassian.net/browse/MBL-13933)