### PR TITLE
Add time to delayed announcement date picker.

### DIFF
--- a/rn/Teacher/src/modules/announcements/edit/AnnouncementEdit.js
+++ b/rn/Teacher/src/modules/announcements/edit/AnnouncementEdit.js
@@ -239,6 +239,7 @@ export class AnnouncementEdit extends Component<Props, any> {
                         value={extractDateFromString(this.state.delayed_post_at) || this.props.defaultDate || new Date()}
                         onChange={(event, date) => this._valuesChanged({ delayed_post_at: date.toISOString() }, true)}
                         testID='announcements.edit.delayed-post-at-date-picker'
+                        mode='datetime'
                       />
                     }
                   </View>

--- a/rn/Teacher/src/modules/announcements/edit/__tests__/AnnouncementEdit.test.js
+++ b/rn/Teacher/src/modules/announcements/edit/__tests__/AnnouncementEdit.test.js
@@ -162,6 +162,14 @@ describe('AnnouncementEdit', () => {
     expect(render(props).find('[testID="announcements.edit.delayed-post-at-row"]').exists()).toEqual(true)
   })
 
+  it('offers date and time selection for delayed post', () => {
+    props.delayed_post_at = (new Date()).toISOString()
+    const component = render(props)
+    tapDelayedPostAtRow(component)
+    const datePicker = component.find('[testID="announcements.edit.delayed-post-at-date-picker"]')
+    expect(datePicker.prop('mode')).toEqual('datetime')
+  })
+
   it('toggles delayed post at row options', () => {
     props.delayed_post_at = null
     const component = render(props)


### PR DESCRIPTION
refs: MBL-14869
affects: Teacher
release note: Date picker for delayed announcement now offers time selection as well.

test plan:
- Enter course / announcements.
- Tap on + to add a new announcement.
- Switch on "Delay Posting" option.
- Tap "Post at..." row.
- Tap on the date row which appeared.
- Date picker should show the option to specify time.