### PR TITLE
Show error if self registration is not allowed

### DIFF
--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -28,13 +28,8 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case favoriteGroups = "favorite_groups"
     case nativeSpeedGrader = "native_speed_grader"
     case nativeDashboard = "native_dashboard"
-    case qrLoginTeacher = "qr_code_login_teacher"
-    case qrLoginParent = "qr_code_login_parent"
-    case qrLoginStudent = "qr_code_login_student"
     case nativeStudentInbox = "native_student_inbox"
     case nativeTeacherInbox = "native_teacher_inbox"
-    case studentQRCodePairing = "student_qr_code_pairing"
-    case parentQRCodePairing = "parent_qr_code_pairing"
 
     public var isEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: userDefaultsKey) }

--- a/Core/Core/Login/LoginDelegate.swift
+++ b/Core/Core/Login/LoginDelegate.swift
@@ -20,7 +20,6 @@ import UIKit
 
 public protocol LoginDelegate: class {
     var supportsCanvasNetwork: Bool { get }
-    var supportsQRCodeLogin: Bool { get }
     var helpURL: URL? { get }
     var whatsNewURL: URL? { get }
     var findSchoolButtonTitle: String { get }
@@ -36,7 +35,6 @@ public protocol LoginDelegate: class {
 
 public extension LoginDelegate {
     var supportsCanvasNetwork: Bool { true }
-    var supportsQRCodeLogin: Bool { true }
     var helpURL: URL? { URL(string: "https://community.canvaslms.com/docs/DOC-1543") }
     var whatsNewURL: URL? { nil }
     var findSchoolButtonTitle: String { NSLocalizedString("Find my school", bundle: .core, comment: "") }

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -92,10 +92,7 @@ class LoginStartViewController: UIViewController {
     func configureButtons() {
         canvasNetworkButton.setTitle(NSLocalizedString("Canvas Network", bundle: .core, comment: ""), for: .normal)
         canvasNetworkButton.isHidden = loginDelegate?.supportsCanvasNetwork == false || MDMManager.shared.host != nil
-
-        let qrCodeEnabled = loginDelegate?.supportsQRCodeLogin == true
-        useQRCodeButton.isHidden = !qrCodeEnabled
-        useQRCodeDivider.isHidden = !qrCodeEnabled || canvasNetworkButton.isHidden
+        useQRCodeDivider.isHidden = canvasNetworkButton.isHidden
     }
 
     @objc func userDefaultsDidChange(_ notification: Notification) {
@@ -221,7 +218,7 @@ class LoginStartViewController: UIViewController {
     }
 
     @IBAction func scanQRCode(_ sender: UIButton) {
-        if ExperimentalFeature.parentQRCodePairing.isEnabled && app == .parent {
+        if app == .parent {
             let sheet = BottomSheetPickerViewController.create()
             sheet.addAction(image: nil, title: NSLocalizedString("I have a Canvas account", comment: "")) { [weak self] in
                 self?.showLoginQRCodeTutorial()

--- a/Core/Core/Profile/Settings/PairWithObserverViewController.storyboard
+++ b/Core/Core/Profile/Settings/PairWithObserverViewController.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
-        <capability name="Named colors" minToolsVersion="9.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,11 +17,18 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="20G-jc-QC6" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
+                                <rect key="frame" x="187" y="433" width="40" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="40" id="5jz-q4-L5f"/>
+                                    <constraint firstAttribute="width" constant="40" id="yCO-AO-aA3"/>
+                                </constraints>
+                            </view>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="24" translatesAutoresizingMaskIntoConstraints="NO" id="dp4-DX-snF">
-                                <rect key="frame" x="16" y="60" width="382" height="157"/>
+                                <rect key="frame" x="16" y="60" width="382" height="57.333333333333343"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3MM-LR-o7s" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="382" height="61"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="57.333333333333336"/>
                                         <string key="text">Share the following pairing code with an observer to allow them to connect with you. This code will expire in seven days, or after one use.</string>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
@@ -30,63 +37,8 @@
                                             <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular16"/>
                                         </userDefinedRuntimeAttributes>
                                     </label>
-                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="EH4-JY-Fzl">
-                                        <rect key="frame" x="0.0" y="85" width="382" height="72"/>
-                                        <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tVC-Xc-ovi" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                <rect key="frame" x="0.0" y="24" width="382" height="24"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" priority="750" constant="30" id="c9e-3L-Tlt"/>
-                                                </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                <nil key="textColor"/>
-                                                <nil key="highlightedColor"/>
-                                                <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="bold24"/>
-                                                </userDefinedRuntimeAttributes>
-                                            </label>
-                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="20G-jc-QC6" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
-                                                <rect key="frame" x="171" y="16" width="40" height="40"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="5jz-q4-L5f"/>
-                                                    <constraint firstAttribute="width" constant="40" id="yCO-AO-aA3"/>
-                                                </constraints>
-                                            </view>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ACR-5K-WJ4">
-                                                <rect key="frame" x="0.0" y="0.0" width="382" height="72"/>
-                                                <connections>
-                                                    <action selector="actionCopyCode:" destination="3nT-fR-RLM" eventType="primaryActionTriggered" id="HaE-o4-Eds"/>
-                                                </connections>
-                                            </button>
-                                        </subviews>
-                                        <color key="backgroundColor" name="backgroundLight"/>
-                                        <constraints>
-                                            <constraint firstAttribute="bottom" secondItem="tVC-Xc-ovi" secondAttribute="bottom" constant="24" id="1v7-sw-umq"/>
-                                            <constraint firstItem="20G-jc-QC6" firstAttribute="centerX" secondItem="EH4-JY-Fzl" secondAttribute="centerX" id="56c-7B-IYd"/>
-                                            <constraint firstItem="tVC-Xc-ovi" firstAttribute="top" secondItem="EH4-JY-Fzl" secondAttribute="top" constant="24" id="6r0-Ey-kEi"/>
-                                            <constraint firstItem="20G-jc-QC6" firstAttribute="centerY" secondItem="EH4-JY-Fzl" secondAttribute="centerY" id="6uI-9j-5Kk"/>
-                                            <constraint firstAttribute="trailing" secondItem="ACR-5K-WJ4" secondAttribute="trailing" id="Nbb-NU-lI0"/>
-                                            <constraint firstAttribute="bottom" secondItem="ACR-5K-WJ4" secondAttribute="bottom" id="VhH-8S-3tf"/>
-                                            <constraint firstItem="tVC-Xc-ovi" firstAttribute="leading" secondItem="EH4-JY-Fzl" secondAttribute="leading" id="caP-jN-0ki"/>
-                                            <constraint firstItem="ACR-5K-WJ4" firstAttribute="leading" secondItem="EH4-JY-Fzl" secondAttribute="leading" id="jDw-wG-TPo"/>
-                                            <constraint firstAttribute="trailing" secondItem="tVC-Xc-ovi" secondAttribute="trailing" id="pHm-Ao-IlV"/>
-                                            <constraint firstItem="ACR-5K-WJ4" firstAttribute="top" secondItem="EH4-JY-Fzl" secondAttribute="top" id="pgO-8W-X5R"/>
-                                            <constraint firstAttribute="height" priority="750" constant="72" id="sSm-YY-Tac"/>
-                                        </constraints>
-                                    </view>
-                                    <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jqL-RC-I4s" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="157" width="382" height="0.0"/>
-                                        <state key="normal" title="Tap to copy"/>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
-                                            <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular16"/>
-                                        </userDefinedRuntimeAttributes>
-                                        <connections>
-                                            <action selector="actionCopyCode:" destination="3nT-fR-RLM" eventType="primaryActionTriggered" id="Mjz-9r-GgX"/>
-                                        </connections>
-                                    </button>
                                     <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dyL-yF-jzV">
-                                        <rect key="frame" x="0.0" y="157" width="382" height="240"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="240"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Nh0-Cv-0H5">
                                                 <rect key="frame" x="131" y="34" width="120" height="120"/>
@@ -105,7 +57,7 @@
                                                 </userDefinedRuntimeAttributes>
                                             </label>
                                         </subviews>
-                                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstItem="1sY-Q5-UiD" firstAttribute="top" secondItem="Nh0-Cv-0H5" secondAttribute="bottom" constant="34" id="Ae4-jB-Igf"/>
                                             <constraint firstItem="1sY-Q5-UiD" firstAttribute="leading" secondItem="dyL-yF-jzV" secondAttribute="leading" id="D8r-tG-ThS"/>
@@ -118,36 +70,23 @@
                                     </view>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="m7p-Jk-zaq" customClass="NotificationView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="954" width="414" height="58"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="58" id="swe-Yj-4eL"/>
-                                </constraints>
-                            </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="hMf-bc-d56"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="hMf-bc-d56" firstAttribute="trailing" secondItem="m7p-Jk-zaq" secondAttribute="trailing" id="1FC-R8-Wv2"/>
+                            <constraint firstItem="20G-jc-QC6" firstAttribute="centerY" secondItem="hMf-bc-d56" secondAttribute="centerY" id="Ez7-Ef-UjH"/>
                             <constraint firstItem="dp4-DX-snF" firstAttribute="top" secondItem="hMf-bc-d56" secondAttribute="top" constant="16" id="Fjm-IK-UMI"/>
-                            <constraint firstItem="hMf-bc-d56" firstAttribute="bottom" secondItem="m7p-Jk-zaq" secondAttribute="bottom" constant="-150" id="QI9-ML-JkL"/>
+                            <constraint firstItem="20G-jc-QC6" firstAttribute="centerX" secondItem="hMf-bc-d56" secondAttribute="centerX" id="OHQ-PW-KjH"/>
                             <constraint firstItem="dp4-DX-snF" firstAttribute="leading" secondItem="hMf-bc-d56" secondAttribute="leading" constant="16" id="aAb-4e-FRs"/>
-                            <constraint firstItem="m7p-Jk-zaq" firstAttribute="leading" secondItem="hMf-bc-d56" secondAttribute="leading" id="dmc-gD-3Z7"/>
                             <constraint firstItem="hMf-bc-d56" firstAttribute="trailing" secondItem="dp4-DX-snF" secondAttribute="trailing" constant="16" id="yV2-4Z-GDS"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="hMf-bc-d56"/>
                     </view>
                     <connections>
-                        <outlet property="codeContainer" destination="EH4-JY-Fzl" id="f8S-6q-Ayf"/>
-                        <outlet property="codeLabel" destination="tVC-Xc-ovi" id="ufL-7B-U84"/>
                         <outlet property="instructionsLabel" destination="3MM-LR-o7s" id="bbb-mK-Bw9"/>
-                        <outlet property="notificationView" destination="m7p-Jk-zaq" id="NTS-4B-rA3"/>
-                        <outlet property="notificationViewBottomConstraint" destination="QI9-ML-JkL" id="Kgp-Nw-CxX"/>
                         <outlet property="qrCodeContainer" destination="dyL-yF-jzV" id="Av1-aY-1Fd"/>
                         <outlet property="qrCodeImageView" destination="Nh0-Cv-0H5" id="489-eF-NRA"/>
                         <outlet property="qrCodePairingCodeLabel" destination="1sY-Q5-UiD" id="cO4-ck-RbB"/>
                         <outlet property="spinner" destination="20G-jc-QC6" id="iKu-AX-Mrt"/>
-                        <outlet property="tapToCopyButton" destination="jqL-RC-I4s" id="aSG-TW-dAd"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="JMI-jv-djC" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
@@ -155,9 +94,17 @@
             <point key="canvasLocation" x="139" y="76"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="1sY-Q5-UiD">
+            <size key="intrinsicContentSize" width="50" height="24"/>
+        </designable>
+        <designable name="3MM-LR-o7s">
+            <size key="intrinsicContentSize" width="989.33333333333337" height="19.333333333333332"/>
+        </designable>
+    </designables>
     <resources>
-        <namedColor name="backgroundLight">
-            <color red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Core/Core/Profile/Settings/PairWithObserverViewController.swift
+++ b/Core/Core/Profile/Settings/PairWithObserverViewController.swift
@@ -43,14 +43,9 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
         super.viewDidLoad()
         title = NSLocalizedString("Pair with Observer", bundle: .core, comment: "")
         //  swiftlint:disable:next line_length
-        instructionsLabel.text = NSLocalizedString("Share the following pairing code with an observer to allow them to connect with you. This code will expire in seven days, or after one use.", comment: "")
-        if ExperimentalFeature.studentQRCodePairing.isEnabled {
-            instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", comment: "")
-            codeContainer.backgroundColor = .backgroundLightest
-            codeContainer.setNeedsDisplay()
-        }
-
-        tapToCopyButton.isHidden = ExperimentalFeature.studentQRCodePairing.isEnabled
+        instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", comment: "")
+        codeContainer.backgroundColor = .backgroundLightest
+        codeContainer.setNeedsDisplay()
 
         notificationView.messageLabel.text = NSLocalizedString("Copied!", bundle: .core, comment: "")
         tapToCopyButton.setTitle(NSLocalizedString("Tap to copy", bundle: .core, comment: ""), for: .normal)
@@ -73,12 +68,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
                     self?.spinner.isHidden = true
                     self?.showError(error)
                 } else {
-                    if ExperimentalFeature.studentQRCodePairing.isEnabled {
-                        self?.generateQRCode(pairingCode: response?.code)
-                    } else {
-                        self?.spinner.isHidden = true
-                        self?.displayPairingCode(response?.code)
-                    }
+                    self?.generateQRCode(pairingCode: response?.code)
                 }
             }
         }

--- a/Core/Core/Profile/Settings/PairWithObserverViewController.swift
+++ b/Core/Core/Profile/Settings/PairWithObserverViewController.swift
@@ -20,18 +20,13 @@ import UIKit
 
 class PairWithObserverViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var instructionsLabel: DynamicLabel!
-    @IBOutlet weak var codeLabel: DynamicLabel!
     @IBOutlet weak var spinner: CircleProgressView!
-    @IBOutlet weak var codeContainer: UIView!
-    @IBOutlet weak var notificationView: NotificationView!
-    @IBOutlet weak var notificationViewBottomConstraint: NSLayoutConstraint!
     @IBOutlet weak var qrCodeImageView: UIImageView!
     @IBOutlet weak var qrCodeContainer: UIView!
     @IBOutlet weak var qrCodePairingCodeLabel: DynamicLabel!
-    @IBOutlet weak var tapToCopyButton: UIButton!
     var animating: Bool = false
     var didGenerateCode = false
-    var deepLinkURL: URL?
+    var pairingCode: String?
 
     let env = AppEnvironment.shared
 
@@ -42,15 +37,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Pair with Observer", bundle: .core, comment: "")
-        //  swiftlint:disable:next line_length
         instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", comment: "")
-        codeContainer.backgroundColor = .backgroundLightest
-        codeContainer.setNeedsDisplay()
-
-        notificationView.messageLabel.text = NSLocalizedString("Copied!", bundle: .core, comment: "")
-        tapToCopyButton.setTitle(NSLocalizedString("Tap to copy", bundle: .core, comment: ""), for: .normal)
-
-        codeContainer.layer.cornerRadius = 8.0
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(actionShare(sender:)))
     }
@@ -92,8 +79,8 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
             let host = baseURL?.host
         else { return }
 
+        self.pairingCode = pairingCode
         let comps = URLComponents(string: "canvas-parent://\(host)/pair?code=\(code)&account_id=\(accountID)")
-
         let input = comps?.url?.absoluteString ?? ""
         let data = input.data(using: String.Encoding.ascii)
         guard let qrFilter = CIFilter(name: "CIQRCodeGenerator") else { return }
@@ -103,9 +90,6 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
 
         qrCodeImageView.image = UIImage(ciImage: qrImage)
         qrCodeContainer.isHidden = false
-        codeContainer.isHidden = true
-        codeLabel.text = comps?.url?.absoluteString
-        deepLinkURL = comps?.url
         let attrStr = NSAttributedString(
             string: NSLocalizedString("Pairing Code: ", comment: ""),
             attributes: [
@@ -129,49 +113,15 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
         qrCodeContainer.layer.borderWidth = 1
         qrCodeContainer.layer.borderColor = UIColor.borderMedium.cgColor
         qrCodeContainer.layer.cornerRadius = 4
-        tapToCopyButton.isHidden = true
-    }
-
-    func displayPairingCode(_ code: String?) {
-        codeLabel.isHidden = false
-        codeLabel.text = code
-    }
-
-    @IBAction func actionCopyCode(_ sender: Any) {
-        if codeLabel.text?.isEmpty == false {
-            UIPasteboard.general.string = codeLabel.text
-            showNotification()
-        }
     }
 
     @objc func actionShare(sender: UIBarButtonItem) {
-        guard let code = codeLabel.text, !code.isEmpty else { return }
+        guard let code = pairingCode, !code.isEmpty else { return }
         let template = NSLocalizedString("Use this code to pair with me in Canvas Parent: %@", bundle: .core, comment: "")
         let message = String.localizedStringWithFormat(template, code)
         let vc = UIActivityViewController(activityItems: [message], applicationActivities: nil)
         let popover = vc.popoverPresentationController
         popover?.barButtonItem = sender
         env.router.show(vc, from: self, options: .modal(isDismissable: false, embedInNav: false, addDoneButton: false))
-    }
-
-    func showNotification(_ show: Bool = true, delay: TimeInterval = 0) {
-        var completion: ((Bool) -> Void)?
-        if show {
-            if animating { return }
-            animating = true
-            notificationViewBottomConstraint.constant = 8
-            completion = { _  in
-                self.showNotification(false, delay: 3.0)
-            }
-        } else {
-            notificationViewBottomConstraint.constant = -150
-            completion = { _  in
-                self.animating = false
-            }
-        }
-
-        UIView.animate(withDuration: 0.15, delay: delay, options: .curveEaseOut, animations: { [weak self] in
-            self?.notificationView.superview?.layoutIfNeeded()
-        }, completion: completion)
     }
 }

--- a/Core/CoreTests/Login/LoginStartViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginStartViewControllerTests.swift
@@ -26,8 +26,6 @@ class LoginStartViewControllerTests: CoreTestCase {
     var opened: URL?
     var hasOpenedSupportTicket = false
     var supportsCanvasNetwork = true
-    var supportsQRCodeLogin: Bool = true
-
     var helpURL: URL?
     var whatsNewURL = URL(string: "whats-new")
 
@@ -36,7 +34,6 @@ class LoginStartViewControllerTests: CoreTestCase {
     override func setUp() {
         super.setUp()
         supportsCanvasNetwork = true
-        supportsQRCodeLogin = true
         MDMManager.mockDefaults()
         api.mock(GetUserRequest(userID: "1"), value: .make())
     }
@@ -170,15 +167,7 @@ class LoginStartViewControllerTests: CoreTestCase {
         XCTAssertEqual(alert.message, "Please generate another QR Code and try again.")
     }
 
-    func testQRCodeNotSupported() {
-        supportsQRCodeLogin = false
-        controller.view.layoutIfNeeded()
-        XCTAssertTrue(controller.useQRCodeButton.isHidden)
-        XCTAssertTrue(controller.useQRCodeDivider.isHidden)
-    }
-
     func testParentCreateAccountQRCode() throws {
-        ExperimentalFeature.parentQRCodePairing.isEnabled = true
         let code = "parent-app://canvas.instructure.com/pair?code=foo"
         controller.app = .parent
         controller.view.layoutIfNeeded()
@@ -196,34 +185,6 @@ class LoginStartViewControllerTests: CoreTestCase {
         let login = try XCTUnwrap(router.last as? LoginWebViewController)
         XCTAssertEqual(login.host, "canvas.instructure.com")
         XCTAssertEqual(login.pairingCode, "foo")
-    }
-
-    func testQRLoginFeatureGetsTurnedOn() {
-        ExperimentalFeature.qrLoginParent.isEnabled = false
-        supportsQRCodeLogin = false
-        controller.view.layoutIfNeeded()
-        XCTAssertTrue(controller.useQRCodeButton.isHidden)
-        XCTAssertTrue(controller.useQRCodeDivider.isHidden)
-        supportsQRCodeLogin = true
-        //  this just triggers userDefaultsDidChange notification
-        //  doesn't matter which feature is changed
-        ExperimentalFeature.qrLoginParent.isEnabled = true
-        XCTAssertFalse(controller.useQRCodeButton.isHidden)
-        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
-    }
-
-    func testQRLoginFeatureGetsTurnedOff() {
-        ExperimentalFeature.qrLoginParent.isEnabled = true
-        supportsQRCodeLogin = true
-        controller.view.layoutIfNeeded()
-        XCTAssertFalse(controller.useQRCodeButton.isHidden)
-        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
-        supportsQRCodeLogin = false
-        //  this just triggers userDefaultsDidChange notification
-        //  doesn't matter which feature is changed
-        ExperimentalFeature.qrLoginParent.isEnabled = false
-        XCTAssertTrue(controller.useQRCodeButton.isHidden)
-        XCTAssertTrue(controller.useQRCodeDivider.isHidden)
     }
 
     func testButtonsBelowLoginButtonWithBothEnabled() {

--- a/Core/CoreTests/Profile/Settings/PairWithObserverViewControllerTests.swift
+++ b/Core/CoreTests/Profile/Settings/PairWithObserverViewControllerTests.swift
@@ -35,14 +35,11 @@ class PairWithObserverViewControllerTests: CoreTestCase {
     }
 
     func testRender() {
-        let code = APIPairingCode.make()
+        let code = APIPairingCode.make(code: "abc")
         api.mock(PostObserverPairingCodes(), value: code)
+        api.mock(GetAccountTermsOfServiceRequest(), value: .make())
         load()
-        XCTAssertEqual(vc.codeLabel.text, code.code)
-        vc.tapToCopyButton.sendActions(for: .primaryActionTriggered)
-        XCTAssertEqual(vc.notificationView.messageLabel.text, "Copied!")
-        XCTAssertEqual(vc.notificationViewBottomConstraint.constant, 8)
         XCTAssertEqual(vc.spinner.isHidden, true)
-        XCTAssertEqual(UIPasteboard.general.string, code.code)
+        XCTAssertEqual(vc.qrCodePairingCodeLabel.attributedText?.string, "Pairing Code: abc")
     }
 }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -139,9 +139,6 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 }
 
 extension ParentAppDelegate: LoginDelegate {
-    var supportsQRCodeLogin: Bool {
-        ExperimentalFeature.qrLoginParent.isEnabled
-    }
     var supportsCanvasNetwork: Bool { false }
     var findSchoolButtonTitle: String { NSLocalizedString("Find School", bundle: .core, comment: "") }
 

--- a/Parent/Parent/Students/AddStudentController.swift
+++ b/Parent/Parent/Students/AddStudentController.swift
@@ -32,26 +32,22 @@ class AddStudentController {
 
     @objc func addStudent() {
         guard let presenting = presentingViewController else { return }
-        if ExperimentalFeature.parentQRCodePairing.isEnabled {
-            let picker = BottomSheetPickerViewController.create()
-            picker.addAction(
-                image: nil,
-                title: NSLocalizedString("QR Code", comment: ""),
-                accessibilityIdentifier: "DashboardViewController.addStudent.qrCode"
-            ) { [weak self] in
-                self?.scanQRCode()
-            }
-            picker.addAction(
-                image: nil,
-                title: NSLocalizedString("Pairing Code", comment: ""),
-                accessibilityIdentifier: "DashboardViewController.addStudent.pairingCode"
-            ) { [weak self] in
-                self?.useInput()
-            }
-            env.router.show(picker, from: presenting, options: .modal())
-        } else {
-            useInput()
+        let picker = BottomSheetPickerViewController.create()
+        picker.addAction(
+            image: nil,
+            title: NSLocalizedString("QR Code", comment: ""),
+            accessibilityIdentifier: "DashboardViewController.addStudent.qrCode"
+        ) { [weak self] in
+            self?.scanQRCode()
         }
+        picker.addAction(
+            image: nil,
+            title: NSLocalizedString("Pairing Code", comment: ""),
+            accessibilityIdentifier: "DashboardViewController.addStudent.pairingCode"
+        ) { [weak self] in
+            self?.useInput()
+        }
+        env.router.show(picker, from: presenting, options: .modal())
     }
 
     func useInput() {

--- a/Parent/ParentE2ETests/LoginTests.swift
+++ b/Parent/ParentE2ETests/LoginTests.swift
@@ -20,7 +20,6 @@ import Core
 import TestsFoundation
 
 class LoginCreateAccountE2ETests: CoreUITestCase {
-    override var experimentalFeatures: [ExperimentalFeature] { [.qrLoginParent, .parentQRCodePairing] }
     override var user: UITestUser? { nil }
 
     override func setUp() {

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -26,7 +26,6 @@ class DashboardViewControllerTests: ParentTestCase {
 
     override class func setUp() {
         super.setUp()
-        ExperimentalFeature.parentQRCodePairing.isEnabled = false
     }
 
     func testLayoutMenu() {
@@ -71,12 +70,6 @@ class DashboardViewControllerTests: ParentTestCase {
         XCTAssertEqual(vc.titleLabel.text, "Bob")
         XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Bob. Tap to switch students")
         XCTAssertEqual(vc.studentListStack.arrangedSubviews.count, students.count + 1) // + add button
-
-        (vc.studentListStack.arrangedSubviews.last as? UIButton)?.sendActions(for: .primaryActionTriggered)
-        XCTAssert(router.presented is UIAlertController)
-        router.dismiss(vc, completion: nil)
-
-        ExperimentalFeature.parentQRCodePairing.isEnabled = true
 
         (vc.studentListStack.arrangedSubviews.last as? UIButton)?.sendActions(for: .primaryActionTriggered)
         let picker = router.presented as! BottomSheetPickerViewController

--- a/Parent/ParentUnitTests/Students/AddStudentControllerTests.swift
+++ b/Parent/ParentUnitTests/Students/AddStudentControllerTests.swift
@@ -27,11 +27,6 @@ class AddStudentControllerTests: ParentTestCase {
     let mock = MockViewController()
     lazy var controller = AddStudentController(presentingViewController: mock) { _ in }
 
-    override func setUp() {
-        super.setUp()
-        ExperimentalFeature.parentQRCodePairing.isEnabled = false
-    }
-
     func testLayout() throws {
         controller.addStudent()
 
@@ -75,7 +70,6 @@ class AddStudentControllerTests: ParentTestCase {
     }
 
     func testScanQRCode() {
-        ExperimentalFeature.parentQRCodePairing.isEnabled = true
         let expectation = XCTestExpectation(description: "handler was called")
         controller.handler = { error in
             XCTAssertNil(error)
@@ -95,7 +89,6 @@ class AddStudentControllerTests: ParentTestCase {
     }
 
     func testScannerDomainMismatch() {
-        ExperimentalFeature.parentQRCodePairing.isEnabled = true
         let expectation = XCTestExpectation(description: "handler was called")
         controller.handler = { error in
             XCTAssertNil(error)

--- a/Parent/ParentUnitTests/Students/AddStudentControllerTests.swift
+++ b/Parent/ParentUnitTests/Students/AddStudentControllerTests.swift
@@ -27,46 +27,49 @@ class AddStudentControllerTests: ParentTestCase {
     let mock = MockViewController()
     lazy var controller = AddStudentController(presentingViewController: mock) { _ in }
 
-    func testLayout() throws {
-        controller.addStudent()
-
-        let alert = try XCTUnwrap(router.presented as? UIAlertController)
-
-        var action = alert.actions[1] as! AlertAction
-        XCTAssertEqual(action.title, "Add")
-        XCTAssertEqual(action.style, .default)
-
-        action = alert.actions[0] as! AlertAction
-        XCTAssertEqual(action.title, "Cancel")
-        XCTAssertEqual(action.style, .cancel)
-
-        let tf = alert.textFields?.first!
-        XCTAssertEqual(tf!.placeholder, "Pairing Code")
-    }
-
     func testAddPairingCodeInput() throws {
+        let expectation = XCTestExpectation(description: "handler was called")
+        controller.handler = { error in
+            XCTAssertNil(error)
+            expectation.fulfill()
+        }
         api.mock(PostObserveesRequest(userID: "self", pairingCode: "abc"), value: .make())
         controller.addStudent()
+        let picker = router.presented as! BottomSheetPickerViewController
+        XCTAssertEqual(picker.actions.count, 2)
+        XCTAssertEqual(picker.actions[0].title, "QR Code")
+        XCTAssertEqual(picker.actions[1].title, "Pairing Code")
+        picker.actions[1].action()
         let alert = try XCTUnwrap(router.presented as? UIAlertController)
-        router.dismiss()
         let textField = try XCTUnwrap(alert.textFields?.first)
         textField.text = "abc"
         let add = try XCTUnwrap(alert.actions.first { $0.title == "Add" } as? AlertAction)
         add.handler?(add)
-        XCTAssertNil(router.presented, "Nothing presented so no error alert shown")
+        wait(for: [expectation], timeout: 1)
     }
 
     func testAddPairingCodeError() throws {
-        api.mock(PostObserveesRequest(userID: "self", pairingCode: "abc"), error: NSError.instructureError("Oops!"))
+        let expectation = XCTestExpectation(description: "handler was called")
+        controller.handler = { error in
+            XCTAssertNotNil(error)
+            expectation.fulfill()
+        }
+        let error = NSError.internalError()
+        api.mock(PostObserveesRequest(userID: "self", pairingCode: "abc"), error: error)
         controller.addStudent()
+        let picker = router.presented as! BottomSheetPickerViewController
+        XCTAssertEqual(picker.actions.count, 2)
+        XCTAssertEqual(picker.actions[0].title, "QR Code")
+        XCTAssertEqual(picker.actions[1].title, "Pairing Code")
+        picker.actions[1].action()
         let alert = try XCTUnwrap(router.presented as? UIAlertController)
-        router.dismiss()
         let textField = try XCTUnwrap(alert.textFields?.first)
         textField.text = "abc"
         let add = try XCTUnwrap(alert.actions.first { $0.title == "Add" } as? AlertAction)
         add.handler?(add)
-        let error = try XCTUnwrap(router.presented as? UIAlertController)
-        XCTAssertEqual(error.message, "Oops!")
+        wait(for: [expectation], timeout: 1)
+        let errorAlert = router.presented as! UIAlertController
+        XCTAssertEqual(errorAlert.message, error.localizedDescription)
     }
 
     func testScanQRCode() {

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -320,10 +320,6 @@ extension StudentAppDelegate {
 }
 
 extension StudentAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
-    var supportsQRCodeLogin: Bool {
-        ExperimentalFeature.qrLoginStudent.isEnabled
-    }
-
     func changeUser() {
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -211,10 +211,6 @@ extension TeacherAppDelegate: RCTBridgeDelegate {
 }
 
 extension TeacherAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
-    var supportsQRCodeLogin: Bool {
-        ExperimentalFeature.qrLoginTeacher.isEnabled
-    }
-
     func changeUser() {
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {


### PR DESCRIPTION
Also removes QR feature flags.

refs: MBL-14722
affects: parent
release note: Added a message for parents that try to create an account using the QR code pairing feature when self registration is not allowed

test plan:
1. On web, go to account settings > Authentication
2. Set `Self registration` to `All account types`
3. Parent app > QR Login > I don't have an account > Scan student QR code
4. You should get the self registration form
5. Set `Self registration` to `Observer accounts only`
6. Repeat step 3
7. You should get the self registration form
8. Set `Self registration` to `Disabled`
9. Repeat step 3
10. You should get an error alert