### PR TITLE
disable the [run-nightly] hook on master

### DIFF
--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -32,7 +32,7 @@ workflows:
             #!/bin/zsh
             set -exo pipefail
 
-            if printf "%s\n" "$BITRISE_GIT_MESSAGE" | grep -iE "\[run.nightly\]"; then
+            if printf "%s\n" "$BITRISE_GIT_MESSAGE" | grep -iE "\[run.nightly\]" && [[ $BITRISE_GIT_BRANCH != master ]]; then
                 envman add --key RUN_NIGHTLY --value YES
             fi
     - build-router-start:


### PR DESCRIPTION
test plan: this should trigger nightly on this PR, but not once this PR gets merged, so I guess the testing has to happen after approval... but it's a small change.