### PR TITLE
Disable user interaction on empty module cells

### DIFF
--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -235,6 +235,7 @@ extension ModuleListViewController {
         override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
             super.init(style: .default, reuseIdentifier: reuseIdentifier)
 
+            isUserInteractionEnabled = false
             fullDivider = true
             let label = UILabel()
             label.translatesAutoresizingMaskIntoConstraints = false

--- a/Core/CoreTests/Modules/ModuleListViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleListViewControllerTests.swift
@@ -163,8 +163,9 @@ class ModuleListViewControllerTests: CoreTestCase {
         api.mock(GetModulesRequest(courseID: "1", include: []), value: [.make(id: "1")])
         api.mock(GetModuleItemsRequest(courseID: "1", moduleID: "1", include: [.content_details, .mastery_paths]), value: [])
         loadView()
-        XCTAssertEqual(viewController.emptyView.isHidden, true)
-        XCTAssertNotNil(viewController.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? ModuleListViewController.EmptyCell)
+        XCTAssert(viewController.emptyView.isHidden)
+        let emptyCell = viewController.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as! ModuleListViewController.EmptyCell
+        XCTAssertFalse(emptyCell.isUserInteractionEnabled)
     }
 
     func testNoModules() {


### PR DESCRIPTION
refs: MBL-14511
affects: student, teacher
release note: none

Test plan:
- narmstrong > s > CS 1400 > Modules > Empty Module
- Verify you can tap select `This module is empty.` row