### PR TITLE
Fix student context card submission count

### DIFF
--- a/rn/Teacher/ios/TeacherE2ETests/ContextCardE2ETests.swift
+++ b/rn/Teacher/ios/TeacherE2ETests/ContextCardE2ETests.swift
@@ -44,7 +44,7 @@ class ContextCardE2ETests: CoreUITestCase {
         XCTAssertEqual(ContextCard.courseLabel.label(), "Assignments")
         XCTAssertEqual(ContextCard.sectionLabel.label(), "Section: Assignments")
         XCTAssertEqual(ContextCard.currentGradeLabel.label(), "Current grade 72.73%")
-        XCTAssertEqual(ContextCard.submissionsTotalLabel.label(), "Total Submissions 9")
+        XCTAssertEqual(ContextCard.submissionsTotalLabel.label(), "Total Submissions 3")
         XCTAssertEqual(ContextCard.submissionsLateLabel.label(), "Late Submissions 0")
         XCTAssertEqual(ContextCard.submissionsMissingLabel.label(), "Missing Submissions 2")
         XCTAssertEqual(ContextCard.submissionCell("5431").label(), "Published, New Grade Book Quiz, Submitted, 1/1")

--- a/rn/Teacher/src/canvas-api-v2/queries/ContextCard.js
+++ b/rn/Teacher/src/canvas-api-v2/queries/ContextCard.js
@@ -70,7 +70,6 @@ export const courseQuery = gql`query StudentContextCardCourse($courseID: ID!, $u
                 late
                 missing
                 onTime
-                total
               }
             }
           }

--- a/rn/Teacher/src/modules/users/ContextCard.js
+++ b/rn/Teacher/src/modules/users/ContextCard.js
@@ -69,6 +69,7 @@ export class ContextCard extends Component {
     const selectedText = { color: colors.white }
     const gradeSelected = !unpostedGrade && !overrideGrade
     const unpostedSelected = Boolean(unpostedGrade && !overrideGrade)
+    const totalSubmissions = user.analytics && (user.analytics.tardinessBreakdown.onTime + user.analytics.tardinessBreakdown.late)
 
     return (
       <View>
@@ -166,10 +167,10 @@ export class ContextCard extends Component {
                 style={styles.box}
                 testID='ContextCard.submissionsTotalLabel'
                 accessibilityLabel={i18n('Total Submissions {total, number}', {
-                  total: user.analytics.tardinessBreakdown.total,
+                  total: totalSubmissions,
                 })}
               >
-                <Text style={styles.largeText}>{i18n.number(user.analytics.tardinessBreakdown.total)}</Text>
+                <Text style={styles.largeText}>{i18n.number(totalSubmissions)}</Text>
                 <Text style={styles.label}>{i18n('Submitted')}</Text>
               </View>
               <View


### PR DESCRIPTION
very surprisingly, no snapshots needed updating

This is now how android does it.

Test plan: [run-nightly] succeeds

refs: MBL-14698
affects: teacher
release note: fix submitted assignment count on context card