### PR TITLE
Add checkmark to previously selected course in course list when composing a new message

### DIFF
--- a/rn/Teacher/src/modules/inbox/Compose.js
+++ b/rn/Teacher/src/modules/inbox/Compose.js
@@ -68,6 +68,7 @@ type ComposeState = {
   sendDisabled: boolean,
   sendToAll: boolean,
   recipients: AddressBookResult[],
+  contextId: ?string,
   contextCode: ?string,
   contextName: ?string,
   body: ?string,
@@ -91,6 +92,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
     sendDisabled: true,
     sendToAll: this.props.onlySendIndividualMessages,
     recipients: this.props.recipients || [],
+    contextId: null,
     contextCode: this.props.contextCode || null,
     contextName: this.props.contextName || null,
     body: null,
@@ -108,8 +110,10 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
       '/conversations/course-select',
       undefined,
       {
+        selectedCourseId: this.state.contextId,
         onSelect: (course: Course) => {
           this.props.navigator.pop()
+          const contextId = course.id
           const contextName = course.name
           const contextCode = `course_${course.id}`
           let recipients = []
@@ -117,7 +121,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
             const teachers = { id: `course_${course.id}_teachers`, name: i18n('Teachers') }
             recipients = [teachers]
           }
-          this.setStateAndUpdate({ contextName, contextCode, recipients })
+          this.setStateAndUpdate({ contextId, contextName, contextCode, recipients })
         },
       }
     )

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -21,10 +21,13 @@
 import React, { PureComponent } from 'react'
 import {
   SectionList,
+  Image,
 } from 'react-native'
 import { connect } from 'react-redux'
+import { createStyleSheet } from '../../common/stylesheet'
 import refresh from '../../utils/refresh'
 import Screen from '../../routing/Screen'
+import icon from '../../images/inst-icons'
 import i18n from 'format-message'
 import CourseActions from '../courses/actions'
 import GroupActions from '../groups/actions'
@@ -49,6 +52,7 @@ type CourseActionProps = {
 
 type CourseSelectProps = {
   navigator: Navigator,
+  selectedCourseId: ?string,
   onSelect: (course: Course) => void,
 } & CourseSelectDataProps
 
@@ -66,7 +70,16 @@ export class CourseSelect extends PureComponent<CourseSelectProps> {
       border={border}
       onPress={this.onCourseSelect}
       identifier={item}
-      testID={`inbox.course-select.course-${item.id}`} />
+      testID={`inbox.course-select.course-${item.id}`}
+      accessories={
+        this.props.selectedCourseId === item.id &&
+        <Image
+          style={styles.check}
+          source={icon('check', 'solid')}
+          testID={`inbox.course-select.course-${item.id}-checkmark`}
+        />
+      }
+    />
   }
 
   renderSectionHeader = ({ section }: any) => {
@@ -123,7 +136,7 @@ export function mapStateToProps (state: AppState): CourseSelectDataProps {
   const sections: CourseSelectSection[] = [
     {
       key: 0,
-      title: i18n('Favorite Courses'),
+      title: i18n('Favorited Courses'),
       data: favoriteCourses,
     },
     {
@@ -138,3 +151,13 @@ export function mapStateToProps (state: AppState): CourseSelectDataProps {
 
 const Connected = connect(mapStateToProps, { ...CourseActions, ...GroupActions })(Refreshed)
 export default (Connected: PureComponent<CourseSelectDataProps, any>)
+
+const styles = createStyleSheet((colors, vars) => ({
+  check: {
+    tintColor: colors.primary,
+    height: 20,
+    width: 20,
+    resizeMode: 'contain',
+    marginLeft: vars.padding,
+  },
+}))

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -76,7 +76,7 @@ export class CourseSelect extends PureComponent<CourseSelectProps> {
         <Image
           style={styles.check}
           source={icon('check', 'solid')}
-          testID={`inbox.course-select.course-${item.id}-checkmark`}
+          testID={`inbox.course-select.course-${item.id}.checkmark`}
         />
       }
     />

--- a/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
@@ -73,6 +73,7 @@ let defaultProps = {
       data: [c2, c3],
     },
   ],
+  selectedCourseId: '2',
 }
 
 describe('CourseSelect', () => {
@@ -102,6 +103,13 @@ describe('CourseSelect', () => {
     expect(defaultProps.onSelect).toHaveBeenCalled()
   })
 
+  it('indicates the previously selected course', () => {
+    const tree = renderer.create(<CourseSelect {...defaultProps} />).toJSON()
+    expect(explore(tree).selectByID(`inbox.course-select.course-${c1.id}.checkmark`)).toBeNull()
+    expect(explore(tree).selectByID(`inbox.course-select.course-${c2.id}.checkmark`)).not.toBeNull()
+    expect(explore(tree).selectByID(`inbox.course-select.course-${c3.id}.checkmark`)).toBeNull()
+  })
+
   it('mapStateToProps', () => {
     const appState = template.appState({
       entities: {
@@ -127,7 +135,7 @@ describe('CourseSelect', () => {
       sections: [
         {
           key: 0,
-          title: i18n('Favorite Courses'),
+          title: i18n('Favorited Courses'),
           data: [c1],
         },
         {

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/CourseSelect.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/CourseSelect.test.js.snap
@@ -254,6 +254,42 @@ exports[`CourseSelect renders 1`] = `
                 Learn React Native
               </Text>
             </View>
+            <View
+              style={
+                Object {
+                  "flex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "flex-end",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "checkSolid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 20,
+                      "marginLeft": 16,
+                      "resizeMode": "contain",
+                      "tintColor": "#008EE2",
+                      "width": 20,
+                    }
+                  }
+                  testID="inbox.course-select.course-2.checkmark"
+                />
+              </View>
+            </View>
           </View>
         </TouchableHighlight>
       </item>
@@ -593,6 +629,42 @@ exports[`CourseSelect renders and then selects a course and then dismisses 1`] =
               >
                 Learn React Native
               </Text>
+            </View>
+            <View
+              style={
+                Object {
+                  "flex": 0,
+                }
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "flex": 1,
+                    "flexDirection": "row",
+                    "justifyContent": "flex-end",
+                  }
+                }
+              >
+                <Image
+                  source={
+                    Object {
+                      "uri": "checkSolid",
+                    }
+                  }
+                  style={
+                    Object {
+                      "height": 20,
+                      "marginLeft": 16,
+                      "resizeMode": "contain",
+                      "tintColor": "#008EE2",
+                      "width": 20,
+                    }
+                  }
+                  testID="inbox.course-select.course-2.checkmark"
+                />
+              </View>
             </View>
           </View>
         </TouchableHighlight>


### PR DESCRIPTION
refs: MBL-10465
affects: Teacher
release note: The previously selected course is now indicated in the course list when composing a new message.

test plan:
- Go to Inbox tab.
- Start composing a new message.
- Select a Course.
- Tap the course line again.
- Course list should indicate the previously selected course with a checkmark.
- The first group should be called "Favorited Courses"