### PR TITLE
Add a11y & ui tests for planner filter

### DIFF
--- a/Core/Core/Planner/CalendarViewController.swift
+++ b/Core/Core/Planner/CalendarViewController.swift
@@ -86,8 +86,7 @@ class CalendarViewController: UIViewController {
         monthButton.contentEdgeInsets = UIEdgeInsets(top: 0, left: isRTL ? 28 : 0, bottom: 0, right: isRTL ? 0 : 28)
         monthButton.accessibilityLabel = NSLocalizedString("Show a month at a time", bundle: .core, comment: "")
 
-        filterButton.setTitle(NSLocalizedString("Calendar", bundle: .core, comment: ""), for: .normal)
-        filterButton.accessibilityLabel = NSLocalizedString("Filter events", bundle: .core, comment: "")
+        updateFilterButton()
 
         dropdownView.transform = CGAffineTransform(rotationAngle: 4 * .pi)
 
@@ -134,12 +133,15 @@ class CalendarViewController: UIViewController {
     }
 
     func updateFilterButton() {
-        var title = NSLocalizedString("Calendars", bundle: .core, comment: "")
         if let count = delegate?.numberOfCalendars() {
             let template = NSLocalizedString("Calendars (%d)", bundle: .core, comment: "")
-            title = String.localizedStringWithFormat(template, count)
+            filterButton.setTitle(String.localizedStringWithFormat(template, count), for: .normal)
+            let a11y = NSLocalizedString("filter_events_d_calendars_selected", bundle: .core, comment: "")
+            filterButton.accessibilityLabel = String.localizedStringWithFormat(a11y, count)
+        } else {
+            filterButton.setTitle(NSLocalizedString("Calendars", bundle: .core, comment: ""), for: .normal)
+            filterButton.accessibilityLabel = NSLocalizedString("Filter events", bundle: .core, comment: "")
         }
-        filterButton.setTitle(title, for: .normal)
     }
 
     @IBAction func toggleExpanded() {

--- a/Core/Core/Planner/GetPlannerCourses.swift
+++ b/Core/Core/Planner/GetPlannerCourses.swift
@@ -33,7 +33,7 @@ class GetPlannerCourses: APIUseCase {
         .where(
             #keyPath(Course.planner.studentID),
             equals: studentID,
-            orderBy: #keyPath(Course.courseCode),
+            orderBy: #keyPath(Course.name),
             ascending: true,
             naturally: true
         )

--- a/Core/Core/Planner/PlannerFilterViewController.storyboard
+++ b/Core/Core/Planner/PlannerFilterViewController.storyboard
@@ -23,8 +23,9 @@
                                     <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
-                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lXQ-4T-DWz" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Tap to select the courses you want to see on the calendar." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lXQ-4T-DWz" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                             <rect key="frame" x="16" y="12" width="382" height="20"/>
+                                            <accessibility key="accessibilityConfiguration" identifier="PlannerFilter.headerLabel"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -58,15 +59,15 @@
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="jGj-E4-EVP">
                                             <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
                                             <subviews>
-                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PandaBook" translatesAutoresizingMaskIntoConstraints="NO" id="3rq-Gc-TcY">
+                                                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PandaBook" translatesAutoresizingMaskIntoConstraints="NO" id="3rq-Gc-TcY" customClass="IconView" customModule="Core" customModuleProvider="target">
                                                     <rect key="frame" x="157" y="40" width="100" height="48"/>
-                                                    <constraints>
-                                                        <constraint firstAttribute="height" constant="131" id="Zu2-BQ-npB"/>
-                                                        <constraint firstAttribute="width" constant="100" id="knZ-Dx-hBa"/>
-                                                    </constraints>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="PandaBook"/>
+                                                    </userDefinedRuntimeAttributes>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="No Courses" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1iH-S2-U4d" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                     <rect key="frame" x="32" y="120" width="350" height="0.0"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="PlannerFilter.emptyTitleLabel"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -77,6 +78,7 @@
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your child's courses might not be published yet." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UBS-km-9uq" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                     <rect key="frame" x="32" y="128" width="350" height="0.0"/>
+                                                    <accessibility key="accessibilityConfiguration" identifier="PlannerFilter.emptyMessageLabel"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -123,7 +125,7 @@
                                     </constraints>
                                 </view>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PlannerFilterCell" id="WTs-tm-ubq" customClass="PlannerFilterCell" customModule="Core" customModuleProvider="target">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="PlannerFilterCell" id="WTs-tm-ubq" customClass="PlannerFilterCell" customModule="Core" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="72" width="414" height="63.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="WTs-tm-ubq" id="7Vj-S3-utd">
@@ -135,15 +137,22 @@
                                                     <subviews>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yHF-Le-Bv1">
                                                             <rect key="frame" x="0.0" y="0.5" width="20" height="20"/>
-                                                            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="20" id="8E8-fR-Pzr"/>
                                                                 <constraint firstAttribute="height" constant="20" id="iAp-rr-HRS"/>
                                                             </constraints>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                    <integer key="value" value="3"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                                <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                                    <integer key="value" value="1"/>
+                                                                </userDefinedRuntimeAttribute>
+                                                            </userDefinedRuntimeAttributes>
                                                         </view>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AE7-tL-tjB" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Course Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AE7-tL-tjB" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                             <rect key="frame" x="36" y="0.5" width="346" height="19.5"/>
-                                                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                             <userDefinedRuntimeAttributes>
@@ -174,6 +183,9 @@
                                                 <constraint firstAttribute="trailing" secondItem="onQ-KF-Jfi" secondAttribute="trailing" constant="16" id="zWc-bg-lZI"/>
                                             </constraints>
                                         </tableViewCellContentView>
+                                        <accessibility key="accessibilityConfiguration">
+                                            <accessibilityTraits key="traits" button="YES"/>
+                                        </accessibility>
                                         <userDefinedRuntimeAttributes>
                                             <userDefinedRuntimeAttribute type="boolean" keyPath="fullDivider" value="YES"/>
                                         </userDefinedRuntimeAttributes>
@@ -200,9 +212,9 @@
                         <viewLayoutGuide key="safeArea" id="vgZ-Zu-fC4"/>
                     </view>
                     <connections>
-                        <outlet property="emptyStateHeader" destination="1iH-S2-U4d" id="ob6-pE-kYn"/>
-                        <outlet property="emptyStateSubHeader" destination="UBS-km-9uq" id="R6l-mK-XzA"/>
+                        <outlet property="emptyMessageLabel" destination="UBS-km-9uq" id="R6l-mK-XzA"/>
                         <outlet property="emptyStateView" destination="jGj-E4-EVP" id="LBx-7r-mJh"/>
+                        <outlet property="emptyTitleLabel" destination="1iH-S2-U4d" id="ob6-pE-kYn"/>
                         <outlet property="errorView" destination="smp-Fu-4ao" id="33b-kB-TP4"/>
                         <outlet property="headerLabel" destination="lXQ-4T-DWz" id="IPe-DA-4F3"/>
                         <outlet property="spinnerView" destination="2Vg-sR-X8x" id="egI-Kt-R26"/>

--- a/Core/Core/Planner/PlannerFilterViewController.swift
+++ b/Core/Core/Planner/PlannerFilterViewController.swift
@@ -23,8 +23,8 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
     @IBOutlet weak var headerLabel: DynamicLabel!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var emptyStateView: UIView!
-    @IBOutlet weak var emptyStateHeader: UILabel!
-    @IBOutlet weak var emptyStateSubHeader: UILabel!
+    @IBOutlet weak var emptyTitleLabel: UILabel!
+    @IBOutlet weak var emptyMessageLabel: UILabel!
     @IBOutlet weak var errorView: ListErrorView!
     @IBOutlet weak var spinnerView: UIView!
 
@@ -56,8 +56,8 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
         tableView.registerHeaderFooterView(SectionHeaderView.self)
         headerLabel.text = NSLocalizedString("Tap to select the courses you want to see on the calendar.", bundle: .core, comment: "")
 
-        emptyStateHeader.text = NSLocalizedString("No Courses", bundle: .core, comment: "")
-        emptyStateSubHeader.text = NSLocalizedString("Your child's courses might not be published yet.", bundle: .core, comment: "")
+        emptyTitleLabel.text = NSLocalizedString("No Courses", bundle: .core, comment: "")
+        emptyMessageLabel.text = NSLocalizedString("Your child's courses might not be published yet.", bundle: .core, comment: "")
         errorView.messageLabel.text = NSLocalizedString("There was an error loading courses. Pull to refresh to try again.", bundle: .core, comment: "")
         errorView.retryButton.addTarget(self, action: #selector(refresh(_:)), for: .primaryActionTriggered)
         emptyStateView.isHidden = true
@@ -110,8 +110,10 @@ extension PlannerFilterViewController: UITableViewDataSource {
         }
         let cell = tableView.dequeue(for: indexPath) as PlannerFilterCell
         let course = courses[indexPath]
-        cell.courseNameLabel.text = course?.courseCode
-        cell.isChecked = course.flatMap { planner?.selectedCourses.contains($0) } ?? false
+        cell.accessibilityIdentifier = "PlannerFilter.section.\(indexPath.section).row.\(indexPath.row)"
+        cell.accessibilityLabel = course?.name
+        cell.courseNameLabel.text = course?.name
+        cell.isSelected = course.flatMap { planner?.selectedCourses.contains($0) } == true
         return cell
     }
 
@@ -140,20 +142,21 @@ class PlannerFilterCell: UITableViewCell {
     @IBOutlet weak var courseNameLabel: UILabel!
     @IBOutlet weak var checkmark: UIImageView!
 
-    var isChecked: Bool = false {
+    override var isSelected: Bool {
         didSet {
-            checkboxView.layer.borderWidth = isChecked ? 0 : 1
-            checkmark.isHidden = !isChecked
+            checkboxView.layer.borderWidth = isSelected ? 0 : 1
+            checkmark.isHidden = !isSelected
+            if isSelected {
+                accessibilityTraits.insert(.selected)
+            } else {
+                accessibilityTraits.remove(.selected)
+            }
         }
     }
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        checkboxView.backgroundColor = .clear
-        checkboxView.layer.cornerRadius = 3
-        checkboxView.layer.borderWidth = 1
         checkboxView.layer.borderColor = UIColor.named(.borderDark).cgColor
         checkmark.tintColor = .named(.backgroundInfo)
-        selectionStyle = .none
     }
 }

--- a/Core/Core/en.lproj/Localizable.stringsdict
+++ b/Core/Core/en.lproj/Localizable.stringsdict
@@ -34,6 +34,22 @@
 			<string>%d events</string>
 		</dict>
 	</dict>
+	<key>filter_events_d_calendars_selected</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>Filter events, %#@calendars@</string>
+		<key>calendars</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d calendar selected</string>
+			<key>other</key>
+			<string>%d calendars selected</string>
+		</dict>
+	</dict>
 	<key>final_grade_g_pts</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>

--- a/Core/CoreTests/Planner/CalendarViewControllerTests.swift
+++ b/Core/CoreTests/Planner/CalendarViewControllerTests.swift
@@ -42,8 +42,9 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
     func calendarWillFilter() {
         willFilter = true
     }
+    var calendarCount: Int?
     func numberOfCalendars() -> Int? {
-        return nil
+        calendarCount
     }
 
     lazy var controller = CalendarViewController.create(delegate: self)
@@ -64,8 +65,19 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
         XCTAssertEqual(controller.monthButton.isSelected, true)
         XCTAssertGreaterThanOrEqual(height, 883)
 
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events")
+        XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars")
         controller.filterButton.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(willFilter)
+        calendarCount = 1
+        controller.refresh()
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events, 1 calendar selected")
+        XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars (1)")
+        calendarCount = 7
+        controller.refresh()
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events, 7 calendars selected")
+        XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars (7)")
+
         controller.calendarDidSelectDate(DateComponents(calendar: .current, year: 2020, month: 1, day: 16).date!)
         controller.updateSelectedDate(selectedDate)
 

--- a/Core/CoreTests/Planner/PlannerFilterViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerFilterViewControllerTests.swift
@@ -27,14 +27,14 @@ class PlannerFilterViewControllerTests: CoreTestCase {
 
     lazy var course1 = APICourse.make(
         id: "1",
-        course_code: "BIO 101",
+        name: "BIO 101",
         enrollments: [
             .make(type: "observer", associated_user_id: studentID),
         ]
     )
     lazy var course2 = APICourse.make(
         id: "2",
-        course_code: "BIO 102",
+        name: "BIO 102",
         enrollments: [
             .make(type: "observer", associated_user_id: studentID),
         ]
@@ -52,10 +52,10 @@ class PlannerFilterViewControllerTests: CoreTestCase {
         XCTAssertEqual(tableView.dataSource?.tableView(tableView, numberOfRowsInSection: 0), 1)
         var cell1 = tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as! PlannerFilterCell
         XCTAssertEqual(cell1.courseNameLabel.text, "BIO 101")
-        XCTAssertTrue(cell1.isChecked)
+        XCTAssertTrue(cell1.isSelected)
         tableView.delegate?.tableView?(tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         cell1 = tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 0, section: 0)) as! PlannerFilterCell
-        XCTAssertFalse(cell1.isChecked)
+        XCTAssertFalse(cell1.isSelected)
     }
 
     func testPaginatedRefresh() {
@@ -70,7 +70,7 @@ class PlannerFilterViewControllerTests: CoreTestCase {
         XCTAssertNotNil(loading)
         XCTAssertEqual(tableView.dataSource?.tableView(tableView, numberOfRowsInSection: 0), 2)
         let cell = tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 1, section: 0)) as! PlannerFilterCell
-        XCTAssertEqual(cell.courseNameLabel.text, course2.course_code)
+        XCTAssertEqual(cell.courseNameLabel.text, course2.name)
     }
 
     func testLoadingState() {
@@ -91,7 +91,7 @@ class PlannerFilterViewControllerTests: CoreTestCase {
         controller.errorView.retryButton.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(controller.errorView.isHidden)
         XCTAssertFalse(controller.emptyStateView.isHidden)
-        XCTAssertEqual(controller.emptyStateHeader.text, "No Courses")
-        XCTAssertEqual(controller.emptyStateSubHeader.text, "Your child's courses might not be published yet.")
+        XCTAssertEqual(controller.emptyTitleLabel.text, "No Courses")
+        XCTAssertEqual(controller.emptyMessageLabel.text, "Your child's courses might not be published yet.")
     }
 }

--- a/Core/CoreTests/Planner/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerViewControllerTests.swift
@@ -57,8 +57,8 @@ class PlannerViewControllerTests: CoreTestCase {
 
         // hide first calendar
         api.mock(GetCoursesRequest(enrollmentState: .active, state: [.available], include: [.observed_users], perPage: 100, studentID: "1"), value: [
-            .make(id: "1", course_code: "BIO 101", enrollments: [.make(associated_user_id: "1")]),
-            .make(id: "2", course_code: "BIO 102", enrollments: [.make(associated_user_id: "1")]),
+            .make(id: "1", name: "BIO 101", enrollments: [.make(associated_user_id: "1")]),
+            .make(id: "2", name: "BIO 102", enrollments: [.make(associated_user_id: "1")]),
         ])
         XCTAssertEqual(controller.list.plannables?.useCase.contextCodes, []) // planner nil
         XCTAssertEqual(controller.calendar.filterButton.title(for: .normal), "Calendars")

--- a/Core/CoreUITests/Planner/Planner.swift
+++ b/Core/CoreUITests/Planner/Planner.swift
@@ -41,3 +41,11 @@ enum PlannerList: String, ElementWrapper {
         return app.find(id: "PlannerList.event.\(id)")
     }
 }
+
+enum PlannerFilter: String, ElementWrapper {
+    case headerLabel, emptyTitleLabel, emptyMessageLabel
+
+    static func cell(section: Int, row: Int) -> Element {
+        return app.find(id: "PlannerFilter.section.\(section).row.\(row)")
+    }
+}

--- a/Parent/ParentE2ETests/PlannerTests.swift
+++ b/Parent/ParentE2ETests/PlannerTests.swift
@@ -26,8 +26,6 @@ class PlannerTests: CoreUITestCase {
     let m = 3
     lazy var reference = DateComponents(calendar: .current, year: y, month: m, day: 1).date!
 
-    override var experimentalFeatures: [ExperimentalFeature] { [.parentCalendar] }
-
     override func setUp() {
         super.setUp()
         Courses.course(id: "263").waitToExist()
@@ -71,7 +69,7 @@ class PlannerTests: CoreUITestCase {
 
         PlannerCalendar.dayButton(year: y, month: m, day: 3).tap()
         PlannerList.event(id: "2236").waitToExist() // third
-        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 3 events")
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
 
         PlannerList.event(id: "2236").tap()
         app.find(label: "third").waitToExist()
@@ -127,5 +125,31 @@ class PlannerTests: CoreUITestCase {
         for _ in 0..<7 { PlannerList.emptyTitle.swipeLeft() }
         PlannerCalendar.dayButton(year: y, month: m, day: 8).waitToVanish()
         PlannerCalendar.dayButton(year: y, month: m, day: 15).waitToExist()
+    }
+
+    func testCalendarFilter() {
+        PlannerCalendar.dayButton(year: y, month: m, day: 3).tap()
+        PlannerCalendar.monthButton.tap() // collapse
+        PlannerCalendar.filterButton.tap()
+        XCTAssertEqual(PlannerFilter.headerLabel.label(), "Tap to select the courses you want to see on the calendar.")
+
+        let assignments = { PlannerFilter.cell(section: 0, row: 1) }
+        XCTAssertEqual(assignments().label(), "Assignments")
+        XCTAssertEqual(assignments().isSelected, true)
+        assignments().tap()
+        XCTAssertEqual(assignments().isSelected, false)
+        NavBar.backButton(label: "Done").tap()
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 3 events")
+        PlannerList.event(id: "23334").waitToVanish()
+
+        PlannerCalendar.filterButton.tap()
+        XCTAssertEqual(assignments().isSelected, false)
+        assignments().tap()
+        XCTAssertEqual(assignments().isSelected, true)
+        NavBar.backButton(label: "Done").tap()
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
+
+        PlannerList.event(id: "23334").tap()
+        app.find(label: "This exists just for testing the planner").waitToExist()
     }
 }

--- a/Parent/ParentE2ETests/PlannerTests.swift
+++ b/Parent/ParentE2ETests/PlannerTests.swift
@@ -69,6 +69,7 @@ class PlannerTests: CoreUITestCase {
 
         PlannerCalendar.dayButton(year: y, month: m, day: 3).tap()
         PlannerList.event(id: "2236").waitToExist() // third
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
 
         PlannerList.event(id: "2236").tap()
         app.find(label: "third").waitToExist()
@@ -139,12 +140,16 @@ class PlannerTests: CoreUITestCase {
         XCTAssertEqual(assignments().isSelected, false)
         NavBar.backButton(label: "Done").tap()
         PlannerList.event(id: "23334").waitToVanish()
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 3 events")
 
         PlannerCalendar.filterButton.tap()
         XCTAssertEqual(assignments().isSelected, false)
         assignments().tap()
         XCTAssertEqual(assignments().isSelected, true)
         NavBar.backButton(label: "Done").tap()
+        PlannerList.event(id: "23334").waitToExist()
+        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
+
         PlannerList.event(id: "23334").tap()
         app.find(label: "This exists just for testing the planner").waitToExist()
     }

--- a/Parent/ParentE2ETests/PlannerTests.swift
+++ b/Parent/ParentE2ETests/PlannerTests.swift
@@ -69,7 +69,6 @@ class PlannerTests: CoreUITestCase {
 
         PlannerCalendar.dayButton(year: y, month: m, day: 3).tap()
         PlannerList.event(id: "2236").waitToExist() // third
-        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
 
         PlannerList.event(id: "2236").tap()
         app.find(label: "third").waitToExist()
@@ -139,7 +138,6 @@ class PlannerTests: CoreUITestCase {
         assignments().tap()
         XCTAssertEqual(assignments().isSelected, false)
         NavBar.backButton(label: "Done").tap()
-        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 3 events")
         PlannerList.event(id: "23334").waitToVanish()
 
         PlannerCalendar.filterButton.tap()
@@ -147,8 +145,6 @@ class PlannerTests: CoreUITestCase {
         assignments().tap()
         XCTAssertEqual(assignments().isSelected, true)
         NavBar.backButton(label: "Done").tap()
-        XCTAssertEqual(PlannerCalendar.dayButton(year: y, month: m, day: 3).label(), "March 3, \(y), 4 events")
-
         PlannerList.event(id: "23334").tap()
         app.find(label: "This exists just for testing the planner").waitToExist()
     }

--- a/Student/Student.xcodeproj/xcshareddata/xcschemes/NightlyTests.xcscheme
+++ b/Student/Student.xcodeproj/xcshareddata/xcschemes/NightlyTests.xcscheme
@@ -230,13 +230,6 @@
             ReferencedContainer = "container:Student.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "TZ"
-            value = "America/Denver"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Student/Student.xcodeproj/xcshareddata/xcschemes/NightlyTests.xcscheme
+++ b/Student/Student.xcodeproj/xcshareddata/xcschemes/NightlyTests.xcscheme
@@ -230,6 +230,13 @@
             ReferencedContainer = "container:Student.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "TZ"
+            value = "America/Denver"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -28,6 +28,7 @@ workflows:
             #!/bin/zsh
             set -exo pipefail
 
+            sudo systemsetup -settimezone America/Denver
             if printf "%s\n" "$BITRISE_GIT_MESSAGE" | grep -iE "\[run.nightly\]"; then
                 envman add --key RUN_NIGHTLY --value YES
             fi
@@ -327,6 +328,7 @@ workflows:
             #!/bin/zsh
             set -exo pipefail
 
+            sudo systemsetup -settimezone America/Denver
             case $BITRISE_GIT_BRANCH in
                 release/student|release/teacher|release/parent|master)
                     envman add --key NOTIFY_SLACK --value YES


### PR DESCRIPTION
Displays course name instead of code to match Android & other parts of the app

[run nightly]
refs: MBL-14079
affects: Parent
release note: none