### PR TITLE
End edititing thus hide keyboard, when it's not needed anymore

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -20,6 +20,8 @@ import SwiftUI
 import Core
 
 struct CommentEditor: View {
+    @Environment(\.viewController) var controller
+
     @Binding var text: String
     let action: () -> Void
 
@@ -37,7 +39,10 @@ struct CommentEditor: View {
                     .identifier("SubmissionComments.commentTextView")
                     .padding(.vertical, 2)
             }
-            Button(action: action, label: {
+            Button(action: {
+                action()
+                controller.view.endEditing(true)
+            }, label: {
                 Icon.miniArrowUpSolid.foregroundColor(Color(Brand.shared.buttonPrimaryText))
                     .background(Circle().fill(Color(Brand.shared.buttonPrimaryBackground)))
             })

--- a/rn/Teacher/ios/Teacher/SpeedGrader/Drawer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/Drawer.swift
@@ -37,7 +37,16 @@ struct Drawer<Content: View>: View {
         case .max: return maxHeight
         }
     }
-    @Binding var state: DrawerState
+
+    @Environment(\.viewController) var controller
+
+    @Binding var state: DrawerState {
+        didSet {
+            if state == .min {
+                controller.view.endEditing(true)
+            }
+        }
+    }
     @State var translation: CGFloat = 0
 
     init(state: Binding<DrawerState>, minHeight: CGFloat, maxHeight: CGFloat, @ViewBuilder content: () -> Content) {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -25,6 +25,8 @@ struct SubmissionGrader: View {
     private let submission: Submission
     private var handleRefresh: (() -> Void)?
 
+    @Environment(\.viewController) var controller
+
     @ObservedObject var attempts: Store<LocalUseCase<Submission>>
 
     @Binding var isPagingEnabled: Bool
@@ -201,6 +203,7 @@ struct SubmissionGrader: View {
             withAnimation(.default) {
                 tab = newValue
             }
+            controller.view.endEditing(true)
         }), label: Text(verbatim: "")) {
             Text("Grades").tag(Optional(GraderTab.grades))
             Text("Comments").tag(Optional(GraderTab.comments))


### PR DESCRIPTION
refs: MBL-15093
affects: Teacher
release note: none

test plan:

SpeedGrader comment editor keyboard should hide on
* drawer close
* drawer tab switch
* submit pressed