### PR TITLE
Fix rerendering of new document

### DIFF
--- a/CanvasCore/CanvasCore/ReactNativeModules/DocViewerWrapper.swift
+++ b/CanvasCore/CanvasCore/ReactNativeModules/DocViewerWrapper.swift
@@ -27,9 +27,15 @@ public class DocViewerWrapper: UIView {
             controller?.setContentInsets(contentInset)
         }
     }
-    @objc public var fallbackURL: String?
-    @objc public var filename: String?
-    @objc public var previewURL: String?
+    @objc public var fallbackURL: String? {
+        didSet { setNeedsLayout() }
+    }
+    @objc public var filename: String? {
+        didSet { setNeedsLayout() }
+    }
+    @objc public var previewURL: String? {
+        didSet { setNeedsLayout() }
+    }
 
     public override func layoutSubviews() {
         guard let filename = filename, let fallbackURL = fallbackURL.flatMap({ URL(string: $0) }) else {


### PR DESCRIPTION
even though a new previewURL was set, the view didn't realize it needed to layoutSubviews() which handles making sure the right document is displayed.

refs: MBL-14702
affects: Teacher
release note: none