### PR TITLE
Fix Parent reply-all

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -718,6 +718,7 @@
 		B14B7055229468BC00B568D6 /* FilePickerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14B7054229468BC00B568D6 /* FilePickerViewControllerTests.swift */; };
 		B14B70572294758600B568D6 /* UploadFileCommentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14B70562294758600B568D6 /* UploadFileCommentTests.swift */; };
 		B14D55612130B6740066D275 /* TestOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14D55602130B6740066D275 /* TestOperationQueue.swift */; };
+		B14D993524BE65A9006DFF12 /* CommonCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14D993424BE65A9006DFF12 /* CommonCourse.swift */; };
 		B14FE5D92134F68800328CD7 /* CoreTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B14FE5D82134F68800328CD7 /* CoreTestCase.swift */; };
 		B150C63C2298DE590096D58C /* WKWebViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B150C63B2298DE590096D58C /* WKWebViewExtensionsTests.swift */; };
 		B150C63E2298E6410096D58C /* GetArcTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B150C63D2298E6410096D58C /* GetArcTests.swift */; };
@@ -1769,6 +1770,7 @@
 		B14B7054229468BC00B568D6 /* FilePickerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePickerViewControllerTests.swift; sourceTree = "<group>"; };
 		B14B70562294758600B568D6 /* UploadFileCommentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileCommentTests.swift; sourceTree = "<group>"; };
 		B14D55602130B6740066D275 /* TestOperationQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestOperationQueue.swift; sourceTree = "<group>"; };
+		B14D993424BE65A9006DFF12 /* CommonCourse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonCourse.swift; sourceTree = "<group>"; };
 		B14FE5D82134F68800328CD7 /* CoreTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTestCase.swift; sourceTree = "<group>"; };
 		B150C623229733C50096D58C /* GetArc.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetArc.swift; sourceTree = "<group>"; };
 		B150C62C2297814E0096D58C /* ExternalTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalTool.swift; sourceTree = "<group>"; };
@@ -2858,6 +2860,7 @@
 				7D26B84223A7F24400262380 /* GetConversations.swift */,
 				9F87D07A2322F4C500EDA363 /* GetSearchRecipients.swift */,
 				9F87D0782322EF5A00EDA363 /* SearchRecipient.swift */,
+				B14D993424BE65A9006DFF12 /* CommonCourse.swift */,
 			);
 			path = Conversations;
 			sourceTree = "<group>";
@@ -5119,6 +5122,7 @@
 				7DA2602D23F722C2005D2121 /* LoginStartMDMLoginCell.swift in Sources */,
 				7DA2607123F722E9005D2121 /* NotificationCategory.swift in Sources */,
 				97DDE0DA24119D6800A05B55 /* CreateTodoViewController.swift in Sources */,
+				B14D993524BE65A9006DFF12 /* CommonCourse.swift in Sources */,
 				7DA260D123F72359005D2121 /* CoreWebView.swift in Sources */,
 				7DA25FCA23F72136005D2121 /* APIRequestable.swift in Sources */,
 				7DA2608A23F72315005D2121 /* APIHelpLinks.swift in Sources */,

--- a/Core/Core/Conversations/APIConversation.swift
+++ b/Core/Core/Conversations/APIConversation.swift
@@ -55,6 +55,7 @@ public struct APIConversationParticipant: Codable, Equatable {
     let name: String
     let avatar_url: APIURL?
     let pronouns: String?
+    let common_courses: [String: [String]]?
 }
 
 public struct APIConversationMessage: Codable, Equatable {
@@ -121,13 +122,15 @@ extension APIConversationParticipant {
         id: String = "1",
         name: String = "Participant One",
         avatar_url: URL? = nil,
-        pronouns: String? = nil
+        pronouns: String? = nil,
+        common_courses: [String: [String]]? = nil
     ) -> APIConversationParticipant {
         return APIConversationParticipant(
             id: ID(id),
             name: name,
             avatar_url: APIURL(rawValue: avatar_url),
-            pronouns: pronouns
+            pronouns: pronouns,
+            common_courses: common_courses
         )
     }
 }

--- a/Core/Core/Conversations/APISearchRecipient.swift
+++ b/Core/Core/Conversations/APISearchRecipient.swift
@@ -88,7 +88,7 @@ public struct GetSearchRecipientsRequest: APIRequestable {
             .optionalValue("user_id", userID),
         ]
         if skipVisibilityChecks {
-            items.append(.value("skip_visibility_checks", "1"))
+            items.append(.bool("skip_visibility_checks", true))
         }
         if !includeContexts {
             items.append(.value("type", "user"))

--- a/Core/Core/Conversations/CommonCourse.swift
+++ b/Core/Core/Conversations/CommonCourse.swift
@@ -1,0 +1,27 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import CoreData
+
+public class CommonCourse: NSManagedObject {
+    @NSManaged public var courseID: String
+    @NSManaged public var role: String
+    @NSManaged public var searchRecipient: SearchRecipient?
+    @NSManaged public var conversationParticipant: ConversationParticipant?
+}

--- a/Core/Core/Conversations/ConversationParticipant.swift
+++ b/Core/Core/Conversations/ConversationParticipant.swift
@@ -24,6 +24,7 @@ public final class ConversationParticipant: NSManagedObject, WriteableModel {
     @NSManaged public var id: String
     @NSManaged public var name: String
     @NSManaged public var pronouns: String?
+    @NSManaged public var commonCourses: Set<CommonCourse>
 
     public var displayName: String {
         User.displayName(name, pronouns: pronouns)
@@ -35,6 +36,16 @@ public final class ConversationParticipant: NSManagedObject, WriteableModel {
         model.id = item.id.value
         model.name = item.name
         model.pronouns = item.pronouns
+        model.commonCourses = []
+        for (courseID, roles) in item.common_courses ?? [:] {
+            for role in roles {
+                let commonCourse: CommonCourse = context.insert()
+                commonCourse.courseID = courseID
+                commonCourse.role = role
+                model.commonCourses.insert(commonCourse)
+            }
+        }
+
         return model
     }
 }

--- a/Core/Core/Conversations/SearchRecipient.swift
+++ b/Core/Core/Conversations/SearchRecipient.swift
@@ -60,9 +60,3 @@ public final class SearchRecipient: NSManagedObject {
         return commonCourses.first { $0.courseID == context.id && Role(rawValue: $0.role) == role } != nil
     }
 }
-
-public class CommonCourse: NSManagedObject {
-    @NSManaged public var courseID: String
-    @NSManaged public var role: String
-    @NSManaged public var searchRecipient: SearchRecipient?
-}

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -93,6 +93,7 @@
     <entity name="CommonCourse" representedClassName="Core.CommonCourse" syncable="YES">
         <attribute name="courseID" attributeType="String"/>
         <attribute name="role" attributeType="String"/>
+        <relationship name="conversationParticipant" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ConversationParticipant" inverseName="commonCourses" inverseEntity="ConversationParticipant"/>
         <relationship name="searchRecipient" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SearchRecipient" inverseName="commonCourses" inverseEntity="SearchRecipient"/>
     </entity>
     <entity name="CommunicationChannel" representedClassName="Core.CommunicationChannel" syncable="YES">
@@ -166,6 +167,7 @@
         <attribute name="id" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="pronouns" optional="YES" attributeType="String"/>
+        <relationship name="commonCourses" toMany="YES" deletionRule="Nullify" destinationEntity="CommonCourse" inverseName="conversationParticipant" inverseEntity="CommonCourse"/>
         <relationship name="conversations" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Conversation" inverseName="participants" inverseEntity="Conversation"/>
     </entity>
     <entity name="Course" representedClassName="Core.Course" syncable="YES">
@@ -790,14 +792,14 @@
         <element name="AssignmentDate" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="AssignmentGroup" positionX="-540" positionY="-27" width="128" height="120"/>
         <element name="CalendarEventItem" positionX="-531" positionY="-18" width="128" height="253"/>
-        <element name="CommonCourse" positionX="-540" positionY="-18" width="128" height="88"/>
+        <element name="CommonCourse" positionX="-540" positionY="-18" width="128" height="103"/>
         <element name="CommunicationChannel" positionX="-531" positionY="-9" width="128" height="133"/>
         <element name="Conference" positionX="-540" positionY="-18" width="128" height="268"/>
         <element name="ConferenceRecording" positionX="-531" positionY="-9" width="128" height="148"/>
         <element name="ContextColor" positionX="-177.3046875" positionY="-36" width="128" height="73"/>
         <element name="Conversation" positionX="-540" positionY="-18" width="128" height="238"/>
         <element name="ConversationMessage" positionX="-522" positionY="0" width="128" height="208"/>
-        <element name="ConversationParticipant" positionX="-531" positionY="-9" width="128" height="118"/>
+        <element name="ConversationParticipant" positionX="-531" positionY="-9" width="128" height="133"/>
         <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="253"/>
         <element name="CourseSection" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="CourseSettings" positionX="-540" positionY="-18" width="128" height="88"/>

--- a/Core/CoreTests/Conversations/ComposeReplyViewControllerTests.swift
+++ b/Core/CoreTests/Conversations/ComposeReplyViewControllerTests.swift
@@ -56,7 +56,8 @@ class ComposeReplyViewControllerTests: CoreTestCase {
         task.paused = true
         XCTAssertNoThrow(sendButton.target?.perform(sendButton.action))
         XCTAssert(sendButton.customView is CircleProgressView)
-        task.resume()
+        task.paused = false
+        XCTAssertEqual(router.dismissed, controller)
     }
 
     func testAttachments() {
@@ -95,5 +96,33 @@ class ComposeReplyViewControllerTests: CoreTestCase {
         controller.viewWillAppear(false)
         XCTAssertEqual(controller.toLabel.text, "to user 2 (She/Her)")
         XCTAssertEqual(controller.fromLabel.text, "user 1 (He/Him)")
+    }
+
+    func testParentReplyAll() {
+        environment.app = .parent
+        conversation = Conversation.make(from: .make(
+            participants: [
+                .make(id: currentSession.userID, name: "current user"),
+                .make(id: "20", name: "a teacher", common_courses: ["1": [ Role.teacher.rawValue ]]),
+                .make(id: "21", name: "a ta", common_courses: ["1": [ Role.ta.rawValue ]]),
+                .make(id: "22", name: "my kid", common_courses: ["1": [ Role.student.rawValue ]]),
+                .make(id: "23", name: "other kid", common_courses: ["1": [ Role.student.rawValue ]]),
+                .make(id: "24", name: "other teacher", common_courses: ["2": [ Role.teacher.rawValue ]]),
+                .make(id: "25", name: "other observer", common_courses: ["2": [ Role.observer.rawValue ]])
+            ],
+            context_code: "course_1",
+            messages: [ .make(participating_user_ids: [ ID(currentSession.userID), "20", "21", "22", "23", "24", "25" ]) ]
+        ))
+        api.mock(GetObservedStudents(observerID: currentSession.userID), value: [ .make(observed_user: .make(id: "22")) ])
+        api.mock(AddMessage(conversationID: conversation.id, body: "").request, value: .make())
+        controller.all = true
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+        controller.bodyView.text = "Replying"
+        controller.bodyView.delegate?.textViewDidChange?(controller.bodyView)
+        XCTAssertEqual(controller.replyAllRecipientIDs, ["20", "21", "22"])
+        let sendButton = controller.sendButton
+        XCTAssertNoThrow(sendButton.target?.perform(sendButton.action))
+        XCTAssertEqual(router.dismissed, controller)
     }
 }

--- a/Core/CoreTests/Conversations/ComposeReplyViewControllerTests.swift
+++ b/Core/CoreTests/Conversations/ComposeReplyViewControllerTests.swift
@@ -108,7 +108,7 @@ class ComposeReplyViewControllerTests: CoreTestCase {
                 .make(id: "22", name: "my kid", common_courses: ["1": [ Role.student.rawValue ]]),
                 .make(id: "23", name: "other kid", common_courses: ["1": [ Role.student.rawValue ]]),
                 .make(id: "24", name: "other teacher", common_courses: ["2": [ Role.teacher.rawValue ]]),
-                .make(id: "25", name: "other observer", common_courses: ["2": [ Role.observer.rawValue ]])
+                .make(id: "25", name: "other observer", common_courses: ["2": [ Role.observer.rawValue ]]),
             ],
             context_code: "course_1",
             messages: [ .make(participating_user_ids: [ ID(currentSession.userID), "20", "21", "22", "23", "24", "25" ]) ]


### PR DESCRIPTION
Prevents parents from messaging students that they are not observing.

refs: MBL-14389
affects: parent
release note: Inbox privacy improvements

Test plan:
- As a teacher, start a conversation with an observer, the observed user, and
another student (not being observed by observer)
- As the observer, reply-all to the conversation in the parent app
- The message should only be sent to the teacher and the observed child
- You can use the most recent conversation as `o` on `narmstrong`