### PR TITLE
Fix discussion module items in teacher

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -387,7 +387,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         }
         if showRepliesToEntryID == nil {
             AppStoreReview.handleNavigateToAssignment()
-            if !ExperimentalFeature.studentModules.isEnabled {
+            if !ExperimentalFeature.studentModules.isEnabled, env.app == .student {
                 MarkDiscussionTopicRead(context: context, topicID: topicID, isRead: true).fetch()
             }
         }


### PR DESCRIPTION
refs: MBL-14468
affects: teacher
release note: none

Test plan:
- View a discussion item through modules
- It should not reload infinitely
- narmstrong > CS 1400 > Modules > pick any discussion