### PR TITLE
Assignments: show attempts section only if it makes sense

### DIFF
--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -218,6 +218,10 @@ extension Assignment {
             (submissionTypes.contains(.basic_lti_launch) || submissionTypes.contains(.external_tool))
     }
 
+    public var attemptPossible: Bool {
+        return canMakeSubmissions && !isLTIAssignment
+    }
+
     public var isDiscussion: Bool {
         return submissionTypes.count == 1 &&
             submissionTypes.contains(.discussion_topic)

--- a/Core/CoreTests/Assignments/AssignmentTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentTests.swift
@@ -149,6 +149,17 @@ class AssignmentTests: CoreTestCase {
         XCTAssertTrue(a.isLTIAssignment)
     }
 
+    func testAttemptPossible() {
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.external_tool])).attemptPossible)
+        XCTAssertTrue(Assignment.make(from: .make(submission_types: [.media_recording])).attemptPossible)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.none])).attemptPossible)
+        XCTAssertTrue(Assignment.make(from: .make(submission_types: [.online_upload])).attemptPossible)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.on_paper])).attemptPossible)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.basic_lti_launch])).attemptPossible)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [.wiki_page])).attemptPossible)
+        XCTAssertFalse(Assignment.make(from: .make(submission_types: [])).attemptPossible)
+    }
+
     func testIsDiscussion() {
         let a = Assignment.make(from: .make(submission_types: [ .discussion_topic ] ))
         XCTAssertTrue(a.isDiscussion)

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -268,6 +268,7 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
         return (
             features.first(where: { $0.name == "assignment_attempts" })?.enabled != true ||
             assignment?.allowedAttempts == 0 ||
+            assignment?.attemptPossible == false ||
             assignment?.lockStatus == .before ||
             assignment?.submissionTypes.contains(.online_quiz) == true // attempts show up elsewhere
         )


### PR DESCRIPTION
refs: MBL-14797
affects: Student
release note: Hide attempts section, when not applicable