### PR TITLE
Fix deep linking to canvas-teacher://

### DIFF
--- a/rn/Teacher/ios/Teacher/AppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/AppDelegate.swift
@@ -174,7 +174,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
                 }
 
                 guard let navController = navigationController, let helmVC = navController.viewControllers.first as? HelmViewController else { break }
-                if helmVC.moduleName == url.path {
+                let path = url.path.isEmpty ? "/" : url.path
+                if helmVC.moduleName == path {
                     rootView.selectedIndex = index
                     rootView.resetSelectedViewController()
                     return


### PR DESCRIPTION
refs: MBL-14461
affects: teacher
release note: Fixed launching the app with canvas-teacher://

Test plan:
Go to canvas-teacher:// in safari. Should launch the app without error.