### PR TITLE
Fix decoding TurnItIn data

### DIFF
--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -172,14 +172,14 @@ extension Submission: WriteableModel {
             Insecure.MD5.hash(data: $0).map { String(format: "%02x", $0) } .joined()
         } ?? ""
 
-        let turnitin = item.turnitin_data?["submission_\(model.id)"]
+        let turnitin = item.turnitin_data?.rawValue["submission_\(model.id)"]
         model.similarityScore = turnitin?.similarity_score ?? 0
         model.similarityStatus = turnitin?.status
         model.similarityURL = turnitin?.outcome_response?.outcomes_tool_placement_url?.rawValue
 
         model.attachments = Set(item.attachments?.map { attachment in
             let file = File.save(attachment, in: client)
-            let turnitin = item.turnitin_data?["attachment_\(attachment.id)"]
+            let turnitin = item.turnitin_data?.rawValue["attachment_\(attachment.id)"]
             file.similarityScore = turnitin?.similarity_score ?? 0
             file.similarityStatus = turnitin?.status
             file.similarityURL = turnitin?.outcome_response?.outcomes_tool_placement_url?.rawValue

--- a/Core/CoreTests/Submissions/APISubmissionTests.swift
+++ b/Core/CoreTests/Submissions/APISubmissionTests.swift
@@ -109,4 +109,30 @@ class APISubmissionTests: CoreTestCase {
         let req = GetSubmissionSummaryRequest(context: .course("1"), assignmentID: "2")
         XCTAssertEqual(req.path, "courses/1/assignments/2/submission_summary")
     }
+
+    func testDecodeAPITurnItInData() {
+        let json: Any = [
+            "eula_agreement_timestamp": "123456",
+            "attachment_1": [
+                "status": "scored",
+                "similarity_score": 0,
+                "outcome_response": [
+                    "outcomes_tool_placement_url": "https://canvas.instructure.com/tool/1",
+                ],
+            ],
+            "submission_1": [
+                "status": "scored",
+            ],
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json, options: [])
+        let turnItInData = try! JSONDecoder().decode(APITurnItInData.self, from: data)
+        XCTAssertEqual(turnItInData.rawValue.keys.count, 2)
+        XCTAssertEqual(turnItInData.rawValue["attachment_1"]?.status, "scored")
+        XCTAssertEqual(turnItInData.rawValue["attachment_1"]?.similarity_score, 0)
+        XCTAssertEqual(
+            turnItInData.rawValue["attachment_1"]?.outcome_response?.outcomes_tool_placement_url?.rawValue.absoluteString,
+            "https://canvas.instructure.com/tool/1"
+        )
+        XCTAssertEqual(turnItInData.rawValue["submission_1"]?.status, "scored")
+    }
 }


### PR DESCRIPTION
refs: MBL-14937
affects: student, teacher, parent
release note: Fixed viewing grades for some courses

test plan:
- Masquerade as user and observer of user in ticket
- View grades in student and parent app
- View similarity scores from To Do in teacher app as `turnitin.instructure.com` user in 1Password (search for `turnitin`)