### PR TITLE
Fix ActAsUser E2E test

### DIFF
--- a/Student/StudentE2ETests/ActAsUser/ActAsUserE2ETests.swift
+++ b/Student/StudentE2ETests/ActAsUser/ActAsUserE2ETests.swift
@@ -30,7 +30,6 @@ class ActAsUserE2ETests: CoreUITestCase {
         XCTAssertEqual(ActAsUser.domainField.value(), "https://\(user!.host)")
         ActAsUser.actAsUserButton.tap()
 
-        Dashboard.courseCard(id: "263").waitToExist()
         Profile.open()
         XCTAssertEqual(Profile.userNameLabel.label(), "Student One")
         Profile.close()


### PR DESCRIPTION
Remove waiting step failing on bitrise, it's unnecessary for the test.

refs: MBL-14917
affects: none
release note: none

test plan:
- Act as user E2E test should pass