### PR TITLE
Fix crash in trying to share before pdf is loaded

### DIFF
--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -68,12 +68,6 @@ public class DocViewerViewController: UIViewController {
         pdf.updateConfiguration(builder: docViewerConfigurationBuilder)
         pdf.delegate = self
 
-        let share = UIBarButtonItem(barButtonSystemItem: .action, target: pdf.activityButtonItem.target, action: pdf.activityButtonItem.action)
-        share.accessibilityIdentifier = "DocViewer.shareButton"
-        let search = UIBarButtonItem(barButtonSystemItem: .search, target: pdf.searchButtonItem.target, action: pdf.searchButtonItem.action)
-        search.accessibilityIdentifier = "DocViewer.searchButton"
-        parentNavigationItem?.rightBarButtonItems = [ share, search ]
-
         syncAnnotationsButton.isHidden = true
         syncAnnotationsButton.setTitleColor(.named(.white), for: .normal)
         syncAnnotationsButton.setTitleColor(.named(.textDark), for: .disabled)
@@ -132,6 +126,12 @@ public class DocViewerViewController: UIViewController {
         pdf.documentViewController?.scrollToSpread(at: 0, scrollPosition: .start, animated: false)
         pdf.view.isHidden = false
         loadingView.isHidden = true
+
+        let share = UIBarButtonItem(barButtonSystemItem: .action, target: pdf.activityButtonItem.target, action: pdf.activityButtonItem.action)
+        share.accessibilityIdentifier = "DocViewer.shareButton"
+        let search = UIBarButtonItem(barButtonSystemItem: .search, target: pdf.searchButtonItem.target, action: pdf.searchButtonItem.action)
+        search.accessibilityIdentifier = "DocViewer.searchButton"
+        parentNavigationItem?.rightBarButtonItems = [ share, search ]
     }
 
     public func showError(_ error: Error) {

--- a/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
@@ -61,6 +61,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         session.error = err
         controller.view.layoutIfNeeded()
         XCTAssertEqual((router.presented as? UIAlertController)?.message, err.localizedDescription)
+        XCTAssertEqual(navigationItem.rightBarButtonItems, nil)
     }
 
     func testFallback() {
@@ -78,6 +79,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         let providers = controller.pdf.document?.documentProviders.first?.annotationManager.annotationProviders
         XCTAssertTrue(providers?.contains(where: { $0 is DocViewerAnnotationProvider }) ?? false)
+        XCTAssertEqual(navigationItem.rightBarButtonItems?.count, 2)
     }
 
     func testLoadFallback() {
@@ -85,6 +87,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         controller.previewURL = nil
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.pdf.document?.fileURL, url)
+        XCTAssertEqual(navigationItem.rightBarButtonItems?.count, 2)
     }
 
     func testLoadFallbackRepeat() {
@@ -92,6 +95,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         XCTAssertNotNil(router.presented)
         XCTAssertEqual(controller.fallbackUsed, true)
+        XCTAssertEqual(navigationItem.rightBarButtonItems, nil)
 
         session.error = APIDocViewerError.noData
         controller.view.layoutIfNeeded()


### PR DESCRIPTION
refs: none
affects: Student
release note: Fixed a crash when trying to share a pdf before it has loaded