### PR TITLE
Support create account in parent from qr scanner

### DIFF
--- a/Core/Core/Login/LoginDelegate.swift
+++ b/Core/Core/Login/LoginDelegate.swift
@@ -24,6 +24,7 @@ public protocol LoginDelegate: class {
     var helpURL: URL? { get }
     var whatsNewURL: URL? { get }
     var findSchoolButtonTitle: String { get }
+    var supportedDeepLinkActions: [String] { get }
 
     func openExternalURL(_ url: URL)
     func openSupportTicket()
@@ -32,30 +33,33 @@ public protocol LoginDelegate: class {
     func userDidStopActing(as session: LoginSession)
     func userDidLogout(session: LoginSession)
     func changeUser()
+    func handleDeepLink(url: URL)
 }
 
-extension LoginDelegate {
-    public var supportsCanvasNetwork: Bool { true }
-    public var supportsQRCodeLogin: Bool { true }
-    public var helpURL: URL? { URL(string: "https://community.canvaslms.com/docs/DOC-1543") }
-    public var whatsNewURL: URL? { nil }
-    public var findSchoolButtonTitle: String { NSLocalizedString("Find my school", bundle: .core, comment: "") }
+public extension LoginDelegate {
+    var supportsCanvasNetwork: Bool { true }
+    var supportsQRCodeLogin: Bool { true }
+    var helpURL: URL? { URL(string: "https://community.canvaslms.com/docs/DOC-1543") }
+    var whatsNewURL: URL? { nil }
+    var findSchoolButtonTitle: String { NSLocalizedString("Find my school", bundle: .core, comment: "") }
+    var supportedDeepLinkActions: [String] { [] }
 
-    public func openSupportTicket() {}
-    public func changeUser() {}
+    func openSupportTicket() {}
+    func changeUser() {}
+    func handleDeepLink(url: URL) {}
 
-    public func userDidStartActing(as session: LoginSession) {
+    func userDidStartActing(as session: LoginSession) {
         userDidLogin(session: session)
     }
-    public func userDidStopActing(as session: LoginSession) {
+    func userDidStopActing(as session: LoginSession) {
         userDidLogout(session: session)
     }
 
-    public func startActing(as session: LoginSession) {
+    func startActing(as session: LoginSession) {
         userDidStartActing(as: session)
     }
 
-    public func stopActing(as session: LoginSession, findOriginalFrom entries: Set<LoginSession> = LoginSession.sessions) {
+    func stopActing(as session: LoginSession, findOriginalFrom entries: Set<LoginSession> = LoginSession.sessions) {
         guard let baseURL = session.originalBaseURL, let userID = session.originalUserID else { return }
         if let original = entries.first(where: { $0.baseURL == baseURL && $0.userID == userID && $0.masquerader == nil }) {
             userDidStopActing(as: session)

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -360,7 +360,13 @@ extension LoginStartViewController: UITableViewDataSource, UITableViewDelegate, 
 extension LoginStartViewController: ScannerDelegate, ErrorViewController {
     func scanner(_ scanner: ScannerViewController, didScanCode code: String) {
         env.router.dismiss(scanner) {
-            self.logIn(withCode: code)
+            if let url = URL(string: code),
+                let host = url.host,
+                self.loginDelegate?.supportedDeepLinkActions.contains(host) == true {
+                self.loginDelegate?.handleDeepLink(url: url)
+            } else {
+                self.logIn(withCode: code)
+            }
         }
     }
 }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -140,6 +140,10 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 extension ParentAppDelegate: LoginDelegate {
+    var supportedDeepLinkActions: [String] {
+        return ["create-account"]
+    }
+
     var supportsQRCodeLogin: Bool {
         ExperimentalFeature.qrLoginParent.isEnabled
     }
@@ -207,6 +211,10 @@ extension ParentAppDelegate: LoginDelegate {
         if let session = environment.currentSession {
             userDidLogout(session: session)
         }
+    }
+
+    func handleDeepLink(url: URL) {
+        _ = application(UIApplication.shared, open: url, options: [:])
     }
 }
 


### PR DESCRIPTION
refs: MBL-14413
affects: Parent
release note: none

Test plan:
1. make sure you can still login with qr code from web using the qr code scanner in parent app
2. bring up the parent create account screen using the qr code scanner in parent app