### PR TITLE
Fix adding new comments in Speed Grader

### DIFF
--- a/rn/Teacher/src/canvas-api/apis/submissions.js
+++ b/rn/Teacher/src/canvas-api/apis/submissions.js
@@ -61,7 +61,7 @@ export function commentOnSubmission (courseID: string, assignmentID: string, use
   const data = { comment: {} }
   switch (comment.type) {
     case 'text':
-      data.comment.text_comment = comment.message
+      data.comment.text_comment = comment.comment
       break
     case 'media':
       if (comment.groupComment) {

--- a/rn/Teacher/src/modules/speedgrader/comments/CommentInput.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/CommentInput.js
@@ -33,7 +33,7 @@ import DrawerState from '../utils/drawer-state'
 import { getBottomSpace } from 'react-native-iphone-x-helper'
 
 export type Comment
-  = { type: 'text', message: string }
+  = { type: 'text', comment: string }
 
 type CommentInputProps = {
   makeComment(comment: Comment): void,
@@ -73,7 +73,7 @@ export default class CommentInput extends Component<CommentInputProps, State> {
 
     this.props.makeComment({
       type: 'text',
-      message: text,
+      comment: text,
     })
   }
 

--- a/rn/Teacher/src/modules/speedgrader/comments/CommentsTab.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/CommentsTab.js
@@ -432,7 +432,9 @@ function extractPendingComments (assignments: ?AssignmentContentState, userID): 
     name: session.user.name,
     avatarURL: session.user.avatar_url,
     userID: session.user.id,
-    contents: pending.mediaComment ? { ...pending.comment, url: pending.mediaComment.url } : pending.comment,
+    contents: pending.mediaComment
+      ? { ...pending.comment, url: pending.mediaComment.url }
+      : { type: 'text', comment: pending.comment },
     pending: pending.pending,
     error: pending.error || undefined, // this fixes flow even though error could already be undefined...
   }))

--- a/rn/Teacher/src/modules/speedgrader/comments/CommentsTab.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/CommentsTab.js
@@ -432,8 +432,8 @@ function extractPendingComments (assignments: ?AssignmentContentState, userID): 
     name: session.user.name,
     avatarURL: session.user.avatar_url,
     userID: session.user.id,
-    contents: pending.mediaComment
-      ? { ...pending.comment, url: pending.mediaComment.url }
+    contents: pending.comment.type === 'media'
+      ? { ...pending.comment, url: pending.mediaFilePath }
       : { type: 'text', comment: pending.comment },
     pending: pending.pending,
     error: pending.error || undefined, // this fixes flow even though error could already be undefined...

--- a/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentInput.test.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentInput.test.js
@@ -69,7 +69,7 @@ describe('CommentInput', () => {
       .selectByID('comment-input.send') || {}
     send.props.onPress()
 
-    expect(makeComment).toHaveBeenCalledWith({ type: 'text', message: 'Hello!' })
+    expect(makeComment).toHaveBeenCalledWith({ type: 'text', comment: 'Hello!' })
     expect(blur).toHaveBeenCalled()
   })
 

--- a/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentsTab.test.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentsTab.test.js
@@ -508,7 +508,6 @@ test('mapStateToProps returns comment and submission rows', () => {
   props = mapStateToProps(appState, ownProps)
   textAttempt = props.commentRows.find(({ contents }) => contents.attemptIndex === text.attempt)
   expect(textAttempt.name).toEqual('Bob (He/Him)')
-
 })
 
 test('mapStateToProps returns true when the assignment is a quiz that is an anonymous survey', () => {

--- a/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentsTab.test.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/__tests__/CommentsTab.test.js
@@ -448,7 +448,16 @@ test('mapStateToProps returns comment and submission rows', () => {
   appState.entities.assignments = {
     '200': {
       data: {},
-      pendingComments: {},
+      pendingComments: {
+        [student.id]: [
+          {
+            timestamp: new Date(),
+            localID: '1',
+            comment: { type: 'text', comment: 'new comment' },
+            pending: 1,
+          },
+        ],
+      },
       submissions: { refs: [], pending: 0 },
       submissionSummary: { error: null, pending: 0, data: { graded: 0, ungraded: 0, not_submitted: 0 } },
       gradeableStudents: { refs: [], pending: 0 },
@@ -481,20 +490,25 @@ test('mapStateToProps returns comment and submission rows', () => {
   expect(quizAttempt.submissionID).toEqual(submission.id)
   expect(quizAttempt.submissionID).not.toEqual(quizAttempt.id)
 
-  teacherComment = props.commentRows.filter(({ userID }) => userID === teacherComment.author.id)[0]
+  let teacherComments = props.commentRows.filter(({ userID }) => userID === teacherComment.author.id)
+  teacherComment = teacherComments.find(({ pending }) => pending !== 1)
   expect(teacherComment.contents.comment.attachments).toHaveLength(1)
   expect(teacherComment.name).toEqual('Severus Snape')
+  let pendingComment = teacherComments.find(({ pending }) => pending === 1)
+  expect(pendingComment.contents.type).toEqual('text')
+  expect(pendingComment.contents.comment.comment).toEqual('new comment')
 
   studentComment = props.commentRows.filter(({ userID }) => userID === student.id)[0]
   expect(studentComment.name).toEqual('Harry Potter (He/Him)')
 
-  let textAttempt = props.commentRows.find(({ contents }) => contents.attemptIndex === text.attempt != null)
+  let textAttempt = props.commentRows.find(({ contents }) => contents.attemptIndex === text.attempt)
   expect(textAttempt.name).toEqual('Bob')
 
   appState.entities.submissions[submission.id].submission.user.pronouns = 'He/Him'
   props = mapStateToProps(appState, ownProps)
-  textAttempt = props.commentRows.find(({ contents }) => contents.attemptIndex === text.attempt != null)
+  textAttempt = props.commentRows.find(({ contents }) => contents.attemptIndex === text.attempt)
   expect(textAttempt.name).toEqual('Bob (He/Him)')
+
 })
 
 test('mapStateToProps returns true when the assignment is a quiz that is an anonymous survey', () => {

--- a/rn/Teacher/src/modules/speedgrader/comments/__tests__/pending-comments-reducer.test.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/__tests__/pending-comments-reducer.test.js
@@ -38,6 +38,14 @@ const pending: PendingCommentState = {
   comment: { type: 'text', message: 'Hello!' },
 }
 
+const pendingMedia = {
+  pending: 1,
+  localID: 'a24b6b08-d5a5-4cc3-b4b7-6199dd1756b8',
+  timestamp: '2017-05-17T05:59:00Z',
+  comment: { type: 'media', mediaID: '1', mediaType: 'audio' },
+  mediaFilePath: '/var/media/1',
+}
+
 const completed: PendingCommentState = {
   pending: 0,
   commentID: '34',
@@ -71,6 +79,23 @@ test('reduces pending comments', () => {
   }
   expect(pendingComments({}, action)).toEqual({
     '32': [pending],
+  })
+})
+
+test('reduces pending media comments', () => {
+  const action = {
+    type: makeAComment.toString(),
+    pending: true,
+    payload: {
+      userID: '32',
+      timestamp: pendingMedia.timestamp,
+      localID: pendingMedia.localID,
+      comment: pendingMedia.comment,
+      mediaFilePath: pendingMedia.mediaFilePath,
+    },
+  }
+  expect(pendingComments({}, action)).toEqual({
+    '32': [pendingMedia],
   })
 })
 

--- a/rn/Teacher/src/modules/speedgrader/comments/pending-comments-reducer.js
+++ b/rn/Teacher/src/modules/speedgrader/comments/pending-comments-reducer.js
@@ -43,13 +43,14 @@ const pendingComments: Reducer<PendingCommentsState, any> = handleActions({
     },
   }),
   [makeAComment.toString()]: handleAsync({
-    pending: (state, { timestamp, localID, userID, comment }) => {
+    pending: (state, { timestamp, localID, userID, comment, mediaFilePath }) => {
       const userComments = state[userID] || []
       const newComment = {
         timestamp,
         localID,
         comment,
         pending: 1,
+        mediaFilePath,
       }
       return {
         ...state,


### PR DESCRIPTION
refs: MBL-13966
affects: teacher
release note: Fixed adding comments in Speed Grader

Test plan:
* Add a new comment in Speed Grader, ensure it does not Whoops out
* Add a new media comment and make sure it all works
* narmstrong > s
* CS 1400 > Assignments > File Upload > Student 1 > Comments > Add a new text, audio, and video comment