### PR TITLE
Add option to allow cross-website tracking

### DIFF
--- a/Parent/Parent/Info.plist
+++ b/Parent/Parent/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Canvas uses cookies to load media embedded in rich content.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/Student/Student/Info.plist
+++ b/Student/Student/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Canvas uses cookies to load media embedded in rich content.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>

--- a/rn/Teacher/ios/Teacher/Info.plist
+++ b/rn/Teacher/ios/Teacher/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Canvas uses cookies to load media embedded in rich content.</string>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>canvas-student</string>


### PR DESCRIPTION
refs: MBL-14793
affects: student, teacher, parent
release note: Added an option to Settings to allow cross-website tracking to temporarily fix images not loading in rich content

test plan:
- Go to iOS Settings > Settings for the app > Enable `Allow Cross-Website Tracking`
- Repro steps in ticket
- Images should load

![simulator_screenshot_4DDF042C-30EB-4F1C-B163-C381E1A9D116](https://user-images.githubusercontent.com/1187499/95225833-7482b780-07b9-11eb-92d7-feb9050cf1f8.png)
