### PR TITLE
Fix Studio videos embedded in RCE for non-US

### DIFF
--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -204,8 +204,8 @@ open class CoreWebView: WKWebView {
                     if (match.length == 2) {
                         const mediaID = match[1]
                         const video = document.createElement('video')
-                        video.src = 'https://canvas.instructure.com/users/self/media_download?entryId='+mediaID+'&media_type=video&redirect=1'
-                        video.setAttribute('poster', 'https://canvas.instructure.com/media_objects/'+mediaID+'/thumbnail?width=550&height=448')
+                        video.src = '/users/self/media_download?entryId='+mediaID+'&media_type=video&redirect=1'
+                        video.setAttribute('poster', '/media_objects/'+mediaID+'/thumbnail?width=550&height=448')
                         video.setAttribute('controls', '')
                         video.setAttribute('preload', 'none')
                         iframe.parentNode.parentNode.replaceChild(video, iframe.parentNode)


### PR DESCRIPTION
refs: MBL-14354
affects: teacher, student
release notes: Fixed a but that could prevent Studio videos from playing

Test plan:
* Log in to Student as siteadmin
* Masquerade as user 13716 on `jcatibog.instructure.com`
* Course > Pages > new rce test
* Studio video should be playable