### PR TITLE
Append our pdf provider instead of insert

### DIFF
--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -104,7 +104,7 @@ public class DocViewerViewController: UIViewController {
             document.didCreateDocumentProviderBlock = { documentProvider in
                 let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, metadata: metadata, annotations: annotations, api: self.session.api, sessionID: sessionID)
                 provider.docViewerDelegate = self
-                documentProvider.annotationManager.annotationProviders.insert(provider, at: 0)
+                documentProvider.annotationManager.annotationProviders.append(provider)
                 self.annotationProvider = provider
             }
         }

--- a/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
@@ -57,7 +57,7 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
             api: environment.api,
             sessionID: "a"
         )
-        documentProvider.annotationManager.annotationProviders.insert(provider, at: 0)
+        documentProvider.annotationManager.annotationProviders.append(provider)
         return provider
     }
 


### PR DESCRIPTION
refs: MBL-14809
affects: teacher
release note: Fixed a bug with annotating documents with 3rd party annotations

test plan:
- see ticket
- new annotations should be applied and saved above all others

In case this causes issues in the future, here's some additional context:
- https://github.com/instructure/ios/pull/1678
- https://github.com/instructure/ios/commit/0343ef9cd6aa55aa072609dd59f010d5d6f79bf5#diff-e6097e3aee4336373b57d5b73007dfadR127