### PR TITLE
Hide hidden calendar events

### DIFF
--- a/Core/Core/Planner/APICalendarEvent.swift
+++ b/Core/Core/Planner/APICalendarEvent.swift
@@ -37,6 +37,7 @@ public struct APICalendarEvent: Codable, Equatable {
     let description: String?
     let location_name: String?
     let location_address: String?
+    let hidden: Bool
 }
 
 #if DEBUG
@@ -58,7 +59,8 @@ extension APICalendarEvent {
         assignment: APIAssignment? = nil,
         description: String? = nil,
         location_name: String? = nil,
-        location_address: String? = nil
+        location_address: String? = nil,
+        hidden: Bool = false
     ) -> APICalendarEvent {
         return APICalendarEvent(
             id: id,
@@ -77,7 +79,8 @@ extension APICalendarEvent {
             assignment: assignment,
             description: description,
             location_name: location_name,
-            location_address: location_address
+            location_address: location_address,
+            hidden: hidden
         )
     }
 }

--- a/Core/Core/Planner/GetPlannables.swift
+++ b/Core/Core/Planner/GetPlannables.swift
@@ -28,6 +28,7 @@ public protocol PlannableItem {
     var date: Date? { get }
     var pointsPossible: Double? { get }
     var details: String? { get }
+    var isHidden: Bool { get }
 }
 
 extension APIPlannable: PlannableItem {
@@ -39,6 +40,7 @@ extension APIPlannable: PlannableItem {
     public var pointsPossible: Double? { self.plannable?.points_possible }
     public var details: String? { self.plannable?.details }
     public var contextName: String? { context_name }
+    public var isHidden: Bool { false }
     public var context: Context? {
         guard let raw = context_type, let type = ContextType(rawValue: raw.lowercased()) else {
             return nil
@@ -75,7 +77,7 @@ extension APICalendarEvent: PlannableItem {
     public var date: Date? { start_at }
     public var pointsPossible: Double? { assignment?.points_possible }
     public var details: String? { description }
-
+    public var isHidden: Bool { hidden }
 }
 
 public class GetPlannables: UseCase {
@@ -148,7 +150,7 @@ public class GetPlannables: UseCase {
 
     public func write(response: Response?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         let items: [PlannableItem] = response?.plannables ?? response?.calendarEvents ?? []
-        for item in items where item.plannableType != .announcement {
+        for item in items where item.plannableType != .announcement && !item.isHidden {
             Plannable.save(item, userID: userID, in: client)
         }
     }

--- a/Core/CoreTests/Planner/GetPlannablesTests.swift
+++ b/Core/CoreTests/Planner/GetPlannablesTests.swift
@@ -118,4 +118,15 @@ class GetPlannablesTests: CoreTestCase {
         }
         wait(for: [expectation], timeout: 1)
     }
+
+    func testWriteCalendarEvents() {
+        let response = GetPlannables.Response(plannables: nil, calendarEvents: [
+            .make(id: "1", start_at: start, hidden: false),
+            .make(id: "2", start_at: start, hidden: true),
+        ])
+        useCase.write(response: response, urlResponse: nil, to: databaseClient)
+        let plannables = databaseClient.fetch(scope: useCase.scope) as [Plannable]
+        XCTAssertEqual(plannables.count, 1)
+        XCTAssertEqual(plannables.first?.id, "1")
+    }
 }


### PR DESCRIPTION
refs: MBL-14737
affects: parent
release note: Fixed a bug that could cause duplicate calendar events to show.

test plan:
- see ticket for creds
- sept 18 should only show one event
- it should be the event with "(Parent App Duplicate Test)"