### PR TITLE
Fix URL parsing for external module urls

### DIFF
--- a/Core/Core/Modules/ModuleItemType.swift
+++ b/Core/Core/Modules/ModuleItemType.swift
@@ -58,12 +58,12 @@ public enum ModuleItemType: Equatable, Codable {
         case .subHeader:
             self = .subHeader
         case .externalURL:
-            let url = try container.decode(URL.self, forKey: .external_url)
-            self = .externalURL(url)
+            let url = try container.decode(APIURL.self, forKey: .external_url)
+            self = .externalURL(url.rawValue)
         case .externalTool:
             let id = try container.decode(ID.self, forKey: .content_id)
-            let url = try container.decode(URL.self, forKey: .external_url)
-            self = .externalTool(id.value, url)
+            let url = try container.decode(APIURL.self, forKey: .external_url)
+            self = .externalTool(id.value, url.rawValue)
         }
     }
 


### PR DESCRIPTION
refs: MBL-14675
affects: Student, Teacher
release note: Fixed an issue preventing some modules with LTI tools from appearing