### PR TITLE
Add score statistics to assignment, display with graph

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -77,6 +77,10 @@
 		3BEA6CCD24588D1400BE4589 /* ConversationDetailViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEA6CC724588D1400BE4589 /* ConversationDetailViewControllerTests.swift */; };
 		3BEA6CCF2458A10700BE4589 /* ConversationListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BEA6CCE2458A10700BE4589 /* ConversationListViewControllerTests.swift */; };
 		3BF5C55321879A430081A858 /* GetAssignmentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BF5C55221879A430081A858 /* GetAssignmentsTests.swift */; };
+		49428D5824BA525F00EF3EAB /* GradeStatisticGraphView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 49428D5724BA525F00EF3EAB /* GradeStatisticGraphView.xib */; };
+		49428D5A24BA526F00EF3EAB /* GradeStatisticGraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49428D5924BA526F00EF3EAB /* GradeStatisticGraphView.swift */; };
+		49C56C9D24BECA7400E96799 /* ClosedRangeExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C56C9C24BECA7400E96799 /* ClosedRangeExtensions.swift */; };
+		49E3BF3A24BBC7E200EF1E8F /* GradeStatisticsGraphViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E3BF3924BBC7E200EF1E8F /* GradeStatisticsGraphViewTests.swift */; };
 		5BF786A6218599B600471A5F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5BF786A8218599B600471A5F /* InfoPlist.strings */; };
 		76C331C8F363ABC602A1B6DD /* Pods_needs_pspdfkit_CoreTester.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 180BC2536A70738540E5EE74 /* Pods_needs_pspdfkit_CoreTester.framework */; };
 		78151DCF21AE7E0500692862 /* APIDiscussionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78151DCE21AE7E0500692862 /* APIDiscussionTests.swift */; };
@@ -1034,6 +1038,10 @@
 		3BF5C54E2187800B0081A858 /* GetAssignments.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAssignments.swift; sourceTree = "<group>"; };
 		3BF5C55221879A430081A858 /* GetAssignmentsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GetAssignmentsTests.swift; sourceTree = "<group>"; };
 		40DBE7EA2442FB031DB6DE12 /* Pods-needs-pspdfkit-CoreTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-CoreTests.debug.xcconfig"; path = "Target Support Files/Pods-needs-pspdfkit-CoreTests/Pods-needs-pspdfkit-CoreTests.debug.xcconfig"; sourceTree = "<group>"; };
+		49428D5724BA525F00EF3EAB /* GradeStatisticGraphView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GradeStatisticGraphView.xib; sourceTree = "<group>"; };
+		49428D5924BA526F00EF3EAB /* GradeStatisticGraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeStatisticGraphView.swift; sourceTree = "<group>"; };
+		49C56C9C24BECA7400E96799 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
+		49E3BF3924BBC7E200EF1E8F /* GradeStatisticsGraphViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeStatisticsGraphViewTests.swift; sourceTree = "<group>"; };
 		54941F97B58CF7F03A55EAF8 /* Pods_needs_pspdfkit_Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_needs_pspdfkit_Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		58595E38E685A009AA510843 /* IPC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IPC.swift; sourceTree = "<group>"; };
 		5B030508218599BD00B3C13E /* cy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = cy; path = cy.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -2487,6 +2495,8 @@
 				7D231BE223AC30B5005BA31D /* FloatingButton.swift */,
 				9FCF1541227B6DB6009D35F6 /* GradeCircleView.swift */,
 				9FCF153F227B6BC1009D35F6 /* GradeCircleView.xib */,
+				49428D5924BA526F00EF3EAB /* GradeStatisticGraphView.swift */,
+				49428D5724BA525F00EF3EAB /* GradeStatisticGraphView.xib */,
 				7D70DE91233E808600F5C3D4 /* GroupedSectionFooterView.swift */,
 				7D9E80D1233D9934003C608B /* GroupedSectionHeaderView.swift */,
 				3B166A562343CEAF00B2EFAB /* HorizontalMenuViewController.swift */,
@@ -2533,6 +2543,7 @@
 				9F5C93042375FBBA005105BB /* EmptyViewControllerTests.swift */,
 				7D231BE523AC3871005BA31D /* FloatingButtonTests.swift */,
 				9FCF1553227CC927009D35F6 /* GradeCircleViewTests.swift */,
+				49E3BF3924BBC7E200EF1E8F /* GradeStatisticsGraphViewTests.swift */,
 				9727093A23C8C572008253B2 /* HorizontalMenuViewControllerTests.swift */,
 				7DD6947A21949DC900BA4984 /* IconViewTests.swift */,
 				7D1758C3215A995200F88613 /* ListFormatterTests.swift */,
@@ -2996,6 +3007,7 @@
 			isa = PBXGroup;
 			children = (
 				7DF9BF03215191840099026B /* BundleExtensions.swift */,
+				49C56C9C24BECA7400E96799 /* ClosedRangeExtensions.swift */,
 				B1EA5AF5212E67CE00DABC5F /* DateExtensions.swift */,
 				B1A464BA225669140052F8DF /* DispatchExtensions.swift */,
 				E8D6949324D4635B0080D883 /* EnvironmentValuesExtensions.swift */,
@@ -4073,6 +4085,7 @@
 				B14707B52437BC1C00CE1DBD /* ExternalURLViewController.storyboard in Resources */,
 				3B4D89362450A8F4004ED120 /* ConversationListViewController.storyboard in Resources */,
 				7DBED00C232C031C00392F3C /* ProfileViewController.storyboard in Resources */,
+				49428D5824BA525F00EF3EAB /* GradeStatisticGraphView.xib in Resources */,
 				7D06A2B52469B7EF00D76267 /* DiscussionReplyViewController.storyboard in Resources */,
 				7DD694892195F7A200BA4984 /* DocViewerViewController.storyboard in Resources */,
 				7D842A8E22A818C800484B92 /* WrongAppLinkView.xib in Resources */,
@@ -4408,6 +4421,7 @@
 				7DDC4511215BF7AA003F3209 /* BundleExtensionsTests.swift in Sources */,
 				7D303DE82412F9AB001F5F36 /* PagesViewControllerTests.swift in Sources */,
 				B18E19BB2386216B00B03C73 /* GradeFormatterTests.swift in Sources */,
+				49E3BF3A24BBC7E200EF1E8F /* GradeStatisticsGraphViewTests.swift in Sources */,
 				3BA9FF792332B39700196A06 /* GetGradingPeriodsTests.swift in Sources */,
 				7DB0A1BA21BF1904009ABB40 /* LoginStartViewControllerTests.swift in Sources */,
 				3BEA6CCD24588D1400BE4589 /* ConversationDetailViewControllerTests.swift in Sources */,
@@ -4765,6 +4779,8 @@
 				7DA25FD923F72148005D2121 /* ExperimentalFeature.swift in Sources */,
 				7DA2601023F7227A005D2121 /* UIColorExtensions.swift in Sources */,
 				7DA25FD123F72136005D2121 /* APIURL.swift in Sources */,
+				49428D5A24BA526F00EF3EAB /* GradeStatisticGraphView.swift in Sources */,
+				7DA2605E23F722D9005D2121 /* QuizType.swift in Sources */,
 				7DA260C923F72359005D2121 /* AlertAction.swift in Sources */,
 				7DA2604B23F722D9005D2121 /* GradingPeriod.swift in Sources */,
 				7DA2603A23F722D9005D2121 /* Assignment.swift in Sources */,
@@ -5008,6 +5024,7 @@
 				7DA260E723F72359005D2121 /* SectionHeaderView.swift in Sources */,
 				7DA260CC23F72359005D2121 /* BottomSheetPickerViewController.swift in Sources */,
 				E8D6949824D46B1E0080D883 /* CoreHostingController.swift in Sources */,
+				49C56C9D24BECA7400E96799 /* ClosedRangeExtensions.swift in Sources */,
 				7D5F103D2429BA5D00803324 /* CardView.swift in Sources */,
 				7DA2609423F72327005D2121 /* RichContentEditorViewController.swift in Sources */,
 			);

--- a/Core/Core/Assignments/APIAssignment.swift
+++ b/Core/Core/Assignments/APIAssignment.swift
@@ -47,6 +47,7 @@ public struct APIAssignment: Codable, Equatable {
     let all_dates: [APIAssignmentDate]?
     let allowed_attempts: Int?
     let external_tool_tag_attributes: APIExternalToolTagAttributes?
+    let score_statistics: APIAssignmentScoreStatistics?
 }
 
 // https://canvas.instructure.com/doc/api/assignments.html#AssignmentDate
@@ -62,6 +63,12 @@ public struct APIAssignmentDate: Codable, Equatable {
 // https://canvas.instructure.com/doc/api/assignments.html#ExternalToolTagAttributes
 public struct APIExternalToolTagAttributes: Codable, Equatable {
     let content_id: ID? // undocumented
+}
+
+public struct APIAssignmentScoreStatistics: Codable, Equatable {
+    let mean: Double
+    let min: Double
+    let max: Double
 }
 
 public enum GradingType: String, Codable {
@@ -98,7 +105,8 @@ extension APIAssignment {
         assignment_group_id: ID? = nil,
         all_dates: [APIAssignmentDate]? = nil,
         allowed_attempts: Int? = -1,
-        external_tool_tag_attributes: APIExternalToolTagAttributes? = nil
+        external_tool_tag_attributes: APIExternalToolTagAttributes? = nil,
+        score_statistics: APIAssignmentScoreStatistics? = nil
     ) -> APIAssignment {
 
         var submissionList: APIList<APISubmission>?
@@ -135,7 +143,8 @@ extension APIAssignment {
             assignment_group_id: assignment_group_id,
             all_dates: all_dates,
             allowed_attempts: allowed_attempts,
-            external_tool_tag_attributes: external_tool_tag_attributes
+            external_tool_tag_attributes: external_tool_tag_attributes,
+            score_statistics: score_statistics
         )
     }
 }
@@ -165,6 +174,19 @@ extension APIExternalToolTagAttributes {
         return Self(content_id: content_id)
     }
 }
+extension APIAssignmentScoreStatistics {
+    public static func make(
+        mean: Double = 2.0,
+        min: Double = 1.0,
+        max: Double = 5.0
+    ) -> APIAssignmentScoreStatistics {
+        return APIAssignmentScoreStatistics(
+            mean: mean,
+            min: min,
+            max: max
+        )
+    }
+}
 #endif
 
 // https://canvas.instructure.com/doc/api/assignments.html#method.assignments_api.show
@@ -184,7 +206,7 @@ public struct GetAssignmentRequest: APIRequestable {
     }
 
     public enum GetAssignmentInclude: String {
-        case submission, overrides
+        case submission, overrides, score_statistics
     }
 
     public var path: String {
@@ -246,6 +268,7 @@ public struct GetAssignmentsRequest: APIRequestable {
         case observed_users
         case submission
         case all_dates
+        case score_statistics
     }
 
     public typealias Response = [APIAssignment]

--- a/Core/Core/Assignments/APIAssignmentGroup.swift
+++ b/Core/Core/Assignments/APIAssignmentGroup.swift
@@ -48,7 +48,7 @@ public struct GetAssignmentGroupsRequest: APIRequestable {
     public typealias Response = [APIAssignmentGroup]
 
     public enum Include: String {
-        case assignments, discussion_topic, observed_users, submission
+        case assignments, discussion_topic, observed_users, submission, score_statistics
     }
 
     let courseID: String

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -55,6 +55,7 @@ public class Assignment: NSManagedObject {
     @NSManaged public var allDates: Set<AssignmentDate>
     @NSManaged public var allowedAttempts: Int // 0 is flag disabled, -1 is unlimited
     @NSManaged public var externalToolContentID: String?
+    @NSManaged public var scoreStatistics: ScoreStatistics?
 
     /**
      Use this property (vs. submissions) when you want the most recent submission
@@ -109,15 +110,15 @@ public class Assignment: NSManagedObject {
     public var isMasteryPathAssignment: Bool { masteryPathAssignment != nil }
 
     @discardableResult
-    public static func save(_ item: APIAssignment, in context: NSManagedObjectContext, updateSubmission: Bool) -> Assignment {
+    public static func save(_ item: APIAssignment, in context: NSManagedObjectContext, updateSubmission: Bool, updateScoreStatistics: Bool) -> Assignment {
         let assignment: Assignment = context.first(where: #keyPath(Assignment.id), equals: item.id.value) ?? context.insert()
-        assignment.update(fromApiModel: item, in: context, updateSubmission: updateSubmission)
+        assignment.update(fromApiModel: item, in: context, updateSubmission: updateSubmission, updateScoreStatistics: updateScoreStatistics)
         return assignment
     }
 }
 
 extension Assignment {
-    func update(fromApiModel item: APIAssignment, in client: NSManagedObjectContext, updateSubmission: Bool) {
+    func update(fromApiModel item: APIAssignment, in client: NSManagedObjectContext, updateSubmission: Bool, updateScoreStatistics: Bool) {
         id = item.id.value
         name = item.name
         courseID = item.course_id.value
@@ -183,6 +184,17 @@ extension Assignment {
             } else if let submissions = submissions {
                 client.delete(Array(submissions))
                 self.submissions = nil
+            }
+        }
+        
+        if updateScoreStatistics {
+            if let newStatistics = item.score_statistics {
+                let replacementStats = scoreStatistics ?? client.insert()
+                replacementStats.update(fromApiModel: newStatistics, in: client)
+                self.scoreStatistics = replacementStats
+            } else if let scoreStatistics = scoreStatistics {
+                client.delete(scoreStatistics)
+                self.scoreStatistics = nil
             }
         }
 
@@ -315,5 +327,19 @@ public final class AssignmentDate: NSManagedObject {
         model.unlockAt = item.unlock_at
         model.lockAt = item.lock_at
         return model
+    }
+}
+
+public final class ScoreStatistics: NSManagedObject {
+    @NSManaged internal (set) public var mean: Double
+    @NSManaged internal (set) public var min: Double
+    @NSManaged internal (set) public var max: Double
+    @NSManaged internal (set) public var assignment: Assignment
+    
+    
+    public func update(fromApiModel item: APIAssignmentScoreStatistics, in client: NSManagedObjectContext) {
+        mean = item.mean
+        min = item.min
+        max = item.max
     }
 }

--- a/Core/Core/Assignments/AssignmentGroup.swift
+++ b/Core/Core/Assignments/AssignmentGroup.swift
@@ -28,7 +28,7 @@ public final class AssignmentGroup: NSManagedObject {
     @NSManaged public var courseID: String
 
     @discardableResult
-    public static func save(_ item: APIAssignmentGroup, courseID: String, in context: NSManagedObjectContext) -> AssignmentGroup {
+    public static func save(_ item: APIAssignmentGroup, courseID: String, in context: NSManagedObjectContext, updateSubmission: Bool, updateScoreStatistics: Bool) -> AssignmentGroup {
         let model: AssignmentGroup = context.first(where: #keyPath(AssignmentGroup.id), equals: item.id.value) ?? context.insert()
         model.id = item.id.value
         model.name = item.name
@@ -36,7 +36,7 @@ public final class AssignmentGroup: NSManagedObject {
         model.courseID = courseID
 
         for a in item.assignments ?? [] {
-            let assignment = Assignment.save(a, in: context, updateSubmission: true)
+            let assignment = Assignment.save(a, in: context, updateSubmission: updateSubmission, updateScoreStatistics: updateScoreStatistics)
             assignment.assignmentGroupPosition = item.position
             assignment.assignmentGroup = model
         }

--- a/Core/Core/Assignments/GetAssignments.swift
+++ b/Core/Core/Assignments/GetAssignments.swift
@@ -83,7 +83,7 @@ public class GetAssignments: UseCase {
         }
 
         for item in response {
-            Assignment.save(item, in: client, updateSubmission: include.contains(.submission))
+            Assignment.save(item, in: client, updateSubmission: include.contains(.submission), updateScoreStatistics: include.contains(.score_statistics))
         }
     }
 }
@@ -144,6 +144,7 @@ public class GetAssignment: APIUseCase {
 
         let model: Assignment = client.fetch(scope.predicate).first ?? client.insert()
         let updateSubmission = include.contains(.submission)
-        model.update(fromApiModel: response, in: client, updateSubmission: updateSubmission)
+        let updateScoreStatistics = include.contains(.score_statistics)
+        model.update(fromApiModel: response, in: client, updateSubmission: updateSubmission, updateScoreStatistics: updateScoreStatistics)
     }
 }

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -63,6 +63,7 @@
         <relationship name="gradingPeriod" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="GradingPeriod" inverseName="assignments" inverseEntity="GradingPeriod"/>
         <relationship name="masteryPathAssignment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MasteryPathAssignment" inverseName="model" inverseEntity="MasteryPathAssignment"/>
         <relationship name="rubric" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Rubric" inverseName="assignment" inverseEntity="Rubric"/>
+        <relationship name="scoreStatistics" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="ScoreStatistics" inverseName="assignment" inverseEntity="ScoreStatistics"/>
         <relationship name="submissions" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Submission" inverseName="assignment" inverseEntity="Submission"/>
         <relationship name="syllabus" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Syllabus" inverseName="assignments" inverseEntity="Syllabus"/>
         <relationship name="todo" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Todo" inverseName="assignment" inverseEntity="Todo"/>
@@ -676,6 +677,12 @@
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <relationship name="rubric" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Rubric" inverseName="ratings" inverseEntity="Rubric"/>
     </entity>
+    <entity name="ScoreStatistics" representedClassName="Core.ScoreStatistics" syncable="YES">
+        <attribute name="max" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="mean" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="min" attributeType="Double" usesScalarValueType="YES"/>
+        <relationship name="assignment" maxCount="1" deletionRule="Nullify" destinationEntity="Assignment" inverseName="scoreStatistics" inverseEntity="Assignment"/>
+    </entity>
     <entity name="SearchRecipient" representedClassName="Core.SearchRecipient" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="URI"/>
         <attribute name="filter" optional="YES" attributeType="String"/>
@@ -866,5 +873,6 @@
         <element name="User" positionX="-540" positionY="-27" width="128" height="223"/>
         <element name="UserProfile" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="UserSettings" positionX="-540" positionY="-27" width="128" height="90"/>
+        <element name="ScoreStatistics" positionX="-540" positionY="-18" width="128" height="103"/>
     </elements>
 </model>

--- a/Core/Core/Extensions/ClosedRangeExtensions.swift
+++ b/Core/Core/Extensions/ClosedRangeExtensions.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2018-present  Instructure, Inc.
+// Copyright (C) 2020-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,19 +16,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import CoreData
-import Foundation
-@testable import Core
-
-extension AssignmentGroup {
-    @discardableResult
-    public static func make(
-        from api: APIAssignmentGroup = .make(),
-        courseID: String = "1",
-        in context: NSManagedObjectContext = singleSharedTestDatabase.viewContext
-    ) -> AssignmentGroup {
-        let model = AssignmentGroup.save(api, courseID: courseID, in: context, updateSubmission: false, updateScoreStatistics: false)
-        try! context.save()
-        return model
+extension ClosedRange {
+    func clamp(_ value : Bound) -> Bound {
+        return self.lowerBound > value ? self.lowerBound
+            : self.upperBound < value ? self.upperBound
+            : value
     }
 }

--- a/Core/Core/Grades/GetAssignmentsByGroup.swift
+++ b/Core/Core/Grades/GetAssignmentsByGroup.swift
@@ -24,6 +24,8 @@ public class GetAssignmentsByGroup: APIUseCase {
 
     let courseID: String
     let gradingPeriodID: String?
+    
+    private let include: [GetAssignmentGroupsRequest.Include] = [ .assignments, .observed_users, .submission, .score_statistics ]
 
     public init(courseID: String, gradingPeriodID: String? = nil) {
         self.courseID = courseID
@@ -37,7 +39,7 @@ public class GetAssignmentsByGroup: APIUseCase {
     public var request: GetAssignmentGroupsRequest { GetAssignmentGroupsRequest(
         courseID: courseID,
         gradingPeriodID: gradingPeriodID,
-        include: [ .assignments, .observed_users, .submission ],
+        include: include,
         perPage: 100
     ) }
 
@@ -58,7 +60,7 @@ public class GetAssignmentsByGroup: APIUseCase {
 
     public func write(response: [APIAssignmentGroup]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         response?.forEach { item in
-            AssignmentGroup.save(item, courseID: courseID, in: client)
+            AssignmentGroup.save(item, courseID: courseID, in: client, updateSubmission: include.contains(.submission), updateScoreStatistics: include.contains(.score_statistics))
         }
     }
 }

--- a/Core/Core/Modules/MasteryPath.swift
+++ b/Core/Core/Modules/MasteryPath.swift
@@ -68,7 +68,7 @@ public class MasteryPathAssignment: NSManagedObject {
         model.courseID = item.model.course_id.value
         model.name = item.model.name
         model.pointsPossible = NSNumber(value: item.model.points_possible)
-        model.model = Assignment.save(item.model, in: context, updateSubmission: false)
+        model.model = Assignment.save(item.model, in: context, updateSubmission: false, updateScoreStatistics: false)
         return model
     }
 }

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -182,7 +182,7 @@ extension Submission: WriteableModel {
         let assignmentPredicate = NSPredicate(format: "%K == %@", #keyPath(Assignment.id), item.assignment_id.value)
         if let apiAssignment = item.assignment {
             let assignment: Assignment = client.fetch(assignmentPredicate).first ?? client.insert()
-            assignment.update(fromApiModel: apiAssignment, in: client, updateSubmission: false)
+            assignment.update(fromApiModel: apiAssignment, in: client, updateSubmission: false, updateScoreStatistics: false)
             assignment.submission = model
         } else if let assignment: Assignment = client.fetch(assignmentPredicate).first {
             assignment.submission = model

--- a/Core/Core/Todos/Todo.swift
+++ b/Core/Core/Todos/Todo.swift
@@ -61,7 +61,7 @@ public final class Todo: NSManagedObject, WriteableModel {
     public static func save(_ item: APITodo, in context: NSManagedObjectContext) -> Todo {
         let id = item.assignment.id.value
         let assignment: Assignment = context.first(where: #keyPath(Assignment.id), equals: id) ?? context.insert()
-        assignment.update(fromApiModel: item.assignment, in: context, updateSubmission: false)
+        assignment.update(fromApiModel: item.assignment, in: context, updateSubmission: false, updateScoreStatistics: false)
 
         let model: Todo = context.first(where: #keyPath(Todo.id), equals: id) ?? context.insert()
         model.assignment = assignment

--- a/Core/Core/UIViews/GradeStatisticGraphView.swift
+++ b/Core/Core/UIViews/GradeStatisticGraphView.swift
@@ -1,0 +1,125 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+
+public class GradeStatisticGraphView: UIView {
+    @IBOutlet weak var averageLabel: UILabel!
+    @IBOutlet weak var minLabel: UILabel!
+    @IBOutlet weak var maxLabel: UILabel!
+    
+    @IBOutlet weak var minPossibleBar: UIView!
+    @IBOutlet weak var maxPossibleBar: UIView!
+    
+    @IBOutlet weak var graphArea: UIView!
+    
+    @IBOutlet weak var minConstraint: NSLayoutConstraint!
+    @IBOutlet weak var maxConstraint: NSLayoutConstraint!
+    @IBOutlet weak var yourScoreConstraint: NSLayoutConstraint!
+    @IBOutlet weak var meanConstraint: NSLayoutConstraint!
+    
+    // These are here just for tests
+    @IBOutlet weak var leftBoundView: UIView!
+    @IBOutlet weak var rightBoundView: UIView!
+    @IBOutlet weak var minBarView: UIView!
+    @IBOutlet weak var maxBarView: UIView!
+    @IBOutlet weak var meanBarView: UIView!
+    
+    @IBOutlet private var lines: [UIView]!
+    
+    @IBOutlet weak var yourScoreView: UIView!
+    
+    // State: These are computed when update() is called
+    // and are used in layoutSubviews so we can resize
+    // even if update isn't called.
+    private var minPercent: CGFloat?
+    private var maxPercent: CGFloat?
+    private var avgPercent: CGFloat?
+    private var studentPercent: CGFloat?
+
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        loadFromXib()
+    }
+
+    public required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        loadFromXib()
+        
+        yourScoreView.backgroundColor = Brand.shared.primary.ensureContrast(against: .backgroundLightest)
+        yourScoreView.layer.cornerRadius = 8.0
+        for line in lines {
+            line.layer.cornerRadius = 1.0
+        }
+    }
+    
+    public override func layoutSubviews() {
+        if let minPercent = minPercent, let avgPercent = avgPercent, let maxPercent = maxPercent, let studentPercent = studentPercent {
+            let usableWidth = frame.width - 48.0 - 2.0 // subtract 2 for half width of the outermost bars
+            
+            minConstraint.constant = usableWidth * minPercent
+            meanConstraint.constant = usableWidth * avgPercent
+            maxConstraint.constant = usableWidth * maxPercent
+            yourScoreConstraint.constant = usableWidth * studentPercent
+        }
+        super.layoutSubviews()
+    }
+    public func update(_ assignment: Assignment) {
+        setupGraph(assignment: assignment)
+    }
+    
+    func setupGraph(assignment: Assignment) {
+        guard let stats = assignment.scoreStatistics, let points_possible = assignment.pointsPossible, let score = assignment.viewableScore, points_possible > 0 else {
+            isHidden = true
+            return
+        }
+        isHidden = false
+        
+        let allowedInterval = 0 ... points_possible
+        let boundedMin = allowedInterval.clamp(stats.min)
+        let boundedMax = allowedInterval.clamp(stats.max)
+        let boundedMean = allowedInterval.clamp(stats.mean)
+        let boundedScore = allowedInterval.clamp(score)
+        
+        let possible = CGFloat(points_possible)
+        
+        // Store percents, they will be used to fix constraints in layoutSubviews,
+        // even as the view changes
+        minPercent = (CGFloat(boundedMin) / possible)
+        maxPercent = (CGFloat(boundedMax) / possible)
+        avgPercent = (CGFloat(boundedMean) / possible)
+        studentPercent = (CGFloat(boundedScore) / possible)
+        
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 1
+        formatter.maximumFractionDigits = 1
+        
+        minLabel.text = "Min: \(formatter.string(from: NSNumber(value: stats.min)) ?? "")"
+        averageLabel.text = "Avg: \(formatter.string(from: NSNumber(value: stats.mean)) ?? "")"
+        maxLabel.text = "Max: \(formatter.string(from: NSNumber(value: stats.max)) ?? "")"
+        
+                
+        // We want the layout to update NOW -- don't wait for next cycle
+        setNeedsLayout()
+        layoutIfNeeded()
+
+    }
+}
+

--- a/Core/Core/UIViews/GradeStatisticGraphView.xib
+++ b/Core/Core/UIViews/GradeStatisticGraphView.xib
@@ -1,0 +1,194 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GradeStatisticGraphView" customModule="Core" customModuleProvider="target">
+            <connections>
+                <outlet property="averageLabel" destination="0rX-af-3gd" id="u37-jZ-TCg"/>
+                <outlet property="graphArea" destination="mHu-F5-DWY" id="Cu8-rk-V08"/>
+                <outlet property="leftBoundView" destination="uqU-9h-dXH" id="ERL-HJ-ME3"/>
+                <outlet property="maxBarView" destination="e4Z-Dr-wc7" id="duA-ns-gdU"/>
+                <outlet property="maxConstraint" destination="ISW-hs-h7l" id="FPd-EX-5RQ"/>
+                <outlet property="maxLabel" destination="OTg-IB-Qm3" id="YYH-fX-ZBB"/>
+                <outlet property="maxPossibleBar" destination="0YA-zw-daT" id="Wef-ya-hLl"/>
+                <outlet property="meanBarView" destination="Pgh-9b-6ei" id="sZP-Ko-og6"/>
+                <outlet property="meanConstraint" destination="0AX-LS-yzN" id="5XN-AB-X8V"/>
+                <outlet property="minBarView" destination="JMs-5t-D9m" id="BI3-zZ-S8n"/>
+                <outlet property="minConstraint" destination="ddr-Vr-qOZ" id="hmF-SG-let"/>
+                <outlet property="minLabel" destination="rAf-Wd-kzE" id="qaa-w8-2gD"/>
+                <outlet property="minPossibleBar" destination="uqU-9h-dXH" id="EXv-ye-3bJ"/>
+                <outlet property="rightBoundView" destination="0YA-zw-daT" id="Pqv-2o-K1r"/>
+                <outlet property="yourScoreConstraint" destination="HME-gp-Rsz" id="K7p-vC-BlP"/>
+                <outlet property="yourScoreView" destination="xAy-hd-CgW" id="Ukf-EH-Kvy"/>
+                <outletCollection property="lines" destination="uqU-9h-dXH" collectionClass="NSMutableArray" id="gd5-v0-iS3"/>
+                <outletCollection property="lines" destination="JMs-5t-D9m" collectionClass="NSMutableArray" id="2Od-Yd-pMv"/>
+                <outletCollection property="lines" destination="e4Z-Dr-wc7" collectionClass="NSMutableArray" id="g3y-Yq-i99"/>
+                <outletCollection property="lines" destination="0YA-zw-daT" collectionClass="NSMutableArray" id="ONe-fr-niC"/>
+            </connections>
+        </placeholder>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="598" height="312"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mHu-F5-DWY" userLabel="Graph Elements">
+                    <rect key="frame" x="0.0" y="54" width="598" height="40"/>
+                    <subviews>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="uqU-9h-dXH" userLabel="leftBound">
+                            <rect key="frame" x="24" y="10" width="2" height="20"/>
+                            <color key="backgroundColor" name="borderMedium"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="2" id="5U9-pN-iHn"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0YA-zw-daT" userLabel="rightBound">
+                            <rect key="frame" x="572" y="10" width="2" height="20"/>
+                            <color key="backgroundColor" name="borderMedium"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="2" id="SLX-UA-TdX"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JMs-5t-D9m" userLabel="min">
+                            <rect key="frame" x="73.5" y="10" width="3" height="20"/>
+                            <color key="backgroundColor" name="borderDark"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="3" id="AjF-WX-Kmp"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FMa-Ea-gBn" userLabel="Full Width Line">
+                            <rect key="frame" x="24" y="19" width="550" height="2"/>
+                            <color key="backgroundColor" name="borderMedium"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="2" id="Qww-AJ-6x2"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QSs-G5-Beg" userLabel="Partial Width Line">
+                            <rect key="frame" x="73.5" y="18.5" width="3" height="3"/>
+                            <color key="backgroundColor" name="borderDark"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="3" id="SI9-dV-SxV"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Pgh-9b-6ei" userLabel="Avg">
+                            <rect key="frame" x="73.5" y="10" width="3" height="20"/>
+                            <color key="backgroundColor" name="backgroundDarkest"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="3" id="sls-hk-h26"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="e4Z-Dr-wc7" userLabel="max">
+                            <rect key="frame" x="73.5" y="10" width="3" height="20"/>
+                            <color key="backgroundColor" name="borderDark"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="3" id="OP3-Ps-A3A"/>
+                            </constraints>
+                        </view>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xAy-hd-CgW" userLabel="You">
+                            <rect key="frame" x="67" y="12" width="16" height="16"/>
+                            <color key="backgroundColor" systemColor="systemBlueColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="16" id="XQk-08-ejf"/>
+                                <constraint firstAttribute="height" constant="16" id="apg-7k-I7K"/>
+                            </constraints>
+                        </view>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="Pgh-9b-6ei" firstAttribute="centerX" secondItem="uqU-9h-dXH" secondAttribute="centerX" constant="50" id="0AX-LS-yzN"/>
+                        <constraint firstItem="xAy-hd-CgW" firstAttribute="centerY" secondItem="FMa-Ea-gBn" secondAttribute="centerY" id="0en-OK-g5t"/>
+                        <constraint firstItem="QSs-G5-Beg" firstAttribute="centerY" secondItem="FMa-Ea-gBn" secondAttribute="centerY" id="21C-ga-EA9"/>
+                        <constraint firstAttribute="bottom" secondItem="uqU-9h-dXH" secondAttribute="bottom" constant="10" id="8jU-os-yTY"/>
+                        <constraint firstItem="FMa-Ea-gBn" firstAttribute="leading" secondItem="uqU-9h-dXH" secondAttribute="leading" id="Ape-bV-IwC"/>
+                        <constraint firstAttribute="trailing" secondItem="0YA-zw-daT" secondAttribute="trailing" constant="24" id="EwV-eQ-EMF"/>
+                        <constraint firstItem="xAy-hd-CgW" firstAttribute="centerX" secondItem="uqU-9h-dXH" secondAttribute="centerX" constant="50" id="HME-gp-Rsz"/>
+                        <constraint firstItem="e4Z-Dr-wc7" firstAttribute="centerX" secondItem="uqU-9h-dXH" secondAttribute="centerX" constant="50" id="ISW-hs-h7l"/>
+                        <constraint firstItem="QSs-G5-Beg" firstAttribute="leading" secondItem="JMs-5t-D9m" secondAttribute="leading" id="KIh-EZ-iYb"/>
+                        <constraint firstItem="QSs-G5-Beg" firstAttribute="trailing" secondItem="e4Z-Dr-wc7" secondAttribute="trailing" id="LOF-mC-AP0"/>
+                        <constraint firstItem="uqU-9h-dXH" firstAttribute="leading" secondItem="mHu-F5-DWY" secondAttribute="leading" constant="24" id="MUN-7D-eUD"/>
+                        <constraint firstItem="uqU-9h-dXH" firstAttribute="centerY" secondItem="mHu-F5-DWY" secondAttribute="centerY" id="OPW-fR-M42"/>
+                        <constraint firstAttribute="bottom" secondItem="0YA-zw-daT" secondAttribute="bottom" constant="10" id="XWg-MT-aOu"/>
+                        <constraint firstItem="JMs-5t-D9m" firstAttribute="centerX" secondItem="uqU-9h-dXH" secondAttribute="centerX" constant="50" id="ddr-Vr-qOZ"/>
+                        <constraint firstItem="FMa-Ea-gBn" firstAttribute="trailing" secondItem="0YA-zw-daT" secondAttribute="trailing" id="khg-VM-kP0"/>
+                        <constraint firstItem="uqU-9h-dXH" firstAttribute="top" secondItem="mHu-F5-DWY" secondAttribute="top" constant="10" id="l1l-oD-0Tf"/>
+                        <constraint firstAttribute="height" constant="40" id="m8H-jd-YhX"/>
+                        <constraint firstItem="e4Z-Dr-wc7" firstAttribute="bottom" secondItem="0YA-zw-daT" secondAttribute="bottom" id="nLy-bC-HBl"/>
+                        <constraint firstItem="Pgh-9b-6ei" firstAttribute="bottom" secondItem="uqU-9h-dXH" secondAttribute="bottom" id="ohE-Pp-5IX"/>
+                        <constraint firstItem="JMs-5t-D9m" firstAttribute="top" secondItem="uqU-9h-dXH" secondAttribute="top" id="pG8-da-KlF"/>
+                        <constraint firstItem="JMs-5t-D9m" firstAttribute="bottom" secondItem="uqU-9h-dXH" secondAttribute="bottom" id="rTQ-jN-zGv"/>
+                        <constraint firstItem="Pgh-9b-6ei" firstAttribute="centerY" secondItem="mHu-F5-DWY" secondAttribute="centerY" id="sSm-Q7-nEs"/>
+                        <constraint firstItem="e4Z-Dr-wc7" firstAttribute="top" secondItem="0YA-zw-daT" secondAttribute="top" id="wbj-6f-Tde"/>
+                        <constraint firstItem="Pgh-9b-6ei" firstAttribute="top" secondItem="uqU-9h-dXH" secondAttribute="top" id="xnD-FQ-tpB"/>
+                        <constraint firstItem="0YA-zw-daT" firstAttribute="top" secondItem="mHu-F5-DWY" secondAttribute="top" constant="10" id="yGQ-J4-MOP"/>
+                        <constraint firstItem="FMa-Ea-gBn" firstAttribute="centerY" secondItem="mHu-F5-DWY" secondAttribute="centerY" id="yWb-bO-9MO"/>
+                        <constraint firstItem="0YA-zw-daT" firstAttribute="centerY" secondItem="mHu-F5-DWY" secondAttribute="centerY" id="ywe-0m-nVv"/>
+                    </constraints>
+                </view>
+                <stackView opaque="NO" contentMode="scaleToFill" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="VlA-Fj-h0O">
+                    <rect key="frame" x="0.0" y="102" width="598" height="17"/>
+                    <subviews>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Min: 7" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rAf-Wd-kzE" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="0.0" y="0.0" width="199.5" height="17"/>
+                            <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                            <color key="textColor" name="ashHighContrast"/>
+                            <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold14"/>
+                            </userDefinedRuntimeAttributes>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="Avg: 9" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0rX-af-3gd" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="207.5" y="0.0" width="183" height="17"/>
+                            <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                            <color key="textColor" name="ashHighContrast"/>
+                            <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold14"/>
+                            </userDefinedRuntimeAttributes>
+                        </label>
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Max: 9" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="OTg-IB-Qm3" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="398.5" y="0.0" width="199.5" height="17"/>
+                            <fontDescription key="fontDescription" name=".AppleSystemUIFont" family=".AppleSystemUIFont" pointSize="17"/>
+                            <color key="textColor" name="ashHighContrast"/>
+                            <nil key="highlightedColor"/>
+                            <userDefinedRuntimeAttributes>
+                                <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold14"/>
+                            </userDefinedRuntimeAttributes>
+                        </label>
+                    </subviews>
+                </stackView>
+            </subviews>
+            <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+            <constraints>
+                <constraint firstItem="IrV-ai-eG7" firstAttribute="trailing" secondItem="mHu-F5-DWY" secondAttribute="trailing" id="4zX-zt-OiX"/>
+                <constraint firstItem="VlA-Fj-h0O" firstAttribute="leading" secondItem="IrV-ai-eG7" secondAttribute="leading" id="5WN-ed-UqH"/>
+                <constraint firstItem="VlA-Fj-h0O" firstAttribute="top" secondItem="mHu-F5-DWY" secondAttribute="bottom" constant="8" id="ODm-It-jpH"/>
+                <constraint firstItem="mHu-F5-DWY" firstAttribute="leading" secondItem="IrV-ai-eG7" secondAttribute="leading" id="bE1-7I-Jcs"/>
+                <constraint firstItem="IrV-ai-eG7" firstAttribute="trailing" secondItem="VlA-Fj-h0O" secondAttribute="trailing" id="gpy-3Y-AE1"/>
+                <constraint firstItem="mHu-F5-DWY" firstAttribute="top" secondItem="IrV-ai-eG7" secondAttribute="top" constant="10" id="iJD-e4-wjw"/>
+            </constraints>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <viewLayoutGuide key="safeArea" id="IrV-ai-eG7"/>
+            <point key="canvasLocation" x="28.985507246376812" y="1.3392857142857142"/>
+        </view>
+    </objects>
+    <resources>
+        <namedColor name="ashHighContrast">
+            <color red="0.33333333333333331" green="0.396078431372549" blue="0.44705882352941179" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="backgroundDarkest">
+            <color red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="borderDark">
+            <color red="0.54509803921568623" green="0.58823529411764708" blue="0.61960784313725492" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="borderMedium">
+            <color red="0.7803921568627451" green="0.80392156862745101" blue="0.81960784313725488" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
+</document>

--- a/Core/CoreTests/Assignments/AssignmentTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentTests.swift
@@ -35,7 +35,7 @@ class AssignmentTests: CoreTestCase {
 
         XCTAssertNil(a.submission)
 
-        a.update(fromApiModel: api, in: client, updateSubmission: true)
+        a.update(fromApiModel: api, in: client, updateSubmission: true, updateScoreStatistics: false)
 
         XCTAssertEqual(a.id, api.id.value)
         XCTAssertEqual(a.name, api.name)
@@ -61,7 +61,7 @@ class AssignmentTests: CoreTestCase {
 
         XCTAssertNil(a.submission)
 
-        a.update(fromApiModel: api, in: client, updateSubmission: false)
+        a.update(fromApiModel: api, in: client, updateSubmission: false, updateScoreStatistics: false)
 
         XCTAssertNil(a.submission)
     }
@@ -72,13 +72,67 @@ class AssignmentTests: CoreTestCase {
         let api = APIAssignment.make(name: "api_a", submission: nil)
         XCTAssertNil(api.submission)
 
-        a.update(fromApiModel: api, in: client, updateSubmission: true)
+        a.update(fromApiModel: api, in: client, updateSubmission: true, updateScoreStatistics: false)
         XCTAssertNil(a.submission)
 
         let list: [Assignment] = client.fetch(NSPredicate(format: "%K == %@", #keyPath(Assignment.id), a.id))
         let result = list.first
         XCTAssertNotNil(result)
         XCTAssertNil(result?.submission)
+    }
+    
+    func testUpdateFromAPIItemWithAPIScoreStatistics() {
+        let client = databaseClient
+        let a = Assignment.make(from: .make(name: "a", score_statistics: nil))
+        let api = APIAssignment.make(name: "api_a", score_statistics: APIAssignmentScoreStatistics(mean: 5.0, min: 1.0, max: 10.0))
+
+        XCTAssertNil(a.scoreStatistics)
+
+        a.update(fromApiModel: api, in: client, updateSubmission: false, updateScoreStatistics: true)
+
+        XCTAssertEqual(a.id, api.id.value)
+        XCTAssertEqual(a.name, api.name)
+        XCTAssertEqual(a.courseID, api.course_id.value)
+        XCTAssertEqual(a.details, api.description)
+        XCTAssertEqual(a.pointsPossible, api.points_possible)
+        XCTAssertEqual(a.dueAt, api.due_at)
+        XCTAssertEqual(a.htmlURL, api.html_url)
+        XCTAssertEqual(a.gradingType, api.grading_type)
+        XCTAssertEqual(a.submissionTypes, api.submission_types)
+        XCTAssertEqual(a.position, api.position)
+        XCTAssertFalse(a.useRubricForGrading)
+        XCTAssertFalse(a.hideRubricPoints)
+        XCTAssertFalse(a.freeFormCriterionCommentsOnRubric)
+
+        XCTAssertNotNil(a.scoreStatistics)
+
+    }
+
+    func testUpdateFromAPIItemWithAPIScoreStatisticsButDoNotUpdateStatistics() {
+        let client = databaseClient
+        let a = Assignment.make(from: .make(name: "a", score_statistics: nil))
+        let api = APIAssignment.make(name: "api_a", score_statistics: APIAssignmentScoreStatistics(mean: 5.0, min: 1.0, max: 10.0))
+
+        XCTAssertNil(a.scoreStatistics)
+
+        a.update(fromApiModel: api, in: client, updateSubmission: false, updateScoreStatistics: false)
+
+        XCTAssertNil(a.scoreStatistics)
+    }
+
+    func testUpdateFromAPIItemWithExistingScoreStatistics() {
+        let client = databaseClient
+        let a = Assignment.make(from: .make(name: "a", score_statistics: APIAssignmentScoreStatistics(mean: 5.0, min: 2.0, max: 10.0)))
+        let api = APIAssignment.make(name: "api_a", score_statistics: nil)
+        XCTAssertNil(api.score_statistics)
+
+        a.update(fromApiModel: api, in: client, updateSubmission: false, updateScoreStatistics: true)
+        XCTAssertNil(a.scoreStatistics)
+
+        let list: [Assignment] = client.fetch(NSPredicate(format: "%K == %@", #keyPath(Assignment.id), a.id))
+        let result = list.first
+        XCTAssertNotNil(result)
+        XCTAssertNil(result?.scoreStatistics)
     }
 
     func testCanMakeSubmissions() {
@@ -131,7 +185,7 @@ class AssignmentTests: CoreTestCase {
         let apiAssignment = APIAssignment.make(use_rubric_for_grading: true)
         let assignment = Assignment.make()
 
-        assignment.update(fromApiModel: apiAssignment, in: databaseClient, updateSubmission: true)
+        assignment.update(fromApiModel: apiAssignment, in: databaseClient, updateSubmission: true, updateScoreStatistics: false)
 
         XCTAssertTrue(assignment.useRubricForGrading)
     }

--- a/Core/CoreTests/Assignments/GetAssignmentsTests.swift
+++ b/Core/CoreTests/Assignments/GetAssignmentsTests.swift
@@ -240,12 +240,12 @@ class GetAssignmentsTests: CoreTestCase {
         let a7 = Assignment.make(from: .make(id: "7"))
 
        //   must do this so dueAtSortNilsAtBottom property gets updated
-        a2.update(fromApiModel: api2, in: databaseClient, updateSubmission: false)
-        a3.update(fromApiModel: api3, in: databaseClient, updateSubmission: false)
-        a4.update(fromApiModel: api4, in: databaseClient, updateSubmission: false)
-        a5.update(fromApiModel: api5, in: databaseClient, updateSubmission: false)
-        a6.update(fromApiModel: api6, in: databaseClient, updateSubmission: false)
-        a7.update(fromApiModel: api7, in: databaseClient, updateSubmission: false)
+        a2.update(fromApiModel: api2, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
+        a3.update(fromApiModel: api3, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
+        a4.update(fromApiModel: api4, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
+        a5.update(fromApiModel: api5, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
+        a6.update(fromApiModel: api6, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
+        a7.update(fromApiModel: api7, in: databaseClient, updateSubmission: false, updateScoreStatistics: false)
 
         let useCase = GetAssignments(courseID: "1", sort: .dueAt)
 

--- a/Core/CoreTests/Views/GradeStatisticsGraphViewTests.swift
+++ b/Core/CoreTests/Views/GradeStatisticsGraphViewTests.swift
@@ -1,0 +1,146 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2019-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+class GradeStatisticsGraphViewTests: XCTestCase {
+    var view: GradeStatisticGraphView!
+
+    override func setUp() {
+        super.setUp()
+        view = GradeStatisticGraphView(frame: CGRect(x: 0, y: 0, width: 800, height: 200))
+    }
+    
+    // Helper func to validate the layout
+    private func validateLayout(assignment: Assignment, allowedError: CGFloat) {
+        guard let scoreStatistics = assignment.scoreStatistics, let maxPossible = assignment.pointsPossible else {
+            XCTFail("Tried to validate layout when there were no score statistics")
+            return
+        }
+        XCTAssertFalse(view.isHidden, "GradeStatisticGraphView should not be hidden")
+        
+        // Check order of markers
+        let x1 = view.minPossibleBar.frame.midX, x2 = view.minBarView.frame.midX, x3 = view.meanBarView.frame.midX, x4 = view.maxBarView.frame.midX, x5 = view.maxPossibleBar.frame.midX
+        XCTAssertTrue(x1 <= x2 && x2 <= x3 && x3 <= x4 && x4 <= x5, "Graph view text labels were not correctly ordered")
+        
+        let minX = view.minPossibleBar.frame.midX
+        let width = view.maxPossibleBar.frame.midX - view.minPossibleBar.frame.midX
+        
+        let expected = [0, scoreStatistics.min, scoreStatistics.mean, scoreStatistics.max, maxPossible].map { (d: Double) -> CGFloat in
+            return CGFloat(d / maxPossible) * width + minX
+        }
+        XCTAssertLessThan((x1 - expected[0]).magnitude, allowedError, "Min possible label was too far from it's expected location")
+        XCTAssertLessThan((x2 - expected[1]).magnitude, allowedError, "Min label was too far from it's expected location")
+        XCTAssertLessThan((x3 - expected[2]).magnitude, allowedError, "Avg label was too far from it's expected location")
+        XCTAssertLessThan((x4 - expected[3]).magnitude, allowedError, "Max label was too far from it's expected location")
+        XCTAssertLessThan((x5 - expected[4]).magnitude, allowedError, "Max possible label was too far from it's expected location")
+        
+    }
+    
+    // Helper func to call update on the view and then re-layout as if being displayed
+    func updateAndValidateLayoutForAssignment(assignment: Assignment, allowedError: CGFloat = 2.0) {
+        view.layoutIfNeeded()
+        view.update(assignment)
+        
+        // This is needed for tests since we aren't actually in a view controller or render loop
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        
+        validateLayout(assignment: assignment, allowedError: allowedError)
+    }
+
+    func testLabelsCorrectLocationNoPressure() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 5.0, min: 2.0, max: 8.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "6.0",
+            score: 6.0,
+            workflow_state: .graded
+        ))
+        updateAndValidateLayoutForAssignment(assignment: a)
+    }
+    
+    func testLabelsCorrectLocationAllZero() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 0.0, min: 0.0, max: 0.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "0.0",
+            score: 0.0,
+            workflow_state: .graded
+        ))
+        updateAndValidateLayoutForAssignment(assignment: a)
+    }
+    
+    func testLabelsCorrectLocationAllMax() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 10.0, min: 10.0, max: 10.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "10.0",
+            score: 10.0,
+            workflow_state: .graded
+        ))
+        updateAndValidateLayoutForAssignment(assignment: a)
+    }
+    
+    func testLabelsCorrectLocationFullSplit() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 0.0, min: 0.0, max: 10.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "10.0",
+            score: 10.0,
+            workflow_state: .graded
+        ))
+        updateAndValidateLayoutForAssignment(assignment: a)
+    }
+    
+    func testLabelsOutOfBounds() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 11.0, min: -5000.0, max: 6000.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "15.0",
+            score: 15.0,
+            workflow_state: .graded
+        ))
+        
+        view.layoutIfNeeded()
+        view.update(a)
+        
+        // This is needed for tests since we aren't actually in a view controller or render loop
+        view.setNeedsLayout()
+        view.layoutIfNeeded()
+        
+        // Should appear the same as the layout for min=0, max=max_possible, and mean=max_possible
+        let lookalike = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 10.0, min: 0.0, max: 10.0)))
+        lookalike.submission = Submission.make(from: .make(
+            grade: "10.0",
+            score: 10.0,
+            workflow_state: .graded
+        ))
+
+        validateLayout(assignment: lookalike, allowedError: 1.0)
+    }
+    
+    func testLabelsCorrectText() {
+        let a = Assignment.make(from: .make(points_possible: 10.0, grading_type: .points, score_statistics: .make(mean: 5.0, min: 2.0, max: 8.0)))
+        a.submission = Submission.make(from: .make(
+            grade: "6.0",
+            score: 6.0,
+            workflow_state: .graded
+        ))
+        view.update(a)
+        XCTAssertEqual(view.minLabel.text, "Min: 2.0")
+        XCTAssertEqual(view.maxLabel.text, "Max: 8.0")
+        XCTAssertEqual(view.averageLabel.text, "Avg: 5.0")
+    }
+}

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -45,7 +45,10 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
     lazy var arc = env.subscribe(GetArc(courseID: courseID)) { [weak self] in
         self?.updateArc()
     }
-    lazy var assignments = env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID, include: [.submission])) { [weak self] in
+    
+    private let includes: [GetAssignmentRequest.GetAssignmentInclude] = [.submission, .score_statistics]
+    
+    lazy var assignments = env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID, include: includes)) { [weak self] in
         self?.update()
     }
     lazy var colors = env.subscribe(GetCustomColors()) { [weak self] in
@@ -268,6 +271,13 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
             assignment?.lockStatus == .before ||
             assignment?.submissionTypes.contains(.online_quiz) == true // attempts show up elsewhere
         )
+    }
+    
+    func statisticsIsHidden() -> Bool {
+        // If there are no statistics, or the statistics are invalid, don't show them
+        // (Valid statistics should have min <= mean <= max
+        guard let scoreStatistics = assignment?.scoreStatistics else { return true }
+        return (scoreStatistics.min > scoreStatistics.mean) || (scoreStatistics.mean > scoreStatistics.max)
     }
 
     func assignmentDescription() -> String {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -27,16 +27,16 @@
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QTp-Qq-8ZA">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1311"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="1441"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="top" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="VdI-qu-MC8">
-                                                <rect key="frame" x="16" y="16" width="343" height="1295"/>
+                                                <rect key="frame" x="16" y="16" width="343" height="1425"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="7yL-fW-mIX">
                                                         <rect key="frame" x="0.0" y="0.0" width="210.5" height="66.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Assignment Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kpV-J8-jIO" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="210.5" height="24"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="210.5" height="20.5"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.name">
                                                                     <accessibilityTraits key="traits" staticText="YES" header="YES"/>
                                                                 </accessibility>
@@ -49,7 +49,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100 pts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ei9-yY-MdM" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="28" width="55.5" height="19.5"/>
+                                                                <rect key="frame" x="0.0" y="24.5" width="57" height="20.5"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.points"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
@@ -60,14 +60,14 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Tdl-M0-B5e">
-                                                                <rect key="frame" x="67.5" y="25" width="24" height="24"/>
+                                                                <rect key="frame" x="69" y="22" width="24" height="24"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="24" id="Coj-fh-S7r"/>
                                                                     <constraint firstAttribute="width" constant="24" id="ogD-U5-Oec"/>
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Not Submitted" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="co0-jJ-6sI" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="95.5" y="28" width="115" height="19.5"/>
+                                                                <rect key="frame" x="97" y="24.5" width="113.5" height="20.5"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.status"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
@@ -262,10 +262,10 @@
                                                         </constraints>
                                                     </view>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uqK-cv-6c4">
-                                                        <rect key="frame" x="0.0" y="724" width="343" height="179.5"/>
+                                                        <rect key="frame" x="0.0" y="724" width="343" height="308.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Grade" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="POu-Bn-aGg" userLabel="Grade Label" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="19.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="20.5"/>
                                                                 <accessibility key="accessibilityConfiguration">
                                                                     <accessibilityTraits key="traits" staticText="YES" header="YES"/>
                                                                 </accessibility>
@@ -278,14 +278,21 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E1l-zH-QmF" userLabel="GradedView" customClass="GradeCircleView" customModule="Core">
-                                                                <rect key="frame" x="0.0" y="19.5" width="343" height="144"/>
+                                                                <rect key="frame" x="0.0" y="20.5" width="343" height="144"/>
                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.gradeCell"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="144" id="9w5-U6-mq8"/>
                                                                 </constraints>
                                                             </view>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="M0E-ux-Sst" customClass="GradeStatisticGraphView" customModule="Core">
+                                                                <rect key="frame" x="0.0" y="164.5" width="343" height="128"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="128" id="hiK-el-hxz"/>
+                                                                </constraints>
+                                                            </view>
                                                             <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="A1G-mN-QCX" userLabel="SubmittedView">
-                                                                <rect key="frame" x="0.0" y="163.5" width="343" height="56"/>
+                                                                <rect key="frame" x="0.0" y="292.5" width="343" height="56"/>
                                                                 <subviews>
                                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Successfully submitted!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x12-ry-KqJ" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
                                                                         <rect key="frame" x="61" y="24" width="221" height="0.0"/>
@@ -331,7 +338,7 @@
                                                                 </constraints>
                                                             </view>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="f8d-eS-gk6" customClass="DividerView" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="163.5" width="343" height="16"/>
+                                                                <rect key="frame" x="0.0" y="292.5" width="343" height="16"/>
                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="16" id="oA9-Vj-s0g"/>
@@ -343,7 +350,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="RfK-cc-MnV">
-                                                        <rect key="frame" x="0.0" y="911.5" width="343" height="66"/>
+                                                        <rect key="frame" x="0.0" y="1040.5" width="343" height="66"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="WQo-YB-o43" userLabel="Submission Button View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="343" height="50"/>
@@ -404,10 +411,10 @@
                                                         </constraints>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RBf-wD-x1b">
-                                                        <rect key="frame" x="0.0" y="985.5" width="343" height="130"/>
+                                                        <rect key="frame" x="0.0" y="1114.5" width="343" height="130"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wuJ-9M-78d" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="31.5"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="28.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -417,7 +424,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Questions:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NdW-Bs-vlK" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="39.5" width="82" height="19.5"/>
+                                                                <rect key="frame" x="0.0" y="36.5" width="82" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -427,7 +434,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="100" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WJw-Fp-IaJ" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="90" y="39.5" width="27" height="19.5"/>
+                                                                <rect key="frame" x="90" y="36.5" width="28.5" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -437,7 +444,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Time Limit:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T2P-Lx-IQN" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="63" width="84" height="19.5"/>
+                                                                <rect key="frame" x="0.0" y="61" width="84.5" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -447,7 +454,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="None" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vY4-Ty-iuC" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="92" y="63" width="39" height="19.5"/>
+                                                                <rect key="frame" x="92.5" y="61" width="41" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -457,7 +464,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Allowed Attempts:" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eqO-N7-cRy" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="0.0" y="86.5" width="139" height="19.5"/>
+                                                                <rect key="frame" x="0.0" y="85.5" width="139" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -467,7 +474,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Unlimited" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZC6-2y-Lay" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                <rect key="frame" x="147" y="86.5" width="69" height="19.5"/>
+                                                                <rect key="frame" x="147" y="85.5" width="73" height="20.5"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -514,7 +521,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TO1-FI-dAE">
-                                                        <rect key="frame" x="0.0" y="1123.5" width="343" height="144"/>
+                                                        <rect key="frame" x="0.0" y="1252.5" width="343" height="144"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Core.PandaLocked" translatesAutoresizingMaskIntoConstraints="NO" id="Yw2-71-XHM" userLabel="LockedIconView">
                                                                 <rect key="frame" x="81" y="0.0" width="181" height="144"/>
@@ -533,7 +540,7 @@
                                                         </constraints>
                                                     </view>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="NUD-Zm-lzB" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="1275.5" width="85.5" height="19.5"/>
+                                                        <rect key="frame" x="0.0" y="1404.5" width="88" height="20.5"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="AssingmentDetails.descriptionHeading">
                                                             <accessibilityTraits key="traits" staticText="YES" header="YES"/>
                                                         </accessibility>
@@ -579,7 +586,7 @@
                                         </constraints>
                                     </view>
                                     <wkWebView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q3R-vd-zmQ" customClass="CoreWebView" customModule="Student" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="1311" width="375" height="20"/>
+                                        <rect key="frame" x="0.0" y="1441" width="375" height="20"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="20" id="KpP-H1-iAI"/>
                                         </constraints>
@@ -592,7 +599,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </wkWebView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gpb-je-B3z" userLabel="PaddingView">
-                                        <rect key="frame" x="0.0" y="1331" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="1461" width="375" height="0.0"/>
                                         <constraints>
                                             <constraint firstAttribute="height" id="0LL-Ka-xXn"/>
                                         </constraints>
@@ -659,6 +666,7 @@
                         <outlet property="gradeCellDivider" destination="f8d-eS-gk6" id="pXB-E1-8S2"/>
                         <outlet property="gradeHeadingLabel" destination="POu-Bn-aGg" id="NF2-DK-7UI"/>
                         <outlet property="gradeSection" destination="uqK-cv-6c4" id="5hS-6j-EwI"/>
+                        <outlet property="gradeStatisticGraphView" destination="M0E-ux-Sst" id="oVe-TN-bkh"/>
                         <outlet property="gradedView" destination="E1l-zH-QmF" id="JRc-bg-TcS"/>
                         <outlet property="loadingView" destination="Y4n-B5-455" id="ZmV-Eq-S3r"/>
                         <outlet property="lockedIconContainerView" destination="TO1-FI-dAE" id="xJ8-6I-LRF"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -38,6 +38,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
     @IBOutlet weak var gradeCell: UIView?
     @IBOutlet weak var gradeCellDivider: DividerView?
     @IBOutlet weak var gradedView: GradeCircleView?
+    @IBOutlet weak var gradeStatisticGraphView: GradeStatisticGraphView?
     @IBOutlet weak var gradeCircleBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var submittedView: UIView?
     @IBOutlet weak var submittedLabel: UILabel?
@@ -192,6 +193,15 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
 
     func updateGradeCell(_ assignment: Assignment) {
         self.gradedView?.update(assignment)
+        
+        // Update grade statistics view
+        if let presenter = presenter {
+            let shouldHide = presenter.statisticsIsHidden()
+            self.gradeStatisticGraphView?.isHidden = shouldHide
+            if !shouldHide {
+                self.gradeStatisticGraphView?.update(assignment)
+            }
+        }
 
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -63,7 +63,8 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
 
         XCTAssertEqual(presenter.assignments.useCase.courseID, presenter.courseID)
         XCTAssertEqual(presenter.assignments.useCase.assignmentID, presenter.assignmentID)
-        XCTAssertEqual(presenter.assignments.useCase.include, [.submission])
+        
+        XCTAssertEqual(presenter.assignments.useCase.include, [.submission, .score_statistics])
 
         XCTAssertEqual(presenter.arc.useCase.courseID, presenter.courseID)
     }
@@ -303,6 +304,31 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
     func testGradesSectionNotHidden() {
         Assignment.make(from: .make(submission: APISubmission.make(workflow_state: .graded)))
         XCTAssertFalse( presenter.gradesSectionIsHidden() )
+    }
+    
+    func testStatisticsSectionIsHiddenBeforeAvailability() {
+        setupIsHiddenTest(lockStatus: .before)
+        XCTAssertTrue( presenter.statisticsIsHidden() )
+    }
+
+    func testStatisticsSectionNotHiddenAfterAvailability() {
+        Assignment.make(from: .make(submission: APISubmission.make(workflow_state: .graded), unlock_at: Date().addYears(-1), locked_for_user: true, lock_explanation: "this is locked", score_statistics: APIAssignmentScoreStatistics(mean: 2.0, min: 1.0, max: 3.0)))
+        XCTAssertFalse( presenter.statisticsIsHidden() )
+    }
+
+    func testStatisticsSectionNotHidden() {
+        Assignment.make(from: .make(submission: APISubmission.make(workflow_state: .graded), score_statistics: APIAssignmentScoreStatistics(mean: 2.0, min: 1.0, max: 3.0)))
+        XCTAssertFalse( presenter.statisticsIsHidden() )
+    }
+    
+    func testStatisticsSectionHiddenWhenNoScoreStatistics() {
+        Assignment.make(from: .make(submission: APISubmission.make(workflow_state: .graded)))
+        XCTAssertTrue( presenter.statisticsIsHidden() )
+    }
+    
+    func testStatisticsSectionHiddenWhenInvalidScoreStatistics() {
+        Assignment.make(from: .make(submission: APISubmission.make(workflow_state: .graded), score_statistics: APIAssignmentScoreStatistics(mean: 2.0, min: 2.1, max: 3.0)))
+        XCTAssertTrue( presenter.statisticsIsHidden() )
     }
 
     func testViewSubmissionButtonSectionIsHiddenBeforeAvailability() {

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
@@ -124,6 +124,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         load()
 
         XCTAssertEqual(viewController.gradeSection?.isHidden, true)
+        XCTAssertEqual(viewController.gradeStatisticGraphView?.isHidden, true)
     }
 
     func testUpdateQuizSettings() {
@@ -209,6 +210,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         XCTAssertEqual(viewController.gradeSection?.isHidden, false)
         XCTAssertEqual(viewController.gradeCellDivider?.isHidden, false)
         XCTAssertEqual(viewController.gradedView?.isHidden, true)
+        XCTAssertEqual(viewController.gradeStatisticGraphView?.isHidden, true)
         XCTAssertEqual(viewController.submittedView?.isHidden, false)
         XCTAssertEqual(viewController.fileSubmissionButton?.isHidden, false)
         XCTAssertEqual(viewController.submittedDetailsLabel?.isHidden, true)
@@ -228,6 +230,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         XCTAssertEqual(viewController.gradeSection?.isHidden, false)
         XCTAssertEqual(viewController.gradeCellDivider?.isHidden, false)
         XCTAssertEqual(viewController.gradedView?.isHidden, true)
+        XCTAssertEqual(viewController.gradeStatisticGraphView?.isHidden, true)
         XCTAssertEqual(viewController.submittedView?.isHidden, false)
         XCTAssertEqual(viewController.fileSubmissionButton?.isHidden, false)
         XCTAssertEqual(viewController.submittedDetailsLabel?.isHidden, true)
@@ -334,6 +337,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         drainMainQueue()
         XCTAssertFalse(viewController.submittedView!.isHidden)
         XCTAssertFalse(viewController.gradeSection!.isHidden)
+        XCTAssertTrue(viewController.gradeStatisticGraphView!.isHidden)
         XCTAssertTrue(viewController.gradedView!.isHidden)
     }
 
@@ -374,6 +378,30 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         drainMainQueue()
         XCTAssertTrue(viewController.submittedView!.isHidden)
         XCTAssertFalse(viewController.gradeSection!.isHidden)
+        XCTAssertTrue(viewController.gradeStatisticGraphView!.isHidden)
+        XCTAssertFalse(viewController.gradedView!.isHidden)
+    }
+    
+    func testGradedWithScoreStatistics() {
+        let course = APICourse.make(id: ID(courseID))
+        api.mock(viewController.presenter!.courses, value: course)
+        let assignment = APIAssignment.make(
+            id: ID(assignmentID),
+            course_id: ID(courseID),
+            submission: .make(
+                grade: "10",
+                score: 10,
+                submission_type: .discussion_topic,
+                workflow_state: .graded
+            ),
+            score_statistics: APIAssignmentScoreStatistics.make(mean: 5.0, min: 1.0, max: 10.0)
+        )
+        api.mock(viewController.presenter!.assignments, value: assignment)
+        load()
+        drainMainQueue()
+        XCTAssertTrue(viewController.submittedView!.isHidden)
+        XCTAssertFalse(viewController.gradeSection!.isHidden)
+        XCTAssertFalse(viewController.gradeStatisticGraphView!.isHidden)
         XCTAssertFalse(viewController.gradedView!.isHidden)
     }
 

--- a/TestsFoundation/TestsFoundation/Fixtures/Model/AssignmentFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Model/AssignmentFixture.swift
@@ -28,7 +28,7 @@ extension Assignment {
         in context: NSManagedObjectContext = singleSharedTestDatabase.viewContext
     ) -> Assignment {
         let model: Assignment = context.insert()
-        model.update(fromApiModel: api, in: context, updateSubmission: true)
+        model.update(fromApiModel: api, in: context, updateSubmission: true, updateScoreStatistics: true)
         model.syllabus = syllabus
         try! context.save()
         return model

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -544,6 +544,7 @@ open class CoreUITestCase: XCTestCase {
         }
         if Bundle.main.isStudentApp {
             mock(include: [ .submission ])
+            mock(include: [ .submission, .score_statistics ])
             mock(include: [])
         } else if Bundle.main.isTeacherApp {
             mock(include: [ .overrides ], allDates: true)


### PR DESCRIPTION
This depends on this PR to add score statistics to the API: https://github.com/instructure/canvas-lms/pull/1669

Screenshot:
<img src="https://user-images.githubusercontent.com/2116451/87271915-a29a7900-c4a2-11ea-9116-67302106f3e9.png" height="500">

This feature is modeled after the (honestly, rather lame) web UI feature (it's a click-to-reveal thing on the student grades screen).
<img width="890" alt="Screen Shot 2020-07-13 at 1 01 43 AM" src="https://user-images.githubusercontent.com/2116451/87272513-767ff780-c4a4-11ea-825a-850275414319.png">

What I implemented (the UI part, at least) is kinda overkill and I'd be perfectly happy if the app just displayed the min, max, and avg as text, but I thought I could do a little better.

Edge cases still display well:

<img src="https://user-images.githubusercontent.com/2116451/87272047-1f2d5780-c4a3-11ea-94f0-af9c5dc1049a.png" height="400">  <img src="https://user-images.githubusercontent.com/2116451/87272095-42580700-c4a3-11ea-8cbb-7187c3755900.png" height="400">  <img src="https://user-images.githubusercontent.com/2116451/87272192-7df2d100-c4a3-11ea-8862-91d900573856.png" height="400">

Supports dynamic text sizing:
<img src="https://user-images.githubusercontent.com/2116451/87272383-138e6080-c4a4-11ea-9813-43f320f1a008.png" height="400">

Tests included. Localization for the "min", "max", and "avg" strings is not included (if you even need that).

I would like to see this feature added to the app in some form (pending my API PR getting accepted), so if there's anything I can do to revise or rework this PR, let me know. 