### PR TITLE
Fix push notifications for vanity domain users

### DIFF
--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -181,12 +181,6 @@ public class Router: RouterProtocol {
         DeveloperMenuViewController.recordRouteInHistory(url.url?.absoluteString)
         #endif
         Analytics.shared.logEvent("route", parameters: ["url": String(describing: url)])
-
-        if url.host?.isEmpty == false && !urlMatchesSessionHost(url) {
-            fallback(url, from, options)
-            return
-        }
-
         for route in handlers {
             if let params = route.match(url) {
                 if let view = route.factory(url, params) {
@@ -196,10 +190,5 @@ public class Router: RouterProtocol {
             }
         }
         fallback(url, from, options)
-    }
-
-    private func urlMatchesSessionHost(_ url: URLComponents) -> Bool {
-        let sessionHost = AppEnvironment.shared.currentSession?.baseURL.host ?? ""
-        return url.host == sessionHost
     }
 }

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -341,20 +341,6 @@ class RouterTests: CoreTestCase {
         XCTAssertNotNil(router.match(components))
     }
 
-    func testRouteToExternalURL() {
-        let mockView = MockViewController()
-        let url = URLComponents(string: "https://foobar.com/support")!
-        var didUseLocalSupportRoute = false
-        let router = Router(routes: [
-            RouteHandler("/support") { _, _ in
-                didUseLocalSupportRoute = true
-                return UIViewController()
-            },
-        ]) { _, _, _ in }
-        router.route(to: url, from: mockView)
-        XCTAssertFalse(didUseLocalSupportRoute)
-    }
-
     func testShowAlertController() {
         let mockView = MockViewController()
         let router = Router(routes: []) { _, _, _ in }

--- a/Student/Student/CanvasAppDelegate.swift
+++ b/Student/Student/CanvasAppDelegate.swift
@@ -184,6 +184,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         withCompletionHandler completionHandler: @escaping () -> Void
     ) {
         handlePush(userInfo: response.notification.request.content.userInfo)
+        completionHandler()
     }
 
     func userNotificationCenter(

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -367,9 +367,12 @@ let routeMap: KeyValuePairs<String, RouteHandler.ViewFactory?> = [
         return ProfileSettingsViewController.create()
     },
 
-    "/support/:type": { _, params in
-        let type = params["type"].flatMap { ErrorReportType(rawValue: $0) } ?? .problem
-        return ErrorReportViewController.create(type: type)
+    "/support/problem": { _, _ in
+        return ErrorReportViewController.create(type: .problem)
+    },
+
+    "/support/feature": { _, _ in
+        return ErrorReportViewController.create(type: .feature)
     },
 ]
 


### PR DESCRIPTION
refs: MBL-14220, MBL-14325
affects: student
release note: Fixed a bug that could cause push notifications to open up in Safari

Test plan:
* Check out the changes locally (so you can simulate a push notification)
* Log in as narmstrong > s
* Drag the attached `push.apns` file over the simulator and tap the notification
* Should launch the course details