### PR TITLE
Remove storage bloat

### DIFF
--- a/Core/Core/AppEnvironment/CacheManager.swift
+++ b/Core/Core/AppEnvironment/CacheManager.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import PSPDFKit
 
 public class CacheManager {
     public private(set) static var lastDeletedAt: Int {
@@ -74,6 +75,30 @@ public class CacheManager {
 
     public static func clearLibrary() {
         clearDirectory(.libraryDirectory)
+    }
+
+    public static func removeBloat() {
+        let timeout = Clock.now.addSeconds(5)
+        let fs = FileManager.default
+        let enumerator = fs.enumerator(at: .documentsDirectory, includingPropertiesForKeys: [.isDirectoryKey])
+        while let url = enumerator?.nextObject() as? URL {
+            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            if isDirectory { continue }
+            if Document(url: url).containsAnnotations {
+                Analytics.shared.logEvent("clear_bloat_item_skipped", parameters: nil)
+                continue
+            }
+            do {
+                try fs.removeItem(at: url)
+                Analytics.shared.logEvent("clear_bloat_item_succeeded", parameters: nil)
+            } catch {
+                Analytics.shared.logEvent("clear_bloat_item_failed", parameters: ["error": error.localizedDescription])
+            }
+            if Clock.now > timeout {
+                Analytics.shared.logEvent("clear_bloat_timeout_exceeded")
+                break
+            }
+        }
     }
 
     public static func clearRNAsyncStorage() {

--- a/Core/Core/Files/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/FileDetails/FileDetailsViewController.swift
@@ -366,7 +366,12 @@ extension FileDetailsViewController: PDFViewControllerDelegate {
 
     func saveAnnotations() {
         for child in children {
-            _ = try? (child as? PDFViewController)?.document?.save()
+            if let pdf = child as? PDFViewController {
+                _ = try? pdf.document?.save()
+                if let document = pdf.document {
+                    pdfViewController(pdf, didSave: document, error: nil)
+                }
+            }
         }
     }
 

--- a/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
@@ -18,6 +18,8 @@
 
 import XCTest
 @testable import Core
+import PSPDFKit
+import PDFKit
 
 class CacheManagerTests: CoreTestCase {
     let rnManifestURL = URL.documentsDirectory
@@ -97,5 +99,27 @@ class CacheManagerTests: CoreTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: extra.path))
         XCTAssertEqual(json?["speed-grader-tutorial"] as? String, "preserved")
         XCTAssertNil(json?["something-else"])
+    }
+
+    func testRemoveBloat() {
+        let fs = FileManager.default
+        let url = URL.documentsDirectory.appendingPathComponent("bloat.pdf")
+        PDFDocument().write(to: url)
+        XCTAssertTrue(fs.fileExists(atPath: url.path))
+        CacheManager.removeBloat()
+        XCTAssertFalse(fs.fileExists(atPath: url.path))
+    }
+
+    func testRemoveBloatSkipsAnnotatedPDFs() {
+        let fs = FileManager.default
+        let url = URL.documentsDirectory.appendingPathComponent("bloat.pdf")
+        PDFDocument().write(to: url)
+        let pdf = Document(url: url)
+        let annotation = SquigglyAnnotation()
+        pdf.add(annotations: [annotation], options: nil)
+        try! pdf.save()
+        XCTAssertTrue(fs.fileExists(atPath: url.path))
+        CacheManager.removeBloat()
+        XCTAssertTrue(fs.fileExists(atPath: url.path))
     }
 }

--- a/Student/Student/CanvasAppDelegate.swift
+++ b/Student/Student/CanvasAppDelegate.swift
@@ -40,6 +40,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         setupFirebase()
         CacheManager.resetAppIfNecessary()
+        CacheManager.removeBloat()
         #if DEBUG
             UITestHelpers.setup(self)
         #endif

--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -41,6 +41,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         if NSClassFromString("XCTestCase") != nil { return true }
         setupFirebase()
         CacheManager.resetAppIfNecessary()
+        CacheManager.removeBloat()
         #if DEBUG
             UITestHelpers.setup(self)
         #endif


### PR DESCRIPTION
refs: MBL-14258
affects: student, teacher
release note: Optimized storage

Test plan:
* In Student app, view a PDF in course files and add annotations to it.
* Background the app (to trigger `viewWillDisappear`) then force-quit and
  relaunch the app
* View the same pdf again, annotations should still be there

Aside from print debugging, it's difficult to tell if the bloat actually
gets removed. For one, you will need [this
build](https://app.bitrise.io/artifact/36705347/p/fe2588d5cd3365e27ac8f4e168a319fc)
or older, then download a file and install this build over it in order
for bloated files to get removed. But even then it's difficult to
verify that the files were removed. The numbers in Storage settings are
not consistent enough.