### PR TITLE
Remove "locked until date" message from unlocked modules

### DIFF
--- a/Student/Canvas/Modules/ModuleViewModel.swift
+++ b/Student/Canvas/Modules/ModuleViewModel.swift
@@ -29,17 +29,13 @@ class ModuleViewModel {
     // Output
     let name: Property<String?>
     let prerequisiteModuleIDs: Property<[String]>
-    lazy var unlockDate: Property<String?> = {
-        return self.module
-            .map { $0?.unlockDate }
-            .map { $0.flatMap(self.unlockDateFormatter.string) }
-            .map {
-                $0.flatMap {
-                    let template = NSLocalizedString("Locked until %@", comment: "locked date")
-                    return String.localizedStringWithFormat(template, $0)
-                }
-        }
-    }()
+    lazy var unlockDate: Property<String?> = module.map { [weak self] module in
+        guard module?.state == .locked,
+            let unlockDate = module?.unlockDate,
+            let formatter = self?.unlockDateFormatter else { return nil }
+        let template = NSLocalizedString("Locked until %@", comment: "locked date")
+        return String.localizedStringWithFormat(template, formatter.string(from: unlockDate))
+    }
 
     // Private
     fileprivate let module: Property<Module?>

--- a/Student/StudentE2ETests/Modules/ModulesE2ETests.swift
+++ b/Student/StudentE2ETests/Modules/ModulesE2ETests.swift
@@ -42,6 +42,16 @@ class ModulesE2ETests: CoreUITestCase {
         ModulesDetail.moduleItem(index: 0).waitToExist()
     }
 
+    func testLockedModulesDisplayCorrectly() {
+        Dashboard.courseCard(id: "263").tap()
+        CourseNavigation.modules.tap()
+
+        XCTAssertEqual(ModulesDetail.module(index: 8).label(),
+                       "Locked Module. Locked until January 1, 3000. Status: Locked")
+        XCTAssertEqual(ModulesDetail.module(index: 9).label(),
+                       "Previously Locked Module")
+    }
+
     func testLaunchIntoDiscussionModuleItem() {
         Dashboard.courseCard(id: "263").tap()
 


### PR DESCRIPTION
[run-nightly]

refs: MBL-14024
affects: student
release note: Fixed "locked until date" message appearing on unlocked modules