### PR TITLE
Fix crasher with quiz file upload questions

### DIFF
--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -126,7 +126,7 @@ class SubmissionButtonPresenter: NSObject {
         case .online_quiz:
             Analytics.shared.logEvent("assignment_detail_quizlaunch")
             guard let quizID = assignment.quizID else { return }
-            env.router.route(to: .takeQuiz(forCourse: courseID, quizID: quizID), from: view, options: .modal(isDismissable: false, embedInNav: true))
+            env.router.route(to: .takeQuiz(forCourse: courseID, quizID: quizID), from: view, options: .modal(.fullScreen, isDismissable: false, embedInNav: true))
         case .online_upload:
             Analytics.shared.logEvent("submit_fileupload_selected")
             pickFiles(for: assignment, selectedSubmissionTypes: [type])


### PR DESCRIPTION
refs: MBL-14225
affects: Student
release note: Fixed crash in quizzes when uploading a file.

testing
1. go to twilson 
2. in quizzes questions course
3. assignments > Geometry (last assignment)
4. click resume quiz
5. Resume quiz again
6. on first question, click "Choose a File"
If this is fixed it should show a little action sheet for selecting an upload, if it's broken, it will crash at this point.