### PR TITLE
Fix white navbar on course navigation for ios 13

### DIFF
--- a/CanvasCore/CanvasCore/Helm/HelmViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmViewController.swift
@@ -185,6 +185,11 @@ public final class HelmViewController: UIViewController, HelmScreen, PageViewEve
         handleStyles()
         startTrackingTimeOnViewController()
     }
+
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        handleStyles()
+    }
     
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)


### PR DESCRIPTION
refs: MBL-15093
affects: Teacher, Student
release note: none

test plan:
Open a course, navigation bar should be normal