### PR TITLE
Limit web access in Parent if flag set

### DIFF
--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -73,6 +73,11 @@ public struct SessionDefaults {
         }
     }
 
+    public var limitWebAccess: Bool? {
+        get { self["limitWebAccess"] as? Bool }
+        set { self["limitWebAccess"] = newValue }
+    }
+
     public mutating func reset() {
         sessionDefaults = nil
     }

--- a/Core/Core/People/APIUser.swift
+++ b/Core/Core/People/APIUser.swift
@@ -46,10 +46,11 @@ public struct APIUser: Codable, Equatable {
     let bio: String?
     let pronouns: String?
 
-    let permissions: Permissions?
+    public let permissions: Permissions?
     public struct Permissions: Codable, Equatable {
-        let can_update_name: Bool?
-        let can_update_avatar: Bool?
+        public let can_update_name: Bool?
+        public let can_update_avatar: Bool?
+        public let limit_parent_app_web_access: Bool?
     }
 }
 
@@ -86,12 +87,16 @@ public struct GetCustomColorsRequest: APIRequestable {
 }
 
 // https://canvas.instructure.com/doc/api/users.html#method.users.api_show
-struct GetUserRequest: APIRequestable {
-    typealias Response = APIUser
+public struct GetUserRequest: APIRequestable {
+    public typealias Response = APIUser
 
-    let userID: String
+    public let userID: String
 
-    var path: String {
+    public init(userID: String) {
+        self.userID = userID
+    }
+
+    public var path: String {
         return ContextModel(.user, id: userID).pathComponent
     }
 }

--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -36,6 +36,8 @@ open class CoreWebView: WKWebView {
     @IBInspectable public var autoresizesHeight: Bool = false
     public weak var linkDelegate: CoreWebViewLinkDelegate?
 
+    public var isLinkNavigationEnabled = true
+
     public static let processPool = WKProcessPool()
 
     public required init?(coder: NSCoder) {
@@ -219,6 +221,11 @@ open class CoreWebView: WKWebView {
 
 extension CoreWebView: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, decidePolicyFor action: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        if action.navigationType == .linkActivated && !isLinkNavigationEnabled {
+            decisionHandler(.cancel)
+            return
+        }
+
         // Check for #fragment link click
         if action.navigationType == .linkActivated, action.sourceFrame == action.targetFrame,
             let url = action.request.url, let fragment = url.fragment,

--- a/Core/CoreTests/Views/CoreWebViewTests.swift
+++ b/Core/CoreTests/Views/CoreWebViewTests.swift
@@ -144,6 +144,10 @@ class CoreWebViewTests: CoreTestCase {
         view.webView(view, decidePolicyFor: MockNavigationAction(url: "example.com", type: .linkActivated)) { policy in
             XCTAssertEqual(policy, .allow)
         }
+        view.isLinkNavigationEnabled = false
+        view.webView(view, decidePolicyFor: MockNavigationAction(url: "example.com", type: .linkActivated)) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
     }
 
     func testDecidePolicyForExternal() {
@@ -153,11 +157,19 @@ class CoreWebViewTests: CoreTestCase {
         view.webView(view, decidePolicyFor: MockNavigationAction(url: "example.com", type: .linkActivated)) { policy in
             XCTAssertEqual(policy, .allow)
         }
+        let expectation = XCTestExpectation(description: "link delegate was called")
+        expectation.assertForOverFulfill = true
         linkDelegate = LinkDelegate { url in
             XCTAssertEqual(url, URL(string: "example.com"))
+            expectation.fulfill()
             return true
         }
         view.linkDelegate = linkDelegate
+        view.webView(view, decidePolicyFor: MockNavigationAction(url: "example.com", type: .linkActivated)) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        wait(for: [expectation], timeout: 1)
+        view.isLinkNavigationEnabled = false
         view.webView(view, decidePolicyFor: MockNavigationAction(url: "example.com", type: .linkActivated)) { policy in
             XCTAssertEqual(policy, .cancel)
         }
@@ -191,5 +203,9 @@ class CoreWebViewTests: CoreTestCase {
         XCTAssertEqual(CoreWebView.htmlString(""), "")
         XCTAssertEqual(CoreWebView.htmlString("html"), "html")
         XCTAssertEqual(CoreWebView.htmlString("&'\"<>"), "&amp;&#39;&quot;&lt;&gt;")
+    }
+
+    func testIsLinkNavigationEnabled() {
+
     }
 }

--- a/Core/CoreTests/Views/CoreWebViewTests.swift
+++ b/Core/CoreTests/Views/CoreWebViewTests.swift
@@ -204,8 +204,4 @@ class CoreWebViewTests: CoreTestCase {
         XCTAssertEqual(CoreWebView.htmlString("html"), "html")
         XCTAssertEqual(CoreWebView.htmlString("&'\"<>"), "&amp;&#39;&quot;&lt;&gt;")
     }
-
-    func testIsLinkNavigationEnabled() {
-
-    }
 }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -191,6 +191,7 @@ extension ParentAppDelegate: LoginDelegate {
     func launchLimitedWebView(url: URL, from sourceViewController: UIViewController) {
         let controller = CoreWebViewController()
         controller.webView.isLinkNavigationEnabled = false
+        controller.webView.allowsLinkPreview = false
         controller.webView.load(URLRequest(url: url))
         environment.router.show(controller, from: sourceViewController, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
     }

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APIUserFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APIUserFixture.swift
@@ -56,11 +56,13 @@ extension APIUser {
 extension APIUser.Permissions {
     public static func make(
         can_update_name: Bool? = true,
-        can_update_avatar: Bool? = true
+        can_update_avatar: Bool? = true,
+        limit_parent_app_web_access: Bool? = false
     ) -> APIUser.Permissions {
         return APIUser.Permissions(
             can_update_name: can_update_name,
-            can_update_avatar: can_update_avatar
+            can_update_avatar: can_update_avatar,
+            limit_parent_app_web_access: limit_parent_app_web_access
         )
     }
 }


### PR DESCRIPTION
refs: MBL-13884
affects: parent
release note: Disables links in web views if the setting is set in Canvas

Test plan:
* narmstrong.beta.instructure.com > s
* CS 1400 > Front Page > Tap 'Modules' link
* URL should load modally in a web view controller
* Try to tap a link to a module item or use course navigation to get around
* Links should not work

* twilson.beta.instructure.com > Observer1
* Assignment Overrides > Syllabus
* Tap 'Assignments' link
* URL should open in SFSafari
* Links should be tappable