### PR TITLE
Make sure you can't hit send more than once

### DIFF
--- a/Core/Core/Views/CircleProgressView.swift
+++ b/Core/Core/Views/CircleProgressView.swift
@@ -123,4 +123,9 @@ public class CircleProgressView: UIView {
         super.tintColorDidChange()
         fill.strokeColor = color?.cgColor ?? tintColor.cgColor
     }
+
+    public override func didMoveToWindow() {
+        super.didMoveToWindow()
+        updateProgress() // Make sure animations are re-added once visible
+    }
 }

--- a/Core/CoreTests/Views/CircleProgressViewTests.swift
+++ b/Core/CoreTests/Views/CircleProgressViewTests.swift
@@ -68,5 +68,12 @@ class CircleProgressViewTests: CoreTestCase {
             endAngle: pi * 1.5,
             clockwise: true
         ).cgPath)
+
+        view.progress = nil
+        view.layer.removeAllAnimations()
+        view.fill.removeAllAnimations()
+        view.didMoveToWindow()
+        XCTAssertNotNil(view.layer.animation(forKey: view.rotateKey))
+        XCTAssertNotNil(view.fill.animation(forKey: view.morphKey))
     }
 }

--- a/Parent/Parent/Conversations/ComposeViewController.swift
+++ b/Parent/Parent/Conversations/ComposeViewController.swift
@@ -146,9 +146,10 @@ class ComposeViewController: UIViewController, ErrorViewController {
     }
 
     @objc func send() {
-        let activityIndicator = UIActivityIndicatorView(frame: CGRect(x: 0, y: 0, width: 40, height: 40))
-        activityIndicator.startAnimating()
-        sendButton.customView = activityIndicator
+        guard sendButton.isEnabled else { return }
+        let spinner = CircleProgressView(frame: CGRect(x: 0, y: 0, width: 40, height: 24))
+        spinner.color = nil
+        sendButton.customView = spinner
         updateSendButton()
         let subject = subjectField.text ?? ""
         let recipientIDs = recipientsView.recipients.map({ $0.id })

--- a/Parent/ParentUnitTests/Conversations/ComposeReplyViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeReplyViewControllerTests.swift
@@ -53,8 +53,11 @@ class ComposeReplyViewControllerTests: ParentTestCase {
         XCTAssertEqual((router.presented as? UIAlertController)?.message, "Oops")
 
         controller.all = true
-        api.mock(AddMessage(conversationID: conversation.id, body: "").request, value: .make())
+        let task = api.mock(AddMessage(conversationID: conversation.id, body: "").request, value: .make())
+        task.paused = true
         XCTAssertNoThrow(sendButton.target?.perform(sendButton.action))
+        XCTAssert(sendButton.customView is CircleProgressView)
+        task.resume()
     }
 
     func testAttachments() {

--- a/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Conversations/ComposeViewControllerTests.swift
@@ -99,7 +99,7 @@ class ComposeViewControllerTests: ParentTestCase {
         task.paused = true
         let sendButton = controller.sendButton
         XCTAssertNoThrow(sendButton.target?.perform(sendButton.action))
-        XCTAssert(controller.sendButton.customView is UIActivityIndicatorView)
+        XCTAssert(controller.sendButton.customView is CircleProgressView)
         task.resume()
     }
 


### PR DESCRIPTION
Also fixed a bug where CircleProgressView wouldn't animate.

refs: MBL-14082
affects: Parent
release note: Fixed an issue where you could accidentally send duplicate messages