### PR TITLE
Fix launching LTI assignments when URL re-used

### DIFF
--- a/CanvasCore/CanvasCore/React Native Modules/LTITools.m
+++ b/CanvasCore/CanvasCore/React Native Modules/LTITools.m
@@ -27,11 +27,11 @@
 @implementation LTIToolsReact
 RCT_EXPORT_MODULE(LTITools);
 
-RCT_REMAP_METHOD(launchExternalTool, launchExternalTool:(NSString *)url resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+RCT_REMAP_METHOD(launchExternalTool, launchExternalTool:(NSString *)url context:(NSString *)context toolID:(NSString *)toolID launchType:(NSString *)launchType assignmentID:(NSString *)assignmentID resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
     UIViewController *current = [[HelmManager shared] topMostViewController];
-    NSURL *launchURL = [[NSURL alloc] initWithString:url];
+    NSURL *launchURL = url ? [[NSURL alloc] initWithString:url] : nil;
 
-    [LTITools launch:launchURL from:current animated:YES completionHandler:^(BOOL success) {
+    [LTITools launchWithContext:context id:toolID url:launchURL launchType:launchType assignmentID:assignmentID from:current animated:YES completionHandler:^(BOOL success) {
         resolve(nil);
     }];
 }

--- a/Core/Core/Assignments/APIAssignment.swift
+++ b/Core/Core/Assignments/APIAssignment.swift
@@ -46,6 +46,7 @@ public struct APIAssignment: Codable, Equatable {
     let assignment_group_id: ID?
     let all_dates: [APIAssignmentDate]?
     let allowed_attempts: Int?
+    let external_tool_tag_attributes: APIExternalToolTagAttributes?
 }
 
 // https://canvas.instructure.com/doc/api/assignments.html#AssignmentDate
@@ -56,6 +57,11 @@ public struct APIAssignmentDate: Codable, Equatable {
     let due_at: Date?
     let unlock_at: Date?
     let lock_at: Date?
+}
+
+// https://canvas.instructure.com/doc/api/assignments.html#ExternalToolTagAttributes
+public struct APIExternalToolTagAttributes: Codable, Equatable {
+    let content_id: ID? // undocumented
 }
 
 public enum GradingType: String, Codable {
@@ -91,7 +97,8 @@ extension APIAssignment {
         rubric_settings: APIRubricSettings? = nil,
         assignment_group_id: ID? = nil,
         all_dates: [APIAssignmentDate]? = nil,
-        allowed_attempts: Int? = -1
+        allowed_attempts: Int? = -1,
+        external_tool_tag_attributes: APIExternalToolTagAttributes? = nil
     ) -> APIAssignment {
 
         var submissionList: APIList<APISubmission>?
@@ -127,7 +134,8 @@ extension APIAssignment {
             rubric_settings: rubric_settings,
             assignment_group_id: assignment_group_id,
             all_dates: all_dates,
-            allowed_attempts: allowed_attempts
+            allowed_attempts: allowed_attempts,
+            external_tool_tag_attributes: external_tool_tag_attributes
         )
     }
 }
@@ -149,6 +157,12 @@ extension APIAssignmentDate {
             unlock_at: unlock_at,
             lock_at: lock_at
         )
+    }
+}
+
+extension APIExternalToolTagAttributes {
+    public static func make(content_id: ID? = nil) -> Self {
+        return Self(content_id: content_id)
     }
 }
 #endif

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -54,6 +54,7 @@ public class Assignment: NSManagedObject {
     @NSManaged public var masteryPathAssignment: MasteryPathAssignment?
     @NSManaged public var allDates: Set<AssignmentDate>
     @NSManaged public var allowedAttempts: Int // 0 is flag disabled, -1 is unlimited
+    @NSManaged public var externalToolContentID: String?
 
     /**
      Use this property (vs. submissions) when you want the most recent submission
@@ -140,6 +141,7 @@ extension Assignment {
         lastUpdatedAt = Date()
         assignmentGroupID = item.assignment_group_id?.value
         allowedAttempts = item.allowed_attempts ?? 0
+        externalToolContentID = item.external_tool_tag_attributes?.content_id?.rawValue
 
         if let topic = item.discussion_topic {
             discussionTopic = DiscussionTopic.save(topic, in: client)

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17162" systemVersion="19G73" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="16119" systemVersion="19F101" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -36,6 +36,7 @@
         <attribute name="details" optional="YES" attributeType="String"/>
         <attribute name="dueAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="dueAtSortNilsAtBottom" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="externalToolContentID" optional="YES" attributeType="String"/>
         <attribute name="externalToolTagAttributeURL" optional="YES" attributeType="URI"/>
         <attribute name="freeFormCriterionCommentsOnRubric" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="gradedIndividually" optional="YES" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
@@ -803,7 +804,7 @@
         <element name="AccountNotification" positionX="-540" positionY="-18" width="128" height="133"/>
         <element name="Activity" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="AlertThreshold" positionX="-540" positionY="-27" width="128" height="118"/>
-        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="628"/>
+        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="643"/>
         <element name="AssignmentDate" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="AssignmentGroup" positionX="-540" positionY="-27" width="128" height="120"/>
         <element name="CalendarEvent" positionX="-531" positionY="-18" width="128" height="253"/>

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -42,8 +42,23 @@ public class LTITools: NSObject {
     }
 
     @objc
-    public static func launch(_ url: URL, from view: UIViewController, animated: Bool = true, completionHandler: ((Bool) -> Void)? = nil) {
-        let tools = LTITools(url: url)
+    public static func launch(
+        context: String?,
+        id: String?,
+        url: URL?,
+        launchType: String?,
+        assignmentID: String?,
+        from view: UIViewController,
+        animated: Bool = true,
+        completionHandler: ((Bool) -> Void)? = nil
+    ) {
+        let tools = LTITools(
+            context: context.flatMap { Context(canvasContextID: $0) },
+            id: id,
+            url: url,
+            launchType: launchType.flatMap { GetSessionlessLaunchURLRequest.LaunchType(rawValue: $0) },
+            assignmentID: assignmentID
+        )
         tools.presentTool(from: view, animated: animated, completionHandler: completionHandler)
     }
 

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -116,6 +116,7 @@ class SubmissionButtonPresenter: NSObject {
             LTITools(
                 env: env,
                 context: .course(courseID),
+                id: assignment.externalToolContentID,
                 launchType: .assessment,
                 assignmentID: assignment.id
             ).presentTool(from: view, animated: true)

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -138,12 +138,20 @@ class SubmissionButtonPresenterTests: StudentTestCase {
 
     func testSubmitTypeLTI() {
         let a = Assignment.make(from: .make(
-            discussion_topic: .make(html_url: URL(string: "/discussion"))
+            discussion_topic: .make(html_url: URL(string: "/discussion")),
+            external_tool_tag_attributes: .make(content_id: "1")
         ))
         presenter.submitType(.external_tool, for: a, button: UIView())
         XCTAssertNil(router.presented)
 
-        let request = GetSessionlessLaunchURLRequest(context: .course("1"), id: nil, url: nil, assignmentID: "1", moduleItemID: nil, launchType: .assessment)
+        let request = GetSessionlessLaunchURLRequest(
+            context: .course("1"),
+            id: "1",
+            url: nil,
+            assignmentID: "1",
+            moduleItemID: nil,
+            launchType: .assessment
+        )
         api.mock(request, value: .make(url: URL(string: "https://instructure.com")!))
         presenter.submitType(.external_tool, for: a, button: UIView())
         wait(for: [router.showExpectation], timeout: 5)

--- a/rn/Teacher/src/common/LTITools.js
+++ b/rn/Teacher/src/common/LTITools.js
@@ -16,10 +16,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-// @flow
-
 import { NativeModules } from 'react-native'
 
-export function launchExternalTool (url: string): Promise<*> {
-  return NativeModules.LTITools.launchExternalTool(url)
+export function launchExternalTool (url, context, toolID, launchType, assignmentID) {
+  return NativeModules.LTITools.launchExternalTool(url, context, toolID, launchType, assignmentID)
 }

--- a/rn/Teacher/src/common/__tests__/LTITools.test.js
+++ b/rn/Teacher/src/common/__tests__/LTITools.test.js
@@ -25,6 +25,12 @@ describe('LTITools', () => {
   it('defers to native on launchExternalTool', () => {
     const url = 'https://arc.instructure.com/login'
     launchExternalTool(url)
-    expect(NativeModules.LTITools.launchExternalTool).toHaveBeenCalledWith(url)
+    expect(NativeModules.LTITools.launchExternalTool).toHaveBeenCalledWith(
+      url,
+      undefined,
+      undefined,
+      undefined,
+      undefined
+    )
   })
 })

--- a/rn/Teacher/src/modules/assignment-details/AssignmentDetails.js
+++ b/rn/Teacher/src/modules/assignment-details/AssignmentDetails.js
@@ -287,7 +287,21 @@ export class AssignmentDetails extends Component<AssignmentDetailsProps, any> {
   }
 
   launchExternalTool = () => {
-    LTITools.launchExternalTool(this.props.assignmentDetails.url)
+    let {
+      assignmentDetails: {
+        external_tool_tag_attributes,
+      },
+      assignmentID,
+      courseID,
+    } = this.props
+    let contentID = external_tool_tag_attributes?.content_id
+    LTITools.launchExternalTool(
+      null,
+      `course_${courseID}`,
+      contentID,
+      'assessment',
+      assignmentID,
+    )
   }
 }
 


### PR DESCRIPTION
refs: MBL-14482
affects: student, teacher
release note: Fixed launching some LTI tools

Release plan:
- View the assignments from the ticket as a student and a teacher (in
the respective apps)
- Each assignment should launch the correct youtube video (you have to
tap the button to show in a new window)