### PR TITLE
Rename StudentSyllabus View and move to Core, use it in teacher

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -785,6 +785,8 @@
 		B1F614AE243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F614AD243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift */; };
 		B1F6D6BA22EB675000CDD44D /* SessionDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */; };
 		CF5C5B422534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */; };
+		D9FD8EF5254185DF00C6842B /* SyllabusTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9FD8EF4254185DF00C6842B /* SyllabusTabViewController.swift */; };
+		D9FD8EF8254187D600C6842B /* SyllabusTabViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9FD8EF7254187D600C6842B /* SyllabusTabViewControllerTests.swift */; };
 		DFE1FF20212F5E41003F27AA /* LoginSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE1FF1F212F5E41003F27AA /* LoginSessionTests.swift */; };
 		DFE1FF28212F69B3003F27AA /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE1FF27212F69B3003F27AA /* AppDelegate.swift */; };
 		DFE1FF2D212F69B3003F27AA /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DFE1FF2B212F69B3003F27AA /* Main.storyboard */; };
@@ -1789,6 +1791,8 @@
 		B1F6D6B722EB672500CDD44D /* SessionDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaults.swift; sourceTree = "<group>"; };
 		B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaultsTests.swift; sourceTree = "<group>"; };
 		CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupPeopleListViewControllerTests.swift; sourceTree = "<group>"; };
+		D9FD8EF4254185DF00C6842B /* SyllabusTabViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SyllabusTabViewController.swift; sourceTree = "<group>"; };
+		D9FD8EF7254187D600C6842B /* SyllabusTabViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyllabusTabViewControllerTests.swift; sourceTree = "<group>"; };
 		DA9CB84219E4586BF79FBBAA /* Pods-needs-pspdfkit-Core.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-Core.release.xcconfig"; path = "Target Support Files/Pods-needs-pspdfkit-Core/Pods-needs-pspdfkit-Core.release.xcconfig"; sourceTree = "<group>"; };
 		DD44F6EDD0A85E0D8AFC1EF4 /* Pods_needs_pspdfkit_CoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_needs_pspdfkit_CoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD5B10F40238556EA8BA6B6A /* Pods_defaults_CoreTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_defaults_CoreTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -2090,6 +2094,7 @@
 				B1F2F8A623F493A100F3B5F3 /* SyllabusSummaryViewControllerTests.swift */,
 				B1EA933823F6FF6200A0231E /* SyllabusTests.swift */,
 				97A486CA239AB2ED00084499 /* SyllabusViewControllerTests.swift */,
+				D9FD8EF7254187D600C6842B /* SyllabusTabViewControllerTests.swift */,
 			);
 			path = Syllabus;
 			sourceTree = "<group>";
@@ -2237,6 +2242,7 @@
 		3BF34288233D2C7F0095D0D3 /* Syllabus */ = {
 			isa = PBXGroup;
 			children = (
+				D9FD8EF4254185DF00C6842B /* SyllabusTabViewController.swift */,
 				B15E4B86238C4DC2002119CF /* Syllabus.swift */,
 				7DA260FC23F77281005D2121 /* SyllabusSummaryItemCell.xib */,
 				3B4687B22355109C00F293A5 /* SyllabusSummaryViewController.swift */,
@@ -4352,6 +4358,7 @@
 				E887275F24E1F85B00798DCA /* SequenceExtensionsTests.swift in Sources */,
 				3B1988B524256CE7004ADCC6 /* PairWithObserverViewControllerTests.swift in Sources */,
 				3B3FCA3323802D680011F11A /* GetActivitiesTests.swift in Sources */,
+				D9FD8EF8254187D600C6842B /* SyllabusTabViewControllerTests.swift in Sources */,
 				7D8B78F8215EC74A005E08F1 /* UIImageExtensionsTests.swift in Sources */,
 				7D016B5F23E8984B00C6E0CA /* BottomSheetPickerViewControllerTests.swift in Sources */,
 				7D148645230B491C003944A2 /* APIAccountNotificationTests.swift in Sources */,
@@ -4827,6 +4834,7 @@
 				7DA2603523F722D9005D2121 /* LockStatusViewable.swift in Sources */,
 				E8A8FA8E24D328C3000B27DF /* SearchBarView.swift in Sources */,
 				7DA2608823F72315005D2121 /* NotificationChannelsViewController.swift in Sources */,
+				D9FD8EF5254185DF00C6842B /* SyllabusTabViewController.swift in Sources */,
 				7DA2606C23F722D9005D2121 /* Activity.swift in Sources */,
 				3B4D89272450A8E9004ED120 /* ComposeReplyViewController.swift in Sources */,
 				7DA260F123F72391005D2121 /* FileUploadTarget.swift in Sources */,

--- a/Core/Core/Syllabus/SyllabusTabViewController.swift
+++ b/Core/Core/Syllabus/SyllabusTabViewController.swift
@@ -17,17 +17,16 @@
 //
 
 import UIKit
-import Core
 
-class StudentSyllabusViewController: HorizontalMenuViewController, ColoredNavViewProtocol, CoreWebViewLinkDelegate {
-    let titleSubtitleView = TitleSubtitleView.create()
+open class SyllabusTabViewController: HorizontalMenuViewController, ColoredNavViewProtocol, CoreWebViewLinkDelegate {
+    public let titleSubtitleView = TitleSubtitleView.create()
+    public var courseID: String = ""
+    public var color: UIColor?
+
+    lazy public var viewControllers: [UIViewController] = [ syllabus, summary ]
+
     lazy var summary = SyllabusSummaryViewController.create(courseID: courseID)
     lazy var syllabus = SyllabusViewController.create(courseID: courseID)
-
-    lazy var viewControllers: [UIViewController] = [ syllabus, summary ]
-
-    var courseID: String = ""
-    var color: UIColor?
     let env = AppEnvironment.shared
 
     lazy var colors = env.subscribe(GetCustomColors()) { [weak self] in
@@ -40,13 +39,13 @@ class StudentSyllabusViewController: HorizontalMenuViewController, ColoredNavVie
         self?.update()
     }
 
-    static func create(courseID: String) -> StudentSyllabusViewController {
-        let controller = StudentSyllabusViewController(nibName: nil, bundle: nil)
+    public static func create(courseID: String) -> SyllabusTabViewController {
+        let controller = SyllabusTabViewController(nibName: nil, bundle: nil)
         controller.courseID = courseID
         return controller
     }
 
-    override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         delegate = self
         setupTitleViewInNavbar(title: NSLocalizedString("Course Syllabus", comment: ""))
@@ -57,7 +56,7 @@ class StudentSyllabusViewController: HorizontalMenuViewController, ColoredNavVie
         course.refresh()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
+    open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.navigationBar.useContextColor(color)
     }
@@ -76,16 +75,16 @@ class StudentSyllabusViewController: HorizontalMenuViewController, ColoredNavVie
     }
 }
 
-extension StudentSyllabusViewController: HorizontalPagedMenuDelegate {
-    var menuItemSelectedColor: UIColor? { color }
+extension SyllabusTabViewController: HorizontalPagedMenuDelegate {
+    public var menuItemSelectedColor: UIColor? { color }
 
-    func accessibilityIdentifier(at: IndexPath) -> String {
+    public func accessibilityIdentifier(at: IndexPath) -> String {
         return viewControllers.count > at.row && viewControllers[at.row] === syllabus
             ? "Syllabus.syllabusMenuItem"
             : "Syllabus.assignmentsMenuItem"
     }
 
-    func menuItemTitle(at: IndexPath) -> String {
+    public func menuItemTitle(at: IndexPath) -> String {
         return viewControllers.count > at.row && viewControllers[at.row] === syllabus
             ? NSLocalizedString("Syllabus", comment: "")
             : NSLocalizedString("Summary", comment: "")

--- a/Core/CoreTests/Syllabus/SyllabusTabViewControllerTests.swift
+++ b/Core/CoreTests/Syllabus/SyllabusTabViewControllerTests.swift
@@ -18,13 +18,11 @@
 
 import UIKit
 import XCTest
-import Core
-@testable import Student
 @testable import Core
 @testable import TestsFoundation
 
-class StudentSyllabusViewControllerTests: StudentTestCase {
-    lazy var controller = StudentSyllabusViewController.create(courseID: "1")
+class SyllabusTabViewControllerTests: CoreTestCase {
+    lazy var controller = SyllabusTabViewController.create(courseID: "1")
 
     func testLayout() {
         api.mock(controller.colors, value: APICustomColors(custom_colors: [

--- a/Student/Student.xcodeproj/project.pbxproj
+++ b/Student/Student.xcodeproj/project.pbxproj
@@ -80,7 +80,6 @@
 		7DCF0F8522F8A831000AACCE /* AssignmentDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0E9922F89FB0000AACCE /* AssignmentDetailsViewController.swift */; };
 		7DCF0F8622F8A831000AACCE /* AssignmentDetailsSectionContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0E9A22F89FB0000AACCE /* AssignmentDetailsSectionContainerView.swift */; };
 		7DCF0F8722F8A831000AACCE /* AssignmentDetailsSectionContainerView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 7DCF0E9B22F89FB0000AACCE /* AssignmentDetailsSectionContainerView.xib */; };
-		7DCF0F8C22F8A84D000AACCE /* StudentSyllabusViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0EA322F89FC2000AACCE /* StudentSyllabusViewController.swift */; };
 		7DCF0F8F22F8A84D000AACCE /* CourseNavigationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0EA722F89FC2000AACCE /* CourseNavigationViewController.swift */; };
 		7DCF0F9022F8A84D000AACCE /* CourseNavigationPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0EA822F89FC2000AACCE /* CourseNavigationPresenter.swift */; };
 		7DCF0F9622F8A860000AACCE /* BundleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DCF0EBA22F8A001000AACCE /* BundleExtensions.swift */; };
@@ -146,7 +145,6 @@
 		9734351523866A7B002E9CE5 /* ActivityStreamViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9734351423866A7B002E9CE5 /* ActivityStreamViewControllerTests.swift */; };
 		9767F2A32383C741006633CA /* ActivityStreamViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9767F2A12383C741006633CA /* ActivityStreamViewController.swift */; };
 		9767F2A42383C741006633CA /* ActivityStreamViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 9767F2A22383C741006633CA /* ActivityStreamViewController.storyboard */; };
-		97A486C6239A5B3D00084499 /* StudentSyllabusViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A486C5239A5B3D00084499 /* StudentSyllabusViewControllerTests.swift */; };
 		97BA196423C82808009AB8AC /* RubricViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97BA196323C82808009AB8AC /* RubricViewControllerTests.swift */; };
 		9F00A5692245593200C0CC32 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D1D7E04213743D300F7CCFE /* Core.framework */; };
 		9F00A56B2245599800C0CC32 /* GradesWidgetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F00A56A2245599800C0CC32 /* GradesWidgetViewController.swift */; };
@@ -535,7 +533,6 @@
 		7DCF0E9922F89FB0000AACCE /* AssignmentDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssignmentDetailsViewController.swift; sourceTree = "<group>"; };
 		7DCF0E9A22F89FB0000AACCE /* AssignmentDetailsSectionContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDetailsSectionContainerView.swift; sourceTree = "<group>"; };
 		7DCF0E9B22F89FB0000AACCE /* AssignmentDetailsSectionContainerView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AssignmentDetailsSectionContainerView.xib; sourceTree = "<group>"; };
-		7DCF0EA322F89FC2000AACCE /* StudentSyllabusViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentSyllabusViewController.swift; sourceTree = "<group>"; };
 		7DCF0EA722F89FC2000AACCE /* CourseNavigationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseNavigationViewController.swift; sourceTree = "<group>"; };
 		7DCF0EA822F89FC2000AACCE /* CourseNavigationPresenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CourseNavigationPresenter.swift; sourceTree = "<group>"; };
 		7DCF0EBA22F8A001000AACCE /* BundleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundleExtensions.swift; sourceTree = "<group>"; };
@@ -632,7 +629,6 @@
 		9734351423866A7B002E9CE5 /* ActivityStreamViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityStreamViewControllerTests.swift; sourceTree = "<group>"; };
 		9767F2A12383C741006633CA /* ActivityStreamViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActivityStreamViewController.swift; sourceTree = "<group>"; };
 		9767F2A22383C741006633CA /* ActivityStreamViewController.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = ActivityStreamViewController.storyboard; sourceTree = "<group>"; };
-		97A486C5239A5B3D00084499 /* StudentSyllabusViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentSyllabusViewControllerTests.swift; sourceTree = "<group>"; };
 		97BA196323C82808009AB8AC /* RubricViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricViewControllerTests.swift; sourceTree = "<group>"; };
 		98F5AEA722584DFE82613E6B /* Pods-defaults-Student.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-Student.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-Student/Pods-defaults-Student.debug.xcconfig"; sourceTree = "<group>"; };
 		99747510483FA8853301B9F5 /* Pods-defaults-CanvasTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-CanvasTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-CanvasTests/Pods-defaults-CanvasTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -912,7 +908,6 @@
 				7DB3C83C24AA613B00B85D35 /* Planner */,
 				7DCF0ED522F8A03D000AACCE /* Quizzes */,
 				7DCF0F0A22F8A050000AACCE /* Submissions */,
-				7DCF0EA622F89FC2000AACCE /* Syllabus */,
 				2CE205B720EBF68F002A6A64 /* GoogleService-Info.plist */,
 				492704821CF4AF7100C631C6 /* Info.plist */,
 				2C0CAD771DEF6C33008D90FA /* InfoPlist.strings */,
@@ -1051,14 +1046,6 @@
 				7DCF0E9C22F89FB0000AACCE /* AssignmentDetails */,
 			);
 			path = Assignments;
-			sourceTree = "<group>";
-		};
-		7DCF0EA622F89FC2000AACCE /* Syllabus */ = {
-			isa = PBXGroup;
-			children = (
-				7DCF0EA322F89FC2000AACCE /* StudentSyllabusViewController.swift */,
-			);
-			path = Syllabus;
 			sourceTree = "<group>";
 		};
 		7DCF0EA922F89FC2000AACCE /* CourseNavigation */ = {
@@ -1276,14 +1263,6 @@
 			path = Assignments;
 			sourceTree = "<group>";
 		};
-		7DCF0F1222F8A096000AACCE /* Syllabus */ = {
-			isa = PBXGroup;
-			children = (
-				97A486C5239A5B3D00084499 /* StudentSyllabusViewControllerTests.swift */,
-			);
-			path = Syllabus;
-			sourceTree = "<group>";
-		};
 		7DCF0F1422F8A096000AACCE /* CourseNavigation */ = {
 			isa = PBXGroup;
 			children = (
@@ -1418,7 +1397,6 @@
 				7DC4A0BB24BE5024007A7EAD /* Planner */,
 				7DCF0F1E22F8A096000AACCE /* Quizzes */,
 				7DCF0F3322F8A096000AACCE /* Submissions */,
-				7DCF0F1222F8A096000AACCE /* Syllabus */,
 				7DCF0F3622F8A096000AACCE /* Info.plist */,
 				7DCF0F3722F8A096000AACCE /* RoutesTests.swift */,
 				7DCF0F3822F8A096000AACCE /* StudentTestCase.swift */,
@@ -2634,7 +2612,6 @@
 				7DCF0FB022F8A8D7000AACCE /* RubricCircleView.swift in Sources */,
 				7DCF0FAD22F8A8D7000AACCE /* RubricPresenter.swift in Sources */,
 				7DCF0FB922F8A8D7000AACCE /* SubmissionCommentsViewController.swift in Sources */,
-				7DCF0F8C22F8A84D000AACCE /* StudentSyllabusViewController.swift in Sources */,
 				7DCF0F8122F8A82C000AACCE /* AssignmentListViewController.swift in Sources */,
 				7DCF0FC422F8A8D7000AACCE /* SubmissionDetailsViewController.swift in Sources */,
 				3B72B93E243204FF00197BE6 /* AssignmentListModel.swift in Sources */,
@@ -2692,7 +2669,6 @@
 				7DE1162522F8AB5C005BFE98 /* StudentTestCase.swift in Sources */,
 				7D46624324D0C82D00C74DB4 /* QuizWebViewControllerTests.swift in Sources */,
 				9734351523866A7B002E9CE5 /* ActivityStreamViewControllerTests.swift in Sources */,
-				97A486C6239A5B3D00084499 /* StudentSyllabusViewControllerTests.swift in Sources */,
 				7DE1161A22F8AB5C005BFE98 /* UIViewControllerExtensionsTests.swift in Sources */,
 				7DE1161E22F8AB5C005BFE98 /* SubmissionButtonPresenterTests.swift in Sources */,
 				7DE1161222F8AB5C005BFE98 /* AssignmentDetailsPresenterTests.swift in Sources */,

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -93,13 +93,13 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 
     "/courses/:courseID/syllabus": { _, params, _ in
         guard let courseID = params["courseID"] else { return nil }
-        return StudentSyllabusViewController.create(courseID: ID.expandTildeID(courseID))
+        return SyllabusTabViewController.create(courseID: ID.expandTildeID(courseID))
     },
 
     "/courses/:courseID/assignments/:assignmentID": { url, params, _ in
         guard let courseID = params["courseID"], let assignmentID = params["assignmentID"] else { return nil }
         if assignmentID == "syllabus" {
-            return StudentSyllabusViewController.create(courseID: ID.expandTildeID(courseID))
+            return SyllabusTabViewController.create(courseID: ID.expandTildeID(courseID))
         }
         if !url.originIsModuleItemDetails {
             return ModuleItemSequenceViewController.create(

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -113,7 +113,7 @@ class RoutesTests: XCTestCase {
     }
 
     func testModuleItems() {
-        XCTAssert(router.match("/courses/1/assignments/syllabus") is StudentSyllabusViewController)
+        XCTAssert(router.match("/courses/1/assignments/syllabus") is SyllabusTabViewController)
         XCTAssert(router.match("/courses/1/assignments/2") is ModuleItemSequenceViewController)
         XCTAssert(router.match("/courses/1/assignments/2?origin=module_item_details") is AssignmentDetailsViewController)
         XCTAssert(router.match("/courses/1/discussions/2") is ModuleItemSequenceViewController)

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -295,7 +295,7 @@ private func syllabus(url: URLComponents, params: [String: String], userInfo: [S
         return nil
     }
     guard let courseID = params["courseID"] else { return nil }
-    return SyllabusViewController.create(courseID: ID.expandTildeID(courseID))
+    return SyllabusTabViewController.create(courseID: ID.expandTildeID(courseID))
 }
 
 // MARK: - HelmModules

--- a/rn/Teacher/ios/TeacherTests/RoutesTests.swift
+++ b/rn/Teacher/ios/TeacherTests/RoutesTests.swift
@@ -95,7 +95,7 @@ class RoutesTests: XCTestCase {
         XCTAssertNil(router.match( "/courses/1/assignments/syllabus"))
         XCTAssertNil(router.match( "/courses/1/syllabus"))
         ExperimentalFeature.nativeTeacherSyllabus.isEnabled = true
-        XCTAssert(router.match( "/courses/1/assignments/syllabus") is SyllabusViewController)
-        XCTAssert(router.match( "/courses/1/syllabus") is SyllabusViewController)
+        XCTAssert(router.match( "/courses/1/assignments/syllabus") is SyllabusTabViewController)
+        XCTAssert(router.match( "/courses/1/syllabus") is SyllabusTabViewController)
     }
 }


### PR DESCRIPTION
refs: MBL-14872
affects: Teacher, Student
release note: none

test plan:
student: no change, should check, that syllabus still works the same
teacher:
* turn on experimental feature: native_teacher_syllabus
* check a course, that has a syllabus
* native syllabus page should open with summary tabbed, same is in student