### PR TITLE
Fix Planner for manually enrolled observers

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3370,6 +3370,7 @@
 			isa = PBXGroup;
 			children = (
 				97F69C3723F1F9A6009622E3 /* APIPlannableTests.swift */,
+				977EAC442412AA26005E1290 /* CreateTodoViewControllerTests.swift */,
 				7DD4763923FF21B500AB045C /* CalendarDaysViewControllerTests.swift */,
 				7DD4763A23FF21B500AB045C /* CalendarViewControllerTests.swift */,
 				97F69C4323F2208D009622E3 /* GetPlannablesTests.swift */,
@@ -3378,7 +3379,6 @@
 				97F69C4923F34DB1009622E3 /* PlannerListViewControllerTests.swift */,
 				7D3E522524059A740092A5F8 /* PlannerViewControllerTests.swift */,
 				97F5520724062199005D80FC /* PlannerNoteDetailViewControllerTests.swift */,
-				977EAC442412AA26005E1290 /* CreateTodoViewControllerTests.swift */,
 			);
 			path = Planner;
 			sourceTree = "<group>";

--- a/Core/Core/API/APICalendarEvent.swift
+++ b/Core/Core/API/APICalendarEvent.swift
@@ -30,6 +30,7 @@ public struct APICalendarEvent: Codable, Equatable {
     let updated_at: Date
     let workflow_state: CalendarEventWorkflowState
     let assignment: APIAssignment?
+    let description: String?
 }
 
 #if DEBUG
@@ -45,7 +46,8 @@ extension APICalendarEvent {
         created_at: Date = Clock.now,
         updated_at: Date = Clock.now,
         workflow_state: CalendarEventWorkflowState = .active,
-        assignment: APIAssignment? = nil
+        assignment: APIAssignment? = nil,
+        description: String? = nil
     ) -> APICalendarEvent {
         return APICalendarEvent(
             id: id,
@@ -58,7 +60,8 @@ extension APICalendarEvent {
             created_at: created_at,
             updated_at: updated_at,
             workflow_state: workflow_state,
-            assignment: assignment
+            assignment: assignment,
+            description: description
         )
     }
 }

--- a/Core/Core/API/APICalendarRequestable.swift
+++ b/Core/Core/API/APICalendarRequestable.swift
@@ -25,7 +25,13 @@ public struct GetCalendarEventsRequest: APIRequestable {
         case submission
     }
 
-    public let path = "calendar_events"
+    public var path: String {
+        if let userID = userID {
+            let context = ContextModel(.user, id: userID)
+            return "\(context.pathComponent)/calendar_events"
+        }
+        return "calendar_events"
+    }
     public let contexts: [Context]?
     public let startDate: Date?
     public let endDate: Date?
@@ -33,6 +39,7 @@ public struct GetCalendarEventsRequest: APIRequestable {
     public let perPage: Int
     public let include: [Include]
     public let allEvents: Bool?
+    public let userID: String?
     private static let dateFormatter: DateFormatter = {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
@@ -46,7 +53,8 @@ public struct GetCalendarEventsRequest: APIRequestable {
         type: CalendarEventType = .event,
         perPage: Int = 100,
         include: [Include] = [],
-        allEvents: Bool? = nil
+        allEvents: Bool? = nil,
+        userID: String? = nil
     ) {
         self.contexts = contexts
         self.startDate = startDate
@@ -55,6 +63,7 @@ public struct GetCalendarEventsRequest: APIRequestable {
         self.perPage = perPage
         self.include = include
         self.allEvents = allEvents
+        self.userID = userID
     }
 
     public var query: [APIQueryItem] {

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -24,6 +24,11 @@ public protocol AppEnvironmentDelegate {
 }
 
 open class AppEnvironment {
+    public enum App {
+        case parent, student, teacher
+    }
+
+    public var app: App?
     public var api: API
     public var database: NSPersistentContainer
     public var globalDatabase: NSPersistentContainer = NSPersistentContainer.shared

--- a/Core/Core/Courses/APICourse.swift
+++ b/Core/Core/Courses/APICourse.swift
@@ -170,6 +170,10 @@ public struct GetCoursesRequest: APIRequestable {
         case active, invited_or_pending, completed
     }
 
+    public enum EnrollmentType: String {
+        case teacher, student, ta, observer, designer
+    }
+
     public enum State: String {
         case available, completed, unpublished
     }
@@ -198,6 +202,7 @@ public struct GetCoursesRequest: APIRequestable {
     ]
 
     let enrollmentState: EnrollmentState?
+    let enrollmentType: EnrollmentType?
     let state: [State]?
     let include: [Include]
     let perPage: Int
@@ -205,12 +210,14 @@ public struct GetCoursesRequest: APIRequestable {
 
     public init(
         enrollmentState: EnrollmentState? = .active,
+        enrollmentType: EnrollmentType? = nil,
         state: [State]? = nil,
         include: [Include] = Self.defaultIncludes,
         perPage: Int = 10,
         studentID: String? = nil
     ) {
         self.enrollmentState = enrollmentState
+        self.enrollmentType = enrollmentType
         self.state = state
         self.include = include
         self.perPage = perPage
@@ -231,6 +238,7 @@ public struct GetCoursesRequest: APIRequestable {
             .perPage(perPage),
             .optionalValue("enrollment_state", enrollmentState?.rawValue),
             .array("state", (state ?? []).map { $0.rawValue }),
+            .optionalValue("enrollment_type", enrollmentType?.rawValue),
         ]
     }
 }

--- a/Core/Core/Planner/APIPlannable.swift
+++ b/Core/Core/Planner/APIPlannable.swift
@@ -169,7 +169,7 @@ public struct PostPlannerNoteRequest: APIRequestable {
         let details: String?
         let todo_date: Date
         let course_id: String?
-        let linked_object_type: Plannable.PlannableType?
+        let linked_object_type: PlannableType?
         let linked_object_id: String?
     }
 }

--- a/Core/Core/Planner/CreatePlannerNote.swift
+++ b/Core/Core/Planner/CreatePlannerNote.swift
@@ -30,7 +30,7 @@ public class CreatePlannerNote: APIUseCase {
         details: String? = nil,
         todoDate: Date,
         courseID: String? = nil,
-        linkedObjectType: Plannable.PlannableType = .planner_note,
+        linkedObjectType: PlannableType = .planner_note,
         linkedObjectId: String? = nil
     ) {
         request = PostPlannerNoteRequest(body: PostPlannerNoteRequest.Body(

--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -18,18 +18,82 @@
 
 import CoreData
 
-public class GetPlannables: CollectionUseCase {
+public protocol PlannableItem {
+    var plannableID: String { get }
+    var plannableType: PlannableType { get }
+    var htmlURL: URL? { get }
+    var context: Context? { get }
+    var contextName: String? { get }
+    var plannableTitle: String? { get }
+    var date: Date? { get }
+    var pointsPossible: Double? { get }
+    var details: String? { get }
+}
+
+extension APIPlannable: PlannableItem {
+    public var plannableID: String { plannable_id.value }
+    public var plannableType: PlannableType { PlannableType(rawValue: plannable_type) ?? .other }
+    public var htmlURL: URL? { html_url?.rawValue }
+    public var plannableTitle: String? { self.plannable?.title }
+    public var date: Date? { plannable_date }
+    public var pointsPossible: Double? { self.plannable?.points_possible }
+    public var details: String? { self.plannable?.details }
+    public var contextName: String? { context_name }
+    public var context: Context? {
+        guard let raw = context_type, let type = ContextType(rawValue: raw.lowercased()) else {
+            return nil
+        }
+        switch type {
+        case .course:
+            if let id = course_id?.rawValue {
+                return ContextModel(.course, id: id)
+            }
+        case .group:
+            if let id = group_id?.rawValue {
+                return ContextModel(.group, id: id)
+            }
+        case .user:
+            if let id = user_id?.rawValue {
+                return ContextModel(.user, id: id)
+            }
+        default: return nil
+        }
+        return nil
+    }
+}
+
+extension APICalendarEvent: PlannableItem {
+    public var plannableID: String { id.value }
+    public var plannableType: PlannableType {
+        if case .assignment = type { return .assignment }
+        return .calendar_event
+    }
+    public var plannableTitle: String? { title }
+    public var htmlURL: URL? { html_url }
+    public var context: Context? { ContextModel(canvasContextID: context_code) }
+    public var contextName: String? { nil }
+    public var date: Date? { start_at }
+    public var pointsPossible: Double? { assignment?.points_possible }
+    public var details: String? { description }
+
+}
+
+public class GetPlannables: UseCase {
     public typealias Model = Plannable
+    public struct Response: Codable, Equatable {
+        let plannables: [APIPlannable]?
+        let calendarEvents: [APICalendarEvent]?
+    }
 
     var userID: String?
     var startDate: Date
     var endDate: Date
-    var contextCodes: [String] = []
+    var contextCodes: [String]?
     var filter: String = ""
 
     public let syncContext: NSManagedObjectContext?
 
-    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String] = [], filter: String = "", syncContext: NSManagedObjectContext? = nil) {
+    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String]? = nil, filter: String = "", syncContext: NSManagedObjectContext? = nil) {
         self.userID = userID
         self.startDate = startDate
         self.endDate = endDate
@@ -39,7 +103,8 @@ public class GetPlannables: CollectionUseCase {
     }
 
     public var cacheKey: String? {
-        "get-plannables-\(userID ?? "")-\(startDate)-\(endDate)-\(filter)-\(contextCodes.joined(separator: ","))"
+        let codes = contextCodes?.joined(separator: ",") ?? ""
+        return "get-plannables-\(userID ?? "")-\(startDate)-\(endDate)-\(filter)-\(codes)"
     }
 
     public var scope: Scope {
@@ -60,13 +125,93 @@ public class GetPlannables: CollectionUseCase {
         return Scope(predicate: predicate, order: order)
     }
 
-    public var request: GetPlannablesRequest {
-        return GetPlannablesRequest(userID: userID, startDate: startDate, endDate: endDate, contextCodes: contextCodes, filter: filter)
+    public func reset(context: NSManagedObjectContext) {
+        let all: [Plannable] = context.fetch(scope.predicate)
+        context.delete(all)
     }
 
-    public func write(response: [APIPlannable]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
-        for p in response ?? [] {
-            Plannable.save(p, in: client, userID: userID)
+    public func makeRequest(environment: AppEnvironment, completionHandler: @escaping RequestCallback) {
+        if environment.app == .parent {
+            getObserverCalendarEvents(env: environment) { response, urlResponse, error in
+                completionHandler(Response(plannables: nil, calendarEvents: response), urlResponse, error)
+            }
+        } else {
+            let request = GetPlannablesRequest(
+                userID: userID,
+                startDate: startDate,
+                endDate: endDate,
+                contextCodes: contextCodes ?? [],
+                filter: filter
+            )
+            environment.api.makeRequest(request) { response, urlResponse, error in
+                completionHandler(Response(plannables: response, calendarEvents: nil), urlResponse, error)
+            }
         }
+    }
+
+    public func write(response: Response?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        let items: [PlannableItem] = response?.plannables ?? response?.calendarEvents ?? []
+        for item in items {
+            Plannable.save(item, userID: userID, in: client)
+        }
+    }
+
+    func getObserverCalendarEvents(env: AppEnvironment, callback: @escaping ([APICalendarEvent]?, URLResponse?, Error?) -> Void) {
+        getObserverContextCodes(env: env) { contextCodes in
+            let contexts = contextCodes.compactMap(ContextModel.init(canvasContextID:))
+            self.getCalendarEvents(env: env, contexts: contexts, type: .event) { response, urlResponse, error in
+                guard let events = response, error == nil else {
+                    callback(nil, urlResponse, error)
+                    return
+                }
+                self.getCalendarEvents(env: env, contexts: contexts, type: .assignment) { response, urlResponse, error in
+                    guard let assignments = response, error == nil else {
+                        callback(nil, urlResponse, error)
+                        return
+                    }
+                    callback(events + assignments, urlResponse, nil)
+                }
+            }
+        }
+    }
+
+    func getObserverContextCodes(env: AppEnvironment, callback: @escaping ([String]) -> Void) {
+        if let contextCodes = contextCodes { return callback(contextCodes) }
+        guard let userID = userID else { return callback(contextCodes ?? []) }
+        let request = GetCoursesRequest(
+            enrollmentState: .active,
+            enrollmentType: .observer,
+            state: [.available],
+            include: [],
+            perPage: 100
+        )
+        env.api.exhaust(request) { response, _, _ in
+            guard let courses = response else {
+                callback([])
+                return
+            }
+            var codes: [String] = []
+            for course in courses {
+                let enrollments = course.enrollments ?? []
+                for enrollment in enrollments where enrollment.associated_user_id == userID {
+                    codes.append(course.canvasContextID)
+                }
+            }
+            callback(codes)
+        }
+
+    }
+
+    func getCalendarEvents(env: AppEnvironment, contexts: [Context], type: CalendarEventType = .event, callback: @escaping ([APICalendarEvent]?, URLResponse?, Error?) -> Void) {
+        let request = GetCalendarEventsRequest(
+            contexts: contexts,
+            startDate: startDate,
+            endDate: endDate,
+            type: type,
+            include: [.submission],
+            allEvents: false,
+            userID: userID
+        )
+        env.api.exhaust(request, callback: callback)
     }
 }

--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -194,7 +194,7 @@ public class GetPlannables: UseCase {
             for course in courses {
                 let enrollments = course.enrollments ?? []
                 for enrollment in enrollments where enrollment.associated_user_id == userID {
-                    codes.append(course.canvasContextID)
+                    codes.append(ContextModel(.course, id: course.id.value).canvasContextID)
                 }
             }
             callback(codes)

--- a/Core/Core/Planner/Plannable.swift
+++ b/Core/Core/Planner/Plannable.swift
@@ -19,12 +19,12 @@
 import Foundation
 import CoreData
 
-public final class Plannable: NSManagedObject {
-    public enum PlannableType: String, Codable {
-        case announcement, assignment, discussion_topic, quiz, wiki_page, planner_note, calendar_event, assessment_request
-        case other
-    }
+public enum PlannableType: String, Codable {
+    case announcement, assignment, discussion_topic, quiz, wiki_page, planner_note, calendar_event, assessment_request
+    case other
+}
 
+public final class Plannable: NSManagedObject {
     public typealias JSON = APIPlannable
 
     @NSManaged public var id: String
@@ -51,6 +51,22 @@ public final class Plannable: NSManagedObject {
     public var context: Context? {
         get { return ContextModel(canvasContextID: canvasContextIDRaw ?? "") }
         set { canvasContextIDRaw = newValue?.canvasContextID }
+    }
+
+    @discardableResult
+    public static func save(_ item: PlannableItem, userID: String?, in client: NSManagedObjectContext) -> Plannable {
+        let model: Plannable = client.first(where: #keyPath(Plannable.id), equals: item.plannableID) ?? client.insert()
+        model.id = item.plannableID
+        model.plannableType = item.plannableType
+        model.htmlURL = item.htmlURL
+        model.contextName = item.contextName
+        model.title = item.plannableTitle
+        model.date = item.date
+        model.pointsPossible = item.pointsPossible
+        model.details = item.details
+        model.context = item.context
+        model.userID = userID
+        return model
     }
 
     @discardableResult

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -109,11 +109,11 @@ public class PlannerViewController: UIViewController {
     }
 
     func getPlannables(from: Date, to: Date) -> GetPlannables {
-        var contextCodes: [String] = []
+        var contextCodes: [String]?
         if let planner = planner, !planner.allSelected {
             contextCodes = planner.selectedCourses.map { $0.canvasContextID }
             if let studentID = studentID ?? env.currentSession?.userID {
-                contextCodes.append(ContextModel(.user, id: studentID).canvasContextID)
+                contextCodes?.append(ContextModel(.user, id: studentID).canvasContextID)
             }
         }
         return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: contextCodes, syncContext: syncContext)

--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -123,7 +123,7 @@ extension APIUseCase where Response == Request.Response {
 public protocol CollectionUseCase: APIUseCase {}
 extension CollectionUseCase where Response == Request.Response {
     public func reset(context: NSManagedObjectContext) {
-        let all: [Model] = context.fetch(self.scope.predicate)
+        let all: [Model] = context.fetch(scope.predicate)
         context.delete(all)
     }
 }

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -64,6 +64,7 @@ class CoreTestCase: XCTestCase {
         UUID.reset()
         ExperimentalFeature.allEnabled = false
         Analytics.shared.handler = analytics
+        environment.app = .student
     }
 
     override func tearDown() {

--- a/Core/CoreTests/Planner/CalendarDaysViewControllerTests.swift
+++ b/Core/CoreTests/Planner/CalendarDaysViewControllerTests.swift
@@ -42,10 +42,14 @@ class CalendarDaysViewControllerTests: CoreTestCase, CalendarViewControllerDeleg
 
     lazy var controller = CalendarDaysViewController.create(selectedDate: Clock.now, delegate: self)
 
+    func getPlannablesRequest(from: Date, to: Date) -> GetPlannablesRequest {
+        GetPlannablesRequest(startDate: from, endDate: to)
+    }
+
     func testDates() {
         Clock.mockNow(DateComponents(calendar: .current, year: 2020, month: 2, day: 14).date!)
         environment.mockStore = false
-        api.mock(getPlannables(
+        api.mock(getPlannablesRequest(
             from: DateComponents(calendar: .current, year: 2020, month: 1, day: 26).date!,
             to: DateComponents(calendar: .current, year: 2020, month: 3, day: 1).date!
         ), value: [

--- a/Core/CoreTests/Planner/PlannerNoteDetailViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerNoteDetailViewControllerTests.swift
@@ -27,7 +27,7 @@ class PlannerNoteDetailViewControllerTests: CoreTestCase {
 
     override func setUp() {
         p = Plannable.make(from: .make(
-            plannable_type: Plannable.PlannableType.planner_note.rawValue,
+            plannable_type: PlannableType.planner_note.rawValue,
             plannable: APIPlannable.plannable(
                 title: "title", details: "description"),
             plannable_date: date),

--- a/Core/CoreTests/Planner/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerViewControllerTests.swift
@@ -60,7 +60,7 @@ class PlannerViewControllerTests: CoreTestCase {
             .make(id: "1", name: "BIO 101", enrollments: [.make(associated_user_id: "1")]),
             .make(id: "2", name: "BIO 102", enrollments: [.make(associated_user_id: "1")]),
         ])
-        XCTAssertEqual(controller.list.plannables?.useCase.contextCodes, []) // planner nil
+        XCTAssertNil(controller.list.plannables?.useCase.contextCodes) // planner nil
         XCTAssertEqual(controller.calendar.filterButton.title(for: .normal), "Calendars")
         controller.calendar.delegate?.calendarWillFilter()
         var filter = router.presented as! PlannerFilterViewController
@@ -68,10 +68,10 @@ class PlannerViewControllerTests: CoreTestCase {
         filter.tableView.delegate?.tableView?(filter.tableView!, didSelectRowAt: IndexPath(row: 0, section: 0))
         router.dismiss()
         XCTAssertEqual(controller.calendar.filterButton.title(for: .normal), "Calendars (1)")
-        XCTAssert(controller.calendar.days.plannables?.useCase.contextCodes.contains("course_2") == true)
-        XCTAssert(controller.list.plannables?.useCase.contextCodes.contains("course_2") == true)
-        XCTAssert(controller.calendar.days.plannables?.useCase.contextCodes.contains("user_1") == true)
-        XCTAssert(controller.list.plannables?.useCase.contextCodes.contains("user_1") == true)
+        XCTAssert(controller.calendar.days.plannables?.useCase.contextCodes!.contains("course_2") == true)
+        XCTAssert(controller.list.plannables?.useCase.contextCodes!.contains("course_2") == true)
+        XCTAssert(controller.calendar.days.plannables?.useCase.contextCodes!.contains("user_1") == true)
+        XCTAssert(controller.list.plannables?.useCase.contextCodes!.contains("user_1") == true)
 
         // select all calendars
         controller.calendar.filterButton.sendActions(for: .primaryActionTriggered)
@@ -79,7 +79,7 @@ class PlannerViewControllerTests: CoreTestCase {
         filter.view.layoutIfNeeded()
         filter.tableView.delegate?.tableView?(filter.tableView!, didSelectRowAt: IndexPath(row: 0, section: 0))
         router.dismiss()
-        XCTAssertEqual(controller.list.plannables?.useCase.contextCodes, []) // all selected
+        XCTAssertNil(controller.list.plannables?.useCase.contextCodes) // all selected
 
         let height: CGFloat = controller.calendar.maxHeight
         controller.calendar.delegate?.calendarDidResize(height: height, animated: false)

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -35,6 +35,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         let env = AppEnvironment.shared
         env.router = router
         env.loginDelegate = self
+        env.app = .parent
         return env
     }()
 

--- a/Student/Student/CanvasAppDelegate.swift
+++ b/Student/Student/CanvasAppDelegate.swift
@@ -33,6 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
         let env = AppEnvironment.shared
         env.loginDelegate = self
         env.router = router
+        env.app = .student
         return env
     }()
 

--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -33,6 +33,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         let env = AppEnvironment.shared
         env.router = Teacher.router
         env.loginDelegate = self
+        env.app = .teacher
         return env
     }()
 


### PR DESCRIPTION
refs: MBL-14321
affects: parent
release note: Fixed Calendar for manually enrolled observers

Test plan:
* Log in as user from [KNO-403](https://instructure.atlassian.net/browse/KNO-403)
* April 10 and 11 should show planner items
* Use the Calendar filter to remove the only calendar
* April 10 and 11 events should be removed