### PR TITLE
Student Context Card email display fix

### DIFF
--- a/Core/Core/People/ContextCard/ContextCardHeaderView.swift
+++ b/Core/Core/People/ContextCard/ContextCardHeaderView.swift
@@ -33,10 +33,13 @@ struct ContextCardHeaderView: View {
                 .font(.bold20)
                 .foregroundColor(.textDarkest)
                 .identifier("ContextCard.userNameLabel")
-            Text(user.email ?? "")
-                .font(.regular14)
-                .foregroundColor(.textDarkest)
-                .identifier("ContextCard.userEmailLabel")
+            // Only teachers can see user email addresses
+            if let email = user.email {
+                Text(email)
+                    .font(.regular14)
+                    .foregroundColor(.textDarkest)
+                    .identifier("ContextCard.userEmailLabel")
+            }
             if showLastActivity, let activityTime = enrollment.lastActivityAt?.dateTimeString {
                 Text("Last activity on \(activityTime)")
                     .font(.regular12)

--- a/Student/StudentE2ETests/People/PeopleE2ETests.swift
+++ b/Student/StudentE2ETests/People/PeopleE2ETests.swift
@@ -26,8 +26,8 @@ enum CoursePeople {
 }
 
 enum PersonContextCard {
-    static func emailLabel(_ email: String) -> Element {
-        return app.staticTexts.matching(label: email).firstElement
+    static func text(_ text: String) -> Element {
+        return app.staticTexts.matching(label: text).firstElement
     }
 }
 
@@ -42,6 +42,7 @@ class PeopleE2ETests: CoreUITestCase {
         CoursePeople.person(name: "Student Two").waitToExist()
         CoursePeople.person(name: "Student One").tap()
 
-        PersonContextCard.emailLabel("ios+student1@instructure.com").waitToExist()
+        PersonContextCard.text("Student One").waitToExist()
+        PersonContextCard.text("Announcments").waitToExist()
     }
 }


### PR DESCRIPTION
refs: MBL-15072
affects: Student
release note: none

test plan:
- Context card shouldn't display an empty line below username.