### PR TITLE
Master build QR links

### DIFF
--- a/scripts/build_automation/bitrise_workflows/parent.yml
+++ b/scripts/build_automation/bitrise_workflows/parent.yml
@@ -105,7 +105,7 @@ workflows:
     - _common
     steps:
     - script:
-        title: Update build link if part of PR
+        title: Update build link
         is_skippable: true
         inputs:
         - runner_bin: "/bin/zsh"

--- a/scripts/build_automation/bitrise_workflows/student.yml
+++ b/scripts/build_automation/bitrise_workflows/student.yml
@@ -78,7 +78,7 @@ workflows:
     - _common
     steps:
     - script:
-        title: Update build link if part of PR
+        title: Update build link
         is_skippable: true
         inputs:
         - runner_bin: "/bin/zsh"

--- a/scripts/build_automation/bitrise_workflows/teacher.yml
+++ b/scripts/build_automation/bitrise_workflows/teacher.yml
@@ -106,7 +106,7 @@ workflows:
     - _common
     steps:
     - script:
-        title: Update build link if part of PR
+        title: Update build link
         is_skippable: true
         inputs:
         - runner_bin: "/bin/zsh"

--- a/scripts/build_automation/build-link.swift
+++ b/scripts/build_automation/build-link.swift
@@ -233,7 +233,7 @@ if args.count == 3, args[1] == "generate-temp-links" {
 
     let branch = args[3]
     let url = args[4]
-    if branch == "master-build-links" {
+    if branch == "master" {
         guard let appIndex = App.allCases.firstIndex(of: app) else {
             print("Couldn't find build link idendifier!")
             exit(1)

--- a/scripts/build_automation/build-link.swift
+++ b/scripts/build_automation/build-link.swift
@@ -32,13 +32,19 @@ let repoOwner = "instructure"
 let repoName = "canvas-ios"
 let repo = "\(repoOwner)/\(repoName)"
 let magicString = "build-link" + "-magic-string"
+let masterLinkIds = [
+  "5170df518790453cb3c867a36a9befd0",
+  "fe339692b8644ce3be6ec62b7f1c7caf",
+  "fe13f1e303d545c4aec2118366a7ddfc",
+]
 
 enum App: String, CaseIterable {
     case student, teacher, parent
 
-    func title(forPr prID: String) -> String {
-        "\(self) - PR \(prID)"
+    func title(branchDescription: String) -> String {
+        "\(self) - \(branchDescription)"
     }
+
 }
 
 let env = ProcessInfo.processInfo.environment
@@ -187,7 +193,7 @@ func createBuildLinks(prID: String) throws {
     var ids: [String] = []
     var links: [String] = []
     for app in App.allCases {
-        let result = try Rebrandly.shortenOrUpdate(url: tempUrl, title: app.title(forPr: prID))
+        let result = try Rebrandly.shortenOrUpdate(url: tempUrl, title: app.title(branchDescription: "PR \(prID)"))
         ids.append(result.id)
         links.append("\(app): [Link](https://\(result.shortUrl)) | [QR](\(result.qrUrl))")
     }
@@ -209,7 +215,7 @@ func updateBuildLink(prID: String, app: App, url: String) throws {
         print("Couldn't find build link idendifier!")
         return
     }
-    try Rebrandly.shortenOrUpdate(id: ids[appIndex], url: url, title: app.title(forPr: prID))
+    try Rebrandly.shortenOrUpdate(id: ids[appIndex], url: url, title: app.title(branchDescription: "PR \(prID)"))
 }
 
 let usage = """
@@ -227,14 +233,24 @@ if args.count == 3, args[1] == "generate-temp-links" {
 
     let branch = args[3]
     let url = args[4]
-    guard let prID = try Github.findAssociatedPullRequests(branch: branch).max() else {
-        print("can't find a pull request associated with branch \(branch)")
-        exit(1)
+    if branch == "master-build-links" {
+        guard let appIndex = App.allCases.firstIndex(of: app) else {
+            print("Couldn't find build link idendifier!")
+            exit(1)
+        }
+        try Rebrandly.shortenOrUpdate(
+          id: masterLinkIds[appIndex],
+          url: url,
+          title: app.title(branchDescription: "master")
+        )
+    } else {
+        guard let prID = try Github.findAssociatedPullRequests(branch: branch).max() else {
+            print("can't find a pull request associated with branch \(branch)")
+            exit(1)
+        }
+        try updateBuildLink(prID: "\(prID)", app: app, url: url)
     }
-    try updateBuildLink(prID: "\(prID)", app: app, url: url)
 } else {
     print(usage)
     exit(1)
 }
-
-


### PR DESCRIPTION
Adds permanent links and QR codes to the last successful master build, so that installing from master is as easy as installing from a PR.

Links can be found at https://instructure.atlassian.net/wiki/spaces/MOBILE/pages/822378551/Latest+master+QR+install+links

(teacher won't work properly because I retriggered a build too early, but just ignore that)