### PR TITLE
Add activity indicator to create account button.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -62,6 +62,8 @@
 		3BA9FF752332B05700196A06 /* GradingPeriodRequestableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9FF742332B05700196A06 /* GradingPeriodRequestableTests.swift */; };
 		3BA9FF792332B39700196A06 /* GradingPeriodUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9FF782332B39700196A06 /* GradingPeriodUseCaseTests.swift */; };
 		3BC3E0202315A2BC00E15C6D /* AnalyticsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC3E01F2315A2BC00E15C6D /* AnalyticsTests.swift */; };
+		3BC50CC7246CA0AF0023159F /* ActivityIndicatorButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC50CC6246CA0AF0023159F /* ActivityIndicatorButton.swift */; };
+		3BC50CC9246CA1F70023159F /* ActivtyIndicatorButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC50CC8246CA1F70023159F /* ActivtyIndicatorButtonTests.swift */; };
 		3BCDACF824536B9E00E41D27 /* ConversationsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BCDACF724536B9E00E41D27 /* ConversationsViewController.swift */; };
 		3BD364AB225D3C02006CEBD8 /* DiscussionTopicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD364AA225D3C02006CEBD8 /* DiscussionTopicTests.swift */; };
 		3BD364AF225E36FC006CEBD8 /* CalendarEventItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BD364AE225E36FC006CEBD8 /* CalendarEventItemTests.swift */; };
@@ -1088,6 +1090,8 @@
 		3BA9FF7C2332B43C00196A06 /* GradingPeriod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradingPeriod.swift; sourceTree = "<group>"; };
 		3BC3E01C2315A0DE00E15C6D /* Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Analytics.swift; sourceTree = "<group>"; };
 		3BC3E01F2315A2BC00E15C6D /* AnalyticsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTests.swift; sourceTree = "<group>"; };
+		3BC50CC6246CA0AF0023159F /* ActivityIndicatorButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIndicatorButton.swift; sourceTree = "<group>"; };
+		3BC50CC8246CA1F70023159F /* ActivtyIndicatorButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivtyIndicatorButtonTests.swift; sourceTree = "<group>"; };
 		3BCDACF724536B9E00E41D27 /* ConversationsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationsViewController.swift; sourceTree = "<group>"; };
 		3BD364AA225D3C02006CEBD8 /* DiscussionTopicTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionTopicTests.swift; sourceTree = "<group>"; };
 		3BD364AE225E36FC006CEBD8 /* CalendarEventItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarEventItemTests.swift; sourceTree = "<group>"; };
@@ -2687,6 +2691,7 @@
 				7D1758B521598CA400F88613 /* TitleSubtitleView.xib */,
 				9767F2972383B846006633CA /* TokenLabelView.swift */,
 				3BA649D6242530470047D8DC /* NotificationView.swift */,
+				3BC50CC6246CA0AF0023159F /* ActivityIndicatorButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2713,6 +2718,7 @@
 				7D303DE72412F9AB001F5F36 /* PagesViewControllerTests.swift */,
 				B16E05E3242529D4006B6ADB /* ScannerViewControllerTests.swift */,
 				7D1758C7215A9A7800F88613 /* TitleSubtitleViewTests.swift */,
+				3BC50CC8246CA1F70023159F /* ActivtyIndicatorButtonTests.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -4563,6 +4569,7 @@
 				7D80AC19212B697600C40ECE /* APIGroupRequestableTests.swift in Sources */,
 				7D2DC31B219CE469008FE29A /* DocViewerSessionTests.swift in Sources */,
 				7D5762A023849D46001F980D /* APITodoTests.swift in Sources */,
+				3BC50CC9246CA1F70023159F /* ActivtyIndicatorButtonTests.swift in Sources */,
 				B1571E69230756D2009CAA58 /* APIFeatureFlagsRequestableTests.swift in Sources */,
 				B195DC622133326900797FE4 /* GetCourseTest.swift in Sources */,
 				7D88EA2A23A96EA600D5F8FD /* AvatarGroupViewTests.swift in Sources */,
@@ -5169,6 +5176,7 @@
 				7DA25FBF23F72136005D2121 /* APIModule.swift in Sources */,
 				7DA2601123F7227A005D2121 /* UIColorInstColorsExtensions.swift in Sources */,
 				7DA25FF123F7225D005D2121 /* AccountNotificationIcon.swift in Sources */,
+				3BC50CC7246CA0AF0023159F /* ActivityIndicatorButton.swift in Sources */,
 				7DA2600B23F7227A005D2121 /* NSNumberExtensions.swift in Sources */,
 				7DA25FC223F72136005D2121 /* APIPage.swift in Sources */,
 				7DA260C123F72352005D2121 /* GetGradingPeriods.swift in Sources */,

--- a/Core/Core/Views/ActivityIndicatorButton.swift
+++ b/Core/Core/Views/ActivityIndicatorButton.swift
@@ -35,7 +35,7 @@ public class ActivityIndicatorButton: DynamicButton {
         addSubview(spinner)
         spinner.pinToTopAndBottomOfSuperview()
         spinner.widthAnchor.constraint(equalToConstant: 30).isActive = true
-        spinner.centerXAnchor.constraint(equalToSystemSpacingAfter: centerXAnchor, multiplier: 1).isActive = true
+        spinner.centerXAnchor.constraint(equalTo: centerXAnchor).isActive = true
         spinner.isHidden = true
         spinner.hidesWhenStopped = true
         spinner.tintColor = .named(.backgroundLightest)

--- a/Core/Core/Views/ActivityIndicatorButton.swift
+++ b/Core/Core/Views/ActivityIndicatorButton.swift
@@ -1,0 +1,53 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public class ActivityIndicatorButton: DynamicButton {
+    public var spinner: UIActivityIndicatorView = UIActivityIndicatorView(style: .white)
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        commonInit()
+    }
+
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        commonInit()
+    }
+
+    func commonInit() {
+        addSubview(spinner)
+        spinner.pinToTopAndBottomOfSuperview()
+        spinner.widthAnchor.constraint(equalToConstant: 30).isActive = true
+        spinner.centerXAnchor.constraint(equalToSystemSpacingAfter: centerXAnchor, multiplier: 1).isActive = true
+        spinner.isHidden = true
+        spinner.hidesWhenStopped = true
+        spinner.tintColor = .named(.backgroundLightest)
+    }
+
+    public func showSpinner(_ show: Bool) {
+        titleLabel?.layer.opacity = show ? 0 : 1
+        spinner.isHidden = !show
+        if show {
+            spinner.startAnimating()
+        } else {
+            spinner.stopAnimating()
+        }
+    }
+}

--- a/Core/CoreTests/Views/ActivtyIndicatorButtonTests.swift
+++ b/Core/CoreTests/Views/ActivtyIndicatorButtonTests.swift
@@ -1,0 +1,35 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+@testable import Core
+import XCTest
+
+class ActivityIndicatorButtonTests: XCTestCase {
+    func testShowSpinner() {
+        let button = ActivityIndicatorButton(frame: CGRect(x: 0, y: 0, width: 100, height: 50))
+        XCTAssertTrue(button.spinner.isHidden)
+        button.showSpinner(true)
+        XCTAssertFalse(button.spinner.isHidden)
+        XCTAssertEqual(button.titleLabel?.layer.opacity, 0)
+
+        button.showSpinner(false)
+        XCTAssertTrue(button.spinner.isHidden)
+        XCTAssertEqual(button.titleLabel?.layer.opacity, 1)
+    }
+}

--- a/Parent/Parent/Create Account/CreateAccountViewController.storyboard
+++ b/Parent/Parent/Create Account/CreateAccountViewController.storyboard
@@ -57,7 +57,7 @@
                                                     <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular14"/>
                                                 </userDefinedRuntimeAttributes>
                                             </label>
-                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWV-8A-wJd" customClass="DynamicButton" customModule="Parent" customModuleProvider="target">
+                                            <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LWV-8A-wJd" customClass="ActivityIndicatorButton" customModule="Core">
                                                 <rect key="frame" x="0.0" y="548" width="382" height="56"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="56" id="H7U-cm-eXL"/>

--- a/Parent/Parent/Create Account/CreateAccountViewController.swift
+++ b/Parent/Parent/Create Account/CreateAccountViewController.swift
@@ -25,7 +25,7 @@ class CreateAccountViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var name: CreateAccountRow!
     @IBOutlet weak var email: CreateAccountRow!
     @IBOutlet weak var password: CreateAccountRow!
-    @IBOutlet weak var createAccountButton: DynamicButton!
+    @IBOutlet weak var createAccountButton: ActivityIndicatorButton!
     @IBOutlet weak var termsAndConditionsLabel: DynamicLabel!
     @IBOutlet weak var alreadyHaveAccountLabel: DynamicLabel!
     var selectedTextField: UITextField?
@@ -118,8 +118,10 @@ class CreateAccountViewController: UIViewController, ErrorViewController {
             email: userEmail,
             password: userPassword
         )
+        createAccountButton.showSpinner(true)
         AppEnvironment.shared.api.makeRequest(request) { [weak self] (_, _, error) in
             performUIUpdate {
+                self?.createAccountButton.showSpinner(false)
                 if let error = error {
                     self?.showError(error)
                     return


### PR DESCRIPTION
refs: MBL-14413
affects: Parent
release note: none

Test plan
1. enable parent qr code flag, enable student qr code
2. scan student qr code so it opens parent app create account screen
3. when you click on the `create account` button you should see an activity indicator.