### PR TITLE
Exclude inactive enrollments in Speed Grader

### DIFF
--- a/rn/Teacher/src/modules/submissions/list/get-submissions-props.js
+++ b/rn/Teacher/src/modules/submissions/list/get-submissions-props.js
@@ -30,6 +30,7 @@ function getEnrollments (courseContent?: CourseContentState, enrollments: Enroll
   if (!courseContent) { return [] }
   return courseContent.enrollments.refs
     .map(ref => enrollments[ref])
+    .filter(e => e?.enrollment_state === 'active')
 }
 
 export function statusProp (submission: ?Submission, dueDate: ?string): ?SubmissionStatus {


### PR DESCRIPTION
refs: MBL-13922
affects: teacher
release note: Fixed an issue with loading submissions with inactive enrollments

Test plan:
* See [ticket](https://instructure.atlassian.net/browse/MBL-13922)
* Eugene Barnes should load when you tap Ethal Boone from the submissions list