### PR TITLE
Add selecting mastery paths

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -703,6 +703,8 @@
 		B11AEBBB240727AE00B736D6 /* GetPlannerCourses.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11AEBBA240727AE00B736D6 /* GetPlannerCourses.swift */; };
 		B11AEBBD24082E2F00B736D6 /* PlannerFilterViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11AEBBC24082E2F00B736D6 /* PlannerFilterViewControllerTests.swift */; };
 		B12151832447A78900D34BE4 /* CompletionRequirementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12151822447A78900D34BE4 /* CompletionRequirementTests.swift */; };
+		B127C0EE245B2EE3008DB716 /* MasteryPathAssignmentCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = B127C0ED245B2EE3008DB716 /* MasteryPathAssignmentCell.xib */; };
+		B127C0F0245B56BE008DB716 /* MasteryPathViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B127C0EF245B56BE008DB716 /* MasteryPathViewControllerTests.swift */; };
 		B12A763821914059000693DE /* fileupload.txt in Resources */ = {isa = PBXBuildFile; fileRef = B12A763721914059000693DE /* fileupload.txt */; };
 		B12A763A2191459F000693DE /* file-post-body.txt in Resources */ = {isa = PBXBuildFile; fileRef = B12A76392191459F000693DE /* file-post-body.txt */; };
 		B12AB4A32457500F009872C4 /* MasteryPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = B12AB4A22457500F009872C4 /* MasteryPath.swift */; };
@@ -736,6 +738,9 @@
 		B175D61E23A9694E00F8E696 /* SpringBoard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B175D61D23A9694E00F8E696 /* SpringBoard.swift */; };
 		B175D62023A9696200F8E696 /* SpringBoardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B175D61F23A9696200F8E696 /* SpringBoardTests.swift */; };
 		B17855B3226ABDDD00B30C80 /* UploadMediaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17855B2226ABDDD00B30C80 /* UploadMediaTests.swift */; };
+		B17B3E97245A1BB300DC3318 /* MasteryPathAssignmentSetDivider.xib in Resources */ = {isa = PBXBuildFile; fileRef = B17B3E96245A1BB300DC3318 /* MasteryPathAssignmentSetDivider.xib */; };
+		B17C83292459ED4D00CE1FED /* MasteryPathViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B17C83282459ED4D00CE1FED /* MasteryPathViewController.storyboard */; };
+		B17F27652459EDF100CD47A1 /* MasteryPathViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17F27642459EDF100CD47A1 /* MasteryPathViewController.swift */; };
 		B18359AA222450DE0005A918 /* AccessIconView.xib in Resources */ = {isa = PBXBuildFile; fileRef = B18359A9222450DE0005A918 /* AccessIconView.xib */; };
 		B1846D1322EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1846D1222EA32F000BC4C4A /* NotificationCenterExtensionsTests.swift */; };
 		B18E19BB2386216B00B03C73 /* GradeFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B18E19BA2386216B00B03C73 /* GradeFormatterTests.swift */; };
@@ -1742,6 +1747,8 @@
 		B11AEBBC24082E2F00B736D6 /* PlannerFilterViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlannerFilterViewControllerTests.swift; sourceTree = "<group>"; };
 		B11D321621E464AB00F37ABF /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		B12151822447A78900D34BE4 /* CompletionRequirementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRequirementTests.swift; sourceTree = "<group>"; };
+		B127C0ED245B2EE3008DB716 /* MasteryPathAssignmentCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MasteryPathAssignmentCell.xib; sourceTree = "<group>"; };
+		B127C0EF245B56BE008DB716 /* MasteryPathViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryPathViewControllerTests.swift; sourceTree = "<group>"; };
 		B12A763721914059000693DE /* fileupload.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = fileupload.txt; sourceTree = "<group>"; };
 		B12A76392191459F000693DE /* file-post-body.txt */ = {isa = PBXFileReference; lastKnownFileType = text; path = "file-post-body.txt"; sourceTree = "<group>"; };
 		B12AB4A22457500F009872C4 /* MasteryPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryPath.swift; sourceTree = "<group>"; };
@@ -1787,7 +1794,10 @@
 		B175D61F23A9696200F8E696 /* SpringBoardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpringBoardTests.swift; sourceTree = "<group>"; };
 		B17855B0226ABDB100B30C80 /* UploadMedia.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMedia.swift; sourceTree = "<group>"; };
 		B17855B2226ABDDD00B30C80 /* UploadMediaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadMediaTests.swift; sourceTree = "<group>"; };
+		B17B3E96245A1BB300DC3318 /* MasteryPathAssignmentSetDivider.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = MasteryPathAssignmentSetDivider.xib; sourceTree = "<group>"; };
+		B17C83282459ED4D00CE1FED /* MasteryPathViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = MasteryPathViewController.storyboard; sourceTree = "<group>"; };
 		B17F23B02137981B00771F86 /* Clock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Clock.swift; sourceTree = "<group>"; };
+		B17F27642459EDF100CD47A1 /* MasteryPathViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MasteryPathViewController.swift; sourceTree = "<group>"; };
 		B18359A722244E230005A918 /* AccessIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessIconView.swift; sourceTree = "<group>"; };
 		B18359A9222450DE0005A918 /* AccessIconView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AccessIconView.xib; sourceTree = "<group>"; };
 		B183F99C225297F2000A6930 /* PublishedIconView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublishedIconView.swift; sourceTree = "<group>"; };
@@ -2607,6 +2617,7 @@
 		7D159CE9242E553900A77A15 /* Modules */ = {
 			isa = PBXGroup;
 			children = (
+				B17C831F2458C16000CE1FED /* Mastery Paths */,
 				B162469E2445001E00982C52 /* CompletionRequirement.swift */,
 				B1A784892441136C001A2B50 /* GetModuleItem.swift */,
 				B1A7848A2441136C001A2B50 /* GetModuleItemSequence.swift */,
@@ -2927,6 +2938,7 @@
 			isa = PBXGroup;
 			children = (
 				B12151822447A78900D34BE4 /* CompletionRequirementTests.swift */,
+				B127C0EF245B56BE008DB716 /* MasteryPathViewControllerTests.swift */,
 				B1F614AC243D0BD300F1FBA3 /* ModuleItems */,
 				7D67C268242E6BE900BC5CD1 /* ModuleListViewControllerTests.swift */,
 				7D67C269242E6BE900BC5CD1 /* ModuleStoreTests.swift */,
@@ -3563,6 +3575,17 @@
 				B175D61F23A9696200F8E696 /* SpringBoardTests.swift */,
 			);
 			path = SpringBoard;
+			sourceTree = "<group>";
+		};
+		B17C831F2458C16000CE1FED /* Mastery Paths */ = {
+			isa = PBXGroup;
+			children = (
+				B17B3E96245A1BB300DC3318 /* MasteryPathAssignmentSetDivider.xib */,
+				B17C83282459ED4D00CE1FED /* MasteryPathViewController.storyboard */,
+				B17F27642459EDF100CD47A1 /* MasteryPathViewController.swift */,
+				B127C0ED245B2EE3008DB716 /* MasteryPathAssignmentCell.xib */,
+			);
+			path = "Mastery Paths";
 			sourceTree = "<group>";
 		};
 		B1911CE721C845E700F42F91 /* Notifications */ = {
@@ -4321,6 +4344,7 @@
 				3B4D89262450A8E9004ED120 /* ComposeReplyViewController.storyboard in Resources */,
 				5BF786A6218599B600471A5F /* InfoPlist.strings in Resources */,
 				B14707AC24379FED00CE1DBD /* LTIViewController.storyboard in Resources */,
+				B17C83292459ED4D00CE1FED /* MasteryPathViewController.storyboard in Resources */,
 				7DEAD09822789E8A0030C28A /* RichContentEditor.css in Resources */,
 				7DE3D11F225E7058000CAE7C /* RichContentToolbarView.xib in Resources */,
 				7DFFAB1A219DDB22003E71F8 /* CommentListViewController.storyboard in Resources */,
@@ -4329,11 +4353,13 @@
 				7D159CF0242E55AD00A77A15 /* ModuleListViewController.storyboard in Resources */,
 				9FBFE6D322412B9E002B3796 /* ActAsUserViewController.storyboard in Resources */,
 				B14707B92437CC9000CE1DBD /* ModuleItemSequenceViewController.storyboard in Resources */,
+				B17B3E97245A1BB300DC3318 /* MasteryPathAssignmentSetDivider.xib in Resources */,
 				7D2FADC4225BBA5600BCE19E /* RichContentEditor.js in Resources */,
 				B102EEB4243B7989002E04F0 /* ModuleItemDetailsViewController.storyboard in Resources */,
 				7DD6CC6921BCCE20004C4BB6 /* LoginFindSchoolViewController.storyboard in Resources */,
 				7DCF1ECC216BFE5D003AF358 /* Localizable.strings in Resources */,
 				7D7242622429C473007ED42F /* CourseListViewController.storyboard in Resources */,
+				B127C0EE245B2EE3008DB716 /* MasteryPathAssignmentCell.xib in Resources */,
 				B14707B52437BC1C00CE1DBD /* ExternalURLViewController.storyboard in Resources */,
 				3B4D89362450A8F4004ED120 /* ConversationListViewController.storyboard in Resources */,
 				7DBED00C232C031C00392F3C /* ProfileViewController.storyboard in Resources */,
@@ -4526,6 +4552,7 @@
 				B1F3780A22498AF1000B7CAA /* MDMManagerTests.swift in Sources */,
 				3B67BCB821B5E72000055324 /* CreateSubmissionTests.swift in Sources */,
 				B19792F7217697E30000369C /* AssignmentTests.swift in Sources */,
+				B127C0F0245B56BE008DB716 /* MasteryPathViewControllerTests.swift in Sources */,
 				3B158CBC22E267FF0039A568 /* PageViewSessionTests.swift in Sources */,
 				7DE949822385E68100B27F93 /* TodoListViewControllerTests.swift in Sources */,
 				7DF9BF082152AEF10099026B /* UIColorExtensionsTests.swift in Sources */,
@@ -5101,6 +5128,7 @@
 				7DA25F9E23F72136005D2121 /* APIAssignmentOverride.swift in Sources */,
 				7DA2609223F72315005D2121 /* UploadAvatar.swift in Sources */,
 				7DA25FCE23F72136005D2121 /* APISubmissionRequestable.swift in Sources */,
+				B17F27652459EDF100CD47A1 /* MasteryPathViewController.swift in Sources */,
 				7DA25FEB23F721DE005D2121 /* ConversationMessage.swift in Sources */,
 				7DA2604D23F722D9005D2121 /* Group.swift in Sources */,
 				3B4D893A2450A8FC004ED120 /* EditComposeRecipientsViewController.swift in Sources */,

--- a/Core/Core/API/APIModule.swift
+++ b/Core/Core/API/APIModule.swift
@@ -160,10 +160,13 @@ public struct APIModuleItemSequence: Codable, Equatable {
 
 public struct APIMasteryPath: Codable, Equatable {
     public struct AssignmentSet: Codable, Equatable {
+        public let id: ID
+        public let position: Int?
         public let assignments: [Assignment]
     }
 
     public struct Assignment: Codable, Equatable {
+        public let position: Int?
         public let model: APIAssignment
     }
 

--- a/Core/Core/API/APIModuleRequestable.swift
+++ b/Core/Core/API/APIModuleRequestable.swift
@@ -167,3 +167,22 @@ public struct PutMarkModuleItemDone: APIRequestable {
         return "\(context.pathComponent)/modules/\(moduleID)/items/\(moduleItemID)/done"
     }
 }
+
+// https://canvas.instructure.com/doc/api/modules.html#method.context_module_items_api.select_mastery_path
+public struct PostSelectMasteryPath: APIRequestable {
+    public typealias Response = APINoContent
+
+    public let courseID: String
+    public let moduleID: String
+    public let moduleItemID: String
+    public let assignmentSetID: String
+
+    public let method = APIMethod.post
+    public var path: String {
+        let context = ContextModel(.course, id: courseID)
+        return "\(context.pathComponent)/modules/\(moduleID)/items/\(moduleItemID)/select_mastery_path"
+    }
+    public var query: [APIQueryItem] {
+        return [.value("assignment_set_id", assignmentSetID)]
+    }
+}

--- a/Core/Core/Models/Assignment.swift
+++ b/Core/Core/Models/Assignment.swift
@@ -51,6 +51,7 @@ public class Assignment: NSManagedObject {
     @NSManaged public var assignmentGroup: AssignmentGroup?
     @NSManaged public var todo: Todo?
     @NSManaged public var syllabus: Syllabus?
+    @NSManaged public var masteryPathAssignment: MasteryPathAssignment?
 
     /**
      Use this property (vs. submissions) when you want the most recent submission
@@ -101,6 +102,8 @@ public class Assignment: NSManagedObject {
         guard let assignmentGroup = assignmentGroup else { return nil }
         return assignmentGroup.name
     }
+
+    public var isMasteryPathAssignment: Bool { masteryPathAssignment != nil }
 
     @discardableResult
     public static func save(_ item: APIAssignment, in context: NSManagedObjectContext, updateSubmission: Bool) -> Assignment {

--- a/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -50,6 +50,7 @@
         <relationship name="assignmentGroup" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="AssignmentGroup" inverseName="assignments" inverseEntity="AssignmentGroup"/>
         <relationship name="discussionTopic" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DiscussionTopic" inverseName="assignment" inverseEntity="DiscussionTopic"/>
         <relationship name="gradingPeriod" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="GradingPeriod" inverseName="assignments" inverseEntity="GradingPeriod"/>
+        <relationship name="masteryPathAssignment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MasteryPathAssignment" inverseName="model" inverseEntity="MasteryPathAssignment"/>
         <relationship name="rubric" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Rubric" inverseName="assignment" inverseEntity="Rubric"/>
         <relationship name="submissions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Submission" inverseName="assignment" inverseEntity="Submission"/>
         <relationship name="syllabus" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Syllabus" inverseName="assignments" inverseEntity="Syllabus"/>
@@ -320,12 +321,17 @@
         <relationship name="moduleItem" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ModuleItem" inverseName="masteryPath" inverseEntity="ModuleItem"/>
     </entity>
     <entity name="MasteryPathAssignment" representedClassName="Core.MasteryPathAssignment" syncable="YES">
+        <attribute name="courseID" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="pointsPossible" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="assignmentSet" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MasteryPathAssignmentSet" inverseName="assignments" inverseEntity="MasteryPathAssignmentSet"/>
+        <relationship name="model" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Assignment" inverseName="masteryPathAssignment" inverseEntity="Assignment"/>
     </entity>
     <entity name="MasteryPathAssignmentSet" representedClassName="Core.MasteryPathAssignmentSet" syncable="YES">
+        <attribute name="id" attributeType="String"/>
+        <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="assignments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="MasteryPathAssignment" inverseName="assignmentSet" inverseEntity="MasteryPathAssignment"/>
         <relationship name="masteryPath" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MasteryPath" inverseName="assignmentSets" inverseEntity="MasteryPath"/>
     </entity>
@@ -679,7 +685,7 @@
     <elements>
         <element name="Activity" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="AlertThreshold" positionX="-540" positionY="-27" width="128" height="118"/>
-        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="583"/>
+        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="598"/>
         <element name="AssignmentGroup" positionX="-540" positionY="-27" width="128" height="120"/>
         <element name="CalendarEventItem" positionX="-531" positionY="-18" width="128" height="163"/>
         <element name="CommonCourse" positionX="-540" positionY="-18" width="128" height="88"/>
@@ -705,8 +711,8 @@
         <element name="HelpLink" positionX="-540" positionY="-27" width="128" height="135"/>
         <element name="LogEvent" positionX="-743.51953125" positionY="192.92578125" width="128" height="90"/>
         <element name="MasteryPath" positionX="-540" positionY="-18" width="128" height="103"/>
-        <element name="MasteryPathAssignment" positionX="-522" positionY="0" width="128" height="103"/>
-        <element name="MasteryPathAssignmentSet" positionX="-531" positionY="-9" width="128" height="73"/>
+        <element name="MasteryPathAssignment" positionX="-522" positionY="0" width="128" height="148"/>
+        <element name="MasteryPathAssignmentSet" positionX="-531" positionY="-9" width="128" height="103"/>
         <element name="MediaComment" positionX="-369" positionY="-18" width="128" height="148"/>
         <element name="Module" positionX="-369" positionY="-18" width="128" height="133"/>
         <element name="ModuleItem" positionX="-540" positionY="-27" width="128" height="358"/>

--- a/Core/Core/Models/MasteryPath.swift
+++ b/Core/Core/Models/MasteryPath.swift
@@ -38,27 +38,37 @@ public class MasteryPath: NSManagedObject {
 }
 
 public class MasteryPathAssignmentSet: NSManagedObject {
+    @NSManaged public var id: String
+    @NSManaged public var position: Int
     @NSManaged public var masteryPath: MasteryPath?
     @NSManaged public var assignments: Set<MasteryPathAssignment>
 
     public static func save(_ item: APIMasteryPath.AssignmentSet, in context: NSManagedObjectContext) -> MasteryPathAssignmentSet {
         let model = context.insert() as MasteryPathAssignmentSet
-        model.assignments = Set(item.assignments.map { .save($0.model, in: context) })
+        model.id = item.id.value
+        model.assignments = Set(item.assignments.map { .save($0, in: context) })
+        model.position = item.position ?? 0
         return model
     }
 }
 
 public class MasteryPathAssignment: NSManagedObject {
     @NSManaged public var id: String
+    @NSManaged public var courseID: String
     @NSManaged public var name: String
+    @NSManaged public var position: Int
     @NSManaged public var pointsPossible: NSNumber?
     @NSManaged public var assignmentSet: MasteryPathAssignmentSet?
+    @NSManaged public var model: Assignment?
 
-    public static func save(_ item: APIAssignment, in context: NSManagedObjectContext) -> MasteryPathAssignment {
+    public static func save(_ item: APIMasteryPath.Assignment, in context: NSManagedObjectContext) -> MasteryPathAssignment {
         let model = context.insert() as MasteryPathAssignment
-        model.id = item.id.value
-        model.name = item.name
-        model.pointsPossible = NSNumber(value: item.points_possible)
+        model.position = item.position ?? 0
+        model.id = item.model.id.value
+        model.courseID = item.model.course_id.value
+        model.name = item.model.name
+        model.pointsPossible = NSNumber(value: item.model.points_possible)
+        model.model = Assignment.save(item.model, in: context, updateSubmission: false)
         return model
     }
 }

--- a/Core/Core/Models/ModuleItem.swift
+++ b/Core/Core/Models/ModuleItem.swift
@@ -43,6 +43,7 @@ public class ModuleItem: NSManagedObject {
     @NSManaged public var lockExplanation: String?
     @NSManaged public var masteryPathItem: ModuleItem?
     @NSManaged public var masteryPath: MasteryPath?
+    @NSManaged public var moduleItem: ModuleItem? // inverse of masteryPathItem
 
     public var published: Bool? {
         get { return publishedRaw?.boolValue }
@@ -128,6 +129,11 @@ public class ModuleItem: NSManagedObject {
             path.type = item.content
             path.masteryPath = MasteryPath.save(masteryPath, in: context)
             model.masteryPathItem = path
+        } else {
+            if let masteryPathItem = model.masteryPathItem {
+                context.delete(masteryPathItem)
+            }
+            model.masteryPathItem = nil
         }
         return model
     }

--- a/Core/Core/Modules/Mastery Paths/MasteryPathAssignmentCell.xib
+++ b/Core/Core/Modules/Mastery Paths/MasteryPathAssignmentCell.xib
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MasteryPathAssignmentCell" customModule="Core" customModuleProvider="target">
+            <connections>
+                <outlet property="nameLabel" destination="mJm-Y4-6rx" id="0yu-QR-6z5"/>
+                <outlet property="pointsLabel" destination="tDm-eb-rI0" id="5Fr-LW-eOw"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="Fpb-xb-lBG">
+            <rect key="frame" x="0.0" y="0.0" width="425" height="84"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+            <subviews>
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="tW6-CX-oKy">
+                    <rect key="frame" x="16" y="16" width="393" height="52"/>
+                    <subviews>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Etb-lN-yxl" customClass="IconView" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="24" height="52"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="24" id="AB7-PV-qnv"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="assignmentLine"/>
+                            </userDefinedRuntimeAttributes>
+                        </imageView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Osi-ll-ML7">
+                            <rect key="frame" x="40" y="0.0" width="321" height="52"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mJm-Y4-6rx" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="321" height="35"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="sembold16"/>
+                                    </userDefinedRuntimeAttributes>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDm-eb-rI0" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="35" width="321" height="17"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                    <userDefinedRuntimeAttributes>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
+                                        <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium14"/>
+                                    </userDefinedRuntimeAttributes>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="qmN-Wp-uBY" customClass="IconView" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="377" y="0.0" width="16" height="52"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="16" id="CUK-3X-jAs"/>
+                            </constraints>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightSolid"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="borderMedium"/>
+                            </userDefinedRuntimeAttributes>
+                        </imageView>
+                    </subviews>
+                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                </stackView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="Fug-F3-Sai" firstAttribute="trailing" secondItem="tW6-CX-oKy" secondAttribute="trailing" constant="16" id="8eJ-ho-Moo"/>
+                <constraint firstItem="tW6-CX-oKy" firstAttribute="top" secondItem="Fpb-xb-lBG" secondAttribute="top" constant="16" id="Zis-9x-Hcg"/>
+                <constraint firstItem="tW6-CX-oKy" firstAttribute="leading" secondItem="Fug-F3-Sai" secondAttribute="leading" constant="16" id="dWm-Kx-Wya"/>
+                <constraint firstAttribute="bottom" secondItem="tW6-CX-oKy" secondAttribute="bottom" constant="16" id="s6n-a6-Pbp"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="Fug-F3-Sai"/>
+            <point key="canvasLocation" x="-433" y="-111"/>
+        </view>
+    </objects>
+</document>

--- a/Core/Core/Modules/Mastery Paths/MasteryPathAssignmentSetDivider.xib
+++ b/Core/Core/Modules/Mastery Paths/MasteryPathAssignmentSetDivider.xib
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MasteryPathAssignmentSetDivider" customModule="Core" customModuleProvider="target"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="504" height="80"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Tv-BA-DfT">
+                    <rect key="frame" x="0.0" y="0.0" width="504" height="80"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VIW-Yb-q4b">
+                            <rect key="frame" x="0.0" y="0.0" width="228" height="80"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8hc-79-AqX">
+                                    <rect key="frame" x="57" y="40" width="171" height="0.5"/>
+                                    <color key="backgroundColor" name="borderMedium"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="0.5" id="bbF-Rn-idb"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstAttribute="trailing" secondItem="8hc-79-AqX" secondAttribute="trailing" id="VNL-ay-T2S"/>
+                                <constraint firstItem="8hc-79-AqX" firstAttribute="width" secondItem="VIW-Yb-q4b" secondAttribute="width" multiplier="0.75" id="xJ8-KE-kem"/>
+                            </constraints>
+                        </view>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="or" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NQz-rV-JSt" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="244" y="30.5" width="16" height="19.5"/>
+                            <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                            <nil key="textColor"/>
+                            <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium16"/>
+                            </userDefinedRuntimeAttributes>
+                        </label>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j1m-E4-hfO">
+                            <rect key="frame" x="276" y="0.0" width="228" height="80"/>
+                            <subviews>
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZsJ-CD-0N9">
+                                    <rect key="frame" x="0.0" y="40" width="172" height="0.5"/>
+                                    <color key="backgroundColor" name="borderMedium"/>
+                                    <constraints>
+                                        <constraint firstAttribute="height" constant="0.5" id="bmQ-mr-IZP"/>
+                                    </constraints>
+                                </view>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="ZsJ-CD-0N9" firstAttribute="leading" secondItem="j1m-E4-hfO" secondAttribute="leading" id="BkY-oQ-Syd"/>
+                                <constraint firstItem="ZsJ-CD-0N9" firstAttribute="width" secondItem="j1m-E4-hfO" secondAttribute="width" multiplier="0.75" constant="1" id="DLo-Fn-k7I"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <color key="backgroundColor" name="backgroundLightest"/>
+                    <constraints>
+                        <constraint firstItem="j1m-E4-hfO" firstAttribute="leading" secondItem="NQz-rV-JSt" secondAttribute="trailing" constant="16" id="851-y7-0oL"/>
+                        <constraint firstItem="NQz-rV-JSt" firstAttribute="centerY" secondItem="4Tv-BA-DfT" secondAttribute="centerY" id="Sg7-mh-qYV"/>
+                        <constraint firstItem="NQz-rV-JSt" firstAttribute="leading" secondItem="VIW-Yb-q4b" secondAttribute="trailing" constant="16" id="W3E-cS-fcD"/>
+                        <constraint firstItem="j1m-E4-hfO" firstAttribute="top" secondItem="4Tv-BA-DfT" secondAttribute="top" id="ZxQ-bz-XnE"/>
+                        <constraint firstItem="NQz-rV-JSt" firstAttribute="centerX" secondItem="4Tv-BA-DfT" secondAttribute="centerX" id="boJ-bC-w5Z"/>
+                        <constraint firstAttribute="bottom" secondItem="j1m-E4-hfO" secondAttribute="bottom" id="gdD-cv-DT3"/>
+                        <constraint firstItem="VIW-Yb-q4b" firstAttribute="top" secondItem="4Tv-BA-DfT" secondAttribute="top" id="hkb-F8-1vW"/>
+                        <constraint firstAttribute="bottom" secondItem="VIW-Yb-q4b" secondAttribute="bottom" id="im4-PG-lGH"/>
+                        <constraint firstAttribute="height" constant="80" id="jfP-UI-dUu"/>
+                        <constraint firstItem="ZsJ-CD-0N9" firstAttribute="centerY" secondItem="NQz-rV-JSt" secondAttribute="centerY" id="nJV-xR-SUG"/>
+                        <constraint firstAttribute="trailing" secondItem="j1m-E4-hfO" secondAttribute="trailing" id="nLB-30-IWv"/>
+                        <constraint firstItem="8hc-79-AqX" firstAttribute="centerY" secondItem="NQz-rV-JSt" secondAttribute="centerY" id="o2O-yE-F0n"/>
+                        <constraint firstItem="VIW-Yb-q4b" firstAttribute="leading" secondItem="4Tv-BA-DfT" secondAttribute="leading" id="s1X-45-Cpf"/>
+                    </constraints>
+                </view>
+            </subviews>
+            <constraints>
+                <constraint firstItem="4Tv-BA-DfT" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" id="5dK-4s-wmg"/>
+                <constraint firstItem="4Tv-BA-DfT" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="8vW-1F-sqP"/>
+                <constraint firstAttribute="bottom" secondItem="4Tv-BA-DfT" secondAttribute="bottom" id="WFb-tr-YVd"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="4Tv-BA-DfT" secondAttribute="trailing" id="b4O-aT-GSs"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
+            <point key="canvasLocation" x="-260.86956521739131" y="-167.41071428571428"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="backgroundLightest">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="borderMedium">
+            <color red="0.7803921568627451" green="0.80392156862745101" blue="0.81960784313725488" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Core/Core/Modules/Mastery Paths/MasteryPathViewController.storyboard
+++ b/Core/Core/Modules/Mastery Paths/MasteryPathViewController.storyboard
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Mastery Path View Controller-->
+        <scene sceneID="fXM-pV-5QQ">
+            <objects>
+                <viewController storyboardIdentifier="MasteryPathViewController" id="W0r-du-yU1" customClass="MasteryPathViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="BDS-l2-7km">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TyM-ow-38e">
+                                <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="423-1U-zxW">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="128"/>
+                                        <subviews>
+                                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CaC-Ol-a22">
+                                                <rect key="frame" x="16" y="18" width="382" height="94"/>
+                                            </stackView>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="CaC-Ol-a22" secondAttribute="bottom" constant="16" id="ChA-l3-z6G"/>
+                                            <constraint firstAttribute="height" constant="128" placeholder="YES" id="IhX-ou-ZHT"/>
+                                            <constraint firstItem="CaC-Ol-a22" firstAttribute="top" secondItem="423-1U-zxW" secondAttribute="top" constant="18" id="KJK-Wh-I07"/>
+                                            <constraint firstAttribute="trailing" secondItem="CaC-Ol-a22" secondAttribute="trailing" constant="16" id="j99-XO-lLJ"/>
+                                            <constraint firstItem="CaC-Ol-a22" firstAttribute="leading" secondItem="423-1U-zxW" secondAttribute="leading" constant="16" id="t9u-Lh-hxB"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="423-1U-zxW" firstAttribute="bottom" secondItem="tCx-w2-OoD" secondAttribute="bottom" id="EHl-uz-MnR"/>
+                                    <constraint firstItem="423-1U-zxW" firstAttribute="top" secondItem="tCx-w2-OoD" secondAttribute="top" id="UoM-35-lR0"/>
+                                    <constraint firstItem="423-1U-zxW" firstAttribute="trailing" secondItem="tCx-w2-OoD" secondAttribute="trailing" id="ikJ-zi-l8G"/>
+                                    <constraint firstItem="423-1U-zxW" firstAttribute="width" secondItem="pIG-Hi-i2L" secondAttribute="width" id="jDa-8g-OY6"/>
+                                    <constraint firstItem="423-1U-zxW" firstAttribute="leading" secondItem="tCx-w2-OoD" secondAttribute="leading" id="nsg-b4-9bm"/>
+                                </constraints>
+                                <viewLayoutGuide key="contentLayoutGuide" id="tCx-w2-OoD"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="pIG-Hi-i2L"/>
+                            </scrollView>
+                        </subviews>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <constraints>
+                            <constraint firstItem="Nho-gJ-B45" firstAttribute="bottom" secondItem="TyM-ow-38e" secondAttribute="bottom" id="ihp-uR-8p2"/>
+                            <constraint firstItem="TyM-ow-38e" firstAttribute="leading" secondItem="Nho-gJ-B45" secondAttribute="leading" id="kjT-pA-7fl"/>
+                            <constraint firstItem="Nho-gJ-B45" firstAttribute="trailing" secondItem="TyM-ow-38e" secondAttribute="trailing" id="vWC-bK-9wt"/>
+                            <constraint firstItem="TyM-ow-38e" firstAttribute="top" secondItem="Nho-gJ-B45" secondAttribute="top" id="xKy-Y8-4Yk"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="Nho-gJ-B45"/>
+                    </view>
+                    <connections>
+                        <outlet property="stackView" destination="CaC-Ol-a22" id="Q9b-ks-4if"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="3Qi-i1-5Gg" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-129" y="-136"/>
+        </scene>
+    </scenes>
+</document>

--- a/Core/Core/Modules/Mastery Paths/MasteryPathViewController.swift
+++ b/Core/Core/Modules/Mastery Paths/MasteryPathViewController.swift
@@ -1,0 +1,230 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import UIKit
+
+protocol MasteryPathDelegate: class {
+    func didSelectMasteryPath(id: String, inModule moduleID: String, item itemID: String)
+}
+
+class MasteryPathViewController: UIViewController {
+    @IBOutlet weak var stackView: UIStackView!
+    let env = AppEnvironment.shared
+    var masteryPath: MasteryPath!
+    var selectedSetID: String?
+    weak var delegate: MasteryPathDelegate?
+
+    static func create(masteryPath: MasteryPath) -> MasteryPathViewController {
+        let controller = loadFromStoryboard()
+        controller.masteryPath = masteryPath
+        return controller
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        navigationItem.title = NSLocalizedString("Select a Path", bundle: .core, comment: "")
+        let sets = masteryPath.assignmentSets.sorted { $0.position < $1.position }
+        for (index, set) in sets.enumerated() {
+            if index > 0 {
+                let or = MasteryPathAssignmentSetDivider()
+                or.translatesAutoresizingMaskIntoConstraints = false
+                stackView.addArrangedSubview(or)
+            }
+            let setView = MasteryPathAssignmentSetView(set: set)
+            setView.translatesAutoresizingMaskIntoConstraints = false
+            stackView.addArrangedSubview(setView)
+        }
+        NotificationCenter.default.addObserver(self, selector: #selector(onSelectedAssignment(_:)), name: .masteryPathAssignmentSelected, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(onSelectedSet(_:)), name: .masteryPathSelected, object: nil)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // deselect selected row
+        NotificationCenter.default.post(name: .masteryPathAssignmentSelected, object: nil, userInfo: [:])
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // notify delegate when Back triggered
+        let isGoingBack = navigationController?.viewControllers.contains(self) == false
+        if isGoingBack, let selectedSetID = selectedSetID,
+            let item = masteryPath.moduleItem,
+            let itemID = item.moduleItem?.id {
+            delegate?.didSelectMasteryPath(id: selectedSetID, inModule: item.moduleID, item: itemID)
+        }
+    }
+
+    @objc func onSelectedSet(_ notification: Notification) {
+        let id = notification.userInfo?["id"] as? String
+        if id == selectedSetID {
+            NotificationCenter.default.post(name: .masteryPathSelected, object: nil, userInfo: [:])
+        } else {
+            selectedSetID = id
+        }
+    }
+
+    @objc func onSelectedAssignment(_ notification: Notification) {
+        guard let id = notification.userInfo?["id"] as? String,
+            let courseID = masteryPath.moduleItem?.courseID
+        else { return }
+        env.router.route(to: .course(courseID, assignment: id), from: self, options: .detail)
+    }
+}
+
+class MasteryPathAssignmentSetView: UIView {
+    let stackView = UIStackView()
+    let set: MasteryPathAssignmentSet
+
+    init(set: MasteryPathAssignmentSet) {
+        self.set = set
+        super.init(frame: .zero)
+        layer.borderWidth = 1
+        layer.borderColor = UIColor.named(.borderMedium).cgColor
+        layer.cornerRadius = 12
+        backgroundColor = .named(.borderMedium)
+        addSubview(stackView)
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.pin(inside: self)
+        stackView.axis = .vertical
+        stackView.spacing = 0.5
+        for assignment in set.assignments.sorted(by: { $0.position < $1.position }) {
+            let cell = MasteryPathAssignmentCell(assignment: assignment)
+            cell.translatesAutoresizingMaskIntoConstraints = false
+            stackView.addArrangedSubview(cell)
+        }
+        let select = MasteryPathAssignmentSetSelectCell(id: set.id)
+        select.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(select)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+class MasteryPathAssignmentCell: UIView {
+    @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var pointsLabel: UILabel!
+
+    let assignment: MasteryPathAssignment
+
+    init(assignment: MasteryPathAssignment) {
+        self.assignment = assignment
+        super.init(frame: .zero)
+        loadFromXib()
+        backgroundColor = .named(.backgroundLightest)
+        let tap = UITapGestureRecognizer(target: self, action: #selector(onTap(_:)))
+        addGestureRecognizer(tap)
+        accessibilityTraits.insert(.button)
+        NotificationCenter.default.addObserver(self, selector: #selector(onAssignmentSelected(_:)), name: .masteryPathAssignmentSelected, object: nil)
+        update()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update() {
+        nameLabel.text = assignment.name
+        if let pointsPossible = assignment.pointsPossible?.doubleValue {
+            pointsLabel.isHidden = false
+            pointsLabel.text = String.localizedStringWithFormat(NSLocalizedString("g_points", bundle: .core, comment: ""), pointsPossible)
+        } else {
+            pointsLabel.isHidden = true
+        }
+    }
+
+    @objc func onTap(_ gesture: UITapGestureRecognizer) {
+        NotificationCenter.default.post(name: .masteryPathAssignmentSelected, object: nil, userInfo: ["id": assignment.id])
+    }
+
+    @objc func onAssignmentSelected(_ notification: Notification) {
+        setSelected(notification.userInfo?["id"] as? String == assignment.id)
+    }
+
+    func setSelected(_ selected: Bool) {
+        if selected {
+            backgroundColor = .named(.backgroundLight)
+            accessibilityTraits.insert(.selected)
+        } else {
+            UIView.animate(withDuration: 0.25) { self.backgroundColor = .named(.backgroundLightest) }
+            accessibilityTraits.remove(.selected)
+        }
+    }
+}
+
+class MasteryPathAssignmentSetSelectCell: UIView {
+    let button = UIButton()
+    let id: String
+
+    init(id: String) {
+        self.id = id
+        super.init(frame: .zero)
+        backgroundColor = .named(.backgroundLightest)
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.pin(inside: self, leading: 16, trailing: 16, top: 16, bottom: 16)
+        button.layer.cornerRadius = 4
+        button.contentEdgeInsets.top = 14
+        button.contentEdgeInsets.bottom = 14
+        button.titleLabel?.font = .scaledNamedFont(.semibold16)
+        button.addTarget(self, action: #selector(onSelect(_:)), for: .primaryActionTriggered)
+        update(selected: false)
+        NotificationCenter.default.addObserver(self, selector: #selector(onMasteryPathSelected(_:)), name: .masteryPathSelected, object: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(selected: Bool) {
+        button.layer.borderColor = selected ? UIColor.named(.borderMedium).cgColor : Brand.shared.buttonPrimaryBackground.cgColor
+        button.layer.borderWidth = selected ? 1 : 0
+        button.backgroundColor = selected ? .clear : Brand.shared.buttonPrimaryBackground
+        button.setTitleColor(selected ? .named(.textDark) : Brand.shared.buttonPrimaryText, for: .normal)
+        let title = selected ? NSLocalizedString("Selected!", bundle: .core, comment: "") : NSLocalizedString("Select", bundle: .core, comment: "")
+        button.setTitle(title, for: .normal)
+    }
+
+    @objc func onSelect(_ sender: UIButton) {
+        NotificationCenter.default.post(name: .masteryPathSelected, object: nil, userInfo: ["id": id])
+    }
+
+    @objc func onMasteryPathSelected(_ notification: Notification) {
+        update(selected: notification.userInfo?["id"] as? String == id)
+    }
+}
+
+class MasteryPathAssignmentSetDivider: UIView {
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        loadFromXib().backgroundColor = .named(.backgroundLightest)
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        loadFromXib().backgroundColor = .named(.backgroundLightest)
+    }
+}
+
+extension Notification.Name {
+    fileprivate static let masteryPathSelected = Notification.Name(rawValue: "com.instructure.core.notification.masteryPathSelected")
+    fileprivate static let masteryPathAssignmentSelected = Notification.Name("com.instructure.core.notification.masteryPathAssignmentSelected")
+}

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -102,9 +102,6 @@ public class ModuleListViewController: UIViewController, ColoredNavViewProtocol,
         if !store.shouldRefresh {
             scrollToModule()
         }
-
-        // TODO: remove this
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: "Reload", style: .plain, target: self, action: #selector(refreshProgress))
     }
 
     public override func viewWillAppear(_ animated: Bool) {

--- a/Core/Core/Modules/ModuleList/ModuleStore.swift
+++ b/Core/Core/Modules/ModuleList/ModuleStore.swift
@@ -119,7 +119,6 @@ class ModuleStore: NSObject {
         isLoading = true
         api.makeRequest(request) { [weak self] response, urlResponse, error in
             guard let self = self else { return }
-            self.isLoading = false
             guard let response = response else {
                 performUIUpdate {
                     self.delegate?.moduleStoreDidEncounterError(error ?? NSError.internalError())
@@ -143,6 +142,8 @@ class ModuleStore: NSObject {
                     }
                     if let next = urlResponse.flatMap({ request.getNext(from: $0) }) {
                         self.getModules(next)
+                    } else {
+                        self.isLoading = false
                     }
                 } catch {
                     self.delegate?.moduleStoreDidEncounterError(error)
@@ -155,7 +156,6 @@ class ModuleStore: NSObject {
         isLoadingModule[moduleID] = true
         api.makeRequest(request) { [weak self] response, urlResponse, error in
             guard let self = self else { return }
-            self.isLoadingModule[moduleID] = false
             guard let response = response else {
                 performUIUpdate {
                     self.delegate?.moduleStoreDidEncounterError(error ?? NSError.internalError())
@@ -180,6 +180,8 @@ class ModuleStore: NSObject {
             }
             if let next = urlResponse.flatMap({ request.getNext(from: $0) }) {
                 self.getItems(moduleID: moduleID, request: next)
+            } else {
+                self.isLoadingModule[moduleID] = false
             }
         }
     }

--- a/Core/CoreTests/Modules/MasteryPathViewControllerTests.swift
+++ b/Core/CoreTests/Modules/MasteryPathViewControllerTests.swift
@@ -1,0 +1,75 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import Core
+@testable import TestsFoundation
+import XCTest
+
+class MasteryPathViewControllerTests: CoreTestCase {
+    lazy var masteryPath = MasteryPath.save(.make(), in: databaseClient)
+    lazy var controller = MasteryPathViewController.create(masteryPath: masteryPath)
+
+    func testLayout() {
+        masteryPath = MasteryPath.save(.make(
+            locked: false,
+            assignment_sets: [
+                .make(id: "1", position: 0, assignments: [
+                    .make(position: 0, model: .make(id: "1", name: "A1", points_possible: 10)),
+                    .make(position: 1, model: .make(id: "2", course_id: "1", name: "A2")),
+                ]),
+                .make(id: "2", position: 1, assignments: [
+                    .make(position: 0, model: .make(id: "3", name: "A3")),
+                ]),
+            ],
+            selected_set_id: nil
+        ), in: databaseClient)
+        masteryPath.moduleItem = ModuleItem.make(from: .make(), forCourse: "1", in: databaseClient)
+        controller.view.layoutIfNeeded()
+        XCTAssertEqual(controller.stackView.arrangedSubviews.count, 3)
+        let option1 = controller.stackView.arrangedSubviews[0] as! MasteryPathAssignmentSetView
+        XCTAssertEqual(option1.stackView.arrangedSubviews.count, 3)
+        let assignment1 = option1.stackView.arrangedSubviews[0] as! MasteryPathAssignmentCell
+        XCTAssertEqual(assignment1.nameLabel.text, "A1")
+        XCTAssertEqual(assignment1.pointsLabel.text, "10 points")
+        let assignment2 = option1.stackView.arrangedSubviews[1] as! MasteryPathAssignmentCell
+        XCTAssertEqual(assignment2.nameLabel.text, "A2")
+        XCTAssertTrue(assignment2.accessibilityTraits.contains(.button))
+        XCTAssertFalse(assignment2.accessibilityTraits.contains(.selected))
+        assignment2.onTap(assignment2.gestureRecognizers!.first as! UITapGestureRecognizer)
+        XCTAssertTrue(router.lastRoutedTo(.course("1", assignment: "2"), withOptions: .detail))
+        XCTAssertTrue(assignment2.accessibilityTraits.contains(.selected))
+        controller.viewWillAppear(true)
+        XCTAssertFalse(assignment2.accessibilityTraits.contains(.selected))
+        let select1 = option1.stackView.arrangedSubviews[2] as! MasteryPathAssignmentSetSelectCell
+        XCTAssertEqual(select1.button.title(for: .normal), "Select")
+        select1.button.sendActions(for: .primaryActionTriggered)
+        XCTAssertEqual(select1.button.title(for: .normal), "Selected!")
+
+        XCTAssertNotNil(controller.stackView.arrangedSubviews[1] as? MasteryPathAssignmentSetDivider)
+
+        let option2 = controller.stackView.arrangedSubviews[2] as! MasteryPathAssignmentSetView
+        let select2 = option2.stackView.arrangedSubviews[1] as! MasteryPathAssignmentSetSelectCell
+        XCTAssertEqual(select2.button.title(for: .normal), "Select")
+        select2.button.sendActions(for: .primaryActionTriggered)
+        XCTAssertEqual(select2.button.title(for: .normal), "Selected!")
+        XCTAssertEqual(select1.button.title(for: .normal), "Select")
+        select2.button.sendActions(for: .primaryActionTriggered)
+        XCTAssertEqual(select2.button.title(for: .normal), "Select")
+    }
+}

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,6 +76,11 @@ PODS:
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
+    - Folly/Default (= 2018.10.22.00)
+    - glog
+  - Folly/Default (2018.10.22.00):
+    - boost-for-react-native
+    - DoubleConversion
     - glog
   - glog (0.3.5)
   - GoogleAppMeasurement (6.3.1):
@@ -558,7 +563,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   Cartography: 1988b7578871a56c036e7af17195cb2190edf18c
-  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
   Firebase: fe7f74012742ab403451dd283e6909b8f1fb348a
@@ -572,8 +577,8 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
   FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
   FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
-  Folly: de497beb10f102453a1afa9edbf8cf8a251890de
-  glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
+  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   GoogleAppMeasurement: c29d405ff76e18551b5d158eaba6753fda8c7542
   GoogleDataTransport: a857c6a002d201b524dd4bc2ed7e7355ed07e785
   GoogleDataTransportCCTSupport: 32f75fbe904c82772fcbb6b6bd4525bfb6f2a862

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -76,11 +76,6 @@ PODS:
   - Folly (2018.10.22.00):
     - boost-for-react-native
     - DoubleConversion
-    - Folly/Default (= 2018.10.22.00)
-    - glog
-  - Folly/Default (2018.10.22.00):
-    - boost-for-react-native
-    - DoubleConversion
     - glog
   - glog (0.3.5)
   - GoogleAppMeasurement (6.3.1):
@@ -563,7 +558,7 @@ SPEC CHECKSUMS:
   boost-for-react-native: 39c7adb57c4e60d6c5479dd8623128eb5b3f0f2c
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   Cartography: 1988b7578871a56c036e7af17195cb2190edf18c
-  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
+  DoubleConversion: bb338842f62ab1d708ceb63ec3d999f0f3d98ecd
   FBLazyVector: 4aab18c93cd9546e4bfed752b4084585eca8b245
   FBReactNativeSpec: 5465d51ccfeecb7faa12f9ae0024f2044ce4044e
   Firebase: fe7f74012742ab403451dd283e6909b8f1fb348a
@@ -577,8 +572,8 @@ SPEC CHECKSUMS:
   FirebaseInstallations: 575cd32f2aec0feeb0e44f5d0110a09e5e60b47b
   FirebaseInstanceID: 7ee0d6777013bb952f377b41965bf132b6a075be
   FirebaseRemoteConfig: 47abf7a04a9082091955ea555aa79cfdd249b19c
-  Folly: 30e7936e1c45c08d884aa59369ed951a8e68cf51
-  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
+  Folly: de497beb10f102453a1afa9edbf8cf8a251890de
+  glog: aefd1eb5dda2ab95ba0938556f34b98e2da3a60d
   GoogleAppMeasurement: c29d405ff76e18551b5d158eaba6753fda8c7542
   GoogleDataTransport: a857c6a002d201b524dd4bc2ed7e7355ed07e785
   GoogleDataTransportCCTSupport: 32f75fbe904c82772fcbb6b6bd4525bfb6f2a862

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -248,7 +248,7 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
     }
 
     func viewSubmissionButtonSectionIsHidden() -> Bool {
-        return assignment?.lockStatus == .before
+        return assignment?.lockStatus == .before || assignment?.isMasteryPathAssignment == true
     }
 
     func descriptionIsHidden() -> Bool {
@@ -259,7 +259,8 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
         return assignment?.lockStatus != .unlocked ||
             assignment?.lockedForUser == true ||
             assignment?.isSubmittable == false ||
-            assignment?.submission?.excused == true
+            assignment?.submission?.excused == true ||
+            assignment?.isMasteryPathAssignment == true
     }
 
     func assignmentDescription() -> String {

--- a/TestsFoundation/TestsFoundation/Fixtures/API/APIModuleFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/API/APIModuleFixture.swift
@@ -117,3 +117,22 @@ extension APIMasteryPath {
         return .init(locked: locked, assignment_sets: assignment_sets, selected_set_id: selected_set_id)
     }
 }
+
+extension APIMasteryPath.AssignmentSet {
+    public static func make(
+        id: ID = "1",
+        position: Int = 0,
+        assignments: [APIMasteryPath.Assignment] = [.make()]
+    ) -> Self {
+        return .init(id: id, position: position, assignments: assignments)
+    }
+}
+
+extension APIMasteryPath.Assignment {
+    public static func make(
+        position: Int = 0,
+        model: APIAssignment = .make()
+    ) -> Self {
+        return .init(position: position, model: model)
+    }
+}

--- a/TestsFoundation/TestsFoundation/Router/TestRouter.swift
+++ b/TestsFoundation/TestsFoundation/Router/TestRouter.swift
@@ -29,6 +29,7 @@ public class TestRouter: RouterProtocol {
         }
         return nil
     }
+    public var last: UIViewController? { viewControllerCalls.last?.0 }
     public var routes = [URLComponents: () -> UIViewController?]()
 
     public func mock(_ url: URLComponents, factory: @escaping () -> UIViewController?) {


### PR DESCRIPTION
refs: MBL-14157
affects: student
release note: none

Test plan:
* narmstrong > student15 > CS 1400 > Modules > Mastery Path
* Select a path > Tap Back
* Module list should reload with the selected path available
* **Note:** your position in the list might get messed up after
  selecting a list due to the list reloading. I will retain the scroll
  position in a separate commit