### PR TITLE
Fix ImageViewExtensionTests

### DIFF
--- a/Core/Core/Extensions/UIImageViewExtensions.swift
+++ b/Core/Core/Extensions/UIImageViewExtensions.swift
@@ -29,8 +29,6 @@ private var loaderHandle: UInt8 = 0
 
 public protocol ImageLoadingView: class {
     var frame: CGRect { get }
-    var loader: ImageLoader? { get }
-    func load(url: URL?) -> URLSessionTask?
     func load(url: URL, didCompleteWith: LoadedImage?, error: Error?)
 }
 
@@ -99,6 +97,11 @@ public class ImageLoader {
 
     private static var rendered: [String: LoadedImage] = [:]
     private static var loading: [String: [ImageLoader]] = [:]
+
+    static func reset() {
+        rendered = [:]
+        loading = [:]
+    }
 
     init(url: URL, view: ImageLoadingView) {
         self.frame = view.frame

--- a/Core/CoreTests/Grades/GradeListViewControllerTests.swift
+++ b/Core/CoreTests/Grades/GradeListViewControllerTests.swift
@@ -96,8 +96,8 @@ class GradeListViewControllerTests: CoreTestCase {
         mockGrades(gradingPeriodID: "1", score: 20)
         mockGrades(gradingPeriodID: "2", score: nil)
         api.mock(controller.gradingPeriods, value: [
-            .make(id: "1", title: "One"),
-            .make(id: "2", title: "Two"),
+            .make(id: "1", title: "One", start_date: Clock.now.addDays(-7)),
+            .make(id: "2", title: "Two", start_date: Clock.now.addDays(7)),
         ])
     }
 


### PR DESCRIPTION
Use mocked network to make most things synchronous.
Only one svg test waits for a snapshot, to ensure that works properly

refs: MBL-13827
affects: none
release note: none