### PR TITLE
Fix Home when front page

### DIFF
--- a/Core/CoreTests/Pages/PageDetails/PageDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Pages/PageDetails/PageDetailsViewControllerTests.swift
@@ -51,6 +51,18 @@ class PageDetailsViewControllerTests: CoreTestCase {
         XCTAssertNotNil(viewController.webView?.scrollView.refreshControl)
     }
 
+    func testFrontPage() {
+        api.mock(GetFrontPageRequest(context: context), value: .make(
+            front_page: true,
+            html_url: htmlURL,
+            title: "Front Page"
+        ))
+        environment.mockStore = false
+        let viewController = PageDetailsViewController.create(context: context, pageURL: "front_page", app: .student)
+        viewController.view.layoutIfNeeded()
+        XCTAssertEqual(viewController.titleSubtitleView.title, "Front Page")
+    }
+
     func testUpdateNavBar() {
         load()
         _ = UINavigationController(rootViewController: viewController)


### PR DESCRIPTION
refs: MBL-13960
affects: student
release note: Fixed loading the course Home page

Test plan:
* Turn on new_page_details feature flag and make sure a course Home page loads when it is set to Front page
* See [ticket](https://instructure.atlassian.net/browse/MBL-13960)
* Or narmstrong > s > CS 1400 > Home