### PR TITLE
Select a day immediately when paging the calendar

### DIFF
--- a/Parent/ParentUnitTests/Dashboard/Calendar/CalendarDaysViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/Calendar/CalendarDaysViewControllerTests.swift
@@ -22,26 +22,23 @@ import XCTest
 import TestsFoundation
 
 class CalendarDaysViewControllerTests: ParentTestCase, CalendarDaysDelegate {
-    lazy var selectedDate = Clock.now
-    var isExpanded = false
+    lazy var _selectedDate: Date = Clock.now
+    var selectedDate: Date { _selectedDate }
+    func setSelectedDate(_ date: Date) {
+        _selectedDate = date
+    }
 
-    lazy var controller = CalendarDaysViewController.create(anchorDate: Clock.now, delegate: self)
+    lazy var controller = CalendarDaysViewController.create(Clock.now, selectedDate: Clock.now, delegate: self)
 
     func testDates() {
         Clock.mockNow(DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 14).date!)
         controller.view.layoutIfNeeded()
 
-        XCTAssertEqual(controller.firstDate(isExpanded: true), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 26).date)
-        XCTAssertEqual(controller.firstDate(isExpanded: false), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 9).date)
-
-        XCTAssertEqual(controller.monthDate(isExpanded: true), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 12).date)
-        XCTAssertEqual(controller.monthDate(isExpanded: false), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 12).date)
-
-        XCTAssertEqual(controller.lastDate(isExpanded: true), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 29).date)
-        XCTAssertEqual(controller.lastDate(isExpanded: false), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 15).date)
+        XCTAssertEqual(controller.midDate(isExpanded: true), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 12).date)
+        XCTAssertEqual(controller.midDate(isExpanded: false), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 2, day: 12).date)
 
         (controller.weeksStackView.arrangedSubviews.first?.subviews.first as? UIButton)?.sendActions(for: .primaryActionTriggered)
-        XCTAssertEqual(selectedDate, controller.firstDate(isExpanded: isExpanded))
+        XCTAssertEqual(selectedDate, DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 26).date)
         XCTAssertEqual((controller.weeksStackView.arrangedSubviews.first?.subviews.first as? UIButton)?.isSelected, true)
     }
 

--- a/Parent/ParentUnitTests/Dashboard/Calendar/CalendarViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/Calendar/CalendarViewControllerTests.swift
@@ -25,7 +25,7 @@ class CalendarViewControllerTests: ParentTestCase {
     lazy var controller = CalendarViewController.create(studentID: "1")
 
     func testLayout() {
-        Clock.mockNow(DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 15).date!)
+        Clock.mockNow(DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 14).date!)
         controller.view.layoutIfNeeded()
 
         XCTAssertEqual(controller.monthButton.contentEdgeInsets.right, 28)
@@ -39,19 +39,21 @@ class CalendarViewControllerTests: ParentTestCase {
         XCTAssertEqual(controller.monthButton.isSelected, true)
 
         XCTAssertNoThrow(controller.filterButton.sendActions(for: .primaryActionTriggered))
-        controller.selectedDate = DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 16).date!
+        controller.setSelectedDate(DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 16).date!)
 
         let dataSource = controller.daysPageController.dataSource
         let delegate = controller.daysPageController.delegate
         let prev = dataSource?.pageViewController(controller.daysPageController, viewControllerBefore: controller.days)
-        XCTAssertEqual((prev as? CalendarDaysViewController)?.anchorDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2019, month: 12, day: 26).date?.isoString())
+        XCTAssertEqual((prev as? CalendarDaysViewController)?.fromDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2019, month: 12, day: 15).date?.isoString())
+        XCTAssertEqual((prev as? CalendarDaysViewController)?.selectedDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2019, month: 12, day: 14).date?.isoString())
         delegate?.pageViewController?(controller.daysPageController, willTransitionTo: [prev!])
         delegate?.pageViewController?(controller.daysPageController, didFinishAnimating: true, previousViewControllers: [controller.days], transitionCompleted: true)
         XCTAssertEqual(controller.daysHeight.constant, 264)
 
         controller.monthButton.sendActions(for: .primaryActionTriggered)
         let next = dataSource?.pageViewController(controller.daysPageController, viewControllerAfter: controller.days)
-        XCTAssertEqual((next as? CalendarDaysViewController)?.anchorDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 21).date?.isoString())
+        XCTAssertEqual((next as? CalendarDaysViewController)?.fromDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 22).date?.isoString())
+        XCTAssertEqual((next as? CalendarDaysViewController)?.selectedDate.isoString(), DateComponents(calendar: .current, timeZone: .current, year: 2020, month: 1, day: 21).date?.isoString())
         delegate?.pageViewController?(controller.daysPageController, willTransitionTo: [next!])
         XCTAssertEqual(controller.daysHeight.constant, 48)
     }


### PR DESCRIPTION
try to keep the same selected date if possible in expanded calendar
otherwise pick same day of month, or same day of week in collapsed.

refs: MBL-13902
affects: Parent
release note: none