### PR TITLE
Fix crash in HorizontalMenuViewController

### DIFF
--- a/Core/Core/Views/HorizontalMenuViewController.swift
+++ b/Core/Core/Views/HorizontalMenuViewController.swift
@@ -70,6 +70,7 @@ open class HorizontalMenuViewController: UIViewController {
     }
 
     public func layoutViewControllers() {
+        if itemCount == 0 { return }
         if menu != nil {
             updateFrames()
         } else {
@@ -93,7 +94,8 @@ open class HorizontalMenuViewController: UIViewController {
         assert(delegate != nil)
         let layout = UICollectionViewFlowLayout()
         layout.scrollDirection = .horizontal
-        layout.itemSize = CGSize(width: view.bounds.size.width / CGFloat(itemCount), height: menuCellHeight)
+        let width = view.bounds.size.width / CGFloat(itemCount)
+        layout.itemSize = CGSize(width: width, height: menuCellHeight)
         layout.minimumLineSpacing = 0
 
         menu = UICollectionView(frame: .zero, collectionViewLayout: layout)

--- a/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
+++ b/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
@@ -51,6 +51,11 @@ class HorizontalMenuViewControllerTests: XCTestCase {
         wait(for: [vc.expectation], timeout: 0.1)
     }
 
+    func testWithoutMenuItem() {
+        mock.viewControllers = []
+        XCTAssertNoThrow(mock.layoutViewControllers())
+    }
+
     class Mock: HorizontalMenuViewController, HorizontalPagedMenuDelegate {
         init() {
             super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
refs: MBL-14554
affects: student
release note: Fixed a crash when accessing courses

Test plan:
I couldn't reliably repro on device but I did verify that the test threw
the exception without the fix applied.