### PR TITLE
Re-enable testReplyWithAttachments

### DIFF
--- a/Parent/ParentUITests/InboxTests.swift
+++ b/Parent/ParentUITests/InboxTests.swift
@@ -22,7 +22,7 @@ import Foundation
 @testable import TestsFoundation
 
 class InboxTests: ParentUITestCase {
-    func xtestReplyWithAttachments() {
+    func testReplyWithAttachments() {
         mockBaseRequests()
         let message = APIConversationMessage.make(
             id: "1",
@@ -56,6 +56,7 @@ class InboxTests: ParentUITestCase {
             id: conversation.id.value,
             messages: [message, newMessage]
         ))
+
         logIn()
         Dashboard.profileButton.tap()
         Profile.inboxButton.tap()


### PR DESCRIPTION
The signal before showRoot is gone now. I'm not sure about the prior CoreData issue, but the tests ran successfully on my machine many times.

[run-nightly]
refs: MBL-14180
affects: none
release note: none