### PR TITLE
Fix a crash in assignments

### DIFF
--- a/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
+++ b/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
@@ -199,7 +199,7 @@ class AssignmentListViewController: UIViewController, ColoredNavViewProtocol, Er
 
     func selectFirstCellOnIpad() {
         let ip = IndexPath(row: 0, section: 0)
-        if assignment(for: ip) != nil, appTraitCollection?.horizontalSizeClass == .regular && !isInSplitViewDetail {
+        if assignment(for: ip) != nil, splitViewController != nil, appTraitCollection?.horizontalSizeClass == .regular, !isInSplitViewDetail {
             tableView.selectRow(at: ip, animated: true, scrollPosition: .none)
             tableView(tableView, didSelectRowAt: ip)
         }

--- a/Student/StudentUnitTests/Assignments/AssignmentList/AssignmentListViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentList/AssignmentListViewControllerTests.swift
@@ -232,6 +232,18 @@ class AssignmentListViewControllerTests: StudentTestCase {
         XCTAssertEqual(expected, vc.tableView.indexPathForSelectedRow)
     }
 
+    func testDoesNotSelectFirstUnlessInSplitView() {
+        vc = AssignmentListViewController.create(env: env, courseID: courseID, appTraitCollection: UITraitCollection(horizontalSizeClass: .regular))
+        gradingPeriods = [.make()]
+        groups = [.make(id: "1", name: "GroupA", assignments: [.make()])]
+        req = AssignmentListRequestable(courseID: courseID, filter: .allGradingPeriods)
+        mockNetwork()
+        loadView()
+        let expected = IndexPath(row: 0, section: 0)
+        let cell = vc.tableView.cellForRow(at: expected) as! AssignmentListViewController.ListCell
+        XCTAssertFalse(cell.isSelected)
+    }
+
     func testPaging() {
         gradingPeriods = [ APIAssignmentListGradingPeriod.make(title: "grading period a") ]
         var assignmentsGroupA1 = [APIAssignmentListAssignment]()


### PR DESCRIPTION
refs: MBL-14153
affects: student
release note: Fixed a crash in Assignments

Test plan:
* On iPad, view Assignments in a course with lots of assignments
* Try to tap Back before the initial load finishes
* The should not crash
* Do it lots of times
* Try really hard to go back before the initial load