### PR TITLE
Show quiz icon in parent grades list, assignments come back as `lockedForUser` in parent

### DIFF
--- a/Core/Core/Grades/GradesViewController.swift
+++ b/Core/Core/Grades/GradesViewController.swift
@@ -32,6 +32,7 @@ public class GradesViewController: UIViewController {
     @IBOutlet weak var loadingView: UIView!
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     public weak var colorDelegate: ColorDelegate?
+    public weak var gradesCellIconDelegate: GradesCellIconIconProviderProtocol?
 
     let env = AppEnvironment.shared
     var courseID: String!
@@ -159,6 +160,7 @@ extension GradesViewController: UITableViewDataSource, UITableViewDelegate {
         cell.nameLabel.text = a?.name
         cell.typeImage.tintColor = colorDelegate?.iconColor ?? Brand.shared.buttonPrimaryBackground
         cell.accessibilityIdentifier = "grades-list.grades-list-row.cell-\(a?.id ?? "nil")"
+        if let iconDelegate = gradesCellIconDelegate { cell.iconDelegate = iconDelegate }
         return cell
     }
 
@@ -196,17 +198,19 @@ extension GradesViewController: HorizontalPagedMenuItem {
     }
 }
 
-public class GradesCell: UITableViewCell {
+public class GradesCell: UITableViewCell, GradesCellIconIconProviderProtocol {
     @IBOutlet weak var nameLabel: DynamicLabel!
     @IBOutlet weak var stackView: UIStackView!
     @IBOutlet weak var typeImage: UIImageView!
     @IBOutlet weak var dueLabel: DynamicLabel!
     @IBOutlet weak var gradeLabel: DynamicLabel!
     @IBOutlet weak var statusLabel: DynamicLabel!
+    weak var iconDelegate: GradesCellIconIconProviderProtocol?
 
     public override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: .subtitle, reuseIdentifier: reuseIdentifier)
         loadFromXib()
+        iconDelegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -217,7 +221,7 @@ public class GradesCell: UITableViewCell {
     func update(_ assignment: Assignment?, userID: String?) {
         let submission = assignment?.submissions?.first { $0.userID == userID }
         fullDivider = true
-        typeImage.image = assignment?.icon
+        typeImage.image = iconDelegate?.iconImage(forAssignment: assignment)
         nameLabel.text = assignment?.name
         gradeLabel.text = assignment.flatMap { GradeFormatter.string(from: $0, userID: userID, style: .medium) }
         dueLabel.text = assignment?.dueText
@@ -225,4 +229,12 @@ public class GradesCell: UITableViewCell {
         statusLabel.text = submission?.status.text
         statusLabel.textColor = submission?.status.color
     }
+}
+
+public protocol GradesCellIconIconProviderProtocol: class {
+    func iconImage(forAssignment: Assignment?) -> UIImage?
+}
+
+extension GradesCellIconIconProviderProtocol {
+    public func iconImage(forAssignment: Assignment?) -> UIImage? { forAssignment?.icon }
 }

--- a/Parent/Parent/Course/CourseDetailsViewController.swift
+++ b/Parent/Parent/Course/CourseDetailsViewController.swift
@@ -89,6 +89,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
 
     func configureGrades() {
         gradesViewController = GradesViewController.create(courseID: courseID, userID: studentID, colorDelegate: self)
+        gradesViewController.gradesCellIconDelegate = self
         viewControllers.append(gradesViewController)
     }
 
@@ -241,6 +242,18 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
             }
         case .summary:
             return NSLocalizedString("Summary", comment: "")
+        }
+    }
+}
+
+extension CourseDetailsViewController: GradesCellIconIconProviderProtocol {
+    public func iconImage(forAssignment assignment: Assignment?) -> UIImage? {
+        //  all quizzes in parent come back as `lockedForUser` so it's always
+        //  showing the lock icon rather than the quiz icon
+        if assignment?.quizID != nil {
+            return  .icon(.quiz, .line)
+        } else {
+            return assignment?.icon
         }
     }
 }


### PR DESCRIPTION
refs: MBL-14100
affects: Parent
release note: Fix quiz icon always showing locked

Testing
quiz icons in grades on parent should not show locked.