### PR TITLE
Maybe fix lint fix script. Also make pbxproj merging better

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pbxproj merge=union

--- a/scripts/build_automation/suggest-lint-fix.swift
+++ b/scripts/build_automation/suggest-lint-fix.swift
@@ -99,7 +99,7 @@ enum Github {
         ).inputJSON(from: GraphQLRequest(
             query: query,
             variables: [ "prNumber": prNumber ]
-        )) | cmd("jq", ".data.repository.pullRequest.id")).runJson(String.self)
+        )) | cmd("jq", "-r", ".data.repository.pullRequest.id")).runString()
     }
 
     static func postReview(_ input: AddPullRequestReviewInput) throws {


### PR DESCRIPTION
For some reason the old version was throwing an error about JSON fragments only on bitrise

refs: none
affects: none
release note: none