### PR TITLE
Save pdf document before share

### DIFF
--- a/Core/Core/Files/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/FileDetails/FileDetailsViewController.swift
@@ -224,6 +224,8 @@ public class FileDetailsViewController: UIViewController, CoreWebViewLinkDelegat
 
     @IBAction func share(_ sender: UIBarButtonItem) {
         guard let url = localURL else { return }
+        let pdf = children.first { $0 is PDFViewController } as? PDFViewController
+        try? pdf?.document?.save()
         let controller = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         controller.popoverPresentationController?.barButtonItem = sender
         env.router.show(controller, from: self, options: .modal())
@@ -429,8 +431,6 @@ extension FileDetailsViewController: PDFViewControllerDelegate {
         embed(controller, in: contentView)
         addPDFAnnotationChangeNotifications()
 
-        let share = UIBarButtonItem(barButtonSystemItem: .action, target: controller.activityButtonItem.target, action: controller.activityButtonItem.action)
-        share.accessibilityIdentifier = "FileDetails.shareButton"
         let annotate = controller.annotationButtonItem
         annotate.image = .icon(.highlighter, .line)
         annotate.accessibilityIdentifier = "FileDetails.annotateButton"

--- a/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
@@ -202,6 +202,10 @@ class FileDetailsViewControllerTests: CoreTestCase {
         XCTAssertEqual(results[0].title, "Style")
         XCTAssertNotNil(results[1].ps_image)
         pdf.document?.delegate = self
+        _ = controller.shareButton.target?.perform(controller.shareButton.action, with: [controller.shareButton])
+        XCTAssert(router.presented is UIActivityViewController)
+        XCTAssertTrue(saveWasCalled)
+        saveWasCalled = false
         controller.viewWillDisappear(false)
         XCTAssertTrue(saveWasCalled)
     }


### PR DESCRIPTION
refs: MBL-14581
affects: student, teacher
release note: Fixed a bug when sharing files with annotations

Test plan:
- Annotate on a file
- Tap share > Markdown
- Markdown should have the recent annotations