### PR TITLE
Launch directly to live conference from dashboard

### DIFF
--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -144,6 +144,11 @@ let routeMap: KeyValuePairs<String, RouteHandler.ViewFactory?> = [
         return ConferenceDetailsViewController.create(context: context, conferenceID: id)
     },
 
+    "/:context/:contextID/conferences/:conferenceID/join": { url, params in
+        open(url: url)
+        return nil
+    },
+
     "/:context/:contextID/discussions": nil,
     "/:context/:contextID/discussion_topics": nil,
 

--- a/rn/Teacher/src/modules/dashboard/LiveConferenceRow.js
+++ b/rn/Teacher/src/modules/dashboard/LiveConferenceRow.js
@@ -40,7 +40,7 @@ export default class LiveConferenceRow extends React.Component {
 
   navigate = () => {
     const { id, context_type, context_id } = this.props.conference
-    this.props.navigator.show(`/${context_type.toLowerCase()}s/${context_id}/conferences/${id}`)
+    this.props.navigator.show(`/${context_type.toLowerCase()}s/${context_id}/conferences/${id}/join`)
   }
 
   render () {

--- a/rn/Teacher/src/modules/dashboard/__tests__/LiveConferenceRow.test.js
+++ b/rn/Teacher/src/modules/dashboard/__tests__/LiveConferenceRow.test.js
@@ -54,6 +54,6 @@ describe('LiveConferenceRow', () => {
     const navigator = templates.navigator()
     const tree = shallow(<LiveConferenceRow {...defaults} navigator={navigator} />)
     tree.find(`[testID='LiveConference.1.navigateButton']`).simulate('Press')
-    expect(navigator.show).toHaveBeenCalledWith('/courses/1/conferences/1')
+    expect(navigator.show).toHaveBeenCalledWith('/courses/1/conferences/1/join')
   })
 })

--- a/rn/Teacher/src/routing/register-screens.js
+++ b/rn/Teacher/src/routing/register-screens.js
@@ -210,6 +210,7 @@ export function registerScreens (store: Store): void {
     registerScreen('/courses/:courseID/assignments/:assignmentID/submissions/:userID', null, store, { deepLink: true })
     registerScreen('/:context/:contextID/conferences', null, store, { canBecomeMaster: true, deepLink: true })
     registerScreen('/:context/:contextID/conferences/:conferenceID', null, store, { deepLink: true })
+    registerScreen('/:context/:contextID/conferences/:conferenceID/join', null, store, { deepLink: true })
     registerScreen('/courses/:courseID/quizzes/:quizID/take', null, store, { deepLink: true })
     registerScreen('/courses/:courseID/quizzes/:quizID', null, store, { deepLink: true })
     registerScreen('/courses/:courseID/quizzes', null, store, { deepLink: true })


### PR DESCRIPTION
refs: MBL-14224
affects: student
release note: none

Test plan:
* narmstrong.beta.instructure.com > s > Dashboard > Tap live conference
* Should go directly to live conference in safari, not conference details