### PR TITLE
Prevent duplicate events in Planner

### DIFF
--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -53,7 +53,11 @@ public class GetPlannables: CollectionUseCase {
                 predicate,
             ])
         }
-        return Scope(predicate: predicate, orderBy: #keyPath(Plannable.date))
+        let order = [
+            NSSortDescriptor(key: #keyPath(Plannable.date), ascending: true),
+            NSSortDescriptor(key: #keyPath(Plannable.title), ascending: true),
+        ]
+        return Scope(predicate: predicate, order: order)
     }
 
     public var request: GetPlannablesRequest {

--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -27,12 +27,15 @@ public class GetPlannables: CollectionUseCase {
     var contextCodes: [String] = []
     var filter: String = ""
 
-    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String] = [], filter: String = "") {
+    public let syncContext: NSManagedObjectContext?
+
+    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String] = [], filter: String = "", syncContext: NSManagedObjectContext? = nil) {
         self.userID = userID
         self.startDate = startDate
         self.endDate = endDate
         self.contextCodes = contextCodes
         self.filter = filter
+        self.syncContext = syncContext
     }
 
     public var cacheKey: String? {

--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -55,7 +55,7 @@ public class GetPlannables: CollectionUseCase {
         }
         let order = [
             NSSortDescriptor(key: #keyPath(Plannable.date), ascending: true),
-            NSSortDescriptor(key: #keyPath(Plannable.title), ascending: true),
+            NSSortDescriptor(key: #keyPath(Plannable.title), ascending: true, naturally: true),
         ]
         return Scope(predicate: predicate, order: order)
     }

--- a/Core/Core/Planner/Plannable.swift
+++ b/Core/Core/Planner/Plannable.swift
@@ -20,7 +20,6 @@ import Foundation
 import CoreData
 
 public final class Plannable: NSManagedObject {
-
     public enum PlannableType: String, Codable {
         case announcement, assignment, discussion_topic, quiz, wiki_page, planner_note, calendar_event, assessment_request
         case other

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -38,6 +38,7 @@ public class PlannerViewController: UIViewController {
         self?.plannerListWillRefresh()
     }
     var planner: Planner? { planners.first }
+    lazy var syncContext = env.database.newBackgroundContext()
 
     public static func create(studentID: String? = nil, selectedDate: Date = Clock.now) -> PlannerViewController {
         let controller = PlannerViewController()
@@ -116,7 +117,7 @@ public class PlannerViewController: UIViewController {
                 contextCodes.append(ContextModel(.user, id: studentID).canvasContextID)
             }
         }
-        return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: Array(contextCodes))
+        return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: Array(contextCodes), syncContext: syncContext)
     }
 
     func updateList(_ date: Date) {

--- a/Core/CoreTests/Use Cases/UploadManagerTests.swift
+++ b/Core/CoreTests/Use Cases/UploadManagerTests.swift
@@ -139,7 +139,7 @@ class UploadManagerTests: CoreTestCase {
         let tasks = MockURLSession.dataMocks.values
         XCTAssertEqual(tasks.count, 2) // target and upload
         XCTAssertTrue(tasks.allSatisfy { $0.resumed })
-        context.refresh(file, mergeChanges: false)
+        context.refresh(file, mergeChanges: true)
         XCTAssertEqual(file.taskID, 1)
     }
 
@@ -155,7 +155,7 @@ class UploadManagerTests: CoreTestCase {
         let data = try encoder.encode(APIFile.make(id: "1"))
         manager.urlSession(backgroundSession, dataTask: task, didReceive: data)
         manager.urlSession(backgroundSession, task: task, didCompleteWithError: nil)
-        context.refresh(file, mergeChanges: false)
+        context.refresh(file, mergeChanges: true)
         XCTAssertNil(file.taskID)
         XCTAssertNil(file.uploadError)
         XCTAssertFalse(file.isUploading)
@@ -261,7 +261,7 @@ class UploadManagerTests: CoreTestCase {
             totalBytesSent: 10,
             totalBytesExpectedToSend: 100
         )
-        context.refresh(file, mergeChanges: false)
+        context.refresh(file, mergeChanges: true)
         XCTAssertEqual(file.size, 100)
         XCTAssertEqual(file.bytesSent, 10)
     }

--- a/TestsFoundation/TestsFoundation/Database/TestPersistence.swift
+++ b/TestsFoundation/TestsFoundation/Database/TestPersistence.swift
@@ -46,6 +46,13 @@ public func resetSingleSharedTestDatabase() -> NSPersistentContainer {
 }
 
 class TestDatabase: NSPersistentContainer {
+    override func newBackgroundContext() -> NSManagedObjectContext {
+        // create a new view context to avoid recursive saves
+        let context = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        context.parent = viewContext
+        return context
+    }
+
     override  func performBackgroundTask(_ block: @escaping (NSManagedObjectContext) -> Void) {
         self.viewContext.performAndWait {
             block(self.viewContext)

--- a/TestsFoundation/TestsFoundation/Fixtures/Model/PlannableFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Model/PlannableFixture.swift
@@ -24,9 +24,10 @@ extension Plannable {
     @discardableResult
     public static func make(
         from api: APIPlannable = .make(),
+        userID: String? = "1",
         in context: NSManagedObjectContext = singleSharedTestDatabase.viewContext
     ) -> Plannable {
-        let model = Plannable.save(api, in: context, userID: "1")
+        let model = Plannable.save(api, in: context, userID: userID)
         try! context.save()
         return model
     }


### PR DESCRIPTION
refs: MBl-14117
affects: parent, student
release note: none

Test plan:
- Pull to refresh on a day that has one or more events
- Do it many many times (10 or more)
- You should not see any duplicate events