### PR TITLE
Fix sort order of submissions list

### DIFF
--- a/rn/Teacher/src/modules/submissions/list/SubmissionList.js
+++ b/rn/Teacher/src/modules/submissions/list/SubmissionList.js
@@ -43,6 +43,7 @@ import * as canvas from '../../../canvas-api'
 import icon from '../../../images/inst-icons'
 import ExperimentalFeature from '../../../common/ExperimentalFeature'
 import { createStyleSheet } from '../../../common/stylesheet'
+import localeSort from '../../../utils/locale-sort'
 
 const { getEnabledFeatureFlags } = canvas
 
@@ -324,10 +325,7 @@ export function props (props) {
 
       let group2 = groups.find(group => group.members.nodes.find(({ user }) => user.id === s2.user.id))
       let name2 = group2?.name ?? s1.user.name
-
-      if (name1 < name2) return -1
-      if (name1 > name2) return 1
-      return 0
+      return localeSort(name1, name2)
     }) ?? []
   return {
     isGroupGradedAssignment,

--- a/rn/Teacher/src/modules/submissions/list/__tests__/SubmissionList.test.js
+++ b/rn/Teacher/src/modules/submissions/list/__tests__/SubmissionList.test.js
@@ -451,15 +451,21 @@ describe('graphql props', () => {
           groups: {
             nodes: [
               templates.group({
-                name: 'b',
+                name: 'b 2',
                 members: {
                   nodes: [{ user: templates.user({ id: '1' }) }],
                 },
               }),
               templates.group({
-                name: 'a',
+                name: 'a 2',
                 members: {
                   nodes: [{ user: templates.user({ id: '2' }) }],
+                },
+              }),
+              templates.group({
+                name: 'b 10',
+                members: {
+                  nodes: [{ user: templates.user({ id: '3' }) }],
                 },
               }),
             ],
@@ -472,6 +478,7 @@ describe('graphql props', () => {
         groupedSubmissions: { edges: [
           { submission: templates.submission({ user: templates.user({ id: '1' }) }) },
           { submission: templates.submission({ user: templates.user({ id: '2' }) }) },
+          { submission: templates.submission({ user: templates.user({ id: '3' }) }) },
         ] },
       }),
     })
@@ -479,6 +486,7 @@ describe('graphql props', () => {
     expect(graphqlProps({ data: results }).submissions).toEqual([
       templates.submission({ user: templates.user({ id: '2' }) }),
       templates.submission({ user: templates.user({ id: '1' }) }),
+      templates.submission({ user: templates.user({ id: '3' }) }),
     ])
   })
 
@@ -509,9 +517,9 @@ describe('graphql props', () => {
         }),
         submissions: { edges: [] },
         groupedSubmissions: { edges: [
+          { submission: templates.submission({ user: templates.user({ name: 'a' }) }) },
           { submission: templates.submission({ user: templates.user({ id: '1' }) }) },
           { submission: templates.submission({ user: templates.user({ id: '2' }) }) },
-          { submission: templates.submission({ user: templates.user({ name: 'a' }) }) },
         ] },
       }),
     })


### PR DESCRIPTION
refs: MBL-13889
affects: teacher
release note: Fixed a but that would cause the wrong submissiont to load in Speed Grader

Test plan:
* See steps in [ticket](https://instructure.atlassian.net/browse/MBL-13889)
* Submissions list should now be ordered from lowest number to highest
* Tapping any submission row should load the correct on in SG