### PR TITLE
Fix new message navigation bar style

### DIFF
--- a/rn/Teacher/src/modules/address-book/AddressBook.js
+++ b/rn/Teacher/src/modules/address-book/AddressBook.js
@@ -197,6 +197,7 @@ export class AddressBook extends Component<AddressBookProps, State> {
     return (
       <Screen
         drawUnderNavBar
+        navBarStyle='global'
         title={this.props.name}
         rightBarButtons={[{
           title: i18n('Cancel'),

--- a/rn/Teacher/src/modules/address-book/AddressBook.js
+++ b/rn/Teacher/src/modules/address-book/AddressBook.js
@@ -197,7 +197,7 @@ export class AddressBook extends Component<AddressBookProps, State> {
     return (
       <Screen
         drawUnderNavBar
-        navBarStyle='global'
+        navBarStyle='modal'
         title={this.props.name}
         rightBarButtons={[{
           title: i18n('Cancel'),

--- a/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
+++ b/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
@@ -55,7 +55,9 @@ describe('AddressBook', () => {
   })
 
   it('renders', () => {
-    expect(shallow(<AddressBook {...props} />)).toMatchSnapshot()
+    const screen = shallow(<AddressBook {...props} />)
+    expect(screen).toMatchSnapshot()
+    expect(screen.props().navBarStyle).toBe('global')
   })
 
   it('calls getCoursePermissions when rendered', () => {

--- a/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
+++ b/rn/Teacher/src/modules/address-book/__tests__/AddressBook.test.js
@@ -57,7 +57,7 @@ describe('AddressBook', () => {
   it('renders', () => {
     const screen = shallow(<AddressBook {...props} />)
     expect(screen).toMatchSnapshot()
-    expect(screen.props().navBarStyle).toBe('global')
+    expect(screen.props().navBarStyle).toBe('modal')
   })
 
   it('calls getCoursePermissions when rendered', () => {

--- a/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
+++ b/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
@@ -3,6 +3,7 @@
 exports[`AddressBook renders 1`] = `
 <Screen
   drawUnderNavBar={true}
+  navBarStyle="global"
   rightBarButtons={
     Array [
       Object {

--- a/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
+++ b/rn/Teacher/src/modules/address-book/__tests__/__snapshots__/AddressBook.test.js.snap
@@ -3,7 +3,7 @@
 exports[`AddressBook renders 1`] = `
 <Screen
   drawUnderNavBar={true}
-  navBarStyle="global"
+  navBarStyle="modal"
   rightBarButtons={
     Array [
       Object {

--- a/rn/Teacher/src/modules/inbox/Compose.js
+++ b/rn/Teacher/src/modules/inbox/Compose.js
@@ -236,7 +236,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
     return (
       <Screen
         drawUnderNavBar
-        navBarStyle='global'
+        navBarStyle='modal'
         title={this.props.navBarTitle || i18n('New Message')}
         showDismissButton={false}
         leftBarButtons={[{

--- a/rn/Teacher/src/modules/inbox/Compose.js
+++ b/rn/Teacher/src/modules/inbox/Compose.js
@@ -236,6 +236,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
     return (
       <Screen
         drawUnderNavBar
+        navBarStyle='global'
         title={this.props.navBarTitle || i18n('New Message')}
         showDismissButton={false}
         leftBarButtons={[{

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -84,6 +84,7 @@ export class CourseSelect extends PureComponent<CourseSelectProps> {
       <Screen
         title={i18n('Select a Course')}
         drawUnderNavBar
+        navBarStyle='context'
       >
         <SectionList
           sections={this.props.sections}

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -84,7 +84,7 @@ export class CourseSelect extends PureComponent<CourseSelectProps> {
       <Screen
         title={i18n('Select a Course')}
         drawUnderNavBar
-        navBarStyle='context'
+        navBarStyle='modal'
       >
         <SectionList
           sections={this.props.sections}

--- a/rn/Teacher/src/modules/inbox/__tests__/Compose.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/Compose.test.js
@@ -58,6 +58,7 @@ describe('Compose', () => {
   it('renders', () => {
     let tree = shallow(<Compose {...defaultProps} />)
     expect(tree).toMatchSnapshot()
+    expect(tree.props().navBarStyle).toBe('global')
   })
 
   it('allows for a navbar title to be passed in as a prop', () => {

--- a/rn/Teacher/src/modules/inbox/__tests__/Compose.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/Compose.test.js
@@ -58,7 +58,7 @@ describe('Compose', () => {
   it('renders', () => {
     let tree = shallow(<Compose {...defaultProps} />)
     expect(tree).toMatchSnapshot()
-    expect(tree.props().navBarStyle).toBe('global')
+    expect(tree.props().navBarStyle).toBe('modal')
   })
 
   it('allows for a navbar title to be passed in as a prop', () => {

--- a/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
@@ -86,9 +86,9 @@ describe('CourseSelect', () => {
     expect(tree).toMatchSnapshot()
   })
 
-  it('matches nav bar style of the context', () => {
+  it('matches the style of the account', () => {
     let tree = shallow(<CourseSelect {...defaultProps} />)
-    expect(tree.props().navBarStyle).toBe('context')
+    expect(tree.props().navBarStyle).toBe('modal')
   })
 
   it('renders and then selects a course and then dismisses', () => {

--- a/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
@@ -87,8 +87,8 @@ describe('CourseSelect', () => {
   })
 
   it('matches nav bar style of the context', () => {
-      let tree = shallow(<CourseSelect {...defaultProps} />)
-      expect(tree.props().navBarStyle).toBe('context')
+    let tree = shallow(<CourseSelect {...defaultProps} />)
+    expect(tree.props().navBarStyle).toBe('context')
   })
 
   it('renders and then selects a course and then dismisses', () => {

--- a/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
@@ -25,6 +25,7 @@ import {
   shouldRefresh,
   doRefresh,
   isRefreshing } from '../CourseSelect'
+import { shallow } from 'enzyme'
 import renderer from 'react-test-renderer'
 import explore from '../../../../test/helpers/explore'
 import i18n from 'format-message'
@@ -83,6 +84,11 @@ describe('CourseSelect', () => {
     ).toJSON()
 
     expect(tree).toMatchSnapshot()
+  })
+
+  it('matches nav bar style of the context', () => {
+      let tree = shallow(<CourseSelect {...defaultProps} />)
+      expect(tree.props().navBarStyle).toBe('context')
   })
 
   it('renders and then selects a course and then dismisses', () => {

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
@@ -12,7 +12,7 @@ exports[`Compose renders 1`] = `
       },
     ]
   }
-  navBarStyle="global"
+  navBarStyle="modal"
   rightBarButtons={
     Array [
       Object {
@@ -191,7 +191,7 @@ exports[`Compose renders after picking a course 1`] = `
       },
     ]
   }
-  navBarStyle="global"
+  navBarStyle="modal"
   rightBarButtons={
     Array [
       Object {
@@ -452,7 +452,7 @@ exports[`Compose renders reply 1`] = `
       },
     ]
   }
-  navBarStyle="global"
+  navBarStyle="modal"
   rightBarButtons={
     Array [
       Object {
@@ -711,7 +711,7 @@ exports[`Compose renders with passed in recipients 1`] = `
       },
     ]
   }
-  navBarStyle="global"
+  navBarStyle="modal"
   rightBarButtons={
     Array [
       Object {

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
@@ -12,7 +12,7 @@ exports[`Compose renders 1`] = `
       },
     ]
   }
-  navBarStyle="modal"
+  navBarStyle="global"
   rightBarButtons={
     Array [
       Object {
@@ -191,7 +191,7 @@ exports[`Compose renders after picking a course 1`] = `
       },
     ]
   }
-  navBarStyle="modal"
+  navBarStyle="global"
   rightBarButtons={
     Array [
       Object {
@@ -452,7 +452,7 @@ exports[`Compose renders reply 1`] = `
       },
     ]
   }
-  navBarStyle="modal"
+  navBarStyle="global"
   rightBarButtons={
     Array [
       Object {
@@ -711,7 +711,7 @@ exports[`Compose renders with passed in recipients 1`] = `
       },
     ]
   }
-  navBarStyle="modal"
+  navBarStyle="global"
   rightBarButtons={
     Array [
       Object {


### PR DESCRIPTION
refs: MBL-10467
affects: Teacher
release note: Apply color theme to new message dialog navigation bar.

test plan:
- Enter Inbox.
- Start compose a new message.
- Nav bar should reflect the account's theme.
- Enter Select a Course screen.
- Nav bar should reflect the account's theme.
- Select course.
- Tap + sign on the To field.
- Nav bar should reflect the account's theme.