### PR TITLE
Fix push to collapse bugs

### DIFF
--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -109,7 +109,7 @@ extension PlannerListViewController: UITableViewDataSource, UITableViewDelegate 
     }
 
     public func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
-        emptyStateTop.constant = max(scrollView.contentInset.top, -scrollView.contentOffset.y)
+        emptyStateTop.constant = -scrollView.contentOffset.y
         spinnerCenterY.constant = emptyStateTop.constant / 2
     }
 

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -104,19 +104,19 @@ extension PlannerViewController: PlannerListDelegate {
 
     public func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
         listContentOffsetY = scrollView.contentOffset.y
+        scrollView.contentInset.bottom = max(0, scrollView.frame.height - scrollView.contentSize.height - calendar.minHeight)
     }
 
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         guard scrollView.isDragging, scrollView.contentInset.top > calendar.minHeight else { return }
         let topSpace = scrollView.contentInset.top + listContentOffsetY - scrollView.contentOffset.y
-        listContentOffsetY = scrollView.contentOffset.y
         let height = max(calendar.minHeight, min(calendar.maxHeight, topSpace))
         scrollView.scrollIndicatorInsets.top = height
-        scrollView.contentInset.top = height
         calendar.setHeight(height)
     }
 
     public func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        scrollView.contentInset.bottom = 0
         calendar.setExpanded(calendar.isExpanded)
     }
 }

--- a/Core/CoreTests/Planner/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerViewControllerTests.swift
@@ -40,22 +40,31 @@ class PlannerViewControllerTests: CoreTestCase {
         controller.calendar.delegate?.calendarDidSelectDate(Clock.now)
         XCTAssertEqual(controller.calendar.selectedDate, Clock.now)
 
-        let height: CGFloat = 264
+        let height: CGFloat = controller.calendar.maxHeight
         controller.calendar.delegate?.calendarDidResize(height: height, animated: false)
         XCTAssertEqual(controller.list.tableView.scrollIndicatorInsets.top, height)
         XCTAssertEqual(controller.list.tableView.contentInset.top, height)
 
+        controller.calendar.setExpanded(true)
         let mockTable = MockTableView()
+        mockTable.contentInset.top = controller.calendar.height
+        mockTable.contentOffset.y = 0
         controller.list.delegate?.scrollViewWillBeginDragging?(mockTable)
-        mockTable.contentInset.top = height
-        mockTable.contentOffset.y = 200
+        mockTable.contentOffset.y = 500 // push to collapse
         controller.list.delegate?.scrollViewDidScroll?(mockTable)
-        XCTAssertLessThanOrEqual(mockTable.scrollIndicatorInsets.top, 144)
-        XCTAssertLessThanOrEqual(mockTable.contentInset.top, 144)
-        mockTable.contentOffset.y = -200
+        XCTAssertEqual(controller.calendar.height, controller.calendar.minHeight)
+        mockTable.contentOffset.y = -500 // reverse to pull back open
         controller.list.delegate?.scrollViewDidScroll?(mockTable)
-        XCTAssertLessThanOrEqual(mockTable.scrollIndicatorInsets.top, 144)
-        XCTAssertLessThanOrEqual(mockTable.contentInset.top, 144)
+        XCTAssertEqual(controller.calendar.height, controller.calendar.maxHeight)
+        controller.list.delegate?.scrollViewDidEndDragging?(mockTable, willDecelerate: false)
+        XCTAssertEqual(controller.calendar.isExpanded, true)
+
+        controller.calendar.setExpanded(false)
+        mockTable.contentInset.top = controller.calendar.height
+        controller.list.delegate?.scrollViewWillBeginDragging?(mockTable)
+        mockTable.contentOffset.y = -500 // pull should not open if starting at collapsed
+        controller.list.delegate?.scrollViewDidScroll?(mockTable)
+        XCTAssertEqual(controller.calendar.height, controller.calendar.minHeight)
         controller.list.delegate?.scrollViewDidEndDragging?(mockTable, willDecelerate: false)
         XCTAssertEqual(controller.calendar.isExpanded, false)
 


### PR DESCRIPTION
Don't modify contentInset while dragging, instead add a bottom inset to ensure you can scroll up to collapse calendar.

refs: MBL-14029
affects: Parent
release note: none