### PR TITLE
Add native syllabus routes

### DIFF
--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -30,6 +30,7 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case nativeDashboard = "native_dashboard"
     case nativeStudentInbox = "native_student_inbox"
     case nativeTeacherInbox = "native_teacher_inbox"
+    case nativeTeacherSyllabus = "native_teacher_syllabus"
 
     public var isEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: userDefaultsKey) }

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -62,10 +62,8 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 
     "/courses/:courseID/assignments": nil,
 
-    "/courses/:courseID/assignments/syllabus": { url, _, _ in
-        Router.open(url: url)
-        return nil
-    },
+    "/courses/:courseID/assignments/syllabus": syllabus,
+    "/courses/:courseID/syllabus": syllabus,
 
     "/courses/:courseID/assignments/:assignmentID": nil,
     "/courses/:courseID/assignments/:assignmentID/edit": nil,
@@ -289,6 +287,15 @@ private func fileDetails(url: URLComponents, params: [String: String], userInfo:
 private func fileEditor(url: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
     guard let fileID = params["fileID"] else { return nil }
     return CoreHostingController(FileEditorView(context: Context(path: url.path), fileID: fileID))
+}
+
+private func syllabus(url: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
+    guard ExperimentalFeature.nativeTeacherSyllabus.isEnabled else {
+        Router.open(url: url)
+        return nil
+    }
+    guard let courseID = params["courseID"] else { return nil }
+    return SyllabusViewController.create(courseID: ID.expandTildeID(courseID))
 }
 
 // MARK: - HelmModules

--- a/rn/Teacher/ios/TeacherTests/RoutesTests.swift
+++ b/rn/Teacher/ios/TeacherTests/RoutesTests.swift
@@ -91,5 +91,11 @@ class RoutesTests: XCTestCase {
         XCTAssert(router.match("/dev-menu/experimental-features") is ExperimentalFeaturesViewController)
         XCTAssert(router.match("/support/problem") is ErrorReportViewController)
         XCTAssert(router.match("/support/feature") is ErrorReportViewController)
+        ExperimentalFeature.nativeTeacherSyllabus.isEnabled = false
+        XCTAssertNil(router.match( "/courses/1/assignments/syllabus"))
+        XCTAssertNil(router.match( "/courses/1/syllabus"))
+        ExperimentalFeature.nativeTeacherSyllabus.isEnabled = true
+        XCTAssert(router.match( "/courses/1/assignments/syllabus") is SyllabusViewController)
+        XCTAssert(router.match( "/courses/1/syllabus") is SyllabusViewController)
     }
 }

--- a/rn/Teacher/src/common/ExperimentalFeature.js
+++ b/rn/Teacher/src/common/ExperimentalFeature.js
@@ -51,3 +51,4 @@ export default class ExperimentalFeature {
 ExperimentalFeature.favoriteGroups = new ExperimentalFeature('favorite_groups')
 ExperimentalFeature.nativeSpeedGrader = new ExperimentalFeature('native_speed_grader')
 ExperimentalFeature.nativeDashboard = new ExperimentalFeature('native_dashboard')
+ExperimentalFeature.nativeTeacherSyllabus = new ExperimentalFeature('native_teacher_syllabus')

--- a/rn/Teacher/src/modules/courses/CourseNavigation.js
+++ b/rn/Teacher/src/modules/courses/CourseNavigation.js
@@ -46,6 +46,7 @@ import TabsList from '../tabs/TabsList'
 import { logEvent } from '../../common/CanvasAnalytics'
 import showColorOverlayForCourse from '../../common/show-color-overlay-for-course'
 import { getFakeStudent } from '../../canvas-api'
+import ExperimentalFeature from '../../common/ExperimentalFeature'
 
 type RoutingParams = {
   +courseID: string,
@@ -155,6 +156,9 @@ export class CourseNavigation extends Component<CourseNavigationProps, any> {
           this.props.navigator.show(tab.full_url)
         } else if (tab.id === 'student-view') {
           this.launchStudentView()
+        } else if (tab.id === 'syllabus' && ExperimentalFeature.nativeTeacherSyllabus.isEnabled) {
+            const url = `/courses/${this.props.courseID}/syllabus`
+            this.props.navigator.show(url)
         } else if (isTeacher() || tab.id === 'syllabus') {
           this.props.navigator.show(tab.html_url)
         } else if (tab.id === 'home' && this.props.course && this.props.course.default_view === 'wiki') {
@@ -286,6 +290,7 @@ export function mapStateToProps (state: AppState, { courseID }: RoutingParams): 
 
   const availableCourseTabs = ['assignments', 'quizzes', 'discussions', 'announcements', 'people', 'pages', 'files', 'modules']
   if (attendanceTabID) availableCourseTabs.push(attendanceTabID)
+  if (ExperimentalFeature.nativeTeacherSyllabus.isEnabled) availableCourseTabs.push('syllabus')
 
   let tabs = courseState.tabs.tabs
     .filter((tab) => {

--- a/rn/Teacher/src/modules/courses/CourseNavigation.js
+++ b/rn/Teacher/src/modules/courses/CourseNavigation.js
@@ -157,8 +157,8 @@ export class CourseNavigation extends Component<CourseNavigationProps, any> {
         } else if (tab.id === 'student-view') {
           this.launchStudentView()
         } else if (tab.id === 'syllabus' && ExperimentalFeature.nativeTeacherSyllabus.isEnabled) {
-            const url = `/courses/${this.props.courseID}/syllabus`
-            this.props.navigator.show(url)
+          const url = `/courses/${this.props.courseID}/syllabus`
+          this.props.navigator.show(url)
         } else if (isTeacher() || tab.id === 'syllabus') {
           this.props.navigator.show(tab.html_url)
         } else if (tab.id === 'home' && this.props.course && this.props.course.default_view === 'wiki') {

--- a/rn/Teacher/src/routing/register-screens.js
+++ b/rn/Teacher/src/routing/register-screens.js
@@ -144,7 +144,8 @@ export function registerScreens (store: Store): void {
   registerScreen('/act-as-user/:userID')
 
   if (isTeacher()) {
-    registerScreen('/courses/:courseID/assignments/syllabus', null, store, { showInWebView: true, deepLink: true })
+    registerScreen('/courses/:courseID/assignments/syllabus', null, store, ExperimentalFeature.nativeTeacherSyllabus.isEnabled ? { deepLink: true } : { showInWebView: true, deepLink: true })
+    registerScreen('/courses/:courseID/syllabus', null, store, { deepLink: true })
     registerScreen('/courses/:courseID/assignments/:assignmentID', AssignmentDetails, store, { deepLink: true })
     registerScreen('/courses/:courseID/assignments/:assignmentID/edit', AssignmentDetailsEdit, store)
     registerScreen('/courses/:courseID/assignments/:assignmentID/due_dates', AssignmentDueDates, store)


### PR DESCRIPTION
refs: MBL-14814
affects: Teacher
release note: none

test plan:
* turn on experimental feature: native_teacher_syllabus
* check a course, that has a syllabus
* native syllabus page should open