### PR TITLE
Fix To Do list when thumbnail_url is empty string

### DIFF
--- a/Core/Core/API/APIURL.swift
+++ b/Core/Core/API/APIURL.swift
@@ -55,6 +55,16 @@ public struct APIURL: Codable, Equatable {
     }
 }
 
+extension KeyedDecodingContainer {
+    public func decodeURLIfPresent(forKey key: Self.Key) throws -> APIURL? {
+        let rawValue = try decodeIfPresent(String.self, forKey: key)
+        if rawValue?.isEmpty == false {
+            return try decode(APIURL.self, forKey: key)
+        }
+        return nil
+    }
+}
+
 #if DEBUG
 extension APIURL {
     public static func make(

--- a/Core/Core/Files/APIFile.swift
+++ b/Core/Core/Files/APIFile.swift
@@ -138,12 +138,7 @@ public struct APIFile: Codable, Equatable {
         display_name = try container.decode(String.self, forKey: .display_name)
         filename = try container.decode(String.self, forKey: .filename)
         contentType = try container.decode(String.self, forKey: .contentType)
-        let urlRaw = try container.decodeIfPresent(String.self, forKey: .url)
-        if urlRaw == nil || urlRaw?.isEmpty == true {
-            url = nil
-        } else {
-            url = try container.decode(APIURL.self, forKey: .url)
-        }
+        url = try container.decodeURLIfPresent(forKey: .url)
         size = try container.decode(Int.self, forKey: .size)
         created_at = try container.decode(Date.self, forKey: .created_at)
         updated_at = try container.decode(Date.self, forKey: .updated_at)
@@ -152,13 +147,13 @@ public struct APIFile: Codable, Equatable {
         hidden = try container.decode(Bool.self, forKey: .hidden)
         lock_at = try container.decodeIfPresent(Date.self, forKey: .lock_at)
         hidden_for_user = try container.decode(Bool.self, forKey: .hidden_for_user)
-        thumbnail_url = try container.decodeIfPresent(APIURL.self, forKey: .thumbnail_url)
+        thumbnail_url = try container.decodeURLIfPresent(forKey: .thumbnail_url)
         modified_at = try container.decode(Date.self, forKey: .modified_at)
         mime_class = try container.decode(String.self, forKey: .mime_class)
         media_entry_id = try container.decodeIfPresent(String.self, forKey: .media_entry_id)
         locked_for_user = try container.decode(Bool.self, forKey: .locked_for_user)
         lock_explanation = try container.decodeIfPresent(String.self, forKey: .lock_explanation)
-        preview_url = try container.decodeIfPresent(APIURL.self, forKey: .preview_url)
+        preview_url = try container.decodeURLIfPresent(forKey: .preview_url)
         avatar = try container.decodeIfPresent(APIFileToken.self, forKey: .avatar)
     }
 }

--- a/Core/CoreTests/API/APIURLTests.swift
+++ b/Core/CoreTests/API/APIURLTests.swift
@@ -45,4 +45,34 @@ class APIURLTests: CoreTestCase {
         XCTAssertThrowsError(try decoder.decode(APIURL.self, from: try encoder.encode(1)))
         XCTAssertThrowsError(try decoder.decode(APIURL.self, from: try encoder.encode(true)))
     }
+
+    func testDecodeURLIfPresent() throws {
+        var json: [String: Any?] = ["maybeURL": ""]
+        var data = try JSONSerialization.data(withJSONObject: json, options: [])
+        var model = try decoder.decode(TestCodable.self, from: data)
+        XCTAssertNil(model.maybeURL)
+
+        json["maybeURL"] = "https://canvas.instructure.com"
+        data = try JSONSerialization.data(withJSONObject: json, options: [])
+        model = try decoder.decode(TestCodable.self, from: data)
+        XCTAssertEqual(model.maybeURL?.rawValue, URL(string: "https://canvas.instructure.com")!)
+
+        json["maybeURL"] = nil
+        data = try JSONSerialization.data(withJSONObject: json, options: [])
+        model = try decoder.decode(TestCodable.self, from: data)
+        XCTAssertNil(model.maybeURL)
+    }
+}
+
+private class TestCodable: Codable {
+    let maybeURL: APIURL?
+
+    enum CodingKeys: String, CodingKey {
+        case maybeURL
+    }
+
+    required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        maybeURL = try container.decodeURLIfPresent(forKey: .maybeURL)
+    }
 }

--- a/Core/CoreTests/Files/APIFileTests.swift
+++ b/Core/CoreTests/Files/APIFileTests.swift
@@ -29,8 +29,13 @@ class APIFileTests: XCTestCase {
 
         fixture["url"] = ""
         data = try! serialize(json: fixture)
-        let file = try! decoder.decode(APIFile.self, from: data)
+        var file = try! decoder.decode(APIFile.self, from: data)
         XCTAssertNil(file.url)
+
+        fixture["thumbnail_url"] = ""
+        data = try! serialize(json: fixture)
+        file = try! decoder.decode(APIFile.self, from: data)
+        XCTAssertNil(file.thumbnail_url)
     }
 
     func testGetFileRequest() {


### PR DESCRIPTION
refs: MBL-14448
affects: student
release note: Fixed an issue with loading the To Do list

Test plan: See ticket. To Do list should load without error.