### PR TITLE
Fix Numerical quiz question rounding

### DIFF
--- a/CanvasCore/CanvasCore/Quizzes/Taking a Quiz/Answer Cells/ShortAnswerCell.swift
+++ b/CanvasCore/CanvasCore/Quizzes/Taking a Quiz/Answer Cells/ShortAnswerCell.swift
@@ -20,6 +20,12 @@ import UIKit
 
 
 class ShortAnswerCell: UITableViewCell {
+    static let numberFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.maximumFractionDigits = 4
+        formatter.roundingMode = .down
+        return formatter
+    }()
     
     @IBOutlet fileprivate var textFieldBox: UIView!
     @IBOutlet var textField: UITextField!
@@ -72,7 +78,11 @@ extension ShortAnswerCell: UITextFieldDelegate {
         var text = textField.text ?? ""
         if textField.keyboardType == .numbersAndPunctuation {
             while text.last == "." { text = String(text.dropLast()) }
+            if let number = NumberFormatter().number(from: text) {
+                text = Self.numberFormatter.string(from: number) ?? text
+            }
         }
+        textField.text = text
         doneEditing(text)
     }
     


### PR DESCRIPTION
refs: MBL-14083
affects: student
release note: Fixed an issue with numerical quiz questions not rounding properly

Test plan:
* narmstrong > s > CS 1400 > Quizzes > Decimal Quiz > Resume Quiz
* Type 2.4252... > drag to dismiss keyboard > extra '.' should be removed
* Type 2.42525 > drag to dismiss keyboard > should round down to 2.4252
* Type 2.42525111 > drag to dismiss keyboard > should round down to 2.4252
* Type 2.42525111 > Submit > Should be marked as correct on web