### PR TITLE
Fix no-context file links & file details modal from speedgrader

### DIFF
--- a/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/FileDetails/FileDetailsViewControllerTests.swift
@@ -287,7 +287,7 @@ class FileDetailsViewControllerTests: CoreTestCase {
         XCTAssertFalse(controller.lockView.isHidden)
         XCTAssertEqual(controller.lockLabel.text, "Locked, yo.")
         controller.viewModules() // not yet accessible from UI
-        XCTAssertTrue(router.lastRoutedTo("/\(context.pathComponent)/modules"))
+        XCTAssertTrue(router.lastRoutedTo("\(context.pathComponent)/modules"))
     }
 
     func testTeacher() {
@@ -296,7 +296,7 @@ class FileDetailsViewControllerTests: CoreTestCase {
 
         XCTAssert(controller.navigationItem.rightBarButtonItem == controller.editButton)
         _ = controller.editButton.target?.perform(controller.editButton.action)
-        XCTAssert(router.lastRoutedTo("/\(context.pathComponent)/files/1/edit"))
+        XCTAssert(router.lastRoutedTo("\(context.pathComponent)/files/1/edit"))
 
         _ = controller.toolbarLinkButton.target?.perform(controller.toolbarLinkButton.action)
         XCTAssertEqual(controller.copiedView.isHidden, false)

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -200,6 +200,8 @@ let routeMap: KeyValuePairs<String, RouteHandler.ViewFactory?> = [
 
     "/files/:fileID": fileDetails,
     "/files/:fileID/download": fileDetails,
+    "/files/:fileID/preview": fileDetails,
+    "/files/:fileID/edit": nil,
     "/:context/:contextID/files/:fileID": fileDetails,
     "/:context/:contextID/files/:fileID/download": fileDetails,
     "/:context/:contextID/files/:fileID/preview": fileDetails,
@@ -415,12 +417,12 @@ private func fileList(url: URLComponents, params: [String: String], userInfo: [S
 
 private func fileDetails(url: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
     guard let fileID = url.queryItems?.first(where: { $0.name == "preview" })?.value ?? params["fileID"] else { return nil }
-    var context = Context(path: url.path) ?? .currentUser
+    var context = Context(path: url.path)
     if let courseID = url.queryItems?.first(where: { $0.name == "courseID" })?.value {
         context = Context(.course, id: courseID)
     }
     let assignmentID = url.queryItems?.first(where: { $0.name == "assignmentID" })?.value
-    if !url.originIsModuleItemDetails, context.contextType == .course {
+    if !url.originIsModuleItemDetails, let context = context, context.contextType == .course {
         return ModuleItemSequenceViewController.create(
             courseID: context.id,
             assetType: .file,

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -206,6 +206,7 @@ private let nativeRoutes: KeyValuePairs<String, HelmViewControllerFactory.Builde
 
     "/files/:fileID": fileDetails,
     "/files/:fileID/download": fileDetails,
+    "/files/:fileID/preview": fileDetails,
     "/:context/:contextID/files/:fileID": fileDetails,
     "/:context/:contextID/files/:fileID/download": fileDetails,
     "/:context/:contextID/files/:fileID/preview": fileDetails,
@@ -279,8 +280,7 @@ private func fileList(props: Props) -> UIViewController? {
 
 private func fileDetails(props: Props) -> UIViewController? {
     guard let fileID = props["preview"] as? String ?? props["fileID"] as? String else { return nil }
-    let context = props.context ?? .currentUser
-    return FileDetailsViewController.create(context: context, fileID: fileID)
+    return FileDetailsViewController.create(context: props.context, fileID: fileID)
 }
 
 private extension Props {

--- a/rn/Teacher/src/modules/speedgrader/SubmissionViewer.js
+++ b/rn/Teacher/src/modules/speedgrader/SubmissionViewer.js
@@ -80,6 +80,13 @@ export default class SubmissionViewer extends Component<SubmissionViewerProps, S
     return text
   }
 
+  onNavigation = (url) => {
+    this.props.navigator.show(url, {
+      deepLink: true,
+      modal: true,
+    })
+  }
+
   renderCenteredText (text: string) {
     return (
       <View style={styles.centeredText}>
@@ -132,7 +139,7 @@ export default class SubmissionViewer extends Component<SubmissionViewerProps, S
       <CoreWebView
         contentInset={{ bottom: this.props.drawerInset }}
         html={submission.body || ''}
-        navigator={this.props.navigator}
+        onNavigation={this.onNavigation}
         style={styles.viewer}
       />
     )
@@ -152,28 +159,22 @@ export default class SubmissionViewer extends Component<SubmissionViewerProps, S
           <CoreWebView
             contentInset={{ bottom: this.props.drawerInset }}
             html={submission.body || ''}
-            navigator={this.props.navigator}
+            onNavigation={this.onNavigation}
             style={styles.viewer}
           />
         )
+      case 'discussion_topic':
       case 'online_quiz':
         return (
           <AuthenticatedWebView
             contentInset={{ bottom: this.props.drawerInset }}
-            onNavigation={(url) => {
-              this.props.navigator.show(url, {
-                deepLink: true,
-                modal: true,
-              })
-            }}
-            openLinksInSafari={false}
+            onNavigation={this.onNavigation}
             source={{ uri: submission.preview_url }}
             style={styles.viewer}
           />
         )
       case 'online_upload':
         return this.renderFile(submission)
-      case 'discussion_topic':
       case 'basic_lti_launch':
       case 'external_tool':
         return (

--- a/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SubmissionViewer.test.js.snap
+++ b/rn/Teacher/src/modules/speedgrader/__tests__/__snapshots__/SubmissionViewer.test.js.snap
@@ -7,7 +7,7 @@ exports[`SubmissionViewer renders a discussion_topic submission 1`] = `
       "bottom": 0,
     }
   }
-  openLinksInSafari={true}
+  onNavigation={[Function]}
   source={
     Object {
       "uri": "https://google.com",
@@ -124,7 +124,6 @@ exports[`SubmissionViewer renders an online_quiz submission 1`] = `
     }
   }
   onNavigation={[Function]}
-  openLinksInSafari={false}
   source={
     Object {
       "uri": "https://google.com",

--- a/rn/Teacher/src/routing/register-screens.js
+++ b/rn/Teacher/src/routing/register-screens.js
@@ -122,6 +122,8 @@ export function registerScreens (store: Store): void {
 
   registerScreen('/files/:fileID', null, store, { deepLink: true })
   registerScreen('/files/:fileID/download', null, store, { deepLink: true })
+  registerScreen('/files/:fileID/preview', null, store, { deepLink: true })
+  registerScreen('/files/:fileID/edit', EditFile, store)
   registerScreen('/:context/:contextID/files/:fileID', null, store, { deepLink: true })
   registerScreen('/:context/:contextID/files/:fileID/download', null, store, { deepLink: true })
   registerScreen('/:context/:contextID/files/:fileID/preview', null, store, { deepLink: true })


### PR DESCRIPTION
This also makes links in submissions way more consistent across speedgrader.

refs: MBL-14661
affects: Teacher
release note: Fixed an issue loading some links inside a submission