### PR TITLE
Fix To-do tab bar not getting notification badges after app start. 

### DIFF
--- a/Core/Core/Todos/TodoListViewController.swift
+++ b/Core/Core/Todos/TodoListViewController.swift
@@ -70,6 +70,7 @@ public class TodoListViewController: UIViewController, ErrorViewController, Page
         colors.refresh()
         courses.exhaust()
         groups.exhaust()
+        todos.refresh(force: true)
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -174,5 +175,7 @@ class TodoListCell: UITableViewCell {
         contextLabel.text = todo?.contextName
         needsGradingView.isHidden = todo?.type != .grading
         needsGradingLabel.text = todo?.needsGradingText
+        accessibilityIdentifier = "to-do.list.\(todo?.assignment.htmlURL?.absoluteString ?? "unknown").row"
+        accessibilityLabel = [accessIconView.accessibilityLabel, todo?.contextName, todo?.assignment.name, todo?.dueText, todo?.needsGradingText].compactMap { $0 }.joined(separator: ", ")
     }
 }

--- a/rn/Teacher/ios/TeacherUITests/Todo/TodoUITests.swift
+++ b/rn/Teacher/ios/TeacherUITests/Todo/TodoUITests.swift
@@ -35,14 +35,14 @@ class TodoUITests: MiniCanvasUITestCase {
     }
 
     func testTodos() {
-        XCTAssertEqual(TabBar.todoTab.value(), "8 items")
+        XCTAssertEqual(TabBar.todoTab.value(), "4 items")
         TabBar.todoTab.tap()
 
         let assignment = mocked.courses[0].assignments[0]
         let row = app.find(id: "to-do.list.\(assignment.api.html_url).row")
-        XCTAssertEqual(row.label(), "Published, Assignment 1, Course One, No Due Date, 2 NEED GRADING")
+        XCTAssertEqual(row.label(), "Published, Course One, Assignment 1, No Due Date, 2 NEED GRADING")
 
         row.tap()
-        app.find(label: "A submission from Student 10").waitToExist()
+        app.find(label: "A submission from Student 12").waitToExist()
     }
 }


### PR DESCRIPTION
Fix test expectations based on modified speedgrader behavior.

refs: MBL-14917
affects: Student, Teacher
release note: none

test plan:
- Start Teacher app.
- Todo tab should display badge based on the number of todo items.