### PR TITLE
Fix annotation place calculation

### DIFF
--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -270,8 +270,9 @@ extension DocViewerViewController: UIGestureRecognizerDelegate {
 
     @objc func tapGestureRecognizerDidChangeState(_ gestureRecognizer: UITapGestureRecognizer) {
         guard gestureRecognizer.state == .ended, let documentViewController = pdf.documentViewController else { return }
-        let viewPoint = gestureRecognizer.location(in: documentViewController.view)
-        guard let pageView = documentViewController.visiblePageView(at: viewPoint) else { return }
+        let pageViewPoint = gestureRecognizer.location(in: gestureRecognizer.view)
+        guard let pageView = documentViewController.visiblePageView(at: pageViewPoint) else { return }
+        let viewPoint = gestureRecognizer.location(in: pageView)
         performTap(pageView: pageView, at: viewPoint)
     }
 


### PR DESCRIPTION
refs: MBL-14967
affects: teacher
release note: Fixes point annotation position error after scrolling

test plan: as a teacher open an assignment with a submitted pdf in speedgrader
*place some point annotations
*scroll/zoom
*place new annotations: they shouldn't be shifted