### PR TITLE
Remove file cleanup at startup

### DIFF
--- a/Core/Core/AppEnvironment/CacheManager.swift
+++ b/Core/Core/AppEnvironment/CacheManager.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import PSPDFKit
 
 public class CacheManager {
     public private(set) static var lastDeletedAt: Int {
@@ -75,30 +74,6 @@ public class CacheManager {
 
     public static func clearLibrary() {
         clearDirectory(.libraryDirectory)
-    }
-
-    public static func removeBloat() {
-        let timeout = Clock.now.addSeconds(5)
-        let fs = FileManager.default
-        let enumerator = fs.enumerator(at: .documentsDirectory, includingPropertiesForKeys: [.isDirectoryKey])
-        while let url = enumerator?.nextObject() as? URL {
-            let isDirectory = (try? url.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            if isDirectory { continue }
-            if Document(url: url).containsAnnotations {
-                Analytics.shared.logEvent("clear_bloat_item_skipped", parameters: nil)
-                continue
-            }
-            do {
-                try fs.removeItem(at: url)
-                Analytics.shared.logEvent("clear_bloat_item_succeeded", parameters: nil)
-            } catch {
-                Analytics.shared.logEvent("clear_bloat_item_failed", parameters: ["error": error.localizedDescription])
-            }
-            if Clock.now > timeout {
-                Analytics.shared.logEvent("clear_bloat_timeout_exceeded")
-                break
-            }
-        }
     }
 
     public static func clearRNAsyncStorage() {

--- a/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
@@ -18,8 +18,6 @@
 
 import XCTest
 @testable import Core
-import PSPDFKit
-import PDFKit
 
 class CacheManagerTests: CoreTestCase {
     let rnManifestURL = URL.documentsDirectory
@@ -99,27 +97,5 @@ class CacheManagerTests: CoreTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: extra.path))
         XCTAssertEqual(json?["speed-grader-tutorial"] as? String, "preserved")
         XCTAssertNil(json?["something-else"])
-    }
-
-    func testRemoveBloat() {
-        let fs = FileManager.default
-        let url = URL.documentsDirectory.appendingPathComponent("bloat.pdf")
-        PDFDocument().write(to: url)
-        XCTAssertTrue(fs.fileExists(atPath: url.path))
-        CacheManager.removeBloat()
-        XCTAssertFalse(fs.fileExists(atPath: url.path))
-    }
-
-    func testRemoveBloatSkipsAnnotatedPDFs() {
-        let fs = FileManager.default
-        let url = URL.documentsDirectory.appendingPathComponent("bloat.pdf")
-        PDFDocument().write(to: url)
-        let pdf = Document(url: url)
-        let annotation = SquigglyAnnotation()
-        pdf.add(annotations: [annotation], options: nil)
-        try! pdf.save()
-        XCTAssertTrue(fs.fileExists(atPath: url.path))
-        CacheManager.removeBloat()
-        XCTAssertTrue(fs.fileExists(atPath: url.path))
     }
 }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -41,7 +41,6 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         setupFirebase()
         Core.Analytics.shared.handler = self
         CacheManager.resetAppIfNecessary()
-        CacheManager.removeBloat()
         #if DEBUG
             UITestHelpers.setup(self)
         #endif

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -43,7 +43,6 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
         setupFirebase()
         Core.Analytics.shared.handler = self
         CacheManager.resetAppIfNecessary()
-        CacheManager.removeBloat()
         #if DEBUG
             UITestHelpers.setup(self)
         #endif


### PR DESCRIPTION
The FileDetailsViewController has been using tmp for a while now, and only
annotated pdf are moved to documents. There should be nothing else putting
new files in the documents folder, so the cleanup should no longer be
necessary.

refs: MBL-14415
affects: Student, Teacher
release note: none