### PR TITLE
Fix a bug in SpeedGrader

### DIFF
--- a/CanvasCore/CanvasCore/PDF/CanvadocView.swift
+++ b/CanvasCore/CanvasCore/PDF/CanvadocView.swift
@@ -267,11 +267,6 @@ public class CanvadocView: UIView {
         parent?.addChild(controller)
         controller.didMove(toParent: parent)
     }
-
-    public override func removeFromSuperview() {
-        pdfViewController?.dismiss(animated: false) // avoid orphan popovers
-        super.removeFromSuperview()
-    }
 }
 
 extension CanvadocView: AnnotationStateManagerDelegate {


### PR DESCRIPTION
refs: MBL-14345
affects: teacher
release note: Fixed a bug that could cause Speed Grader to close when swiping between submissions

Something in PSPDFKit changed to cause this little hack to do very bad
things. Swiping between submissions where one or more submission uses
PSDFKit would cause Speed Grader to get dismissed.

I couldn't get any orphaned popovers to hang around so.. i dunno.

Test plan:
I was able to repro consistently with this:
- narmstrong > t
- CS 1400 > Assignments > Annotate This > All Submissions
- Tap the first user, swipe left 6+ times
- Speed Grader should not close all on its own