### PR TITLE
Fix submitting iWork from device

### DIFF
--- a/Core/Core/Models/SubmissionType.swift
+++ b/Core/Core/Models/SubmissionType.swift
@@ -87,7 +87,7 @@ extension Array where Element == SubmissionType {
             if allowedExtensions.isEmpty {
                 utis += [.any]
             } else {
-                utis += allowedExtensions.compactMap(UTI.init)
+                utis += UTI.from(extensions: allowedExtensions)
             }
         }
 

--- a/Core/Core/Models/UTI.swift
+++ b/Core/Core/Models/UTI.swift
@@ -19,7 +19,14 @@
 import Foundation
 import MobileCoreServices
 
-public struct UTI: Equatable {
+public struct UTI: Equatable, Hashable {
+    static let pagesBundleIdentifier = "com.apple.iwork.pages.pages"
+    static let pagesSingleFileIdentifier = "com.apple.iwork.pages.sffpages"
+    static let keynoteBundleIdentifier = "com.apple.iwork.keynote.key"
+    static let keynoteSingleFileIdentifier = "com.apple.iwork.keynote.sffkey"
+    static let numbersBundleIdentifier = "com.apple.iwork.numbers.numbers"
+    static let numbersSingleFileIdentifier = "com.apple.iwork.numbers.sffnumbers"
+
     public let rawValue: String
 
     public init?(extension: String) {
@@ -36,6 +43,19 @@ public struct UTI: Equatable {
 
     private init(rawValue: String) {
         self.rawValue = rawValue
+    }
+
+    public static func from(extensions: [String]) -> Set<UTI> {
+        var utis = Set(extensions.compactMap(UTI.init))
+
+        // iWork has types for bundles and single files
+        // Make sure the single file equivalent to the bundles are included
+        // Bundles are typically present on iCloud Drive whereas singe files are "On My Device"
+        if utis.contains(.pagesBundle) { utis.insert(.pagesSingleFile) }
+        if utis.contains(.keynoteBundle) { utis.insert(.keynoteSingleFile) }
+        if utis.contains(.numbersBundle) { utis.insert(.numbersSingleFile) }
+
+        return utis
     }
 
     public static var any: UTI {
@@ -64,6 +84,30 @@ public struct UTI: Equatable {
 
     public static var fileURL: UTI {
         return UTI(rawValue: kUTTypeFileURL as String)
+    }
+
+    public static var pagesBundle: UTI {
+        return UTI(rawValue: UTI.pagesBundleIdentifier)
+    }
+
+    public static var pagesSingleFile: UTI {
+        return UTI(rawValue: UTI.pagesSingleFileIdentifier)
+    }
+
+    public static var keynoteBundle: UTI {
+        return UTI(rawValue: UTI.keynoteBundleIdentifier)
+    }
+
+    public static var keynoteSingleFile: UTI {
+        return UTI(rawValue: UTI.keynoteSingleFileIdentifier)
+    }
+
+    public static var numbersBundle: UTI {
+        return UTI(rawValue: UTI.numbersBundleIdentifier)
+    }
+
+    public static var numbersSingleFile: UTI {
+        return UTI(rawValue: UTI.numbersSingleFileIdentifier)
     }
 
     public var isVideo: Bool {

--- a/Core/CoreTests/Models/SubmissionTypeTests.swift
+++ b/Core/CoreTests/Models/SubmissionTypeTests.swift
@@ -66,9 +66,9 @@ class SubmissionTypeTests: XCTestCase {
         let allowedExtensions = ["png", "mov", "mp3"]
         let result = submissionTypes.allowedUTIs(allowedExtensions: allowedExtensions)
         XCTAssertEqual(result.count, 3)
-        XCTAssertTrue(result[0].isImage)
-        XCTAssertTrue(result[1].isVideo)
-        XCTAssertTrue(result[2].isAudio)
+        XCTAssertTrue(result.contains { $0.isImage })
+        XCTAssertTrue(result.contains { $0.isVideo })
+        XCTAssertTrue(result.contains { $0.isAudio })
     }
 
     func testAllowedUTIsAllowedExtensionsVideo() {
@@ -81,7 +81,9 @@ class SubmissionTypeTests: XCTestCase {
 
     func testAllowedUTIsMediaRecording() {
         let submissionTypes: [SubmissionType] = [.media_recording]
-        XCTAssertEqual(submissionTypes.allowedUTIs(allowedExtensions: []), [.video, .audio])
+        let result = submissionTypes.allowedUTIs(allowedExtensions: [])
+        XCTAssertTrue(result.contains(.video))
+        XCTAssertTrue(result.contains(.audio))
     }
 
     func testAllowedUTIsText() {
@@ -102,7 +104,7 @@ class SubmissionTypeTests: XCTestCase {
         let allowedExtensions = ["jpeg"]
         let result = submissionTypes.allowedUTIs(allowedExtensions: allowedExtensions)
         XCTAssertEqual(result.count, 2)
-        XCTAssertTrue(result[0].isImage)
-        XCTAssertEqual(result[1], .text)
+        XCTAssertTrue(result.contains { $0.isImage })
+        XCTAssertTrue(result.contains(.text))
     }
 }

--- a/Core/CoreTests/Models/UTITests.swift
+++ b/Core/CoreTests/Models/UTITests.swift
@@ -17,7 +17,7 @@
 //
 
 import Foundation
-import Core
+@testable import Core
 import XCTest
 
 class UTITests: XCTestCase {
@@ -70,5 +70,15 @@ class UTITests: XCTestCase {
 
     func testFileURL() {
         XCTAssertEqual(UTI.fileURL.rawValue, "public.file-url")
+    }
+
+    func testIWork() {
+        let result = UTI.from(extensions: ["pages", "key", "numbers"])
+        XCTAssert(result.contains(.pagesBundle))
+        XCTAssert(result.contains(.pagesSingleFile))
+        XCTAssert(result.contains(.keynoteBundle))
+        XCTAssert(result.contains(.keynoteSingleFile))
+        XCTAssert(result.contains(.numbersBundle))
+        XCTAssert(result.contains(.numbersSingleFile))
     }
 }


### PR DESCRIPTION
refs: MBL-13975
affects: student
release note: Fixed a bug with submitting iWork files

Test plan:
* Install Pages, Numbers, and Keynote on your device
* Create a new file for each app
* Use the Files app to copy the files from iCloud Drive to On My Device
* Submit to an assignment that restricts file extensions to iWork
extensions (see [ticket](https://instructure.atlassian.net/browse/MBL-13975) and
also narmstrong > s > CS 1400 > Assignments > iWork
* Verify that you can select the iWork files from both On My Device and
iCloud Drive