### PR TITLE
Make grade circle color reflect the course color.

### DIFF
--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -63,8 +63,17 @@ public class GradeCircleView: UIView {
         loadFromXib()
     }
 
-    public func update(_ assignment: Assignment) {
+    /**
+     - parameters:
+       - circleColor: The color of the grade circle. If not specified it will use the default color specified in `CircleProgressView`.
+     */
+    public func update(_ assignment: Assignment, circleColor: UIColor? = nil) {
         gradeCircle.progress = 1 // make sure it's never spinning
+
+        if let circleColor = circleColor {
+            gradeCircle.color = circleColor
+        }
+
         circleComplete.isAccessibilityElement = true
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case

--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -46,6 +46,7 @@ public class GradeCircleReusableView: UICollectionReusableView {
 public class GradeCircleView: UIView {
     @IBOutlet weak var circlePoints: UILabel!
     @IBOutlet weak var circleLabel: UILabel!
+    /** Displays the checkmark in the middle of the progress circle. */
     @IBOutlet weak var circleComplete: UIImageView!
     @IBOutlet weak var gradeCircle: CircleProgressView!
     @IBOutlet weak var displayGrade: UILabel!
@@ -74,6 +75,7 @@ public class GradeCircleView: UIView {
             gradeCircle.color = circleColor
         }
 
+        circleComplete.tintColor = circleColor
         circleComplete.isAccessibilityElement = true
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -192,7 +192,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
     }
 
     func updateGradeCell(_ assignment: Assignment) {
-        self.gradedView?.update(assignment)
+        self.gradedView?.update(assignment, circleColor: presenter?.courses.first?.color)
 
         // Update grade statistics view
         if let presenter = presenter {


### PR DESCRIPTION
refs: MBL-14830
affects: Student
release note: Make grade circle color reflect the course color.

test plan:
- Have a graded submission as a student on a points assignment.
- View the assignment as the student.
- The colored portion of the grade circle should be the course color.