### PR TITLE
Fix loading some group discussions

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -373,6 +373,7 @@
     <entity name="Group" representedClassName="Core.Group" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="URI"/>
         <attribute name="concluded" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="contextRaw" optional="YES" attributeType="String"/>
         <attribute name="courseID" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
@@ -814,7 +815,7 @@
         <element name="Folder" positionX="-540" positionY="-18" width="128" height="298"/>
         <element name="Grade" positionX="-540" positionY="-18" width="128" height="88"/>
         <element name="GradingPeriod" positionX="-540" positionY="-27" width="128" height="133"/>
-        <element name="Group" positionX="-366.25" positionY="-174.85546875" width="128" height="135"/>
+        <element name="Group" positionX="-366.25" positionY="-174.85546875" width="128" height="148"/>
         <element name="HelpLink" positionX="-540" positionY="-27" width="128" height="135"/>
         <element name="LogEvent" positionX="-743.51953125" positionY="192.92578125" width="128" height="90"/>
         <element name="MasteryPath" positionX="-540" positionY="-18" width="128" height="103"/>

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -66,9 +66,9 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
     lazy var group = env.subscribe(GetGroup(groupID: context.id)) { [weak self] in
         self?.updateNavBar()
     }
-    lazy var groups = context.contextType == .course ? env.subscribe(GetGroups(context: context)) { [weak self] in
+    lazy var groups = env.subscribe(GetGroups(context: .currentUser)) { [weak self] in
         self?.update()
-    } : nil
+    }
     lazy var permissions = env.subscribe(GetContextPermissions(context: context, permissions: [ .postToForum ])) { [weak self] in
         self?.update()
     }
@@ -158,7 +158,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         topic.refresh()
         entries.refresh()
         permissions.refresh()
-        groups?.exhaust(force: false)
+        groups.exhaust(force: false)
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -287,6 +287,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         }
         assignment?.refresh(force: true)
         permissions.refresh(force: true)
+        groups.exhaust(force: true)
     }
 
     @objc func topicEdited(_ notification: NSNotification) {
@@ -309,7 +310,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
             let topic = topic.first, topic.groupCategoryID != nil,
             let subs = topic.groupTopicChildren
         else { return true }
-        if let groupID = groups?.first(where: { subs[$0.id] != nil })?.id, let childID = subs[groupID] {
+        if let groupID = groups.first(where: { subs[$0.id] != nil })?.id, let childID = subs[groupID] {
             context = Context(.group, id: groupID)
             topicID = childID
             isReady = false
@@ -324,7 +325,6 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
             group = env.subscribe(GetGroup(groupID: context.id)) { [weak self] in
                 self?.updateNavBar()
             }
-            groups = nil
             permissions = env.subscribe(GetContextPermissions(context: context, permissions: [ .postToForum ])) { [weak self] in
                 self?.update()
             }
@@ -364,7 +364,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
                 entries: entries,
                 maxDepth: maxDepth,
                 canLike: canLike,
-                groups: groups?.all,
+                groups: groups.all,
                 contextColor: color
             )
         }

--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -97,7 +97,7 @@ enum DiscussionHTML {
         }
         return entry.message?
             .replacingOccurrences(of: "<script(.+)</script>", with: "", options: .regularExpression)
-            .replacingOccurrences(of: "<link(.+)>", with: "", options: .regularExpression) ?? ""
+            .replacingOccurrences(of: "<link[^>]*>", with: "", options: .regularExpression) ?? ""
     }
 
     // Preact-based rendering for updatable content

--- a/Core/Core/Groups/GetGroups.swift
+++ b/Core/Core/Groups/GetGroups.swift
@@ -17,15 +17,27 @@
 //
 
 import Foundation
+import CoreData
 
 class GetGroups: CollectionUseCase {
     typealias Model = Group
+    let context: Context
     let cacheKey: String?
     let request: GetGroupsRequest
+    let scope: Scope
 
     init(context: Context = Context.currentUser) {
+        self.context = context
         cacheKey = "\(context.pathComponent)/groups"
         request = GetGroupsRequest(context: context)
+        scope = .where(#keyPath(Group.contextRaw), equals: context.canvasContextID)
+    }
+
+    func write(response: [APIGroup]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        response?.forEach { item in
+            let group = Group.save(item, in: client)
+            group.context = context
+        }
     }
 }
 

--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -28,6 +28,12 @@ public final class Group: NSManagedObject, WriteableModel {
     @NSManaged public var id: String
     @NSManaged public var name: String
     @NSManaged public var showOnDashboard: Bool
+    @NSManaged public var contextRaw: String?
+
+    public var context: Context? {
+        get { contextRaw.flatMap { Context(canvasContextID: $0) } }
+        set { contextRaw = newValue?.canvasContextID }
+    }
 
     public var canvasContextID: String {
         Context(.group, id: id).canvasContextID

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -95,7 +95,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
             ]
         ))
         api.mock(controller.group, value: .make(course_id: 1))
-        api.mock(GetGroups(context: controller.context), value: [ .make(course_id: 1) ])
+        api.mock(GetGroups(context: .currentUser), value: [ .make(course_id: 1) ])
         api.mock(controller.permissions, value: .make(post_to_forum: true))
         api.mock(controller.topic, value: .make(
             id: 1,

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -95,7 +95,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
             ]
         ))
         api.mock(controller.group, value: .make(course_id: 1))
-        api.mock(GetGroups(context: .currentUser), value: [ .make(course_id: 1) ])
+        api.mock(controller.groups, value: [ .make(course_id: 1) ])
         api.mock(controller.permissions, value: .make(post_to_forum: true))
         api.mock(controller.topic, value: .make(
             id: 1,

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -85,7 +85,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
                 <p>Oreos are sandwiches.</p>
                 """, replies: [
                     .make(id: 100, user_id: 3, parent_id: 1, deleted: true),
-                    .make(id: 2, user_id: 3, parent_id: 1, message: "<link rel=\"stylesheet\">I disagree.<script src=\"foo.js\"></script>", replies: [
+                    .make(id: 2, user_id: 3, parent_id: 1, message: "<link rel=\"stylesheet\"><script src=\"foo.js\"></script><p>I disagree.</p>", replies: [
                         .make(id: 3, user_id: 2, parent_id: 2, message: "Why?"),
                     ]),
                 ]),


### PR DESCRIPTION
The API returns all course groups when we ask for them, even if the
current user isn't in the group. And all the group topics are included
in the discussion, even those that are not for the current user.

So for child group topics we should only request the groups for the
current user so that we can accurately narrow down which child topic to
show.

refs: MBL-14543
affects: student
release note: Fixed loading discussions

Test plan:
- Install student from master or prod
- Masquerade as users in ticket
- View the linked discussions
- They should load