### PR TITLE
Fix showing upload status on assignment details

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -221,6 +221,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
             return
         case .completed:
+            fileSubmissionButton?.isHidden = true
             if let nav = presentedViewController as? UINavigationController, let filePicker = nav.viewControllers.first as? FilePickerViewController {
                 filePicker.dismiss(animated: true, completion: nil)
             }
@@ -255,7 +256,9 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
         lockedSection?.isHidden = presenter.lockedSectionIsHidden()
         fileTypesSection?.isHidden = presenter.fileTypesSectionIsHidden()
         submissionTypesSection?.isHidden = presenter.submissionTypesSectionIsHidden()
-        let showGradeSection = assignment.submission?.needsGrading == true || assignment.submission?.isGraded == true
+        let showGradeSection = assignment.submission?.needsGrading == true ||
+            assignment.submission?.isGraded == true ||
+            presenter.onlineUploadState != nil
         gradeSection?.isHidden = !showGradeSection
         submissionButtonSection?.isHidden = presenter.viewSubmissionButtonSectionIsHidden()
         showDescription(!presenter.descriptionIsHidden())

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
@@ -164,7 +164,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         XCTAssertTrue(viewController.gradeSection?.isHidden == true)
     }
 
-    func testUpdateGradeCelWorkflowStateUnsubmitted() {
+    func testUpdateGradeCellWorkflowStateUnsubmitted() {
         mockCourse()
         let a = APIAssignment.make( submission: .make(
         grade: "10",
@@ -178,7 +178,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         XCTAssertTrue(viewController.gradeSection?.isHidden == true)
     }
 
-    func testUpdateGradeCelWorkflowStateNeedsGrading() {
+    func testUpdateGradeCellWorkflowStateNeedsGrading() {
         mockCourse()
         let assignment = APIAssignment.make(
             id: ID(assignmentID),
@@ -201,6 +201,25 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
             score: 10,
             submission_type: .online_text_entry,
             workflow_state: .graded))
+
+        setupFileForSubmittedLabel(uploadError: "error", apiAssignment: aa)
+        load()
+
+        XCTAssertEqual(viewController.submittedLabel?.text, "Submission Failed")
+        XCTAssertEqual(viewController.gradeSection?.isHidden, false)
+        XCTAssertEqual(viewController.gradeCellDivider?.isHidden, false)
+        XCTAssertEqual(viewController.gradedView?.isHidden, true)
+        XCTAssertEqual(viewController.submittedView?.isHidden, false)
+        XCTAssertEqual(viewController.fileSubmissionButton?.isHidden, false)
+        XCTAssertEqual(viewController.submittedDetailsLabel?.isHidden, true)
+    }
+
+    func testUpdateGradeCellWhenThereIsUploadStateAndUnsubmitted() {
+        let aa = APIAssignment.make(submission: .make(
+            grade: "10",
+            score: 10,
+            submission_type: .online_text_entry,
+            workflow_state: .unsubmitted))
 
         setupFileForSubmittedLabel(uploadError: "error", apiAssignment: aa)
         load()


### PR DESCRIPTION
refs: MBL-14392
affects: student
release note: Fixed file upload status on assignment details page

Test plan:
- narmstrong > s
- Use the Photos app and the Student share extension to submit a photo to the CS 1400 > iWork assignment
- View the iWork assignment in the Student app
- It should display a submission error