### PR TITLE
Fix long help menu item text being cropped on iOS 13.0.

### DIFF
--- a/Core/Core/Profile/Help/View/HelpItemView.swift
+++ b/Core/Core/Profile/Help/View/HelpItemView.swift
@@ -27,14 +27,14 @@ struct HelpItemView: View {
                 Text(model.text)
                     .font(.semibold16)
                     .foregroundColor(.textDarkest)
-                    .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                     .testID()
+                    .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                 if let subtext = model.subtext {
                     Text(subtext)
                         .font(.subheadline)
                         .foregroundColor(.textDark)
-                        .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                         .testID()
+                        .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                 }
             }.frame(maxWidth: .infinity, alignment: .leading)
         })

--- a/Core/Core/Profile/Help/View/HelpItemView.swift
+++ b/Core/Core/Profile/Help/View/HelpItemView.swift
@@ -27,11 +27,13 @@ struct HelpItemView: View {
                 Text(model.text)
                     .font(.semibold16)
                     .foregroundColor(.textDarkest)
+                    .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                     .testID()
                 if let subtext = model.subtext {
                     Text(subtext)
                         .font(.subheadline)
                         .foregroundColor(.textDark)
+                        .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
                         .testID()
                 }
             }.frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
refs: MBL-14959
affects: Parent, Student, Teacher
release note: none

test plan:
- Setup long help menu titles and subtitles.
- Open help menu on a device running iOS 13.0.
- All text should be displayed on multiple lines, instead of being cropped on one line.