### PR TITLE
Add calendar deep link

### DIFF
--- a/Parent/Parent/Routes.swift
+++ b/Parent/Parent/Routes.swift
@@ -27,6 +27,11 @@ let router = Router(routes: [
         return try? AccountNotificationViewController(session: session, announcementID: id)
     },
 
+    RouteHandler("/calendar") { _, _ in
+        guard let studentID = currentStudentID, ExperimentalFeature.parentCalendar.isEnabled else { return nil }
+        return CalendarContainerViewController.create(studentID: studentID)
+    },
+
     RouteHandler(.conversations) { _, _ in
         return ConversationListViewController.create()
     },

--- a/Parent/ParentUnitTests/RoutesTests.swift
+++ b/Parent/ParentUnitTests/RoutesTests.swift
@@ -26,5 +26,10 @@ class RoutesTests: ParentTestCase {
         XCTAssert(Parent.router.match(.parse("/courses/1/grades")) is CourseDetailsViewController)
         XCTAssert(Parent.router.match(Route.conversations.url) is ConversationListViewController)
         XCTAssert(Parent.router.match(Route.conversation("1").url) is ConversationDetailViewController)
+
+        ExperimentalFeature.parentCalendar.isEnabled = true
+        XCTAssert(Parent.router.match(.parse("/calendar")) is CalendarContainerViewController)
+        ExperimentalFeature.parentCalendar.isEnabled = false
+        XCTAssertNil(Parent.router.match(.parse("/calendar")))
     }
 }


### PR DESCRIPTION
test plan:
twilson > Assignment Overrides has a link to the calendar in the syllabus body.
Clicking that should open the new calendar if the flag is enabled, same as other links there work.
Deep links to /calendar should work as well, opening a modal as is typical.

refs: MBL-13906
affects: Parent
release note: none