### PR TITLE
Invert link text and url prefill logic in rich content's link editor dialog.

### DIFF
--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -192,11 +192,11 @@ public class RichContentEditorViewController: UIViewController {
         let alert = UIAlertController(title: NSLocalizedString("Link to Website URL", bundle: .core, comment: ""), message: nil, preferredStyle: .alert)
         alert.addTextField { (field: UITextField) in
             field.placeholder = NSLocalizedString("Text", bundle: .core, comment: "")
-            field.text = href
+            field.text = text
         }
         alert.addTextField { (field: UITextField) in
             field.placeholder = NSLocalizedString("URL", bundle: .core, comment: "")
-            field.text = text
+            field.text = href
             field.keyboardType = .URL
         }
         alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))

--- a/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
+++ b/Core/CoreTests/RichContentEditor/RichContentEditorViewControllerTests.swift
@@ -126,6 +126,17 @@ class RichContentEditorViewControllerTests: CoreTestCase, RichContentEditorDeleg
         waitUntil { getHTML() == "<a href=\"https://splatoon.ink\">Splatoon 2</a>!" }
     }
 
+    func testEditLinkDialog() {
+        controller.updateState([
+            "linkText": "Link Text",
+            "linkHref": "https://instructure.com",
+        ])
+        controller.toolbar.linkButton!.sendActions(for: .primaryActionTriggered)
+        let alert = router.presented as! UIAlertController
+        XCTAssertEqual(alert.textFields![0].text, "Link Text")
+        XCTAssertEqual(alert.textFields![1].text, "https://instructure.com")
+    }
+
     func testImage() {
         controller.toolbar.libraryButton!.sendActions(for: .primaryActionTriggered)
         XCTAssertEqual((router.presented as? UIImagePickerController)?.sourceType, .photoLibrary)


### PR DESCRIPTION
refs: MBL-14868
affects: Teacher, Student
release note: Editing a url in a rich text input now populates link text and url properly in the edit link dialog.

test plan:
- In the teacher app, go to your course, create an announcement/page/assignment/etc.
- In the rich content editor, write some text. Highlight the text and tap the link icon to add a link to the text.
- In the pop up, notice that your text has been moved to the URL field, and you have to re-enter the text in the right field.