### PR TITLE
Handle page assignments

### DIFF
--- a/Core/Core/API/AssignmentListRequestable.swift
+++ b/Core/Core/API/AssignmentListRequestable.swift
@@ -213,6 +213,8 @@ extension APIAssignmentListAssignment {
             image = .icon(.discussion, .line)
         } else if submissionTypes.contains(.external_tool) || submissionTypes.contains(.basic_lti_launch) {
             image = .icon(.lti, .line)
+        } else if submissionTypes.contains(.wiki_page) {
+            image = .icon(.page, .line)
         }
 
         if let lockAt = lockAt, Clock.now > lockAt {

--- a/Core/Core/API/AssignmentListRequestable.swift
+++ b/Core/Core/API/AssignmentListRequestable.swift
@@ -214,7 +214,7 @@ extension APIAssignmentListAssignment {
         } else if submissionTypes.contains(.external_tool) || submissionTypes.contains(.basic_lti_launch) {
             image = .icon(.lti, .line)
         } else if submissionTypes.contains(.wiki_page) {
-            image = .icon(.page, .line)
+            image = .icon(.document, .line)
         }
 
         if let lockAt = lockAt, Clock.now > lockAt {

--- a/Core/Core/Extensions/UIImageInstIconsExtensions.swift
+++ b/Core/Core/Extensions/UIImageInstIconsExtensions.swift
@@ -27,8 +27,6 @@ extension UIImage {
     }
 
     public enum InstIconName: String, CaseIterable {
-        static let page = InstIconName.document
-
         case add, addressBook, alerts, announcement, arrowOpenDown, arrowOpenLeft, arrowOpenRight,
             assignment, audio, bold, box, bulletList, calendarMonth, check, clock, cloudLock,
             comment, complete, courses, dashboard, discussion, document, email, empty,

--- a/Core/Core/Extensions/UIImageInstIconsExtensions.swift
+++ b/Core/Core/Extensions/UIImageInstIconsExtensions.swift
@@ -27,6 +27,8 @@ extension UIImage {
     }
 
     public enum InstIconName: String, CaseIterable {
+        static let page = InstIconName.document
+
         case add, addressBook, alerts, announcement, arrowOpenDown, arrowOpenLeft, arrowOpenRight,
             assignment, audio, bold, box, bulletList, calendarMonth, check, clock, cloudLock,
             comment, complete, courses, dashboard, discussion, document, email, empty,

--- a/Core/Core/Models/Assignment.swift
+++ b/Core/Core/Models/Assignment.swift
@@ -180,6 +180,7 @@ extension Assignment {
     }
 
     public var canMakeSubmissions: Bool {
+        if submissionTypes == [.wiki_page] { return false }
         return submissionTypes.count > 0 &&
             !submissionTypes.contains(.none) && !submissionTypes.contains(.on_paper)
     }

--- a/Core/Core/Models/Submission.swift
+++ b/Core/Core/Models/Submission.swift
@@ -210,6 +210,8 @@ extension Submission {
             return attachments?.first?.icon
         case .online_url:
             return UIImage.icon(.link)
+        case .wiki_page:
+            return UIImage.icon(.page)
         case .none, .not_graded, .on_paper:
             return nil
         }
@@ -237,7 +239,7 @@ extension Submission {
             }
         case .online_url:
             return url?.absoluteString
-        case .none, .not_graded, .on_paper:
+        case .none, .not_graded, .on_paper, .wiki_page:
             return nil
         }
     }

--- a/Core/Core/Models/Submission.swift
+++ b/Core/Core/Models/Submission.swift
@@ -211,7 +211,7 @@ extension Submission {
         case .online_url:
             return UIImage.icon(.link)
         case .wiki_page:
-            return UIImage.icon(.page)
+            return UIImage.icon(.document)
         case .none, .not_graded, .on_paper:
             return nil
         }

--- a/Core/Core/Models/SubmissionType.swift
+++ b/Core/Core/Models/SubmissionType.swift
@@ -31,6 +31,7 @@ public enum SubmissionType: String, Codable {
     case online_url
     case on_paper
     case basic_lti_launch
+    case wiki_page
 
     public var localizedString: String {
         switch self {
@@ -54,6 +55,8 @@ public enum SubmissionType: String, Codable {
             return NSLocalizedString("Website URL", bundle: .core, comment: "")
         case .on_paper:
             return NSLocalizedString("On Paper", bundle: .core, comment: "")
+        case .wiki_page:
+            return NSLocalizedString("Page", bundle: .core, comment: "")
         }
     }
 }

--- a/Core/CoreTests/Models/AssignmentTests.swift
+++ b/Core/CoreTests/Models/AssignmentTests.swift
@@ -82,51 +82,11 @@ class AssignmentTests: CoreTestCase {
     }
 
     func testCanMakeSubmissions() {
-        //  given
-        let a = Assignment.make()
-        a.submissionTypes = [.online_upload]
-
-        //  when
-        let result = a.canMakeSubmissions
-
-        //  then
-        XCTAssertTrue(result)
-    }
-
-    func testCannotMakeSubmissions() {
-        //  given
-        let a = Assignment.make()
-        a.submissionTypes = [.none]
-
-        //  when
-        let result = a.canMakeSubmissions
-
-        //  then
-        XCTAssertFalse(result)
-    }
-
-    func testCannotMakeSubmissionsOnPaper() {
-        //  given
-        let a = Assignment.make()
-        a.submissionTypes = [.on_paper]
-
-        //  when
-        let result = a.canMakeSubmissions
-
-        //  then
-        XCTAssertFalse(result)
-    }
-
-    func testCannotMakeSubmissionsWithNoSubmissionTypes() {
-        //  given
-        let a = Assignment.make()
-        a.submissionTypes = []
-
-        //  when
-        let result = a.canMakeSubmissions
-
-        //  then
-        XCTAssertFalse(result)
+        XCTAssertTrue(Assignment.make(from: .make(submission_types: [.online_upload])).canMakeSubmissions)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.none])).canMakeSubmissions)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.on_paper])).canMakeSubmissions)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [])).canMakeSubmissions)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.wiki_page])).canMakeSubmissions)
     }
 
     func testIsLTIAssignment() {

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -137,7 +137,7 @@ class SubmissionButtonPresenter: NSObject {
                 assignmentID: assignment.id,
                 userID: userID
             ), from: view, options: .modal(.formSheet, embedInNav: true))
-        case .none, .not_graded, .on_paper:
+        case .none, .not_graded, .on_paper, .wiki_page:
             break
         }
     }


### PR DESCRIPTION
Page assignments are new to me. I don't think this should be a thing but the
web does display this page in the assignments list so /shrug.

The assignment object has no reference to the page so we have no way of knowing to
direct to the page or to load the page body so we load a weird assignment details
screen for assignment pages /shrug.

refs: MBL-13880
affects: student
release note: Fixed a bug that would prevent the assignments list from loading after unlocking a mastery path

Test plan:
* Log in as the user in [the ticket](https://instructure.atlassian.net/browse/MBL-13880) and follow the steps to get to the Assignments page
* The Assignments page should load