### PR TITLE
Force GraphQL requests to have a static query

### DIFF
--- a/Core/Core/API/APIGraphQLRequestable.swift
+++ b/Core/Core/API/APIGraphQLRequestable.swift
@@ -18,29 +18,31 @@
 
 import Foundation
 
-public struct GraphQLBody: Codable, Equatable {
+public struct GraphQLBody<Variables: Codable & Equatable>: Codable, Equatable {
     let query: String
     let operationName: String
+    let variables: Variables
 }
 
 protocol APIGraphQLRequestable: APIRequestable {
-    var query: String? { get }
-    var operationName: String { get }
+    associatedtype Variables: Codable & Equatable
+
+    static var query: String { get }
+    static var operationName: String { get }
+    var variables: Variables { get }
 }
 
 extension APIGraphQLRequestable {
     public var method: APIMethod {
-        return .post
+        .post
     }
     public var path: String {
-        return "/api/graphql"
+        "/api/graphql"
     }
-
-    public var body: GraphQLBody? {
-        if let query = query {
-            return GraphQLBody(query: query, operationName: operationName)
-        }
-        return nil
+    public static var operationName: String {
+        "\(self)"
     }
-
+    public var body: GraphQLBody<Variables> {
+        GraphQLBody(query: Self.query, operationName: Self.operationName, variables: variables)
+    }
 }

--- a/Core/Core/API/APIGraphQLRequestable.swift
+++ b/Core/Core/API/APIGraphQLRequestable.swift
@@ -42,7 +42,7 @@ extension APIGraphQLRequestable {
     public static var operationName: String {
         "\(self)"
     }
-    public var body: GraphQLBody<Variables> {
+    public var body: GraphQLBody<Variables>? {
         GraphQLBody(query: Self.query, operationName: Self.operationName, variables: variables)
     }
 }

--- a/Core/Core/API/APIPostPolicyRequestable.swift
+++ b/Core/Core/API/APIPostPolicyRequestable.swift
@@ -22,25 +22,24 @@ public enum PostGradePolicy: String, CaseIterable {
     case everyone, graded
 }
 
-public struct PostAssignmentGradesInput: Codable, Equatable {
-    let gradedOnly: Bool
-    let assignmentId: String
-    let sectionIds: [String]?
-}
-
 public class PostAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
     public typealias Response = APINoContent
+    public struct Input: Codable, Equatable {
+        let gradedOnly: Bool
+        let assignmentId: String
+        let sectionIds: [String]?
+    }
     public struct Variables: Codable, Equatable {
-        let input: PostAssignmentGradesInput
+        let input: Input
     }
     public let variables: Variables
 
-    init(input: PostAssignmentGradesInput) {
+    init(input: Input) {
         self.variables = Variables(input: input)
     }
 
     public convenience init(assignmentID: String, postPolicy: PostGradePolicy) {
-        self.init(input: PostAssignmentGradesInput(
+        self.init(input: Input(
             gradedOnly: postPolicy == .graded,
             assignmentId: assignmentID,
             sectionIds: nil
@@ -58,7 +57,7 @@ public class PostAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
 
 public class PostAssignmentGradesForSectionsPostPolicyRequest: PostAssignmentGradesPostPolicyRequest {
     public init(assignmentID: String, postPolicy: PostGradePolicy, sections: [String]) {
-        super.init(input: PostAssignmentGradesInput(
+        super.init(input: Input(
             gradedOnly: postPolicy == .graded,
             assignmentId: assignmentID,
             sectionIds: sections
@@ -74,24 +73,23 @@ public class PostAssignmentGradesForSectionsPostPolicyRequest: PostAssignmentGra
         """ }
 }
 
-public struct HideAssignmentGradesInput: Codable, Equatable {
-    public let assignmentId: String
-    public let sectionIds: [String]?
-}
-
 public class HideAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
     public typealias Response = APINoContent
+    public struct Input: Codable, Equatable {
+        public let assignmentId: String
+        public let sectionIds: [String]?
+    }
     public struct Variables: Codable, Equatable {
-        let input: HideAssignmentGradesInput
+        let input: Input
     }
     public let variables: Variables
 
-    init(input: HideAssignmentGradesInput) {
+    init(input: Input) {
         variables = Variables(input: input)
     }
 
     public convenience init(assignmentID: String) {
-        self.init(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: nil))
+        self.init(input: Input(assignmentId: assignmentID, sectionIds: nil))
     }
 
     public class var query: String { """
@@ -105,7 +103,7 @@ public class HideAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
 
 public class HideAssignmentGradesForSectionsPostPolicyRequest: HideAssignmentGradesPostPolicyRequest {
     public init(assignmentID: String, sections: [String]) {
-        super.init(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: sections))
+        super.init(input: Input(assignmentId: assignmentID, sectionIds: sections))
     }
 
     public override class var query: String { """

--- a/Core/Core/API/APIPostPolicyRequestable.swift
+++ b/Core/Core/API/APIPostPolicyRequestable.swift
@@ -28,42 +28,50 @@ public struct PostAssignmentGradesInput: Codable, Equatable {
     let sectionIds: [String]?
 }
 
-public struct PostAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
+public class PostAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
     public typealias Response = APINoContent
     public struct Variables: Codable, Equatable {
         let input: PostAssignmentGradesInput
     }
     public let variables: Variables
 
-    public init(assignmentId: String, postPolicy: PostGradePolicy) {
-        variables = Variables(input: PostAssignmentGradesInput(gradedOnly: postPolicy == .graded, assignmentId: assignmentId, sectionIds: nil))
+    init(input: PostAssignmentGradesInput) {
+        self.variables = Variables(input: input)
     }
 
-    public static let query = """
+    public convenience init(assignmentID: String, postPolicy: PostGradePolicy) {
+        self.init(input: PostAssignmentGradesInput(
+            gradedOnly: postPolicy == .graded,
+            assignmentId: assignmentID,
+            sectionIds: nil
+        ))
+    }
+
+    public class var query: String { """
         mutation \(operationName)($input: PostAssignmentGradesInput!) {
           postAssignmentGrades(input: $input) {
             assignment { id }
           }
         }
-        """
+        """ }
 }
 
-public class PostAssignmentGradesForSectionsPostPolicyRequest: APIGraphQLRequestable {
-    public typealias Response = APINoContent
-    public typealias Variables = PostAssignmentGradesPostPolicyRequest.Variables
-    public let variables: Variables
-
+public class PostAssignmentGradesForSectionsPostPolicyRequest: PostAssignmentGradesPostPolicyRequest {
     public init(assignmentID: String, postPolicy: PostGradePolicy, sections: [String]) {
-        variables = Variables(input: PostAssignmentGradesInput(gradedOnly: postPolicy == .graded, assignmentId: assignmentID, sectionIds: sections))
+        super.init(input: PostAssignmentGradesInput(
+            gradedOnly: postPolicy == .graded,
+            assignmentId: assignmentID,
+            sectionIds: sections
+        ))
     }
 
-    public static let query = """
+    public override class var query: String { """
         mutation \(operationName)($input: PostAssignmentGradesForSectionInput!) {
           postAssignmentGradesForSection(input: $input) {
             assignment { id }
           }
         }
-        """
+        """ }
 }
 
 public struct HideAssignmentGradesInput: Codable, Equatable {
@@ -71,41 +79,42 @@ public struct HideAssignmentGradesInput: Codable, Equatable {
     public let sectionIds: [String]?
 }
 
-public struct HideAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
+public class HideAssignmentGradesPostPolicyRequest: APIGraphQLRequestable {
     public typealias Response = APINoContent
     public struct Variables: Codable, Equatable {
         let input: HideAssignmentGradesInput
     }
     public let variables: Variables
 
-    public init(assignmentID: String) {
-        variables = Variables(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: nil))
+    init(input: HideAssignmentGradesInput) {
+        variables = Variables(input: input)
     }
 
-    public static let query = """
+    public convenience init(assignmentID: String) {
+        self.init(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: nil))
+    }
+
+    public class var query: String { """
         mutation \(operationName)($input: HideAssignmentGradesInput!) {
           hideAssignmentGrades(input: $input) {
             assignment { id }
           }
         }
-        """
+        """ }
 }
 
-public struct HideAssignmentGradesForSectionsPostPolicyRequest: APIGraphQLRequestable {
-    public typealias Response = APINoContent
-    public typealias Variables = HideAssignmentGradesPostPolicyRequest.Variables
-    public let variables: Variables
-
+public class HideAssignmentGradesForSectionsPostPolicyRequest: HideAssignmentGradesPostPolicyRequest {
     public init(assignmentID: String, sections: [String]) {
-        variables = Variables(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: sections))
+        super.init(input: HideAssignmentGradesInput(assignmentId: assignmentID, sectionIds: sections))
     }
-    public static let query = """
+
+    public override class var query: String { """
         mutation \(operationName)($input: HideAssignmentGradesForSectionsInput!) {
           hideAssignmentGradesForSections(input: $input) {
             assignment { id }
           }
         }
-        """
+        """ }
 }
 
 public struct GetAssignmentPostPolicyInfoRequest: APIGraphQLRequestable {

--- a/Core/CoreTests/.swiftlint.yml
+++ b/Core/CoreTests/.swiftlint.yml
@@ -10,6 +10,7 @@ disabled_rules: # rule identifiers to exclude from running
   - type_body_length
   - file_length
   - unused_setter_value
+  - type_name
 opt_in_rules: # some rules are only opt-in
   - yoda_condition
 included: # paths to include during linting. `--path` is ignored if present.

--- a/Core/CoreTests/API/APIGraphQLRequestableTests.swift
+++ b/Core/CoreTests/API/APIGraphQLRequestableTests.swift
@@ -19,39 +19,36 @@
 import XCTest
 @testable import Core
 
+extension APIGraphQLRequestable {
+    func assertBodyEquals(_ expected: GraphQLBody<Variables>) {
+        XCTAssertEqual(body, expected)
+    }
+}
+
 class APIGraphQLRequestableTests: XCTestCase {
 
     struct MockRequest: APIGraphQLRequestable {
         typealias Response = APINoContent
-
-        let operationName: String = "Test"
-        var query: String? {
-            return "id name foo"
-        }
+        typealias Variables = [String: String]
+        static let query = "id name foo"
+        let variables: Variables
     }
 
     func testPath() {
-        let mock = MockRequest()
+        let mock = MockRequest(variables: [:])
         XCTAssertEqual(mock.path, "/api/graphql")
     }
 
     func testMethod() {
-        let mock = MockRequest()
+        let mock = MockRequest(variables: [:])
         XCTAssertEqual(mock.method, .post)
     }
 
     func testBody() {
-        let mock = MockRequest()
+        let vars = ["var": "value"]
+        let mock = MockRequest(variables: vars)
         let query = "id name foo"
-        let operationName = "Test"
-        let expectedBody = GraphQLBody(query: query, operationName: operationName)
-        XCTAssertEqual(mock.body, expectedBody)
+        let operationName = "MockRequest"
+        mock.assertBodyEquals(GraphQLBody(query: query, operationName: operationName, variables: vars))
     }
-
-    func testQuery() {
-        let mock = MockRequest()
-        let query = "id name foo"
-        XCTAssertEqual(mock.query, query)
-    }
-
 }

--- a/Core/CoreTests/API/APIPostPolicyRequestableTests.swift
+++ b/Core/CoreTests/API/APIPostPolicyRequestableTests.swift
@@ -24,27 +24,40 @@ class PostAssignmentGradesPostPolicyRequestTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        req = PostAssignmentGradesPostPolicyRequest(assignmentID: "1", postPolicy: .everyone)
+        req = .init(assignmentID: "1", postPolicy: .everyone)
     }
+
     func testPath() {
         XCTAssertEqual(req.path, "/api/graphql")
     }
 
-    func testQuery() {
-        let expected = """
-        mutation PostAssignmentGrades\n    {\n        postAssignmentGrades(input: {assignmentId: \"1\", gradedOnly: false})\n        {\n            assignment { id }\n        }\n    }
-        """
-        XCTAssertEqual(req.query, expected)
+    func testBody() {
+        req.assertBodyEquals(GraphQLBody(
+            query: PostAssignmentGradesPostPolicyRequest.query,
+            operationName: "PostAssignmentGradesPostPolicyRequest",
+            variables: .init(input: .init(gradedOnly: false, assignmentId: "1", sectionIds: nil))
+        ))
+    }
+}
+
+class PostAssignmentGradesForSectionsPostPolicyRequestTests: XCTestCase {
+    var req: PostAssignmentGradesForSectionsPostPolicyRequest!
+
+    override func setUp() {
+        super.setUp()
+        req = .init(assignmentID: "1", postPolicy: .everyone, sections: [ "2", "3" ])
     }
 
-    func testQueryWithSectionIDs() {
-        let sectionIDReq = PostAssignmentGradesPostPolicyRequest(assignmentID: "1", postPolicy: .everyone, sections: [ "2", "3" ])
-        // swiftlint:disable line_length
-        let expected = """
-        mutation PostAssignmentGrades\n    {\n        postAssignmentGradesForSections(input: {assignmentId: \"1\", gradedOnly: false, sectionIds: [ \"2\",\"3\" ]})\n        {\n            assignment { id }\n        }\n    }
-        """
-        // swiftlint:enable line_length
-        XCTAssertEqual(sectionIDReq.query, expected)
+    func testPath() {
+        XCTAssertEqual(req.path, "/api/graphql")
+    }
+
+    func testBody() {
+        req.assertBodyEquals(GraphQLBody(
+            query: PostAssignmentGradesForSectionsPostPolicyRequest.query,
+            operationName: "PostAssignmentGradesForSectionsPostPolicyRequest",
+            variables: .init(input: .init(gradedOnly: false, assignmentId: "1", sectionIds: [ "2", "3" ]))
+        ))
     }
 }
 
@@ -53,22 +66,40 @@ class HideAssignmentGradesPostPolicyRequestTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        req = HideAssignmentGradesPostPolicyRequest(assignmentID: "1")
+        req = .init(assignmentID: "1")
     }
 
-    func testQuery() {
-        let expected = """
-        mutation HideAssignmentGrades\n{\n    hideAssignmentGrades(input: {assignmentId: \"1\"})\n    {\n        assignment { id }\n    }\n}
-        """
-        XCTAssertEqual(req.query, expected)
+    func testPath() {
+        XCTAssertEqual(req.path, "/api/graphql")
     }
 
-    func testQueryWithSectionIDs() {
-        let sectionIDReq = HideAssignmentGradesPostPolicyRequest(assignmentID: "1", sections: [ "2", "3" ])
-        let expected = """
-        mutation HideAssignmentGrades\n{\n    hideAssignmentGradesForSections(input: {assignmentId: \"1\", sectionIds: [ \"2\",\"3\" ]})\n    {\n        assignment { id }\n    }\n}
-        """
-        XCTAssertEqual(sectionIDReq.query, expected)
+    func testBody() {
+        req.assertBodyEquals(GraphQLBody(
+            query: HideAssignmentGradesPostPolicyRequest.query,
+            operationName: "HideAssignmentGradesPostPolicyRequest",
+            variables: .init(input: .init(assignmentId: "1", sectionIds: nil))
+        ))
+    }
+}
+
+class HideAssignmentGradesForSectionPostPolicyRequestTests: XCTestCase {
+    var req: HideAssignmentGradesForSectionsPostPolicyRequest!
+
+    override func setUp() {
+        super.setUp()
+        req = .init(assignmentID: "1", sections: [ "2", "3" ])
+    }
+
+    func testPath() {
+        XCTAssertEqual(req.path, "/api/graphql")
+    }
+
+    func testBody() {
+        req.assertBodyEquals(GraphQLBody(
+            query: HideAssignmentGradesForSectionsPostPolicyRequest.query,
+            operationName: "HideAssignmentGradesForSectionsPostPolicyRequest",
+            variables: .init(input: .init(assignmentId: "1", sectionIds: [ "2", "3"]))
+        ))
     }
 }
 
@@ -77,18 +108,17 @@ class GetAssignmentPostPolicyInfoRequestTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        req = GetAssignmentPostPolicyInfoRequest(courseID: "1", assignmentID: "1")
+        req = .init(courseID: "1", assignmentID: "2")
     }
     func testPath() {
         XCTAssertEqual(req.path, "/api/graphql")
     }
 
-    func testQuery() {
-        // swiftlint:disable line_length
-        let expected = """
-        query GetAssignmentPostPolicyInfo {\n    course(id: \"1\") {\n        sections: sectionsConnection {\n          nodes {\n            id\n            name\n          }\n        }\n      }\n      assignment(id: \"1\") {\n        submissions: submissionsConnection {\n          nodes {\n            score\n            excused\n            state\n            postedAt\n          }\n        }\n      }\n}
-        """
-        // swiftlint:enable line_length
-        XCTAssertEqual(req.query, expected)
+    func testBody() {
+        req.assertBodyEquals(GraphQLBody(
+            query: GetAssignmentPostPolicyInfoRequest.query,
+            operationName: "GetAssignmentPostPolicyInfoRequest",
+            variables: .init(courseID: "1", assignmentID: "2")
+        ))
     }
 }

--- a/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
+++ b/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
@@ -103,7 +103,17 @@ class AssignmentListViewController: UIViewController, ColoredNavViewProtocol, Er
             performUIUpdate { [weak self] in self?.showSpinner() }
         }
 
-        let requestable = AssignmentListRequestable(courseID: courseID, gradingPeriodID: selectedGradingPeriod?.id.value, filter: shouldFilter, pageSize: 25, cursor: pagingCursor)
+        let filter: AssignmentFilter
+        if shouldFilter {
+            if let id = selectedGradingPeriod?.id {
+                filter = .gradingPeriod(id: id.value)
+            } else {
+                filter = .currentGradingPeriod
+            }
+        } else {
+            filter = .allGradingPeriods
+        }
+        let requestable = AssignmentListRequestable(courseID: courseID, filter: filter, pageSize: 25, cursor: pagingCursor)
 
         if let cursor = pagingCursor {
             guard fetchedRequests[cursor] == nil else { return }

--- a/Student/StudentUITests/Assignments/IPadAssignmentsTests.swift
+++ b/Student/StudentUITests/Assignments/IPadAssignmentsTests.swift
@@ -112,7 +112,7 @@ class IPadAssignmentsTest: CoreUITestCase {
                 APIAssignmentListAssignment(apiAssignment: $0)
             }
         )
-        mockData(AssignmentListRequestable(courseID: course.id.value, gradingPeriodID: nil),
+        mockData(AssignmentListRequestable(courseID: course.id.value),
                  value: APIAssignmentListResponse.make(gradingPeriods: [], groups: [group]))
         logIn()
         Dashboard.courseCard(id: course.id).tap()

--- a/Student/StudentUnitTests/Assignments/AssignmentList/AssignmentListViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentList/AssignmentListViewControllerTests.swift
@@ -79,7 +79,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "2", name: "GroupB", assignments: assignmentsGroupB),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
         mockNetwork()
 
         //  when
@@ -121,7 +121,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "4", name: "GroupD", assignments: assignmentsGroupB),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
         mockNetwork()
 
         //  clear filter
@@ -159,7 +159,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "6", name: "GroupF", assignments: assignmentsGroupB),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
         mockNetwork()
 
         // filter by grading period
@@ -221,7 +221,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "2", name: "GroupB", assignments: assignmentsGroupB),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
         mockNetwork()
 
         loadView()
@@ -253,7 +253,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "1", name: "GroupA", assignments: assignmentsGroupA1, pageInfo: APIPageInfo(endCursor: "MQ", hasNextPage: true)),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
 
         let d1 = data(gradingPeriods: gradingPeriods, groups: groups)
 
@@ -298,7 +298,7 @@ class AssignmentListViewControllerTests: StudentTestCase {
             APIAssignmentListGroup.make(id: "2", name: "GroupB", assignments: assignmentsGroupB),
         ]
 
-        req = AssignmentListRequestable(courseID: courseID, gradingPeriodID: nil, filter: false)
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
         mockNetwork()
 
         loadView()

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -435,7 +435,7 @@ open class CoreUITestCase: XCTestCase {
     }
 
     open func mockGraphQL<R: APIGraphQLRequestable>(_ requestable: R, value: R.Response) {
-        mockGraphQL(operationName: requestable.operationName) { _ in
+        mockGraphQL(operationName: type(of: requestable).operationName) { _ in
             try! Self.encoder.encode(value)
         }
     }

--- a/rn/Teacher/ios/Submissions/PostGradesPresenter.swift
+++ b/rn/Teacher/ios/Submissions/PostGradesPresenter.swift
@@ -93,7 +93,12 @@ class PostGradesPresenter {
     }
 
     func postGrades(postPolicy: PostGradePolicy, sectionIDs: [String]) {
-        let req = PostAssignmentGradesPostPolicyRequest(assignmentID: assignmentID, postPolicy: postPolicy, sections: sectionIDs)
+        let req: PostAssignmentGradesPostPolicyRequest
+        if sectionIDs.isEmpty {
+            req = PostAssignmentGradesPostPolicyRequest(assignmentID: assignmentID, postPolicy: postPolicy)
+        } else {
+            req = PostAssignmentGradesForSectionsPostPolicyRequest(assignmentID: assignmentID, postPolicy: postPolicy, sections: sectionIDs)
+        }
         env.api.makeRequest(req, callback: { [weak self] _, _, error in
             DispatchQueue.main.async {
                 if let error = error {
@@ -106,7 +111,12 @@ class PostGradesPresenter {
     }
 
     func hideGrades(sectionIDs: [String]) {
-        let req = HideAssignmentGradesPostPolicyRequest(assignmentID: assignmentID, sections: sectionIDs)
+        let req: HideAssignmentGradesPostPolicyRequest
+        if sectionIDs.isEmpty {
+            req = HideAssignmentGradesPostPolicyRequest(assignmentID: assignmentID)
+        } else {
+            req = HideAssignmentGradesForSectionsPostPolicyRequest(assignmentID: assignmentID, sections: sectionIDs)
+        }
         env.api.makeRequest(req, callback: { [weak self] _, _, error in
             DispatchQueue.main.async {
                 if let error = error {

--- a/rn/Teacher/ios/TeacherUITests/Submissions/AssignmentPostPolicyTests.swift
+++ b/rn/Teacher/ios/TeacherUITests/Submissions/AssignmentPostPolicyTests.swift
@@ -44,7 +44,7 @@ class AssignmentPostPolicyTests: TeacherUITestCase {
         PostPolicy.togglePostToSections.toggleOn()
         PostPolicy.postToSectionToggle(id: "1").toggleOn()
 
-        mockGraphQL(operationName: "PostAssignmentGrades", [
+        mockGraphQL(operationName: PostAssignmentGradesPostPolicyRequest.operationName, [
             "data": [ "postAssignmentGradesForSections": [ "assignment": [ "id": "1" ] ] ],
         ])
         mockGraphQL(GetAssignmentPostPolicyInfoRequest(courseID: "1", assignmentID: "1"),
@@ -58,7 +58,7 @@ class AssignmentPostPolicyTests: TeacherUITestCase {
         PostPolicy.toggleHideGradeSections.toggleOn()
         PostPolicy.hideSectionToggle(id: "1").toggleOn()
 
-        mockGraphQL(operationName: "HideAssignmentGrades", [
+        mockGraphQL(operationName: HideAssignmentGradesPostPolicyRequest.operationName, [
             "data": [ "hideAssignmentGradesForSections": [ "assignment": [ "id": "1" ] ] ],
         ])
         PostPolicy.hideGradesButton.tap()


### PR DESCRIPTION
variables are now passed as graphQL variables, for easier mocking

[run-nightly] [run-ipad-tests]

refs: none
affects: none
release note: none