### PR TITLE
Add qr code pairing to parent dashboard

### DIFF
--- a/Core/Core/Views/ScannerViewController.swift
+++ b/Core/Core/Views/ScannerViewController.swift
@@ -19,16 +19,16 @@
 import AVFoundation
 import UIKit
 
-protocol ScannerDelegate: class {
+public protocol ScannerDelegate: class {
     func scanner(_ scanner: ScannerViewController, didScanCode code: String)
 }
 
-class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
+public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDelegate {
     var captureSession: AVCaptureSession!
     var previewLayer: AVCaptureVideoPreviewLayer!
-    weak var delegate: ScannerDelegate?
+    public weak var delegate: ScannerDelegate?
 
-    override func viewDidLoad() {
+    public override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = UIColor.black
@@ -123,7 +123,7 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
         captureSession = nil
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
         if (captureSession?.isRunning == false) {
@@ -131,7 +131,7 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
         }
     }
 
-    override func viewWillDisappear(_ animated: Bool) {
+    public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         if (captureSession?.isRunning == true) {
@@ -139,7 +139,7 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
         }
     }
 
-    func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
+    public func metadataOutput(_ output: AVCaptureMetadataOutput, didOutput metadataObjects: [AVMetadataObject], from connection: AVCaptureConnection) {
 
         if let metadataObject = metadataObjects.first {
             guard let readableObject = metadataObject as? AVMetadataMachineReadableCodeObject else { return }
@@ -154,11 +154,11 @@ class ScannerViewController: UIViewController, AVCaptureMetadataOutputObjectsDel
         delegate?.scanner(self, didScanCode: code)
     }
 
-    override var prefersStatusBarHidden: Bool {
+    public override var prefersStatusBarHidden: Bool {
         return true
     }
 
-    override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
+    public override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
         return .portrait
     }
 

--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3B801BFD2322FFB400D143F0 /* Alert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497C48B11F912BD100A3BC06 /* Alert.swift */; };
 		3BA9FF6D2332999900196A06 /* CourseDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BA9FF6C2332999900196A06 /* CourseDetailsViewController.swift */; };
 		3BC50CC5246B11C00023159F /* CreateAccountViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC50CC4246B11C00023159F /* CreateAccountViewControllerTests.swift */; };
+		3BC50CCF24746FED0023159F /* SelectAddStudentMethodViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC50CCE24746FED0023159F /* SelectAddStudentMethodViewController.swift */; };
 		3BD0CD732327026400B3341E /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3BD0CD722327026400B3341E /* Core.framework */; };
 		3BD0CD762327027000B3341E /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3BD0CD742327027000B3341E /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3BEA6CC0245887F000BE4589 /* ParentConversationListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3BEA6CBE245887F000BE4589 /* ParentConversationListViewController.storyboard */; };
@@ -447,6 +448,7 @@
 		3B54E3582326F9B000D8D1D2 /* ParentTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentTestCase.swift; sourceTree = "<group>"; };
 		3BA9FF6C2332999900196A06 /* CourseDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailsViewController.swift; sourceTree = "<group>"; };
 		3BC50CC4246B11C00023159F /* CreateAccountViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateAccountViewControllerTests.swift; sourceTree = "<group>"; };
+		3BC50CCE24746FED0023159F /* SelectAddStudentMethodViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectAddStudentMethodViewController.swift; sourceTree = "<group>"; };
 		3BD0CD722327026400B3341E /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BD0CD742327027000B3341E /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3BEA6CBE245887F000BE4589 /* ParentConversationListViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ParentConversationListViewController.storyboard; sourceTree = "<group>"; };
@@ -904,6 +906,7 @@
 				5E0F9A4F1C739E6A00BB7707 /* Alerts */,
 				7DC804D12444D01C001AB80C /* DashboardViewController.storyboard */,
 				5E0F9A5F1C739E6A00BB7707 /* DashboardViewController.swift */,
+				3BC50CCE24746FED0023159F /* SelectAddStudentMethodViewController.swift */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -1680,6 +1683,7 @@
 				3BA9FF6D2332999900196A06 /* CourseDetailsViewController.swift in Sources */,
 				61D6A84D1C8F84E400370117 /* AlertsListViewController.swift in Sources */,
 				497C48C31F912BD100A3BC06 /* ObserverAlertKit.xcdatamodeld in Sources */,
+				3BC50CCF24746FED0023159F /* SelectAddStudentMethodViewController.swift in Sources */,
 				5EF946291CAD76C400D10247 /* TableEmptyView.swift in Sources */,
 				5E41048B1C99E08B0021567C /* UIImage+Resize.swift in Sources */,
 				497C48C21F912BD100A3BC06 /* Alert+Network.swift in Sources */,

--- a/Parent/Parent/Dashboard/SelectAddStudentMethodViewController.swift
+++ b/Parent/Parent/Dashboard/SelectAddStudentMethodViewController.swift
@@ -83,7 +83,7 @@ class SelectAddStudentMethodViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let method = AddObserveeMethod(rawValue: indexPath.row) else { fatalError("Invalid row") }
+        guard let method = AddObserveeMethod(rawValue: indexPath.row) else { return }
         delegate?.didSelectAddStudentMethod(method: method)
     }
 }

--- a/Parent/Parent/Dashboard/SelectAddStudentMethodViewController.swift
+++ b/Parent/Parent/Dashboard/SelectAddStudentMethodViewController.swift
@@ -1,0 +1,89 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+import Core
+
+enum AddObserveeMethod: Int, CaseIterable, CustomStringConvertible {
+    case qr, pairingCode
+
+    var description: String {
+        switch self {
+        case .qr: return NSLocalizedString("QR Code", comment: "")
+        case .pairingCode: return NSLocalizedString("Pairing Code", comment: "")
+        }
+    }
+}
+
+protocol AddStudentMethodProtocol: AnyObject {
+    func didSelectAddStudentMethod(method: AddObserveeMethod)
+}
+
+class SelectAddStudentMethodViewController: UITableViewController {
+
+    weak var delegate: AddStudentMethodProtocol?
+
+    static func create(delegate: AddStudentMethodProtocol?) -> SelectAddStudentMethodViewController {
+        let controller = SelectAddStudentMethodViewController()
+        controller.modalPresentationStyle = .custom
+        controller.modalPresentationCapturesStatusBarAppearance = true
+        controller.transitioningDelegate = BottomSheetTransitioningDelegate.shared
+        controller.delegate = delegate
+        return controller
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .named(.backgroundLightest)
+        view.frame.size.height = 175
+        tableView.registerCell(UITableViewCell.self)
+        tableView.estimatedRowHeight = 62
+        tableView.rowHeight = UITableView.automaticDimension
+
+        let header = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 50))
+        let headerLabel = UILabel()
+        headerLabel.font = UIFont.scaledNamedFont(.semibold14)
+        headerLabel.textColor = .named(.textDark)
+        headerLabel.text = NSLocalizedString("Add student with...", comment: "")
+        headerLabel.sizeToFit()
+        headerLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 25).isActive = true
+        headerLabel.numberOfLines = 0
+        header.addSubview(headerLabel)
+        headerLabel.pin(inside: header, leading: 16, trailing: 16, top: 12, bottom: 8)
+        tableView.tableHeaderView = header
+        tableView.tableFooterView =  UIView()
+    }
+
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return AddObserveeMethod.allCases.count
+    }
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell: UITableViewCell = tableView.dequeue(for: indexPath)
+        guard let row = AddObserveeMethod(rawValue: indexPath.row) else { fatalError("Invalid row") }
+        cell.textLabel?.text = row.description
+        cell.textLabel?.font = .scaledNamedFont(.medium16)
+        cell.textLabel?.textColor = .named(.textDarkest)
+        return cell
+    }
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard let method = AddObserveeMethod(rawValue: indexPath.row) else { fatalError("Invalid row") }
+        delegate?.didSelectAddStudentMethod(method: method)
+    }
+}

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -67,7 +67,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
         if url.scheme == "canvas-parent" {
-            environment.router.route(to: url, from: topMostViewController()!, options: .modal(embedInNav: true, addDoneButton: true))
+            environment.router.route(to: url, from: topMostViewController()!, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
         }
         return false
     }

--- a/Parent/Parent/Students/AddStudentController.swift
+++ b/Parent/Parent/Students/AddStudentController.swift
@@ -46,7 +46,7 @@ class AddStudentController {
         env.router.show(alert, from: vc, options: .modal())
     }
 
-    private func addPairingCode(code: String) {
+    func addPairingCode(code: String) {
         let request = PostObserveesRequest(userID: "self", pairingCode: code)
         env.api.makeRequest(request) { [weak self] _, _, error in
             guard let self = self, let vc = self.presentingViewController else { return }


### PR DESCRIPTION
refs: MBL-14174
affects: Parent
release note: none

test plan
---------------
1. login to parent
2. click the add student button on dashboard
3. make sure modal menu is shown and that is shows 2 options, test both
4. disable flag `parentQRCodePairing` and make sure old behavior is still there where just the pairing alert comes up when you click add student

