### PR TITLE
Fix course preferences if image url is empty string

### DIFF
--- a/rn/Teacher/src/modules/courses/user-prefs/UserCoursePreferences.js
+++ b/rn/Teacher/src/modules/courses/user-prefs/UserCoursePreferences.js
@@ -172,7 +172,7 @@ export class UserCoursePreferences extends Component<Props, any> {
         onRefresh={this.props.refresh}
       >
         <View style={styles.imageWrapper}>
-          {this.props.course.image_download_url &&
+          {Boolean(this.props.course.image_download_url) &&
             <Image source={{ uri: this.props.course.image_download_url }} style={styles.image} />
           }
           {this.props.showColorOverlay &&


### PR DESCRIPTION
truthiness strikes again

refs: MBL-14644
affects: student, teacher
release note: Fix a crash when attempting to change course preferences