### PR TITLE
Fix discussions with script tags

### DIFF
--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -88,12 +88,26 @@ enum DiscussionHTML {
     }
 
     static func message(for entry: DiscussionEntry) -> String {
-        if !entry.isRemoved { return entry.message ?? "" }
-        return """
-        <p class="\(Styles.deleted)">
-            \(t(NSLocalizedString("Deleted this reply.", bundle: .core, comment: "")))
-        </p>
-        """
+        if entry.isRemoved {
+            return """
+            <p class="\(Styles.deleted)">
+                \(t(NSLocalizedString("Deleted this reply.", bundle: .core, comment: "")))
+            </p>
+            """
+        }
+        let message = entry.message ?? ""
+
+        // <script> tags are not supported by dangerouslySetInnerHTML
+        if let regex = try? NSRegularExpression(pattern: "<script(.+)</script>", options: .caseInsensitive) {
+            return regex.stringByReplacingMatches(
+                in: message,
+                options: [],
+                range: NSRange(location: 0, length: message.count),
+                withTemplate: ""
+            )
+        }
+
+        return message
     }
 
     // Preact-based rendering for updatable content

--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -95,19 +95,7 @@ enum DiscussionHTML {
             </p>
             """
         }
-        let message = entry.message ?? ""
-
-        // <script> tags are not supported by dangerouslySetInnerHTML
-        if let regex = try? NSRegularExpression(pattern: "<script(.+)</script>", options: .caseInsensitive) {
-            return regex.stringByReplacingMatches(
-                in: message,
-                options: [],
-                range: NSRange(location: 0, length: message.count),
-                withTemplate: ""
-            )
-        }
-
-        return message
+        return entry.message?.replacingOccurrences(of: "<script(.+)</script>", with: "", options: .regularExpression) ?? ""
     }
 
     // Preact-based rendering for updatable content

--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -95,7 +95,9 @@ enum DiscussionHTML {
             </p>
             """
         }
-        return entry.message?.replacingOccurrences(of: "<script(.+)</script>", with: "", options: .regularExpression) ?? ""
+        return entry.message?
+            .replacingOccurrences(of: "<script(.+)</script>", with: "", options: .regularExpression)
+            .replacingOccurrences(of: "<link(.+)>", with: "", options: .regularExpression) ?? ""
     }
 
     // Preact-based rendering for updatable content

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -85,7 +85,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
                 <p>Oreos are sandwiches.</p>
                 """, replies: [
                     .make(id: 100, user_id: 3, parent_id: 1, deleted: true),
-                    .make(id: 2, user_id: 3, parent_id: 1, message: "<script src=\"\"></script>I disagree.", replies: [
+                    .make(id: 2, user_id: 3, parent_id: 1, message: "<link rel=\"stylesheet\">I disagree.<script src=\"foo.js\"></script>", replies: [
                         .make(id: 3, user_id: 2, parent_id: 2, message: "Why?"),
                     ]),
                 ]),
@@ -141,6 +141,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
         XCTAssert(html.contains("Why?"))
         XCTAssert(!html.contains("Hot Pockets"))
         XCTAssert(!html.contains("<script"))
+        XCTAssert(!html.contains("<link"))
 
         var link = baseURL.appendingPathComponent("courses/1/assignments/2")
         XCTAssertEqual(webView.linkDelegate?.handleLink(link), true)

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -85,7 +85,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
                 <p>Oreos are sandwiches.</p>
                 """, replies: [
                     .make(id: 100, user_id: 3, parent_id: 1, deleted: true),
-                    .make(id: 2, user_id: 3, parent_id: 1, message: "I disagree.", replies: [
+                    .make(id: 2, user_id: 3, parent_id: 1, message: "<script src=\"\"></script>I disagree.", replies: [
                         .make(id: 3, user_id: 2, parent_id: 2, message: "Why?"),
                     ]),
                 ]),
@@ -140,6 +140,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
         XCTAssert(html.contains("I disagree"))
         XCTAssert(html.contains("Why?"))
         XCTAssert(!html.contains("Hot Pockets"))
+        XCTAssert(!html.contains("<script"))
 
         var link = baseURL.appendingPathComponent("courses/1/assignments/2")
         XCTAssertEqual(webView.linkDelegate?.handleLink(link), true)


### PR DESCRIPTION
refs: MBL-14500
affects: student, teacher
release note: Fixed discussions for some schools

Test plan:
- Ticket has users that you can masquerade as
- When an account has custom javascript files, the API inserts those
scripts into every discussion reply
- Discussion replies with script tags should load
- For now we strip out the scripts. We can try to load them in the
future