### PR TITLE
Fix updated rubrics with free-form comments

### DIFF
--- a/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
@@ -104,27 +104,26 @@ class RubricPresenter {
         }
     }
 
-    func transformRubricsToViewModels(_ rubric: [Rubric], assessments: RubricAssessments?, hideRubricPoints: Bool, freeFormCriterionComments: Bool) -> [RubricViewModel] {
+    func transformRubricsToViewModels(_ rubrics: [Rubric], assessments: RubricAssessments?, hideRubricPoints: Bool, freeFormCriterionComments: Bool) -> [RubricViewModel] {
         var models = [RubricViewModel]()
-        for r in rubric {
-            guard let ratings = r.ratings else { continue }
-            let assessment = assessments?[r.id]
-
-            let sorted = Array(ratings).sorted { $0.points < $1.points }
+        for rubric in rubrics {
+            guard var ratings = rubric.ratings.flatMap(Array.init) else { continue }
+            let assessment = assessments?[rubric.id]
+            ratings = ratings.sorted { $0.points < $1.points }
             var selected: RubricRating?
             var selectedIndex: Int?
             var comments: String?
             var description = ""
             var isCustomAssessment = false
 
-            if let index = sorted.firstIndex(where: { rr in assessment?.ratingID == rr.id && ( freeFormCriterionComments || rr.points == assessment?.points) }) {
-                selected = sorted[index]
+            if let index = ratings.firstIndex(where: { rating in assessment?.ratingID == rating.id && rating.points == assessment?.points }) {
+                selected = ratings[index]
                 selectedIndex = index
                 comments = assessment?.comments
                 description = selected?.desc ?? ""
             }
-            var allRatings: [Double] = sorted.map { $0.points }
-            var allDescriptions: [String] = sorted.map { $0.desc }
+            var allRatings: [Double] = ratings.map { $0.points }
+            var allDescriptions: [String] = ratings.map { $0.desc }
             if selected == nil, let assessment = assessment, let points = assessment.points {
                 //  this is a custom assesment
                 allRatings.append(points)
@@ -136,15 +135,15 @@ class RubricPresenter {
             }
 
             let m = RubricViewModel(
-                id: r.id,
-                title: r.desc,
-                longDescription: r.longDesc,
+                id: rubric.id,
+                title: rubric.desc,
+                longDescription: rubric.longDesc,
                 selectedDesc: description,
                 selectedIndex: selectedIndex,
                 ratings: allRatings,
                 descriptions: allDescriptions,
                 comment: comments,
-                rubricRatings: sorted,
+                rubricRatings: ratings,
                 isCustomAssessment: isCustomAssessment,
                 hideRubricPoints: hideRubricPoints,
                 freeFormCriterionComments: freeFormCriterionComments

--- a/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
@@ -183,6 +183,43 @@ class RubricPresenterTests: StudentTestCase {
         XCTAssertEqual(models.first, expected.first)
     }
 
+    func testCustomGradeAndFreeFormCriterionCommentsTrue() {
+        let ratings: [APIRubricRating] = [
+            .make(id: "1", points: 10, position: 1),
+            .make(id: "2", points: 25, position: 2),
+        ]
+
+        let rubric = Rubric.make(from: .make(id: "1", ratings: ratings))
+        Submission.make(from: .make(rubric_assessment: [
+            "1": .make(points: 1.0, comments: "this is custom", rating_id: "2"),
+        ]))
+        Course.make()
+        Assignment.make(from: .make(rubric_settings: .make(free_form_criterion_comments: true)))
+        ContextColor.make()
+        let expected: [RubricViewModel] = [
+            RubricViewModel(
+                id: "1",
+                title: "Effort",
+                longDescription: "Did you even try?",
+                selectedDesc: "Custom Grade",
+                selectedIndex: 2,
+                ratings: [10.0, 25.0, 1.0],
+                descriptions: ["Excellent", "Excellent", "Custom Grade"],
+                comment: "this is custom",
+                rubricRatings: Array(rubric.ratings!).sorted { $0.points < $1.points },
+                isCustomAssessment: true,
+                hideRubricPoints: false,
+                freeFormCriterionComments: true
+            ),
+        ]
+
+        presenter.update()
+
+        XCTAssertEqual(presenter.rubrics.first?.ratings?.count, 2)
+        XCTAssertEqual(models.count, expected.count)
+        XCTAssertEqual(models.first, expected.first)
+    }
+
     func testRubricViewModelRatingBlurb() {
         let r = Rubric.make()
         let rating = RubricRating.make()


### PR DESCRIPTION
refs: MBL-13329
affects: student
release note: Fixed a bug that caused the wrong rubric score to show

Test plan:
- Test [MBL-13329](https://instructure.atlassian.net/browse/MBL-13329)
- Regression test [MBL-13727](https://instructure.atlassian.net/browse/MBL-13727)