### PR TITLE
Fix planner filtering

### DIFF
--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -78,9 +78,12 @@ public class PlannerViewController: UIViewController {
     }
 
     func getPlannables(from: Date, to: Date) -> GetPlannables {
-        var contextCodes = Set(planner?.selectedCourses.map { $0.canvasContextID } ?? [])
-        if let studentID = studentID {
-            contextCodes.insert("user_\(studentID)")
+        var contextCodes: [String] = []
+        if let planner = planner, !planner.allSelected {
+            contextCodes = planner.selectedCourses.map { $0.canvasContextID }
+            if let studentID = studentID {
+                contextCodes.append(ContextModel(.user, id: studentID).canvasContextID)
+            }
         }
         return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: Array(contextCodes))
     }


### PR DESCRIPTION
refs: MBL-14072
affects: parent
release note: none

Test plan:
* Delete the app
* Log in as twilson > observer1
* February 20 should show 3 events
* Tap Calendars to filter
* Remove all `AG` calendars
* Feb 20 should only show 2 events
* Add back `AG` calendars
* Feb 20 should show all 3 events again