### PR TITLE
Show submission on submission details when user has submitted and assignment is locked.

### DIFF
--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -286,7 +286,9 @@ class SubmissionDetailsPresenter: PageViewLoggerPresenterProtocol {
 
     func lockedEmptyViewIsHidden() -> Bool {
         if let assignment = assignment.first {
-            return assignment.lockExplanation == nil && !(assignment.lockedForUser)
+            let isHidden = ( assignment.lockExplanation == nil && !(assignment.lockedForUser) )
+                || (assignment.submission != nil && assignment.submission?.workflowState != .unsubmitted)
+            return isHidden
         }
         return true
     }

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
@@ -339,6 +339,19 @@ class SubmissionDetailsPresenterTests: StudentTestCase {
         XCTAssertTrue( presenter.lockedEmptyViewIsHidden() )
     }
 
+    func testLockedEmptyViewIsHiddenWithUntilDateInThePast() {
+        Assignment.make(from: .make(
+            submission: .make(id: "1", assignment_id: "1", user_id: 1, workflow_state: SubmissionWorkflowState.submitted),
+            submission_types: [ .online_upload ],
+            allowed_extensions: ["png"],
+            lock_at: Date().addDays(-5),
+            locked_for_user: true,
+            lock_explanation: "this is locked"
+            )
+        )
+        XCTAssertTrue( presenter.lockedEmptyViewIsHidden() )
+    }
+
     func testLockedEmptyViewHeaderWithQuiz() {
         Assignment.make(from: .make(quiz_id: "1",
                                     submission_types: [ .online_upload ],


### PR DESCRIPTION
refs: MBL-14381
affects: Student
release note: none