### PR TITLE
Fix non-http link handling

### DIFF
--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -231,7 +231,7 @@ extension TeacherAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
     }
 
     func openExternalURL(_ url: URL) {
-        guard let from = environment.topViewController else {
+        guard let from = environment.topViewController, url.scheme?.hasPrefix("http") == true else {
             return UIApplication.shared.open(url, options: [:])
         }
         let safari = SFSafariViewController(url: url)


### PR DESCRIPTION
refs: MBL-14955
affects: Teacher
release note: Fixed crash when opening telephone links from help menu

test plan: see ticket (add a tel link to the help menu)