### PR TITLE
Fix loading canvas files in iframes in pages

### DIFF
--- a/Core/Core/Views/CoreWebView.swift
+++ b/Core/Core/Views/CoreWebView.swift
@@ -84,7 +84,7 @@ open class CoreWebView: WKWebView {
     func loadFrame(src: String) {
         let url = URL(string: src)
         let request = GetWebSessionRequest(to: url)
-        AppEnvironment.shared.api.makeRequest(request) { [weak self] response, urlResponse, error in performUIUpdate {
+        AppEnvironment.shared.api.makeRequest(request) { [weak self] response, _, _ in performUIUpdate {
             guard let response = response else { return }
             self?.load(URLRequest(url: response.session_url))
         } }


### PR DESCRIPTION
This hack lives on, unfortunately.

refs: MBL-14360
affects: student, teacher
release note: Fixed loading html files in Pages

Test plan: see ticket