### PR TITLE
Fix a crash in HorizontalMenu

### DIFF
--- a/Core/Core/UIViews/HorizontalMenuViewController.swift
+++ b/Core/Core/UIViews/HorizontalMenuViewController.swift
@@ -41,7 +41,8 @@ open class HorizontalMenuViewController: UIViewController {
     }
 
     private var menuCellWidth: CGFloat {
-        view.bounds.size.width / CGFloat(itemCount)
+        guard itemCount > 0 else { return 0 }
+        return view.bounds.size.width / CGFloat(itemCount)
     }
 
     override open func viewDidLoad() {

--- a/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
+++ b/Core/CoreTests/Views/HorizontalMenuViewControllerTests.swift
@@ -54,6 +54,7 @@ class HorizontalMenuViewControllerTests: XCTestCase {
     func testWithoutMenuItem() {
         mock.viewControllers = []
         XCTAssertNoThrow(mock.layoutViewControllers())
+        XCTAssertNoThrow(mock.viewWillLayoutSubviews())
     }
 
     class Mock: HorizontalMenuViewController, HorizontalPagedMenuDelegate {


### PR DESCRIPTION
refs: MBL-14615
affects: student
release note: Fixed a crash when viewing syllabus

Test plan:
Couldn't repro locally but crash report was pretty obvious.
The test did throw an exception without the fix.
Logs made it clear that it would happen when viewing a course syllabus.

- View a course syllabus
- App should not crash