### PR TITLE
Change label from In-Class to On Paper

### DIFF
--- a/Parent/Parent/Extensions/CalendarEvent+Submissions.swift
+++ b/Parent/Parent/Extensions/CalendarEvent+Submissions.swift
@@ -101,7 +101,7 @@ private struct Submission {
             if missing {
                 return NSLocalizedString("Missing", comment: "")
             } else if onPaper {
-                return NSLocalizedString("In-Class", comment: "")
+                return NSLocalizedString("On Paper", comment: "")
             } else {
                 return ""
             }
@@ -127,7 +127,7 @@ private struct Submission {
                 guard let pointsPossible = pointsPossible else { return self.displayText }
                 return String(format: NSLocalizedString("Missing: (-/%@)", comment: ""), pointsPossible)
             } else if onPaper {
-                return NSLocalizedString("In-Class", comment: "")
+                return NSLocalizedString("On Paper", comment: "")
             } else {
                 return ""
             }


### PR DESCRIPTION
refs: MBL-13430
affects: Parent
release note: Fixed label for paper assignments to be "On Paper" instead of "In-Class"