### PR TITLE
Use UUID for file uploads

### DIFF
--- a/Core/Core/Files/File.swift
+++ b/Core/Core/Files/File.swift
@@ -69,7 +69,7 @@ final public class File: NSManagedObject {
     @NSManaged public var submission: Submission?
     @NSManaged public var uploadError: String?
     @NSManaged public var bytesSent: Int
-    @NSManaged public var taskIDRaw: NSNumber?
+    @NSManaged public var taskID: String?
     @NSManaged public private(set) var userID: String?
     @NSManaged public var contextRaw: Data?
     @NSManaged public var userRaw: Data?
@@ -88,11 +88,6 @@ final public class File: NSManagedObject {
     /// Should only be set in the case of a submission.
     /// Set using `prepareForSubmission(courseID:assignmentID:)`
     @NSManaged public private(set) var assignmentID: String?
-
-    public var taskID: Int? {
-        get { return taskIDRaw?.intValue }
-        set { taskIDRaw = NSNumber(value: newValue) }
-    }
 
     public var context: FileUploadContext? {
         get { return contextRaw.flatMap { try? JSONDecoder().decode(FileUploadContext.self, from: $0) } }

--- a/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Models/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -295,7 +295,7 @@
         <attribute name="previewURL" optional="YES" attributeType="URI"/>
         <attribute name="refreshData" optional="YES" attributeType="Binary"/>
         <attribute name="size" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="taskIDRaw" optional="YES" attributeType="Integer 64" usesScalarValueType="YES"/>
+        <attribute name="taskID" optional="YES" attributeType="String"/>
         <attribute name="thumbnailURL" optional="YES" attributeType="URI"/>
         <attribute name="unlockAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Core/CoreTests/Conversations/AttachmentCardsViewControllerTests.swift
+++ b/Core/CoreTests/Conversations/AttachmentCardsViewControllerTests.swift
@@ -51,7 +51,7 @@ class AttachmentCardsViewControllerTests: CoreTestCase {
         id: "u",
         display_name: "Upload File",
         size: 100
-    ), bytesSent: 25, taskID: 2)
+    ), bytesSent: 25, taskID: "2")
     lazy var thumbFile = File.make(from: .make(
         id: "t",
         display_name: "Thumbnail File",

--- a/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
+++ b/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
@@ -77,7 +77,7 @@ class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate 
         // Progress
         UploadManager.shared.viewContext.performAndWait {
             let file = controller.files.first!
-            file.taskID = 1
+            file.taskID = "1"
             file.bytesSent = 2
             try? UploadManager.shared.viewContext.save()
         }
@@ -131,7 +131,7 @@ class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate 
 
         UploadManager.shared.viewContext.performAndWait {
             let file = controller.files.first!
-            file.taskID = 1
+            file.taskID = "1"
             file.bytesSent = 100
             try? UploadManager.shared.viewContext.save()
         }

--- a/Core/CoreTests/Models/FileTests.swift
+++ b/Core/CoreTests/Models/FileTests.swift
@@ -47,7 +47,7 @@ class FileTests: CoreTestCase {
         file.taskID = nil
         XCTAssertFalse(file.isUploading)
 
-        file.taskID = 1
+        file.taskID = "1"
         XCTAssertTrue(file.isUploading)
     }
 

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
@@ -258,7 +258,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
     }
 
     func testUpdateUpdateSubmissionLabelsUploadingState() {
-        setupFileForSubmittedLabel(removeID: true, taskID: 1)
+        setupFileForSubmittedLabel(removeID: true, taskID: "1")
         load()
 
         XCTAssertEqual(viewController.submittedLabel?.text, "Submission Uploading...")
@@ -399,7 +399,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
 
     }
 
-    func setupFileForSubmittedLabel(removeID: Bool = false, taskID: Int? = nil, uploadError: String? = nil, apiAssignment: APIAssignment? = nil) {
+    func setupFileForSubmittedLabel(removeID: Bool = false, taskID: String? = nil, uploadError: String? = nil, apiAssignment: APIAssignment? = nil) {
         let course = APICourse.make(id: ID(courseID))
         api.mock(viewController.presenter!.courses, value: course)
         let assignment = apiAssignment ?? APIAssignment.make(

--- a/TestsFoundation/TestsFoundation/API/MockURLSession.swift
+++ b/TestsFoundation/TestsFoundation/API/MockURLSession.swift
@@ -148,13 +148,14 @@ public class MockURLSession: URLSession {
         error: Error? = nil,
         baseURL: URL = URL(string: "https://canvas.instructure.com")!,
         accessToken: String? = nil,
-        taskID: Int = 0
+        taskID: Int = 0,
+        taskDescription: String? = nil
     ) -> MockDataTask {
         var data: Data?
         if let value = value {
             data = try! requestable.encode(response: value)
         }
-        return mock(requestable, data: data, response: response, error: error, baseURL: baseURL, accessToken: accessToken, taskID: taskID)
+        return mock(requestable, data: data, response: response, error: error, baseURL: baseURL, accessToken: accessToken, taskID: taskID, taskDescription: taskDescription)
     }
 
     @discardableResult
@@ -164,9 +165,10 @@ public class MockURLSession: URLSession {
         error: Error?,
         baseURL: URL = URL(string: "https://canvas.instructure.com")!,
         accessToken: String? = nil,
-        taskID: Int = 0
+        taskID: Int = 0,
+        taskDescription: String? = nil
     ) -> MockDataTask {
-        return mock(requestable, value: nil, response: response, error: error, baseURL: baseURL, accessToken: accessToken, taskID: taskID)
+        return mock(requestable, value: nil, response: response, error: error, baseURL: baseURL, accessToken: accessToken, taskID: taskID, taskDescription: taskDescription)
     }
 
     @discardableResult
@@ -178,23 +180,28 @@ public class MockURLSession: URLSession {
         baseURL: URL = URL(string: "https://canvas.instructure.com")!,
         accessToken: String? = nil,
         dataHandler: (() -> UrlResponseTuple)? = nil,
-        taskID: Int = 0
+        taskID: Int = 0,
+        taskDescription: String? = nil
     ) -> MockDataTask {
         let request = try! requestable.urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil)
-        return mock(request, data: data, response: response, error: error, dataHandler: dataHandler, taskID: taskID)
+        return mock(request, data: data, response: response, error: error, dataHandler: dataHandler, taskID: taskID, taskDescription: taskDescription)
     }
 
     @discardableResult
-    public static func mock(_ request: URLRequest,
-                            data: Data? = nil,
-                            response: URLResponse? = nil,
-                            error: Error? = nil,
-                            dataHandler: (() -> UrlResponseTuple)? = nil,
-                            taskID: Int = 0) -> MockDataTask {
+    public static func mock(
+        _ request: URLRequest,
+        data: Data? = nil,
+        response: URLResponse? = nil,
+        error: Error? = nil,
+        dataHandler: (() -> UrlResponseTuple)? = nil,
+        taskID: Int = 0,
+        taskDescription: String? = nil
+    ) -> MockDataTask {
         let task = MockDataTask()
         task.mock = MockData(data: data, response: response, error: error)
         task.dataHandler = dataHandler
         task.taskIdentifier = taskID
+        task.taskDescription = taskDescription
         MockURLSession.dataMocks[request.url!.withCanonicalQueryParams!.absoluteString] = task
         return task
     }

--- a/TestsFoundation/TestsFoundation/Fixtures/Model/FileFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Model/FileFixture.swift
@@ -30,7 +30,7 @@ extension File {
         courseID: String? = nil,
         removeID: Bool = false,
         removeURL: Bool = false,
-        taskID: Int? = nil,
+        taskID: String? = nil,
         userID: String? = nil,
         uploadError: String? = nil,
         session: LoginSession? = nil,


### PR DESCRIPTION
`URLSessionTask.taskIdentifier` is only unique to the URLSession so they are not a reliable
way to uniquely identify a file upload in progress. This will hopefully
prevent issues with files being submitted to the wrong assignments

refs: none
affects: student
release note: Improved stability of file upload submissions

Test plan:
- Submit to an assignment using a file upload both within the app and
with the share extension
- narmstrong > s > CS 1400 > Assignments > File Upload