### PR TITLE
Fix uploading videos in RCE

### DIFF
--- a/Core/Core/Files/UploadManager.swift
+++ b/Core/Core/Files/UploadManager.swift
@@ -89,7 +89,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
             .appendingPathComponent("uploads", isDirectory: true)
             .appendingPathComponent(UUID.string, isDirectory: true)
             .appendingPathComponent(url.lastPathComponent)
-        try url.move(to: newURL)
+        try url.copy(to: newURL)
         return newURL
     }
 

--- a/Core/CoreTests/Files/UploadManagerTests.swift
+++ b/Core/CoreTests/Files/UploadManagerTests.swift
@@ -204,8 +204,8 @@ class UploadManagerTests: CoreTestCase {
         XCTAssertEqual(notification?.content.title, "Assignment submitted!")
         XCTAssertEqual(notification?.content.body, "Your files were uploaded and the assignment was submitted successfully.")
         XCTAssertEqual(notification?.route, "/courses/1/assignments/2")
-        XCTAssertFalse(fileManager.fileExists(atPath: oneURL.path))
-        XCTAssertFalse(fileManager.fileExists(atPath: twoURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: oneURL.path))
+        XCTAssertTrue(fileManager.fileExists(atPath: twoURL.path))
     }
 
     func testFailedSubmissionNotification() throws {

--- a/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
+++ b/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
@@ -159,6 +159,7 @@ class RichContentEditorViewControllerTests: CoreTestCase, RichContentEditorDeleg
     }
 
     func testMediaRetry() {
+        UUID.mock("abc")
         let originalUrl = Bundle(for: type(of: self)).url(forResource: "instructure", withExtension: "pdf")!
         // File will get deleted after upload, so use a copy instead
         let url = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
@@ -167,6 +168,12 @@ class RichContentEditorViewControllerTests: CoreTestCase, RichContentEditorDeleg
 
         api.mock(GetMediaServiceRequest(), error: NSError.internalError())
         controller.imagePickerController(MockPicker(), didFinishPickingMediaWithInfo: [ .mediaURL: url ])
+        let copiedTo = URL.temporaryDirectory
+            .appendingPathComponent("uploads", isDirectory: true)
+            .appendingPathComponent(UUID.string, isDirectory: true)
+            .appendingPathComponent("instructure.pdf")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: copiedTo.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: url.path))
         XCTAssertTrue((self.databaseClient.fetch() as [File]).isEmpty)
 
         controller.webView.evaluateJavaScript("document.querySelector('.retry-upload').onclick()")


### PR DESCRIPTION
refs: MBL-14573
affects: student, teacher
release note: Fixed uploading videos in Rich Content Editor

Test plan:
- Use the image picker to insert video into rich content for discussions
and text submissions
- Videos should embed without error