### PR TITLE
Remove unnecessary cancel button from new message recipient picker.

### DIFF
--- a/rn/Teacher/src/modules/address-book/AddressBook.js
+++ b/rn/Teacher/src/modules/address-book/AddressBook.js
@@ -194,6 +194,7 @@ export class AddressBook extends Component<AddressBookProps, State> {
       <Screen
         drawUnderNavBar
         title={this.props.name}
+        showDismissButton={true}
       >
         { this._renderComponent() }
       </Screen>

--- a/rn/Teacher/src/modules/address-book/AddressBook.js
+++ b/rn/Teacher/src/modules/address-book/AddressBook.js
@@ -135,10 +135,6 @@ export class AddressBook extends Component<AddressBookProps, State> {
     this.props.onSelect([item])
   }
 
-  _onCancel = () => {
-    this.props.navigator.dismiss()
-  }
-
   keyExtractor (item: AddressBookResult) {
     return item.id
   }
@@ -198,11 +194,6 @@ export class AddressBook extends Component<AddressBookProps, State> {
       <Screen
         drawUnderNavBar
         title={this.props.name}
-        rightBarButtons={[{
-          title: i18n('Cancel'),
-          testID: 'address-book.cancel',
-          action: this._onCancel,
-        }]}
       >
         { this._renderComponent() }
       </Screen>

--- a/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
+++ b/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
@@ -196,12 +196,12 @@ describe('AddressBook', () => {
     }])
   })
 
-  it('dismisses on cancel', () => {
-    props.navigator.dismiss = jest.fn()
+  it('shows a single dismiss button', () => {
     const screen = shallow(<AddressBook {...props} />)
-    const cancel = screen.find('Screen').props().rightBarButtons[0]
-    cancel.action()
-    expect(props.navigator.dismiss).toHaveBeenCalled()
+    const props = screen.props()
+    expect(props.showDismissButton).toBe(true)
+    expect(props.rightBarButtons).toBeUndefined()
+    expect(props.leftBarButtons).toBeUndefined()
   })
 
   it('calls next on end reached', () => {

--- a/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
+++ b/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
@@ -3,15 +3,7 @@
 exports[`AddressBook renders 1`] = `
 <Screen
   drawUnderNavBar={true}
-  rightBarButtons={
-    Array [
-      Object {
-        "action": [Function],
-        "testID": "address-book.cancel",
-        "title": "Cancel",
-      },
-    ]
-  }
+  showDismissButton={true}
   title="Address Book Course"
 >
   <View


### PR DESCRIPTION
refs: MBL-10466
affects: Teacher
release note: Remove unnecessary cancel button from new message recipient picker.

test plan:
- Bring up the add new message dialog.
- Select a course.
- Start adding recipients.
- The navigation bar in the recipient picker should show a single done button.