### PR TITLE
Remove invalid No Submission date entry from submission picker.

### DIFF
--- a/Student/Student.xcodeproj/project.pbxproj
+++ b/Student/Student.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		B1DC259E23DF81CF0005809D /* SubmitAssignment.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B1BB7A8222BAC820006CA068 /* SubmitAssignment.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B1FF02D02404353E004B7B1C /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FF02CF2404353E004B7B1C /* KeychainTests.swift */; };
 		B5E212D31D88856B009D8C07 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B5E212D51D88856B009D8C07 /* Localizable.strings */; };
+		CF7D8A782535E45000DC7D79 /* SubmissionDetailsPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7D8A772535E45000DC7D79 /* SubmissionDetailsPickerTests.swift */; };
 		DA5C72BF38BB22F39F7FB893 /* Pods_defaults_StudentUnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60DEFAEF2C9B9DFE5512CC77 /* Pods_defaults_StudentUnitTests.framework */; };
 		E809363124C21A5D00D15E9A /* AccountNotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809363024C21A5D00D15E9A /* AccountNotificationsTests.swift */; };
 		E809363824C21B6F00D15E9A /* InboxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E809363724C21B6F00D15E9A /* InboxTests.swift */; };
@@ -717,6 +718,7 @@
 		B5F122D01D8C4E050045063A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B75B05C5859701C8F14179C5 /* Pods-defaults-CanvasTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-CanvasTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-CanvasTests/Pods-defaults-CanvasTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BEDDBB798D4D4EA95C1F9796 /* Pods-defaults-StudentUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-StudentUnitTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-StudentUnitTests/Pods-defaults-StudentUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CF7D8A772535E45000DC7D79 /* SubmissionDetailsPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionDetailsPickerTests.swift; sourceTree = "<group>"; };
 		D125492B8610602A8B0B08BC /* Pods-needs-pspdfkit-StudentUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-StudentUITests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-needs-pspdfkit-StudentUITests/Pods-needs-pspdfkit-StudentUITests.release.xcconfig"; sourceTree = "<group>"; };
 		D668B463DC17BB3443A13DB4 /* Pods-needs-pspdfkit-StudentUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-StudentUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-needs-pspdfkit-StudentUITests/Pods-needs-pspdfkit-StudentUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		E809363024C21A5D00D15E9A /* AccountNotificationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountNotificationsTests.swift; sourceTree = "<group>"; };
@@ -1378,6 +1380,7 @@
 			children = (
 				7DCF0F2E22F8A096000AACCE /* SubmissionDetailsPresenterTests.swift */,
 				7D0E22B823A19E430075E879 /* SubmissionDetailsViewControllerTests.swift */,
+				CF7D8A772535E45000DC7D79 /* SubmissionDetailsPickerTests.swift */,
 			);
 			path = SubmissionDetails;
 			sourceTree = "<group>";
@@ -2703,6 +2706,7 @@
 				7DE1162322F8AB5C005BFE98 /* UrlSubmissionPresenterTests.swift in Sources */,
 				7DC4A0BD24BE5024007A7EAD /* CalendarEventDetailsViewControllerTests.swift in Sources */,
 				7DE1161522F8AB5C005BFE98 /* CourseNavigationPresenterTests.swift in Sources */,
+				CF7D8A782535E45000DC7D79 /* SubmissionDetailsPickerTests.swift in Sources */,
 				B1FF02D02404353E004B7B1C /* KeychainTests.swift in Sources */,
 				7DE1161F22F8AB5C005BFE98 /* RubricPresenterTests.swift in Sources */,
 				7D46624124D0C7C900C74DB4 /* QuizDetailsViewControllerTests.swift in Sources */,

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -47,6 +47,9 @@ class SubmissionDetailsPresenter: PageViewLoggerPresenterProtocol {
         self?.update()
     }
 
+    /** The purpose of this property is to filter out placeholder `Submission` objects returned by the API in case there are no submissions yet. After the first submission, these entities are still in the database but we don't want to show them in the submission picker. */
+    var pickerSubmissions: [Submission] { submissions.all.filter { $0.submittedAt != nil } }
+
     lazy var assignment = env.subscribe(GetAssignment(courseID: context.id, assignmentID: assignmentID)) { [weak self] in
         self?.update()
     }

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -104,10 +104,10 @@ class SubmissionDetailsViewController: UIViewController, SubmissionDetailsViewPr
         if let submittedAt = submission?.submittedAt {
             pickerButton?.setTitle(DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short), for: .normal)
         }
-        pickerButton?.isEnabled = presenter.submissions.count > 1
-        pickerButtonArrow?.isHidden = !isSubmitted || presenter.submissions.count <= 1
+        pickerButton?.isEnabled = presenter.pickerSubmissions.count > 1
+        pickerButtonArrow?.isHidden = !isSubmitted || presenter.pickerSubmissions.count <= 1
         pickerButtonDivider?.isHidden = !isSubmitted
-        if presenter.submissions.count <= 1 || assignment.isExternalToolAssignment {
+        if presenter.pickerSubmissions.count <= 1 || assignment.isExternalToolAssignment {
             picker?.isHidden = true
         }
 
@@ -178,18 +178,18 @@ extension SubmissionDetailsViewController: UIPickerViewDataSource, UIPickerViewD
     }
 
     func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
-        return presenter?.submissions.count ?? 0
+        return presenter?.pickerSubmissions.count ?? 0
     }
 
     func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
-        guard let submittedAt = presenter?.submissions[row]?.submittedAt else {
+        guard let submittedAt = presenter?.pickerSubmissions[row].submittedAt else {
             return NSLocalizedString("No Submission Date", bundle: .student, comment: "")
         }
         return DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short)
     }
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
-        guard let attempt = presenter?.submissions[row]?.attempt else { return }
+        guard let attempt = presenter?.pickerSubmissions[row].attempt else { return }
         presenter?.select(attempt: attempt)
     }
 }

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPickerTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPickerTests.swift
@@ -1,0 +1,67 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2020-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Student
+@testable import Core
+import TestsFoundation
+
+class SubmissionDetailsPickerTests: StudentTestCase {
+    private let context = Context.course("1")
+    private let assignment = APIAssignment.make()
+    private let APISubmissionWithoutDate = APISubmission.make(assignment_id: "1", attempt: 0, submitted_at: nil, user_id: "1")
+    private let APISubmissionWithDate = APISubmission.make(assignment_id: "1", attempt: 1, submitted_at: Date(), user_id: "1")
+    private let APISubmissionWithDate_2 = APISubmission.make(assignment_id: "1", attempt: 2, submitted_at: Date(), user_id: "1")
+
+    override func setUp() {
+        super.setUp()
+
+        let getAssignment = GetAssignment(courseID: context.id, assignmentID: "1")
+        getAssignment.write(response: assignment, urlResponse: nil, to: databaseClient)
+        api.mock(getAssignment)
+    }
+
+    func testPickerHiddenWithTwoSubmissionsOneWithoutDate() {
+        let mockGetSubmission = GetSubmission(context: context, assignmentID: "1", userID: "1")
+        mockGetSubmission.write(response: APISubmissionWithoutDate, urlResponse: nil, to: databaseClient)
+        mockGetSubmission.write(response: APISubmissionWithDate, urlResponse: nil, to: databaseClient)
+        api.mock(mockGetSubmission)
+
+        let testee = SubmissionDetailsViewController.create(context: context, assignmentID: "1", userID: "1")
+        testee.loadViewIfNeeded()
+
+        XCTAssertTrue(testee.pickerButtonArrow!.isHidden)
+        XCTAssertFalse(testee.pickerButton!.isEnabled)
+    }
+
+    func testPickerOffersOnlySubmissionsWithDate() {
+        let mockGetSubmission = GetSubmission(context: context, assignmentID: "1", userID: "1")
+        mockGetSubmission.write(response: APISubmissionWithoutDate, urlResponse: nil, to: databaseClient)
+        mockGetSubmission.write(response: APISubmissionWithDate, urlResponse: nil, to: databaseClient)
+        mockGetSubmission.write(response: APISubmissionWithDate_2, urlResponse: nil, to: databaseClient)
+        api.mock(mockGetSubmission)
+
+        let testee = SubmissionDetailsViewController.create(context: context, assignmentID: "1", userID: "1")
+        testee.loadViewIfNeeded()
+
+        XCTAssertEqual(testee.picker!.dataSource?.pickerView(testee.picker!, numberOfRowsInComponent: 0), 2)
+        let noSubmissionDateTitle = NSLocalizedString("No Submission Date", bundle: .student, comment: "")
+        XCTAssertNotEqual(testee.picker!.delegate?.pickerView?(testee.picker!, titleForRow: 0, forComponent: 0), noSubmissionDateTitle)
+        XCTAssertNotEqual(testee.picker!.delegate?.pickerView?(testee.picker!, titleForRow: 1, forComponent: 0), noSubmissionDateTitle)
+    }
+}


### PR DESCRIPTION
refs: MBL-14803
affects: student
release note: Remove invalid No Submission date entry from submission picker.

test plan:
- Go to an assignment which has no submissions.
- Make a submission.
- Enter Submission & Rubric page.
- Date picker should be inactive.