### PR TITLE
Remove native support for file upload questions

### DIFF
--- a/CanvasCore/CanvasCore/Quizzes/Quiz Details/Controllers/QuizTakeabilityController.swift
+++ b/CanvasCore/CanvasCore/Quizzes/Quiz Details/Controllers/QuizTakeabilityController.swift
@@ -31,7 +31,7 @@ class QuizTakeabilityController {
     /// This is the list of question types that is supported natively. 
     /// This will change as we add support for more question types.
     fileprivate var nativelySupportedQuestionTypes: [Question.Kind] {
-        return [ .TrueFalse, .MultipleChoice, .MultipleAnswers, .Matching, .Essay, .ShortAnswer, .TextOnly, .Numerical, .FileUpload, .MultipleDropdowns ]
+        return [ .TrueFalse, .MultipleChoice, .MultipleAnswers, .Matching, .Essay, .ShortAnswer, .TextOnly, .Numerical, .MultipleDropdowns ]
     }
     
     init(quiz: Quiz, service: QuizService) {


### PR DESCRIPTION
refs: MBL-14308
affects: student
release note: Fixed uploading files in quizzes by showing quizzes with file-upload questions in a web view

Test plan:
- see ticket
- quiz should launch in a web view