### PR TITLE
Append platform param to LTI launches

### DIFF
--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -85,7 +85,7 @@ public class LTITools {
                 self?.markModuleItemRead()
                 completionHandler?(success)
             }
-            let url = response.url
+            let url = response.url.appendingQueryItems(URLQueryItem(name: "platform", value: "mobile"))
             if response.name == "Google Apps" {
                 let controller = GoogleCloudAssignmentViewController(url: url)
                 self.env.router.show(controller, from: view, options: .modal(.overFullScreen, embedInNav: true, addDoneButton: true)) {

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -153,7 +153,7 @@ class LTIToolsTests: CoreTestCase {
         api.mock(request, value: .make(url: url))
         UserDefaults.standard.set(true, forKey: "open_lti_safari")
         tools.presentTool(from: mockView, animated: true)
-        XCTAssertEqual(login.externalURL, url)
+        XCTAssertEqual(login.externalURL, url.appendingQueryItems(URLQueryItem(name: "platform", value: "mobile")))
         XCTAssertNil(router.presented)
     }
 


### PR DESCRIPTION
refs: MBL-14425
affects: student
release note: none

Test plan:
- If the builds pass I think we are good
- There won't be any noticeable difference yet. This won't fix the issue
until Quizzes checks for the query param