### PR TITLE
Fix 'Show Grades' option

### DIFF
--- a/CanvasCore/CanvasCore.xcodeproj/project.pbxproj
+++ b/CanvasCore/CanvasCore.xcodeproj/project.pbxproj
@@ -424,6 +424,8 @@
 		B196F79B206AB60400DE640F /* CoreDataSync.m in Sources */ = {isa = PBXBuildFile; fileRef = B196F79A206AB60400DE640F /* CoreDataSync.m */; };
 		B1A6BC94218CAB51000515E3 /* SessionToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1A6BC93218CAB51000515E3 /* SessionToken.swift */; };
 		B1BE249720AB13FE00C521C3 /* SafariActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1BE249620AB13FE00C521C3 /* SafariActivity.swift */; };
+		B1C316FF2463348700CA368C /* NativeUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = B1C316FE2463348700CA368C /* NativeUserDefaults.m */; };
+		B1C317012463371300CA368C /* NativeUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C317002463371300CA368C /* NativeUserDefaults.swift */; };
 		B1C3407820D1AD3B00D0554D /* ModuleItemsProgress.m in Sources */ = {isa = PBXBuildFile; fileRef = B1C3407720D1AD3B00D0554D /* ModuleItemsProgress.m */; };
 		B1CA05061FE448F300B7D5AA /* NativeNotificationCenter.h in Headers */ = {isa = PBXBuildFile; fileRef = B1CA05041FE448F300B7D5AA /* NativeNotificationCenter.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B1CA05071FE448F300B7D5AA /* NativeNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = B1CA05051FE448F300B7D5AA /* NativeNotificationCenter.m */; };
@@ -958,6 +960,8 @@
 		B196F79A206AB60400DE640F /* CoreDataSync.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CoreDataSync.m; sourceTree = "<group>"; };
 		B1A6BC93218CAB51000515E3 /* SessionToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionToken.swift; sourceTree = "<group>"; };
 		B1BE249620AB13FE00C521C3 /* SafariActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariActivity.swift; sourceTree = "<group>"; };
+		B1C316FE2463348700CA368C /* NativeUserDefaults.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NativeUserDefaults.m; sourceTree = "<group>"; };
+		B1C317002463371300CA368C /* NativeUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeUserDefaults.swift; sourceTree = "<group>"; };
 		B1C3407720D1AD3B00D0554D /* ModuleItemsProgress.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ModuleItemsProgress.m; sourceTree = "<group>"; };
 		B1CA05041FE448F300B7D5AA /* NativeNotificationCenter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = NativeNotificationCenter.h; path = "CanvasCore/React Native Modules/NativeNotificationCenter.h"; sourceTree = SOURCE_ROOT; };
 		B1CA05051FE448F300B7D5AA /* NativeNotificationCenter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = NativeNotificationCenter.m; path = "CanvasCore/React Native Modules/NativeNotificationCenter.m"; sourceTree = SOURCE_ROOT; };
@@ -1393,6 +1397,8 @@
 				7D6410EB2280B74E008FA345 /* NativeLoginManager.swift */,
 				B1CA05041FE448F300B7D5AA /* NativeNotificationCenter.h */,
 				B1CA05051FE448F300B7D5AA /* NativeNotificationCenter.m */,
+				B1C317002463371300CA368C /* NativeUserDefaults.swift */,
+				B1C316FE2463348700CA368C /* NativeUserDefaults.m */,
 				494AE0931F843A02001A8F31 /* PushNotifications.h */,
 				494AE0941F843A03001A8F31 /* PushNotifications.m */,
 				9FBD22DB2264D001007E48E6 /* QLPreviewManager.h */,
@@ -2676,6 +2682,7 @@
 				49CE96A11F8FF4A700121A43 /* ProgressDispatcher.swift in Sources */,
 				4961F5D71F8FB3EB0093EC86 /* FetchedDetailsCollection.swift in Sources */,
 				490F91F11FB0F94A00A7DA38 /* CanvasWebViewController.swift in Sources */,
+				B1C316FF2463348700CA368C /* NativeUserDefaults.m in Sources */,
 				9FB85499208677DB007499DA /* AdjustableManager.m in Sources */,
 				497CA77B1F82D19A00501613 /* UIUserInterfaceSizeClassExtensions.swift in Sources */,
 				4961F5EA1F8FB4030093EC86 /* SynchronizedModel.swift in Sources */,
@@ -2752,6 +2759,7 @@
 				4961F63E1F8FB71B0093EC86 /* Tab+Collections.swift in Sources */,
 				4961F5431F8FAD9A0093EC86 /* WhizzyWigViewController.swift in Sources */,
 				49CE967D1F8FF41B00121A43 /* NextOrSubmitView.swift in Sources */,
+				B1C317012463371300CA368C /* NativeUserDefaults.swift in Sources */,
 				7D52D87822FCC73100684932 /* SubmissionAPI.swift in Sources */,
 				493020791F902462006BD777 /* ContextID.swift in Sources */,
 				497CA7721F82D19600501613 /* HelmNavigationController.swift in Sources */,

--- a/CanvasCore/CanvasCore/React Native Modules/NativeUserDefaults.m
+++ b/CanvasCore/CanvasCore/React Native Modules/NativeUserDefaults.m
@@ -1,0 +1,66 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#import <Foundation/Foundation.h>
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
+#import <CanvasCore/CanvasCore-Swift.h>
+@import React;
+
+@interface NativeUserDefaultsReact: RCTEventEmitter
+@property (nonatomic, strong) NSObject *token;
+@end
+
+@implementation NativeUserDefaultsReact
+RCT_EXPORT_MODULE(UserDefaults);
+
++ (NativeUserDefaultsReact *)sharedInstance {
+    static dispatch_once_t onceToken;
+    static NativeUserDefaultsReact *_sharedInstance;
+    dispatch_once(&onceToken, ^{
+        _sharedInstance = [[NativeUserDefaultsReact alloc] initActual];
+    });
+    return _sharedInstance;
+}
+
+- (instancetype)init {
+    self = [NativeUserDefaultsReact sharedInstance];
+    return self;
+}
+
+- (instancetype)initActual {
+    self = [super init];
+    self.token = [[NSNotificationCenter defaultCenter] addObserverForName:NSUserDefaultsDidChangeNotification object:nil queue:nil usingBlock:^(NSNotification * _Nonnull note) {
+        [self sendEventWithName:NSUserDefaultsDidChangeNotification body:nil];
+    }];
+    return self;
+}
+
+- (NSDictionary *)constantsToExport {
+    return @{ @"didChangeNotification": NSUserDefaultsDidChangeNotification };
+}
+
+RCT_REMAP_METHOD(getShowGradesOnDashboard, resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+    resolve(@([NativeUserDefaults showGradesOnDashboard]));
+}
+
+- (dispatch_queue_t)methodQueue { return dispatch_get_main_queue(); }
++ (BOOL)requiresMainQueueSetup { return YES; }
+- (NSArray<NSString *> *)supportedEvents { return @[NSUserDefaultsDidChangeNotification]; }
+
+@end

--- a/CanvasCore/CanvasCore/React Native Modules/NativeUserDefaults.swift
+++ b/CanvasCore/CanvasCore/React Native Modules/NativeUserDefaults.swift
@@ -1,0 +1,27 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Core
+
+public class NativeUserDefaults: NSObject {
+    @objc
+    public static var showGradesOnDashboard: Bool {
+        AppEnvironment.shared.userDefaults?.showGradesOnDashboard == true
+    }
+}

--- a/Core/Core/AppEnvironment/CacheManager.swift
+++ b/Core/Core/AppEnvironment/CacheManager.swift
@@ -55,7 +55,6 @@ public class CacheManager {
 
     public static func clear() {
         URLCache.shared.removeAllCachedResponses()
-        clearAppGroup(Bundle.main.appGroupID())
         clearAppGroup("group.com.instructure.Contexts") // LocalStoreAppGroupName
         clearCaches()
         clearLibrary()
@@ -64,12 +63,13 @@ public class CacheManager {
     }
 
     public static func clearAppGroup(_ id: String?) {
-        guard let id = id, let folder = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: id) else { return }
+        guard let id = id, let folder = URL.sharedContainer(id) else { return }
         clearDirectory(folder)
     }
 
     public static func clearCaches() {
-        clearDirectory(.cachesDirectory)
+        clearDirectory(.cachesDirectory(appGroup: nil))
+        clearDirectory(.cachesDirectory(appGroup: Bundle.main.appGroupID()))
     }
 
     public static func clearLibrary() {

--- a/Core/Core/Extensions/NSPersistentContainerExtensions.swift
+++ b/Core/Core/Extensions/NSPersistentContainerExtensions.swift
@@ -52,15 +52,7 @@ extension NSPersistentContainer {
     }
 
     public static func databaseURL(for appGroup: String?, session: LoginSession?) -> URL? {
-        var folder = URL.cachesDirectory
-
-        if let appGroup = appGroup {
-            guard let appGroupFolder = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroup) else {
-                return nil
-            }
-            folder = appGroupFolder
-        }
-
+        let folder = URL.cachesDirectory(appGroup: appGroup)
         var fileName = "Database.sqlite"
         if let host = session?.baseURL.host, let userID = session?.userID {
             fileName = "Database-\(host)-\(userID).sqlite"

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -27,6 +27,15 @@ extension URL {
         return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)[0]
     }
 
+    public static func cachesDirectory(appGroup: String?) -> URL {
+        var folder = URL.cachesDirectory
+        if let appGroup = appGroup, let group = sharedContainer(appGroup) {
+            folder = group.appendingPathComponent("caches", isDirectory: true)
+            try? FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)
+        }
+        return folder
+    }
+
     public static var documentsDirectory: URL {
         return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
     }

--- a/Core/Core/Profile/ProfileViewController.swift
+++ b/Core/Core/Profile/ProfileViewController.swift
@@ -180,10 +180,6 @@ public class ProfileViewController: UIViewController {
             cells.append(ProfileViewCell("showGrades", type: .toggle(showGrades), name: NSLocalizedString("Show Grades", bundle: .core, comment: "")) { [weak self] cell in
                 let showGrades = (cell.accessoryView as? UISwitch)?.isOn == true
                 self?.env.userDefaults?.showGradesOnDashboard = showGrades
-                NotificationCenter.default.post(name: NSNotification.Name("redux-action"), object: nil, userInfo: [
-                    "type": "userInfo.updateShowGradesOnDashboard",
-                    "payload": [ "showsGradesOnCourseCards": showGrades ],
-                ])
             })
         }
 

--- a/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
@@ -74,6 +74,7 @@ class CacheManagerTests: CoreTestCase {
 
     func testClearNeeded() {
         UserDefaults.standard.set(-1, forKey: "lastDeletedAt")
+        environment.userDefaults?.showGradesOnDashboard = true
         let cache = write("cache", in: .cachesDirectory)
         let doc = write("doc", in: .documentsDirectory)
         CacheManager.clearIfNeeded()
@@ -81,6 +82,7 @@ class CacheManagerTests: CoreTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: doc.path))
         XCTAssertEqual(UserDefaults.standard.integer(forKey: "lastDeletedAt"), CacheManager.bundleVersion)
         try? FileManager.default.removeItem(at: doc)
+        XCTAssertEqual(environment.userDefaults?.showGradesOnDashboard, true)
     }
 
     func testClearRNAsyncStorage() {

--- a/Core/CoreTests/Extensions/URLExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLExtensionsTests.swift
@@ -49,6 +49,16 @@ class URLExtensionsTests: XCTestCase {
 
     func testCachesDirectory() {
         XCTAssertEqual(URL.cachesDirectory, fs.urls(for: .cachesDirectory, in: .userDomainMask)[0])
+        XCTAssertEqual(URL.cachesDirectory, URL.cachesDirectory(appGroup: nil))
+    }
+
+    func testAppGroupCachesDirectory() {
+        let expected = URL.sharedContainer("group.instructure.shared")!.appendingPathComponent("caches", isDirectory: true)
+        let url = URL.cachesDirectory(appGroup: "group.instructure.shared")
+        XCTAssertEqual(url, expected)
+        var isDir: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir))
+        XCTAssertTrue(isDir.boolValue)
     }
 
     func testDocumentsDirectory() {

--- a/Core/CoreTests/Profile/ProfileViewControllerTests.swift
+++ b/Core/CoreTests/Profile/ProfileViewControllerTests.swift
@@ -30,6 +30,11 @@ class ProfileViewControllerTests: CoreTestCase, LoginDelegate {
         notificationPayload = notification.userInfo
     }
 
+    var defaultsDidChange = false
+    func userDefaultsDidChange(notification: Notification) {
+        defaultsDidChange = true
+    }
+
     var externalURL: URL?
     func openExternalURL(_ url: URL) {
         externalURL = url
@@ -65,6 +70,7 @@ class ProfileViewControllerTests: CoreTestCase, LoginDelegate {
 
         let n = NSNotification.Name("redux-action")
         NotificationCenter.default.addObserver(self, selector: #selector(reduxActionCalled(notification:)), name: n, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(userDefaultsDidChange(notification:)), name: UserDefaults.didChangeNotification, object: nil)
     }
 
     func testLayout() {
@@ -91,18 +97,14 @@ class ProfileViewControllerTests: CoreTestCase, LoginDelegate {
         (cell?.accessoryView as? UISwitch)?.isOn = !existingValue
         (cell?.accessoryView as? UISwitch)?.sendActions(for: .valueChanged)
         XCTAssertEqual(environment.userDefaults?.showGradesOnDashboard, !existingValue)
-        XCTAssertNotNil(notificationPayload)
-        var type: String? = notificationPayload?["type"] as? String
-        var payload: [String: Bool]? = notificationPayload?["payload"] as? [String: Bool]
-        XCTAssertEqual(type, "userInfo.updateShowGradesOnDashboard")
-        XCTAssertEqual(payload?["showsGradesOnCourseCards"], !existingValue)
+        XCTAssertTrue(defaultsDidChange)
 
         index = IndexPath(row: 2, section: 0)
         cell = controller.tableView.cellForRow(at: index) as? ProfileTableViewCell
         XCTAssertEqual(cell?.nameLabel.text, "Color Overlay")
         controller.tableView(controller.tableView, didSelectRowAt: index)
-        type = notificationPayload?["type"] as? String
-        payload = notificationPayload?["payload"] as? [String: Bool]
+        let type = notificationPayload?["type"] as? String
+        let payload = notificationPayload?["payload"] as? [String: Bool]
         XCTAssertEqual(type, "userInfo.updateUserSettings")
         XCTAssertEqual(payload?["hideOverlay"], true)
 

--- a/rn/Teacher/test/scripts/jestSetup.js
+++ b/rn/Teacher/test/scripts/jestSetup.js
@@ -313,6 +313,11 @@ NativeModules.ModuleItemsProgress = {
   contributedDiscussion: jest.fn(),
 }
 
+NativeModules.UserDefaults = {
+  didChangeNotification: 'NSUserDefaultsDidChangeNotification',
+  getShowGradesOnDashboard: jest.fn(() => Promise.resolve(false)),
+}
+
 jest.mock('../../src/common/components/AuthenticatedWebView', () => 'AuthenticatedWebView')
 jest.mock('../../src/common/components/A11yGroup', () => 'A11yGroup')
 

--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -17,7 +17,8 @@
     "Student\/GradesWidget\/",
     "UITestHelpers\/",
     "rn/Teacher\/src\/modules\/graphql-speed-grader\/",
-    "SubmissionButtonPresenter.swift"
+    "SubmissionButtonPresenter.swift",
+    "NSPersistentContainerExtensions.swift"
   ],
   "fileMinCoverage": 0.5,
   "totalMinCoverage": 0.9


### PR DESCRIPTION
I had to update the CacheManager to not blow away everything in the
`Bundle.main.appGroupID()` container because that includes shared
UserDefaults which is where `SessionDefault`s are stored including this
flag.

Instead, CacheManager only deletes the newly added `caches/` directory
in the App Group. Core Data files are now stored in that caches
directory instead of at the root.

refs: MBL-14332
affects: student
release note: Fixed a bug that would cause the 'Show Grades' option to reset

Test plan:
- Checkout the changes locally
- Build and run the app
- From the global nav, toggle 'Show Grades' to On
- Change the build number of Student in Xcode
- Build and run again
- Grades on dashboard should still be shown