### PR TITLE
Modify text submission dialog placeholder text.

### DIFF
--- a/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
+++ b/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
@@ -51,7 +51,7 @@ class TextSubmissionViewController: UIViewController, ErrorViewController, RichC
         addCancelButton(side: .left)
 
         editor.delegate = self
-        editor.placeholder = NSLocalizedString("Enter submission", bundle: .student, comment: "")
+        editor.placeholder = NSLocalizedString("Write...", bundle: .student, comment: "Text submission editor placeholder")
         editor.webView.scrollView.layer.masksToBounds = false
         embed(editor, in: contentView)
     }


### PR DESCRIPTION
refs: MBL-14833
affects: Student
release note: Display more appropriate placeholder text when entering a text submission.

test plan:
- Open the text entry dialog on a text assignment by clicking "Submit assignment" button.
- Editor placeholder text should display "Write..." instead of "Enter submission".