### PR TITLE
Fix planner intermittent missing events

### DIFF
--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -91,15 +91,12 @@ public class GetPlannables: UseCase {
     var contextCodes: [String]?
     var filter: String = ""
 
-    public let syncContext: NSManagedObjectContext?
-
-    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String]? = nil, filter: String = "", syncContext: NSManagedObjectContext? = nil) {
+    public init(userID: String? = nil, startDate: Date, endDate: Date, contextCodes: [String]? = nil, filter: String = "") {
         self.userID = userID
         self.startDate = startDate
         self.endDate = endDate
         self.contextCodes = contextCodes
         self.filter = filter
-        self.syncContext = syncContext
     }
 
     public var cacheKey: String? {
@@ -143,7 +140,7 @@ public class GetPlannables: UseCase {
                 contextCodes: contextCodes ?? [],
                 filter: filter
             )
-            environment.api.makeRequest(request) { response, urlResponse, error in
+            environment.api.exhaust(request) { response, urlResponse, error in
                 completionHandler(Response(plannables: response, calendarEvents: nil), urlResponse, error)
             }
         }

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -85,7 +85,7 @@ public class PlannerListViewController: UIViewController {
         plannables = delegate.flatMap { env.subscribe($0.getPlannables(from: start, to: end)) { [weak self] in
             self?.updatePlannables()
         } }
-         plannables?.refresh(force: force)
+        plannables?.refresh(force: force)
     }
 
     private func updatePlannables() {

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -38,7 +38,6 @@ public class PlannerViewController: UIViewController {
         self?.plannerListWillRefresh()
     }
     var planner: Planner? { planners.first }
-    lazy var syncContext = env.database.newBackgroundContext()
 
     public static func create(studentID: String? = nil, selectedDate: Date = Clock.now) -> PlannerViewController {
         let controller = PlannerViewController()
@@ -118,7 +117,7 @@ public class PlannerViewController: UIViewController {
                 contextCodes?.append(Context(.user, id: studentID).canvasContextID)
             }
         }
-        return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: contextCodes, syncContext: syncContext)
+        return GetPlannables(userID: studentID, startDate: from, endDate: to, contextCodes: contextCodes)
     }
 
     func updateList(_ date: Date) {


### PR DESCRIPTION
The syncContext was added to remove these kinds of races, but pagination re-broke it.
Rather than try to sync the two requests, this exhausts the pagination at request level,
so when each finish they immediately restore anything they reset.

refs: MBL-14610
affects: Student, Teacher
release note: Fixed an issue with missing events in the planner