### PR TITLE
Still show lock icon for locked assignments

### DIFF
--- a/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
+++ b/Student/Canvas/Modules/Module Items/ModuleItemViewModel.swift
@@ -147,7 +147,7 @@ class ModuleItemViewModel: NSObject {
         
         let type = self.moduleItem.value?.contentType
         vm.accessoryView <~ SignalProducer.combineLatest(self.completed.producer, self.locked.producer).map { (completed, locked) -> UIView? in
-            if locked && type != .assignment {
+            if locked {
                 let imageView = UIImageView(image: .icon(.lock))
                 imageView.tintColor = .prettyGray()
                 return imageView


### PR DESCRIPTION
You can still go into the assignment details, which will also tell you it is locked.

refs: MBL-14185
affects: Student
release note: Fixed missing icon for locked assignments in a module