### PR TITLE
Make APITab.visibility a String

### DIFF
--- a/Core/Core/Contexts/APITab.swift
+++ b/Core/Core/Contexts/APITab.swift
@@ -26,7 +26,7 @@ public struct APITab: Codable, Equatable {
     let label: String
     let type: TabType
     let hidden: Bool?
-    let visibility: TabVisibility
+    let visibility: String
     let position: Int
 }
 
@@ -49,7 +49,7 @@ extension APITab {
             label: label,
             type: type,
             hidden: hidden,
-            visibility: visibility,
+            visibility: visibility.rawValue,
             position: position
         )
     }

--- a/Core/Core/Contexts/Tab.swift
+++ b/Core/Core/Contexts/Tab.swift
@@ -56,6 +56,6 @@ public class Tab: NSManagedObject {
         position = item.position
         self.context = context
         type = item.type
-        visibility = item.visibility
+        visibility = TabVisibility(rawValue: item.visibility) ?? .none
     }
 }


### PR DESCRIPTION
refs: MBL-14820
affects: student, teacher
release note: none

test plan: see ticket

I decided to do this now since I don't want to have to hotfix
again with another unknown visibility type.