### PR TITLE
Handle null conference recording length

### DIFF
--- a/Core/Core/Conferences/APIConference.swift
+++ b/Core/Core/Conferences/APIConference.swift
@@ -49,7 +49,7 @@ public struct APIConferenceRecording: Codable {
 }
 
 public struct APIConferencePlaybackFormat: Codable {
-    let length: String
+    let length: String?
     let type: String
     let url: APIURL
 }


### PR DESCRIPTION
refs: MBL-14221
affects: teacher
release note: Fixed a bug that would prevent conferences from loading

Test plan: see ticket https://instructure.atlassian.net/browse/MBL-14221