### PR TITLE
 Fix SpeedGrader animation glitches

### DIFF
--- a/Core/Core/SwiftUIViews/CircleProgress.swift
+++ b/Core/Core/SwiftUIViews/CircleProgress.swift
@@ -62,9 +62,17 @@ public struct CircleProgress: View {
                     } }
 
                     .rotationEffect(rotate)
-                    .onAppear { withAnimation(Animation.linear(duration: 2.25).repeatForever(autoreverses: false)) {
-                        rotate = Angle(radians: 2 * .pi)
-                    } }
+                    .onAppear {
+                        // This repeating animation caused other parts of the UI to animate their appearance repeatedly on iOS 14.0 and below.
+                        if #available(iOS 14.1, *) {
+                            withAnimation(Animation.linear(duration: 2.25).repeatForever(autoreverses: false)) {
+                                rotate = Angle(radians: 2 * .pi)
+                            }
+                        }
+                    }
+                    .onDisappear {
+                        timer.upstream.connect().cancel()
+                    }
             }
         }
             .padding(thickness / 2)


### PR DESCRIPTION
Disable spinner animation on iOS versions where it causes glitches. Fix timer not getting stopped after CircleProgress UI removed from screen.

refs: MBL-15013
affects: Teacher
release note: none

test plan:
- SpeedGrader shouldn't produce strange repeating animations on iOS 13 and 14.0 when grading submissions loaded in WebView.