### PR TITLE
Persist current student

### DIFF
--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -77,7 +77,7 @@ public struct SessionDefaults {
         get { self["limitWebAccess"] as? Bool }
         set { self["limitWebAccess"] = newValue }
     }
-    
+
     public var parentCurrentStudentID: String? {
         get { self["parentCurrentStudentID"] as? String }
         set { self["parentCurrentStudentID"] = newValue }

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -83,6 +83,11 @@ public struct SessionDefaults {
         set { self["parentCurrentStudentID"] = newValue }
     }
 
+    public var parentColorScheme: [String: Int]? {
+        get { self["parentColorScheme"] as? [String: Int] }
+        set { self["parentColorScheme"] = newValue }
+    }
+
     public mutating func reset() {
         sessionDefaults = nil
     }

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -77,6 +77,11 @@ public struct SessionDefaults {
         get { self["limitWebAccess"] as? Bool }
         set { self["limitWebAccess"] = newValue }
     }
+    
+    public var parentCurrentStudentID: String? {
+        get { self["parentCurrentStudentID"] as? String }
+        set { self["parentCurrentStudentID"] = newValue }
+    }
 
     public mutating func reset() {
         sessionDefaults = nil

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -416,7 +416,11 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
     }
 
     func displayDefaultStudent() {
-        currentStudent = studentAtIndex(0)
+        if let id = currentStudentID, let persistedStudent = students.filter({ $0.id == id }).first {
+            currentStudent = persistedStudent
+        } else {
+            currentStudent = studentAtIndex(0)
+        }
     }
 }
 

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -59,6 +59,7 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
         didSet {
             if let student = currentStudent {
                 currentStudentID = student.id
+                env.userDefaults?.parentCurrentStudentID = student.id
                 let color = ColorScheme.observee(student.id).color
                 alertsTabItem.badgeColor = color
                 let displayName = Core.User.displayName(student.shortName, pronouns: student.pronouns)
@@ -416,7 +417,7 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
     }
 
     func displayDefaultStudent() {
-        if let id = currentStudentID, let persistedStudent = students.filter({ $0.id == id }).first {
+        if let id = env.userDefaults?.parentCurrentStudentID, let persistedStudent = students.filter({ $0.id == id }).first {
             currentStudent = persistedStudent
         } else {
             currentStudent = studentAtIndex(0)

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -53,14 +53,14 @@ class DashboardViewController: UIViewController, CustomNavbarProtocol {
     var navbarMenuHeightConstraint: NSLayoutConstraint!
     weak var customNavbarDelegate: CustomNavbarActionDelegate?
     var customNavBarColor: UIColor? {
-        if let id = currentStudentID { return ColorScheme.observee(id).color } else { return ColorScheme.observer.color }
+        if let id = currentStudentID { return ColorScheme.observee(id).color } else { return nil }
     }
     var currentStudent: Core.User? {
         didSet {
             if let student = currentStudent {
                 currentStudentID = student.id
-                env.userDefaults?.parentCurrentStudentID = student.id
                 let color = ColorScheme.observee(student.id).color
+                env.userDefaults?.parentCurrentStudentID = student.id
                 alertsTabItem.badgeColor = color
                 let displayName = Core.User.displayName(student.shortName, pronouns: student.pronouns)
                 navbarNameButton.setTitle(displayName, for: .normal)

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -93,9 +93,12 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     func setup(session: LoginSession) {
         environment.userDidLogin(session: session)
         CoreWebView.keepCookieAlive(for: environment)
-        // UX requires that students are given color schemes in a specific order.
-        // The method call below ensures that we always start with the first color scheme.
-        ColorScheme.clear()
+        currentStudentID = environment.userDefaults?.parentCurrentStudentID
+        if currentStudentID == nil {
+            // UX requires that students are given color schemes in a specific order.
+            // The method call below ensures that we always start with the first color scheme.    
+            ColorScheme.clear()
+        }
         if Locale.current.regionCode != "CA" {
             let crashlyticsUserId = "\(session.userID)@\(session.baseURL.host ?? session.baseURL.absoluteString)"
             Crashlytics.sharedInstance().setUserIdentifier(crashlyticsUserId)

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -28,11 +28,7 @@ import SafariServices
 
 let ParentAppRefresherTTL: TimeInterval = 5.minutes
 var legacySession: Session?
-var currentStudentID: String? {
-    didSet {
-        ParentAppDelegate.persistCurrentStudent(id: currentStudentID)
-    }
-}
+var currentStudentID: String?
 
 @UIApplicationMain
 class ParentAppDelegate: UIResponder, UIApplicationDelegate {
@@ -46,7 +42,6 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         return env
     }()
 
-    static let currentStudentDefaultsKey = "com.instructure.parentapp.currentStudentID"
     let hasFabric = (Bundle.main.object(forInfoDictionaryKey: "Fabric") as? [String: Any])?["APIKey"] != nil
     let hasFirebase = FirebaseOptions.defaultOptions()?.apiKey != nil
 
@@ -207,7 +202,6 @@ extension ParentAppDelegate: LoginDelegate {
         LocalizationManager.localizeForApp(UIApplication.shared, locale: session.locale) {
             setup(session: session)
         }
-        currentStudentID = retrievePersistedCurrentStudent()
     }
 
     func userDidStopActing(as session: LoginSession) {
@@ -219,7 +213,6 @@ extension ParentAppDelegate: LoginDelegate {
     }
 
     func userDidLogout(session: LoginSession) {
-        ParentAppDelegate.persistCurrentStudent(id: nil)
         let wasCurrent = environment.currentSession == session
         environment.api.makeRequest(DeleteLoginOAuthRequest(session: session)) { _, _, _ in }
         userDidStopActing(as: session)
@@ -230,15 +223,6 @@ extension ParentAppDelegate: LoginDelegate {
         if let session = environment.currentSession {
             userDidLogout(session: session)
         }
-    }
-
-    static func persistCurrentStudent(id: String?) {
-        UserDefaults.standard.set(id, forKey: currentStudentDefaultsKey)
-        UserDefaults.standard.synchronize()
-    }
-
-    func retrievePersistedCurrentStudent() -> String? {
-        return UserDefaults.standard.string(forKey: ParentAppDelegate.currentStudentDefaultsKey)
     }
 }
 

--- a/Parent/Parent/UserDefaults/ColorScheme.swift
+++ b/Parent/Parent/UserDefaults/ColorScheme.swift
@@ -26,7 +26,13 @@ enum ColorScheme: String, CaseIterable {
     private static var lastScheme: ColorScheme?
 
     static var observer: ColorScheme {
-        lastScheme ?? ColorScheme.observeeBlue
+        if let id = currentStudentID {
+            return observee(id)
+        } else if let id = AppEnvironment.shared.userDefaults?.parentCurrentStudentID {
+            return observee(id)
+        } else {
+            return lastScheme ?? ColorScheme.observeeBlue
+        }
     }
 
     var color: UIColor {
@@ -41,13 +47,13 @@ enum ColorScheme: String, CaseIterable {
 
     private static let DictionaryKey = "color_scheme_dictionary"
     private static var dictionary: [String: Int]? {
-        get { UserDefaults.standard.object(forKey: DictionaryKey) as? [String: Int] }
-        set { UserDefaults.standard.set(newValue, forKey: DictionaryKey) }
+        get { AppEnvironment.shared.userDefaults?.parentColorScheme }
+        set { AppEnvironment.shared.userDefaults?.parentColorScheme = newValue }
     }
 
     static func clear() {
         UserDefaults.standard.removeObject(forKey: CurrentIndexKey)
-        UserDefaults.standard.removeObject(forKey: DictionaryKey)
+        AppEnvironment.shared.userDefaults?.parentColorScheme = nil
     }
 
     static func observee(_ studentID: String) -> ColorScheme {

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -82,4 +82,45 @@ class DashboardViewControllerTests: ParentTestCase {
 
         XCTAssertTrue(router.lastRoutedTo(.wrongApp))
     }
+
+    func testPersistedUserIsDefaultSelectedUser() {
+        UserDefaults.standard.set("3", forKey: ParentAppDelegate.currentStudentDefaultsKey)
+        UserDefaults.standard.synchronize()
+
+        let students: [APIEnrollment] = [
+            .make(observed_user: .make(id: "2")),
+            .make(observed_user: .make(id: "1", name: "Full Name", short_name: "User 3")),
+            .make(observed_user: .make(id: "4")),
+        ]
+        api.mock(GetObservedStudents(observerID: "1"), value: students)
+
+        vc.viewDidLoad()
+        vc.viewDidAppear(false)
+
+        XCTAssertEqual(vc.navbarNameButton.titleLabel?.text, "User 3")
+        XCTAssertEqual(vc.navbarMenuStackView.arrangedSubviews.count, students.count + 1)
+    }
+
+    func testPersistCurrentStudentWhenValueIsSet() {
+        UserDefaults.standard.set(nil, forKey: ParentAppDelegate.currentStudentDefaultsKey)
+        UserDefaults.standard.synchronize()
+
+        currentStudentID = "5"
+
+        let result = UserDefaults.standard.string(forKey: ParentAppDelegate.currentStudentDefaultsKey)
+
+        XCTAssertEqual(result, "5")
+    }
+
+    func testPersistCurrentStudentClearedOnLogout() {
+        UserDefaults.standard.set("3", forKey: ParentAppDelegate.currentStudentDefaultsKey)
+        UserDefaults.standard.synchronize()
+
+        let appDelegate = UIApplication.shared.delegate as! ParentAppDelegate
+        appDelegate.userDidLogout(session: LoginSession.make())
+
+        let result = UserDefaults.standard.string(forKey: ParentAppDelegate.currentStudentDefaultsKey)
+        XCTAssertNil(result)
+    }
+
 }

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -84,12 +84,11 @@ class DashboardViewControllerTests: ParentTestCase {
     }
 
     func testPersistedUserIsDefaultSelectedUser() {
-        UserDefaults.standard.set("3", forKey: ParentAppDelegate.currentStudentDefaultsKey)
-        UserDefaults.standard.synchronize()
+        env.userDefaults?.parentCurrentStudentID = "3"
 
         let students: [APIEnrollment] = [
             .make(observed_user: .make(id: "2")),
-            .make(observed_user: .make(id: "1", name: "Full Name", short_name: "User 3")),
+            .make(observed_user: .make(id: "3", name: "Full Name", short_name: "User 3")),
             .make(observed_user: .make(id: "4")),
         ]
         api.mock(GetObservedStudents(observerID: "1"), value: students)
@@ -101,26 +100,20 @@ class DashboardViewControllerTests: ParentTestCase {
         XCTAssertEqual(vc.navbarMenuStackView.arrangedSubviews.count, students.count + 1)
     }
 
-    func testPersistCurrentStudentWhenValueIsSet() {
-        UserDefaults.standard.set(nil, forKey: ParentAppDelegate.currentStudentDefaultsKey)
-        UserDefaults.standard.synchronize()
+    func testNoDefaultSelectedUser() {
+        env.userDefaults?.parentCurrentStudentID = nil
 
-        currentStudentID = "5"
+        let students: [APIEnrollment] = [
+            .make(observed_user: .make(id: "2", name: "Full Name", short_name: "User 2")),
+            .make(observed_user: .make(id: "3")),
+            .make(observed_user: .make(id: "4")),
+        ]
+        api.mock(GetObservedStudents(observerID: "1"), value: students)
 
-        let result = UserDefaults.standard.string(forKey: ParentAppDelegate.currentStudentDefaultsKey)
+        vc.viewDidLoad()
+        vc.viewDidAppear(false)
 
-        XCTAssertEqual(result, "5")
+        XCTAssertEqual(vc.navbarNameButton.titleLabel?.text, "User 2")
+        XCTAssertEqual(vc.navbarMenuStackView.arrangedSubviews.count, students.count + 1)
     }
-
-    func testPersistCurrentStudentClearedOnLogout() {
-        UserDefaults.standard.set("3", forKey: ParentAppDelegate.currentStudentDefaultsKey)
-        UserDefaults.standard.synchronize()
-
-        let appDelegate = UIApplication.shared.delegate as! ParentAppDelegate
-        appDelegate.userDidLogout(session: LoginSession.make())
-
-        let result = UserDefaults.standard.string(forKey: ParentAppDelegate.currentStudentDefaultsKey)
-        XCTAssertNil(result)
-    }
-
 }


### PR DESCRIPTION
refs: MBL-14059
affects: Parent
release note: none

Test plan
1. Login with twilson: observer1
2. set student to something other than 1st default student
3. force kill the app, restart
4. default user selected should be the user selected in step 2

