### PR TITLE
Scanned document submissions

### DIFF
--- a/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
+++ b/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 @testable import Core
 import TestsFoundation
+import VisionKit
 
 class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate {
     var cancelled = false
@@ -50,7 +51,7 @@ class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate 
         controller.viewWillAppear(false)
         XCTAssertEqual(controller.view.backgroundColor, .named(.backgroundLightest))
         XCTAssertTrue(controller.progressView.isHidden)
-        XCTAssertEqual(controller.sourcesTabBar.items?.count, 3)
+        XCTAssertEqual(controller.sourcesTabBar.items?.count, 4)
         XCTAssertEqual(navigation.navigationBar.barTintColor, .named(.backgroundLightest))
     }
 
@@ -139,6 +140,15 @@ class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate 
         let doneItem = controller.navigationItem.rightBarButtonItem
         XCTAssertEqual(doneItem?.title, "Done")
         XCTAssertNoThrow(doneItem?.target?.perform(doneItem?.action))
+    }
+
+    @available(iOS 13.0, *)
+    func testDocumentScan() {
+        controller.sources = [.documentScan]
+        controller.view.layoutIfNeeded()
+        let tabBar = controller.sourcesTabBar!
+        tabBar.delegate?.tabBar?(tabBar, didSelect: tabBar.items!.first!)
+        XCTAssertNil(router.presented, "document scanner not supported in simulator")
     }
 }
 

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -179,7 +179,7 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
         let mediaTypes = selectedSubmissionTypes.allowedMediaTypes
         filePicker.sources = [.files]
         if assignment.allowedExtensions.isEmpty == true || allowedUTIs.contains(where: { $0.isImage || $0.isVideo }) {
-            filePicker.sources.append(contentsOf: [.library, .camera])
+            filePicker.sources.append(contentsOf: [.library, .camera, .documentScan])
         }
         if isMediaRecording { filePicker.sources.append(.audio) }
         filePicker.utis = allowedUTIs


### PR DESCRIPTION
refs: none
affects: student
release note: Added the option to submit scanned documents

Test plan:
- Submit to an assignment that accepts image file upload submissions
- Choose the Scanner option from the file picker
- Scan one or more documents
- Submit
- The scanned images should submit successfully