### PR TITLE
Support navigating within login web view

### DIFF
--- a/Core/Core/Login/LoginFindSchoolViewController.swift
+++ b/Core/Core/Login/LoginFindSchoolViewController.swift
@@ -67,6 +67,7 @@ class LoginFindSchoolViewController: UIViewController {
         logoView.heightAnchor.constraint(equalToConstant: 32).isActive = true
         logoView.widthAnchor.constraint(equalToConstant: 32).isActive = true
         navigationItem.titleView = logoView
+        navigationItem.title = NSLocalizedString("Find School", bundle: .core, comment: "")
 
         promptLabel.text = NSLocalizedString("What’s your school’s name?", bundle: .core, comment: "")
         searchField.attributedPlaceholder = NSAttributedString(

--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -72,6 +72,7 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .backgroundLightest
         view.addSubview(webView)
         webView.pin(inside: view)
 

--- a/Core/CoreTests/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginWebViewControllerTests.swift
@@ -66,9 +66,8 @@ class LoginWebViewControllerTests: CoreTestCase {
 
         action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
         controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .cancel)
+            XCTAssertEqual(policy, .allow)
         }
-        XCTAssertEqual(opened, URL(string: "https://community.canvaslms.com"))
 
         action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
         controller.webView(controller.webView, decidePolicyFor: action) { policy in


### PR DESCRIPTION
refs: MBL-14726
affects: student, teacher, parent
release note: Fixed logging in for some institutions

test plan:
- Find My School > search for "mit" > tap Massachusetts Institute of Technology
- Tap MIT Students, Faculty, and Staff
- It should load the next login page within the web view
- A back button should appear at the bottom
- Tapping the back button should take you back in the web view and the back button should disappear