### PR TITLE
Always show month of selected day in Planner

### DIFF
--- a/Core/Core/Planner/CalendarDaysViewController.swift
+++ b/Core/Core/Planner/CalendarDaysViewController.swift
@@ -31,7 +31,6 @@ class CalendarDaysViewController: UIViewController {
     weak var delegate: CalendarViewControllerDelegate?
     var end = Clock.now // exclusive
     let env = AppEnvironment.shared
-    var fromDate = Clock.now
     var plannables: Store<GetPlannables>?
     var selectedDate = Clock.now
     var start = Clock.now // inclusive
@@ -39,10 +38,9 @@ class CalendarDaysViewController: UIViewController {
     let weeksStackView = UIStackView()
     lazy var topOffset = weeksStackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor)
 
-    static func create(_ fromDate: Date, selectedDate: Date, delegate: CalendarViewControllerDelegate?) -> CalendarDaysViewController {
+    static func create(selectedDate: Date, delegate: CalendarViewControllerDelegate?) -> CalendarDaysViewController {
         let controller = CalendarDaysViewController()
         controller.delegate = delegate
-        controller.fromDate = fromDate
         controller.selectedDate = selectedDate
         return controller
     }
@@ -55,10 +53,10 @@ class CalendarDaysViewController: UIViewController {
         weeksStackView.pin(inside: view, top: nil, bottom: nil)
         topOffset.isActive = true
 
-        var currentDate = calendar.date(byAdding: .day, value: 1 - calendar.component(.day, from: fromDate), to: fromDate.startOfDay())!
+        var currentDate = calendar.date(byAdding: .day, value: 1 - calendar.component(.day, from: selectedDate), to: selectedDate.startOfDay())!
         currentDate = calendar.date(byAdding: .day, value: calendar.firstWeekday - calendar.component(.weekday, from: currentDate), to: currentDate)!
         start = currentDate
-        while calendar.compare(currentDate, to: fromDate, toGranularity: .month) != .orderedDescending {
+        while calendar.compare(currentDate, to: selectedDate, toGranularity: .month) != .orderedDescending {
             let week = UIStackView()
             week.distribution = .fillEqually
             weeksStackView.addArrangedSubview(week)
@@ -69,7 +67,7 @@ class CalendarDaysViewController: UIViewController {
                 week.addArrangedSubview(day)
                 currentDate = calendar.date(byAdding: .day, value: 1, to: currentDate)!
             }
-            if currentDate < selectedDate {
+            if currentDate <= selectedDate {
                 selectedWeekIndex += 1
             }
             end = currentDate
@@ -151,6 +149,7 @@ class CalendarDayButton: UIButton {
     let date: Date
     let isToday: Bool
     let isWeekend: Bool
+    let isOtherMonth: Bool
     override var isSelected: Bool {
         didSet { tintColorDidChange() }
     }
@@ -167,6 +166,7 @@ class CalendarDayButton: UIButton {
         self.date = date
         isToday = calendar.isDateInToday(date)
         isWeekend = calendar.isDateInWeekend(date)
+        isOtherMonth = calendar.compare(date, to: selectedDate, toGranularity: .month) != .orderedSame
         super.init(frame: .zero)
         isSelected = calendar.isDate(date, inSameDayAs: selectedDate)
 
@@ -224,7 +224,7 @@ class CalendarDayButton: UIButton {
         label.textColor = (
             isToday ? UIColor.named(.white) :
             isSelected ? tintColor :
-            isWeekend ? UIColor.named(.textDark) :
+            isWeekend || isOtherMonth ? UIColor.named(.textDark) :
             UIColor.named(.textDarkest)
         )
         for dot in dotContainer.arrangedSubviews {

--- a/Core/Core/Planner/CalendarViewController.swift
+++ b/Core/Core/Planner/CalendarViewController.swift
@@ -184,6 +184,13 @@ class CalendarViewController: UIViewController {
         clearPageCache()
         if days.hasDate(date, isExpanded: isExpanded) {
             days.updateSelectedDate(date)
+        } else {
+            let isReverse = date < days.selectedDate
+            // Assumes selected date can't be more than 1 page away
+            let page = daysPageDelta(isReverse ? -1 : 1, from: days)
+            page.loadViewIfNeeded()
+            page.updateSelectedDate(date)
+            daysPageController.setViewControllers([ page ], direction: isReverse ? .reverse : .forward, animated: true)
         }
     }
 

--- a/Core/Core/Planner/CalendarViewController.swift
+++ b/Core/Core/Planner/CalendarViewController.swift
@@ -185,12 +185,7 @@ class CalendarViewController: UIViewController {
         if days.hasDate(date, isExpanded: isExpanded) {
             days.updateSelectedDate(date)
         } else {
-            let isReverse = date < days.selectedDate
-            // Assumes selected date can't be more than 1 page away
-            let page = daysPageDelta(isReverse ? -1 : 1, from: days)
-            page.loadViewIfNeeded()
-            page.updateSelectedDate(date)
-            daysPageController.setViewControllers([ page ], direction: isReverse ? .reverse : .forward, animated: true)
+            showDate(date)
         }
     }
 

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -180,6 +180,6 @@ extension PlannerViewController: UIPageViewControllerDataSource, UIPageViewContr
     }
 
     public func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
-        calendar.updateSelectedDate(list.start)
+        calendar.showDate(list.start)
     }
 }

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -84,11 +84,8 @@ public class PlannerViewController: UIViewController {
         }
         return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: Array(contextCodes))
     }
-}
 
-extension PlannerViewController: CalendarViewControllerDelegate {
-    func calendarDidSelectDate(_ date: Date) {
-        calendar.updateSelectedDate(date)
+    func updateList(_ date: Date) {
         let newList = PlannerListViewController.create(
             start: date.startOfDay(),
             end: date.startOfDay().addDays(1),
@@ -97,6 +94,18 @@ extension PlannerViewController: CalendarViewControllerDelegate {
         newList.loadViewIfNeeded()
         newList.tableView.contentInset = list.tableView.contentInset
         listPageController.setViewControllers([ newList ], direction: date < list.start ? .reverse : .forward, animated: true)
+    }
+}
+
+extension PlannerViewController: CalendarViewControllerDelegate {
+    func calendarDidSelectDate(_ date: Date) {
+        calendar.showDate(date)
+        updateList(date)
+    }
+
+    func calendarDidTransitionToDate(_ date: Date) {
+        calendar.updateSelectedDate(date)
+        updateList(date)
     }
 
     func calendarDidResize(height: CGFloat, animated: Bool) {

--- a/Core/CoreTests/Planner/CalendarDaysViewControllerTests.swift
+++ b/Core/CoreTests/Planner/CalendarDaysViewControllerTests.swift
@@ -25,6 +25,9 @@ class CalendarDaysViewControllerTests: CoreTestCase, CalendarViewControllerDeleg
     func calendarDidSelectDate(_ date: Date) {
         selectedDate = date
     }
+    func calendarDidTransitionToDate(_ date: Date) {
+        selectedDate = date
+    }
 
     func calendarDidResize(height: CGFloat, animated: Bool) {}
 
@@ -37,7 +40,7 @@ class CalendarDaysViewControllerTests: CoreTestCase, CalendarViewControllerDeleg
         return nil
     }
 
-    lazy var controller = CalendarDaysViewController.create(Clock.now, selectedDate: Clock.now, delegate: self)
+    lazy var controller = CalendarDaysViewController.create(selectedDate: Clock.now, delegate: self)
 
     func testDates() {
         Clock.mockNow(DateComponents(calendar: .current, year: 2020, month: 2, day: 14).date!)

--- a/Core/CoreTests/Planner/CalendarViewControllerTests.swift
+++ b/Core/CoreTests/Planner/CalendarViewControllerTests.swift
@@ -25,6 +25,9 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
     func calendarDidSelectDate(_ date: Date) {
         selectedDate = date
     }
+    func calendarDidTransitionToDate(_ date: Date) {
+        selectedDate = date
+    }
 
     var height: CGFloat = 0
     func calendarDidResize(height: CGFloat, animated: Bool) {
@@ -35,7 +38,10 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
         return GetPlannables(startDate: from, endDate: to)
     }
 
-    func calendarWillFilter() {}
+    var willFilter = false
+    func calendarWillFilter() {
+        willFilter = true
+    }
     func numberOfCalendars() -> Int? {
         return nil
     }
@@ -58,14 +64,14 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
         XCTAssertEqual(controller.monthButton.isSelected, true)
         XCTAssertGreaterThanOrEqual(height, 883)
 
-        XCTAssertNoThrow(controller.filterButton.sendActions(for: .primaryActionTriggered))
+        controller.filterButton.sendActions(for: .primaryActionTriggered)
+        XCTAssertTrue(willFilter)
         controller.calendarDidSelectDate(DateComponents(calendar: .current, year: 2020, month: 1, day: 16).date!)
         controller.updateSelectedDate(selectedDate)
 
         let dataSource = controller.daysPageController.dataSource
         let delegate = controller.daysPageController.delegate
         let prev = dataSource?.pageViewController(controller.daysPageController, viewControllerBefore: controller.days) as? CalendarDaysViewController
-        XCTAssertEqual(prev?.fromDate.isoString(), DateComponents(calendar: .current, year: 2019, month: 12, day: 15).date?.isoString())
         XCTAssertEqual(prev?.selectedDate.isoString(), DateComponents(calendar: .current, year: 2019, month: 12, day: 16).date?.isoString())
         delegate?.pageViewController?(controller.daysPageController, willTransitionTo: [prev!])
         delegate?.pageViewController?(controller.daysPageController, didFinishAnimating: true, previousViewControllers: [controller.days], transitionCompleted: true)
@@ -73,9 +79,13 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
 
         controller.monthButton.sendActions(for: .primaryActionTriggered)
         let next = dataSource?.pageViewController(controller.daysPageController, viewControllerAfter: controller.days) as? CalendarDaysViewController
-        XCTAssertEqual(next?.fromDate.isoString(), DateComponents(calendar: .current, year: 2020, month: 1, day: 22).date?.isoString())
         XCTAssertEqual(next?.selectedDate.isoString(), DateComponents(calendar: .current, year: 2020, month: 1, day: 23).date?.isoString())
         delegate?.pageViewController?(controller.daysPageController, willTransitionTo: [next!])
         XCTAssertEqual(controller.daysHeight.constant, 48)
+
+        controller.showDate(DateComponents(calendar: .current, year: 2020, month: 2, day: 1).date!)
+        XCTAssertEqual(controller.monthButton.title(for: .normal), "February")
+        XCTAssertEqual(controller.yearLabel.text, "2020")
+        XCTAssertEqual(controller.days.selectedDate.isoString(), DateComponents(calendar: .current, year: 2020, month: 2, day: 1).date!.isoString())
     }
 }

--- a/Core/CoreTests/Planner/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerViewControllerTests.swift
@@ -37,6 +37,11 @@ class PlannerViewControllerTests: CoreTestCase {
         XCTAssertEqual(controller.calendar.selectedDate, selected)
         XCTAssertEqual(controller.list.start, selected)
         XCTAssertEqual(controller.list.end, selected.addDays(1))
+        controller.calendar.delegate?.calendarDidTransitionToDate(selected.addMonths(1))
+        let transitionTo = selected.addMonths(1)
+        XCTAssertEqual(controller.list.start, transitionTo)
+        XCTAssertEqual(controller.list.end, transitionTo.addDays(1))
+        XCTAssertEqual(controller.calendar.selectedDate, transitionTo)
         controller.calendar.delegate?.calendarDidSelectDate(Clock.now)
         XCTAssertEqual(controller.calendar.selectedDate, Clock.now)
 


### PR DESCRIPTION
[run-nightly]

Also, dims days in other months.

refs: MBL-14061
affects: parent
release note: none

Test plan:
* Swipe around in Calendar, expanding and collapsing the month view
along the way
* Selecting a day in a different month should transition to that month
* Select January 31
* Collapse to week view
* Select February 1
* Expand to month view
* The month of February should be shown
* Days in other months should be dimmed