### PR TITLE
Fix refresh cycle in Teacher modules

### DIFF
--- a/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -353,7 +353,7 @@
         <relationship name="itemsRaw" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ModuleItem" inverseName="module" inverseEntity="ModuleItem"/>
     </entity>
     <entity name="ModuleItem" representedClassName="Core.ModuleItem" syncable="YES">
-        <attribute name="completed" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="completedRaw" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="completionRequirementTypeRaw" optional="YES" attributeType="String"/>
         <attribute name="courseID" attributeType="String"/>
         <attribute name="dueAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Core/Core/Models/ModuleItem.swift
+++ b/Core/Core/Models/ModuleItem.swift
@@ -38,7 +38,7 @@ public class ModuleItem: NSManagedObject {
     @NSManaged public var pointsPossibleRaw: NSNumber?
     @NSManaged public var completionRequirementTypeRaw: String?
     @NSManaged public var minScoreRaw: NSNumber?
-    @NSManaged public var completed: Bool
+    @NSManaged public var completedRaw: NSNumber?
     @NSManaged public var lockedForUser: Bool
     @NSManaged public var lockExplanation: String?
     @NSManaged public var masteryPathItem: ModuleItem?
@@ -82,6 +82,11 @@ public class ModuleItem: NSManagedObject {
         set { minScoreRaw = NSNumber(value: newValue) }
     }
 
+    public var completed: Bool? {
+        get { return completedRaw?.boolValue }
+        set { completedRaw = NSNumber(value: newValue) }
+    }
+
     public var completionRequirement: CompletionRequirement? {
         get {
             guard let type = completionRequirementType else { return nil }
@@ -89,7 +94,7 @@ public class ModuleItem: NSManagedObject {
         }
         set {
             completionRequirementType = newValue?.type
-            completed = newValue?.completed ?? false
+            completed = newValue?.completed
             minScore = newValue?.min_score
         }
     }

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
@@ -144,10 +144,6 @@
                                                                 <constraint firstAttribute="height" constant="24" id="cpF-JT-Qyb"/>
                                                                 <constraint firstAttribute="width" constant="24" id="eI9-xg-Kcy"/>
                                                             </constraints>
-                                                            <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="publishSolid"/>
-                                                                <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="textSuccess"/>
-                                                            </userDefinedRuntimeAttributes>
                                                         </imageView>
                                                     </subviews>
                                                     <constraints>
@@ -181,10 +177,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="CdB-fh-KOY">
-                                                    <rect key="frame" x="15" y="14" width="318" height="24.5"/>
+                                                    <rect key="frame" x="15" y="14" width="344" height="24.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Text subheader" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oQS-d3-6zu" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                            <rect key="frame" x="0.0" y="2.5" width="290" height="19.5"/>
+                                                            <rect key="frame" x="0.0" y="2.5" width="316" height="19.5"/>
                                                             <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                             <color key="textColor" red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <nil key="highlightedColor"/>
@@ -194,7 +190,7 @@
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ahp-vo-ISY" customClass="PublishedIconView" customModule="Core">
-                                                            <rect key="frame" x="294" y="0.5" width="24" height="24"/>
+                                                            <rect key="frame" x="320" y="0.5" width="24" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="24" id="jt5-oJ-Eux"/>
                                                                 <constraint firstAttribute="height" constant="24" id="zc0-hu-MBy"/>
@@ -210,7 +206,7 @@
                                                 <constraint firstItem="CdB-fh-KOY" firstAttribute="top" secondItem="SeG-X8-Qxd" secondAttribute="top" constant="14" id="U6G-wB-VYY"/>
                                                 <constraint firstAttribute="bottom" secondItem="CdB-fh-KOY" secondAttribute="bottom" constant="14" id="i6X-aL-RqN"/>
                                                 <constraint firstItem="CdB-fh-KOY" firstAttribute="leading" secondItem="SeG-X8-Qxd" secondAttribute="leadingMargin" id="nQ2-qs-fHo"/>
-                                                <constraint firstAttribute="trailing" secondItem="CdB-fh-KOY" secondAttribute="trailing" constant="42" id="ybq-Mh-lvr"/>
+                                                <constraint firstAttribute="trailing" secondItem="CdB-fh-KOY" secondAttribute="trailing" constant="16" id="ybq-Mh-lvr"/>
                                             </constraints>
                                         </tableViewCellContentView>
                                         <userDefinedRuntimeAttributes>

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
@@ -167,4 +167,22 @@ class ModuleItemDetailsViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         wait(for: [expectation], timeout: 1)
     }
+
+    func testMarkAsViewedWhenCompletedNilDoesNotPostNotification() {
+        router.mock("/?origin=module_item_details") { DetailViewController() }
+        let expectation = XCTestExpectation(description: "notification was sent when it should not have been")
+        expectation.isInverted = true
+        var token: NSObjectProtocol?
+        token = NotificationCenter.default.addObserver(forName: .moduleItemRequirementCompleted, object: nil, queue: nil) { _ in
+            NotificationCenter.default.removeObserver(token!)
+            expectation.fulfill()
+        }
+        api.mock(controller.store, value: .make(
+            id: "3",
+            url: URL(string: "/")!,
+            completion_requirement: .make(type: .must_view, completed: nil)
+        ))
+        controller.view.layoutIfNeeded()
+        wait(for: [expectation], timeout: 0.1)
+    }
 }


### PR DESCRIPTION
refs: MBL-14347
affects: teacher
release note: Fixed a bug in Modules that would cause the screen to refresh infinitely

Test plan:
* View a module item in Teacher app with a `must_view` completion requirement
* narmstrong > t > CS 1400 > Modules > Michael J Scott > Demo 1 (Discussion)
* The module item details screen should not refresh infinitely