### PR TITLE
Fix login error check

### DIFF
--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -140,7 +140,9 @@ extension LoginWebViewController: WKNavigationDelegate {
                 self.loginDelegate?.userDidLogin(session: session)
             } }
             return decisionHandler(.cancel)
-        } else if queryItems?.first(where: { $0.name == "error" }) != nil {
+        } else if queryItems?.first(where: { $0.name == "error" })?.value == "access_denied" {
+            // access_denied is the only currently implemented error code
+            // https://canvas.instructure.com/doc/api/file.oauth.html#oauth2-flow-2
             let error = NSError.instructureError(NSLocalizedString("Authentication failed. Most likely the user denied the request for access.", bundle: .core, comment: ""))
             self.showError(error)
             return decisionHandler(.cancel)

--- a/Core/CoreTests/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginWebViewControllerTests.swift
@@ -90,11 +90,16 @@ class LoginWebViewControllerTests: CoreTestCase {
         XCTAssertNotNil(loggedIn)
         XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
 
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=e")!)
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
         controller.webView(controller.webView, decidePolicyFor: action) { policy in
             XCTAssertEqual(policy, .cancel)
         }
         XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
+
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
     }
 
     func testLocaleIsSetOnLogin() {


### PR DESCRIPTION
Some auth providers send `?error=false` which would trigger our error
handler.

refs: MBL-14646
affects: student, teacher
release note: Fixed logging in for some institutions

Test plan:
- see ticket for account and credentials
- should login without error