### PR TITLE
Fix marking discussions as read on scroll

### DIFF
--- a/rn/Teacher/src/modules/discussions/details/DiscussionDetails.js
+++ b/rn/Teacher/src/modules/discussions/details/DiscussionDetails.js
@@ -88,13 +88,6 @@ type State = {
   groups: GroupsState,
 }
 
-type ViewableReply = {
-  index: number,
-  isViewable: boolean,
-  key: string,
-  item: DiscussionReply,
-}
-
 const {
   refreshDiscussionEntries,
   refreshSingleDiscussion,
@@ -688,8 +681,8 @@ export class DiscussionDetails extends Component<Props, any> {
     return (unread.has(id)) ? 'unread' : 'read'
   }
 
-  _markViewableAsRead = (info: { viewableItems: Array<ViewableReply>, changed: Array<ViewableReply>}) => {
-    requestIdleCallback(() => {
+  _markViewableAsRead = (info) => {
+    setTimeout(() => {
       let dID = this.props.discussionID
       let inView = info.viewableItems
       let unread = [...this.state.unread_entries] || []
@@ -710,7 +703,7 @@ export class DiscussionDetails extends Component<Props, any> {
         }
       }
       if (update) this.setState({ unread_entries: unread })
-    })
+    }, 1000)
   }
 }
 

--- a/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
+++ b/rn/Teacher/src/modules/discussions/details/__tests__/DiscussionDetails.test.js
@@ -47,6 +47,7 @@ describe('DiscussionDetails', () => {
   let props: Props
   beforeEach(() => {
     jest.clearAllMocks()
+    jest.useFakeTimers()
     app.setCurrentApp('teacher')
     let discussion = template.discussion({
       id: '1',


### PR DESCRIPTION
RN 0.62.2 [broke requestIdleCallback](https://github.com/facebook/react-native/issues/28602).

refs: MBL-14307
affects: student, teacher
release note: none

Test plan:
* Viewing discussion details should automatically mark replies as read