### PR TITLE
Remove waiting for webview from testSVG

### DIFF
--- a/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
@@ -207,19 +207,11 @@ class FileDetailsViewControllerTests: CoreTestCase {
         XCTAssertTrue(saveWasCalled)
     }
 
-    func xtestSVG() {
+    func testSVG() {
         mock(APIFile.make(filename: "File.svg", contentType: "image/svg+xml", mime_class: "file"))
-        let done = expectation(description: "done")
-        var token: NSObjectProtocol?
-        token = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) { _ in
-            NotificationCenter.default.removeObserver(token!)
-            done.fulfill()
-        }
         controller.view.layoutIfNeeded()
-        wait(for: [done], timeout: 5)
         XCTAssert(controller.contentView.subviews.first is CoreWebView)
-        XCTAssertTrue(controller.spinnerView.isHidden)
-        XCTAssertTrue(controller.progressView.isHidden)
+        XCTAssertNotNil(controller.loadObservation)
     }
 
     func testVideo() {


### PR DESCRIPTION
This no longer tries to assert that the webview finishes loading, but we probably don't need to test that WKWebView updates estimatedProgress correctly anyway.
That seemed like a better compromise than simply extending the wait time past 5 seconds.

refs: MBL-13825
affects: none
release note: none