### PR TITLE
Disable avatar presses when anonymous

### DIFF
--- a/rn/Teacher/src/modules/speedgrader/components/Header.js
+++ b/rn/Teacher/src/modules/speedgrader/components/Header.js
@@ -94,11 +94,14 @@ export class Header extends Component<HeaderProps, State> {
       ? ''
       : sub.avatarURL
 
-    let action = this.navigateToContextCard
+    let action
     let testID = `header.context.button.${this.props.userID}`
-    if (sub.groupID && !this.props.anonymous) {
-      action = this.showGroup
-      testID = `header.groupList.button.${sub.groupID}`
+    if (!this.props.anonymous) {
+      action = this.navigateToContextCard
+      if (sub.groupID) {
+        action = this.showGroup
+        testID = `header.groupList.button.${sub.groupID}`
+      }
     }
     const onlineSubmissionType = this.props.assignmentSubmissionTypes?.every(submissionTypeIsOnline)
 

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/Header.test.js
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/Header.test.js
@@ -123,6 +123,7 @@ describe('SpeedGraderHeader', () => {
     let tree = shallow(<Header {...subProps} anonymous />)
     expect(tree.find('Avatar').prop('userName')).toEqual('Student')
     expect(tree.find('[children="Student"]').exists()).toBe(true)
+    expect(tree.find('[testID="header.context.button.4"]').prop('onPress')).toBeUndefined()
   })
 
   it('renders avatar and name', () => {

--- a/rn/Teacher/src/modules/speedgrader/components/__tests__/__snapshots__/Header.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/components/__tests__/__snapshots__/Header.test.js.snap
@@ -23,7 +23,6 @@ exports[`SpeedGraderHeader doesnt show the group name when anonymous 1`] = `
     <TouchableHighlight
       activeOpacity={0.85}
       delayPressOut={100}
-      onPress={[Function]}
       style={
         Object {
           "alignItems": "center",

--- a/rn/Teacher/src/modules/submissions/list/SubmissionRow.js
+++ b/rn/Teacher/src/modules/submissions/list/SubmissionRow.js
@@ -123,7 +123,7 @@ class SubmissionRow extends Component<SubmissionRowProps, any> {
             key={contextID}
             avatarURL={avatarURL}
             userName={avatarName}
-            onPress={this.props.onAvatarPress && this.onAvatarPress}
+            onPress={!this.props.anonymous && this.props.onAvatarPress && this.onAvatarPress}
           />
         </View>
         <View style={styles.textContainer}>

--- a/rn/Teacher/src/modules/submissions/list/__tests__/SubmissionRow.test.js
+++ b/rn/Teacher/src/modules/submissions/list/__tests__/SubmissionRow.test.js
@@ -172,6 +172,13 @@ test('pressing the avatar calls onAvatarPress', () => {
   expect(onAvatarPress).toHaveBeenCalledWith('1')
 })
 
+test('anonymous avatar press', () => {
+  let spy = jest.fn()
+  let tree = shallow(<SubmissionRow {...defaultProps} anonymous={true} onAvatarPress={spy} />)
+  tree.find('Avatar').simulate('Press')
+  expect(spy).not.toHaveBeenCalled()
+})
+
 test('shows the eyeball when grades are not posted', () => {
   let submission = templates.submission({
     submittedAt: '2017-04-05T15:12:45Z',

--- a/rn/Teacher/src/modules/submissions/list/__tests__/__snapshots__/SubmissionRow.test.js.snap
+++ b/rn/Teacher/src/modules/submissions/list/__tests__/__snapshots__/SubmissionRow.test.js.snap
@@ -41,7 +41,7 @@ exports[`anonymous grading doesnt show users names 1`] = `
       >
         <Avatar
           avatarURL={null}
-          onPress={[Function]}
+          onPress={false}
           userName="Student"
         />
       </View>


### PR DESCRIPTION
refs: MBL-13893
affects: teacher
release note: Fixed a bug that could allow viewing users when grading anonymously

Test plan: Steps in [ticket](https://instructure.atlassian.net/browse/MBL-13893)