### PR TITLE
Honor discussion permissions for replies

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -597,7 +597,13 @@ extension DiscussionDetailsViewController {
         guard let entry = self.entry(entryID), let topic = topic.first else { return }
         let canEdit = env.app == .teacher || (
             !topic.lockedForUser &&
-            entry.author?.id == env.currentSession?.userID
+            entry.author?.id == env.currentSession?.userID &&
+            topic.canUpdate
+        )
+        let canDelete = env.app == .teacher || (
+            !topic.lockedForUser &&
+            entry.author?.id == env.currentSession?.userID &&
+            topic.canDelete
         )
 
         let sheet = BottomSheetPickerViewController.create()
@@ -626,6 +632,8 @@ extension DiscussionDetailsViewController {
             ) { [weak self] in
                 self?.editEntry(entryID)
             }
+        }
+        if canDelete {
             sheet.addAction(
                 image: .trashLine,
                 title: NSLocalizedString("Delete", bundle: .core, comment: ""),


### PR DESCRIPTION
refs: MBL-14624
affects: student
release note: Fixed a bug that would appear to allow Edit and Delete buttons for discussion replies when those permissions were disabled

Test plan: see ticket