### PR TITLE
Make file submission list checkmark color reflect course color.

### DIFF
--- a/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
+++ b/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
@@ -62,6 +62,7 @@ extension SubmissionFilesViewController: UITableViewDataSource, UITableViewDeleg
         }
         cell.checkView?.isHidden = (file.id != presenter?.selectedFileID)
         let fileID = file.id ?? ""
+        cell.checkView?.tintColor = presenter?.course.first?.color
         cell.checkView?.accessibilityIdentifier = "SubmissionFiles.cell.\(fileID).checkView"
         cell.checkView?.isAccessibilityElement = !UIAccessibility.isSwitchControlRunning
         cell.accessibilityIdentifier = "SubmissionFiles.cell.\(fileID)"


### PR DESCRIPTION
refs: MBL-14831
affects: Student
release note: Make file submission list checkmark color reflect course color.

test plan:
- Submit a file upload.
- View the submission.
- In the drawer tap the files tab.
- The checkmark that appears on the file row should be the course color.