### PR TITLE
Fix CoreData predicate not to cause an exception during fetch. Add tests for the faulty scenario.

### DIFF
--- a/Core/Core/Grades/GetAssignmentsByGroup.swift
+++ b/Core/Core/Grades/GetAssignmentsByGroup.swift
@@ -51,7 +51,7 @@ public class GetAssignmentsByGroup: APIUseCase {
             NSSortDescriptor(key: #keyPath(Assignment.position), ascending: true),
             NSSortDescriptor(key: #keyPath(Assignment.name), ascending: true, naturally: true),
         ],
-        sectionNameKeyPath: #keyPath(Assignment.assignmentGroup.name)
+        sectionNameKeyPath: #keyPath(Assignment.assignmentGroup.position)
     ) }
 
     public func reset(context: NSManagedObjectContext) {

--- a/Core/CoreTests/Grades/GetAssignmentsByGroupTests.swift
+++ b/Core/CoreTests/Grades/GetAssignmentsByGroupTests.swift
@@ -35,4 +35,18 @@ class GetAssignmentsByGroupTests: CoreTestCase {
         useCase.reset(context: databaseClient)
         XCTAssertEqual((databaseClient.fetch() as [AssignmentGroup]).count, 0)
     }
+
+    func testInvalidSectionOrderException() {
+        let groups: [APIAssignmentGroup] = [
+            .make(id: "9732", name: "Test Assignment Group", position: 1, assignments: [APIAssignment.make(id: "63603", name: "File Upload", position: 1, assignment_group_id: "9732")]),
+            .make(id: "9734", name: "Middle Group", position: 2, assignments: [APIAssignment.make(id: "63604", name: "File Upload 2", position: 1, assignment_group_id: "9734")]),
+            .make(id: "9733", name: "Test Assignment Group", position: 3, assignments: [APIAssignment.make(id: "63606", name: "File Upload 3", position: 1, assignment_group_id: "9733")]),
+        ]
+
+        let getAssignmentGroupsUseCase = GetAssignmentsByGroup(courseID: "20783")
+        getAssignmentGroupsUseCase.write(response: groups, urlResponse: nil, to: databaseClient)
+
+        // Shouldn't trigger assertionFailure in Store.init with error: Error Domain=NSCocoaErrorDomain Code=134060 "A Core Data error occurred." UserInfo={reason=The fetched object at index 2 has an out of order section name 'Middle Group. Objects must be sorted by section name'}
+        _ = environment.subscribe(getAssignmentGroupsUseCase)
+    }
 }


### PR DESCRIPTION
refs: MBL-14827
affects: Student, Parent
release note: Fix assignment groups not being displayed correctly in specific cases.

test plan:
- Create three Assignment groups - two with the same name, and one with a different name between them.
- Add published assignments to each of the assignment groups.
- In the Parent app, as the observer, navigate to the course then away from the course, and then back again.
- In the Student app, navigate to Dashboard > Course > Grades, go back, then visit the page again.
- Assignment groups should be displayed and in the same order as on the site.