### PR TITLE
Fix a11y in Teacher modules and align icons

### DIFF
--- a/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleItemCell.swift
+++ b/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleItemCell.swift
@@ -43,6 +43,14 @@ class ModuleItemCell: UITableViewCell {
                     DateFormatter.localizedString(from: $0, dateStyle: .long, timeStyle: .short)
                 )
             }
+            if let item = item {
+                accessibilityLabel = [
+                    item.title,
+                    item.published == true ? NSLocalizedString("published", comment: "") : NSLocalizedString("unpublished", comment: ""),
+                ].joined(separator: ", ")
+            } else {
+                accessibilityLabel = nil
+            }
         }
     }
 

--- a/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListViewController.storyboard
+++ b/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListViewController.storyboard
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -19,30 +17,30 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="18g-uA-h3W">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ModuleItemCell" id="aAq-Ui-Stp" customClass="ModuleItemCell" customModule="Teacher" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="28" width="375" height="74.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aAq-Ui-Stp" id="UBc-rt-n2v">
-                                            <rect key="frame" x="0.0" y="0.0" width="342" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="349" height="74.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="rv6-mL-EtC">
-                                                    <rect key="frame" x="15" y="12" width="319" height="19.5"/>
+                                                    <rect key="frame" x="15" y="12" width="319" height="50.5"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lwl-X5-mNS" customClass="IconView" customModule="Teacher" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="0.0" width="22" height="19.5"/>
+                                                            <rect key="frame" x="0.0" y="0.5" width="22" height="50"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="22" id="jTw-KY-W6y"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="big-gi-hFf">
-                                                            <rect key="frame" x="38" y="0.0" width="253" height="19.5"/>
+                                                            <rect key="frame" x="38" y="6" width="241" height="38.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="idp-ZT-sKj" customClass="DynamicLabel" customModule="Teacher" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="253" height="17.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="241" height="19.5"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -52,7 +50,7 @@
                                                                     </userDefinedRuntimeAttributes>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SK2-Ab-F0Z" customClass="DynamicLabel" customModule="Teacher" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="19.5" width="253" height="0.0"/>
+                                                                    <rect key="frame" x="0.0" y="21.5" width="241" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <nil key="textColor"/>
                                                                     <nil key="highlightedColor"/>
@@ -64,10 +62,10 @@
                                                             </subviews>
                                                         </stackView>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Bkc-gN-FAf" customClass="PublishedIconView" customModule="Core">
-                                                            <rect key="frame" x="307" y="4" width="12" height="12"/>
+                                                            <rect key="frame" x="295" y="13.5" width="24" height="24"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="12" id="cpF-JT-Qyb"/>
-                                                                <constraint firstAttribute="width" constant="12" id="eI9-xg-Kcy"/>
+                                                                <constraint firstAttribute="height" constant="24" id="cpF-JT-Qyb"/>
+                                                                <constraint firstAttribute="width" constant="24" id="eI9-xg-Kcy"/>
                                                             </constraints>
                                                         </imageView>
                                                     </subviews>
@@ -80,9 +78,11 @@
                                                 <constraint firstAttribute="bottom" secondItem="rv6-mL-EtC" secondAttribute="bottom" constant="12" id="SBy-2l-S0z"/>
                                                 <constraint firstItem="rv6-mL-EtC" firstAttribute="top" secondItem="UBc-rt-n2v" secondAttribute="top" constant="12" id="fHZ-Tc-lue"/>
                                                 <constraint firstItem="rv6-mL-EtC" firstAttribute="leading" secondItem="UBc-rt-n2v" secondAttribute="leadingMargin" id="hq8-pz-Yww"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="rv6-mL-EtC" secondAttribute="trailing" id="rZI-C8-jLL"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="rv6-mL-EtC" secondAttribute="trailing" constant="41" id="8ge-sZ-mLZ"/>
+                                        </constraints>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="fullDivider" value="YES"/>
                                         </userDefinedRuntimeAttributes>
@@ -95,17 +95,17 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ModuleItemSubHeaderCell" id="Wvk-RZ-0fh" customClass="ModuleItemSubHeaderCell" customModule="Teacher" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="72" width="375" height="44"/>
+                                        <rect key="frame" x="0.0" y="102.5" width="375" height="34.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Wvk-RZ-0fh" id="SeG-X8-Qxd">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="34.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="CdB-fh-KOY">
-                                                    <rect key="frame" x="15" y="5" width="319" height="33.5"/>
+                                                    <rect key="frame" x="15" y="5" width="319" height="24.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oQS-d3-6zu" customClass="DynamicLabel" customModule="Teacher" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="6.5" width="303" height="20.5"/>
+                                                            <rect key="frame" x="0.0" y="4" width="291" height="17"/>
                                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
@@ -115,10 +115,10 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ahp-vo-ISY" customClass="PublishedIconView" customModule="Core">
-                                                            <rect key="frame" x="307" y="11" width="12" height="12"/>
+                                                            <rect key="frame" x="295" y="0.5" width="24" height="24"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="width" constant="12" id="jt5-oJ-Eux"/>
-                                                                <constraint firstAttribute="height" constant="12" id="zc0-hu-MBy"/>
+                                                                <constraint firstAttribute="width" constant="24" id="jt5-oJ-Eux"/>
+                                                                <constraint firstAttribute="height" constant="24" id="zc0-hu-MBy"/>
                                                             </constraints>
                                                         </imageView>
                                                     </subviews>
@@ -131,7 +131,7 @@
                                                 <constraint firstItem="CdB-fh-KOY" firstAttribute="top" secondItem="SeG-X8-Qxd" secondAttribute="top" constant="5" id="U6G-wB-VYY"/>
                                                 <constraint firstAttribute="bottom" secondItem="CdB-fh-KOY" secondAttribute="bottom" constant="5" id="i6X-aL-RqN"/>
                                                 <constraint firstItem="CdB-fh-KOY" firstAttribute="leading" secondItem="SeG-X8-Qxd" secondAttribute="leadingMargin" id="nQ2-qs-fHo"/>
-                                                <constraint firstAttribute="trailingMargin" secondItem="CdB-fh-KOY" secondAttribute="trailing" constant="26" id="ybq-Mh-lvr"/>
+                                                <constraint firstAttribute="trailing" secondItem="CdB-fh-KOY" secondAttribute="trailing" constant="41" id="ybq-Mh-lvr"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <userDefinedRuntimeAttributes>

--- a/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleListViewController.swift
@@ -185,6 +185,10 @@ extension ModuleListViewController: UITableViewDataSource {
             cell.accessoryType = .none
             cell.publishedIconView.published = item.published
             cell.indent = item.indent
+            cell.accessibilityLabel = [
+                item.title,
+                item.published == true ? NSLocalizedString("published", comment: "") : NSLocalizedString("unpublished", comment: ""),
+            ].joined(separator: ", ")
             return cell
         default:
             let cell: ModuleItemCell = tableView.dequeue(for: indexPath)
@@ -212,6 +216,12 @@ extension ModuleListViewController: UITableViewDataSource {
         }
         let expanded = isSectionExpanded(section) == true
         header.collapsableIndicator.setCollapsed(!expanded, animated: true)
+        header.accessibilityLabel = [
+            module.name,
+            module.published == true ? NSLocalizedString("published", comment: "") : NSLocalizedString("unpublished", comment: ""),
+            expanded ? NSLocalizedString("expanded", comment: "") : NSLocalizedString("collapsed", comment: ""),
+        ].joined(separator: ", ")
+        header.accessibilityTraits.insert(.button)
         return header
     }
 }

--- a/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleSectionHeaderView.xib
+++ b/rn/Teacher/ios/Teacher/Modules/ModuleList/ModuleSectionHeaderView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15400" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15404"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -34,7 +34,7 @@
                     <rect key="frame" x="16" y="25" width="343" height="633.5"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4NE-AM-KWx" customClass="DynamicLabel" customModule="Teacher" customModuleProvider="target">
-                            <rect key="frame" x="0.0" y="306.5" width="306" height="20.5"/>
+                            <rect key="frame" x="0.0" y="302.5" width="294" height="29"/>
                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                             <nil key="textColor"/>
                             <nil key="highlightedColor"/>
@@ -43,21 +43,21 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
                             </userDefinedRuntimeAttributes>
                         </label>
-                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="SCs-Vj-oh2">
-                            <rect key="frame" x="306" y="311" width="37" height="12"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="SCs-Vj-oh2">
+                            <rect key="frame" x="294" y="305" width="49" height="24"/>
                             <subviews>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="gfV-EK-A87" customClass="PublishedIconView" customModule="Core">
-                                    <rect key="frame" x="0.0" y="0.0" width="12" height="12"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
                                     <constraints>
-                                        <constraint firstAttribute="width" constant="12" id="7Gg-D8-aK5"/>
-                                        <constraint firstAttribute="height" constant="12" id="zty-p2-3gn"/>
+                                        <constraint firstAttribute="width" constant="24" id="7Gg-D8-aK5"/>
+                                        <constraint firstAttribute="height" constant="24" id="zty-p2-3gn"/>
                                     </constraints>
                                 </imageView>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A6B-q1-3Tl" customClass="CollapsableIndicator" customModule="Teacher" customModuleProvider="target">
-                                    <rect key="frame" x="27" y="3.5" width="10" height="5"/>
+                                    <rect key="frame" x="40" y="8.5" width="9" height="7"/>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="5" id="7Ub-3v-RSH"/>
-                                        <constraint firstAttribute="width" constant="10" id="tTo-Ut-92V"/>
+                                        <constraint firstAttribute="height" constant="7" id="7Ub-3v-RSH"/>
+                                        <constraint firstAttribute="width" constant="9" id="tTo-Ut-92V"/>
                                     </constraints>
                                     <userDefinedRuntimeAttributes>
                                         <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="backgroundDarkest"/>


### PR DESCRIPTION
refs: MBL-14035
affects: teacher
release note: Accessibility improvements

Test plan:
* Turn on VO in Teacher modules
* VO should say published and expanded states
* Published icons should all be aligned