### PR TITLE
Fix loading certain modules

### DIFF
--- a/Core/Core/Modules/APIModule.swift
+++ b/Core/Core/Modules/APIModule.swift
@@ -162,7 +162,7 @@ public struct APIMasteryPath: Codable, Equatable {
     public struct AssignmentSet: Codable, Equatable {
         public let id: ID
         public let position: Int?
-        public let assignments: [Assignment]
+        public let assignments: [Assignment]?
     }
 
     public struct Assignment: Codable, Equatable {

--- a/Core/Core/Modules/MasteryPath.swift
+++ b/Core/Core/Modules/MasteryPath.swift
@@ -46,7 +46,7 @@ public class MasteryPathAssignmentSet: NSManagedObject {
     public static func save(_ item: APIMasteryPath.AssignmentSet, in context: NSManagedObjectContext) -> MasteryPathAssignmentSet {
         let model = context.insert() as MasteryPathAssignmentSet
         model.id = item.id.value
-        model.assignments = Set(item.assignments.map { .save($0, in: context) })
+        model.assignments = Set(item.assignments?.map { .save($0, in: context) } ?? [])
         model.position = item.position ?? 0
         return model
     }


### PR DESCRIPTION
refs: MBL-14585
affects: student, teacher
release note: Fixed loading modules in the case that there were Mastery Paths without any assignments linked

Test plan:
- Masquerade as the student from the ticket
- View modules in the course from the ticket
- The second module, _Unit 2: Creative mind_, should load