### PR TITLE
Remove attachment from deleted discussion entries.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		B1F614AE243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F614AD243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift */; };
 		B1F6D6BA22EB675000CDD44D /* SessionDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */; };
 		CF326B352563D4D3005ABAAA /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF326B342563D4D3005ABAAA /* HelpView.swift */; };
+		CF4E5E9025BAF91F008609C5 /* DiscussionHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */; };
 		CF5C5B422534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */; };
 		CF80134C25B19DF200E5E744 /* SwiftUIExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80134B25B19DF200E5E744 /* SwiftUIExtensionsTests.swift */; };
 		CF80135125B1A03700E5E744 /* GetSubmissionSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */; };
@@ -1864,6 +1865,7 @@
 		B1F6D6B722EB672500CDD44D /* SessionDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaults.swift; sourceTree = "<group>"; };
 		B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaultsTests.swift; sourceTree = "<group>"; };
 		CF326B342563D4D3005ABAAA /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
+		CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionHTMLTests.swift; sourceTree = "<group>"; };
 		CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupPeopleListViewControllerTests.swift; sourceTree = "<group>"; };
 		CF80134B25B19DF200E5E744 /* SwiftUIExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensionsTests.swift; sourceTree = "<group>"; };
 		CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSubmissionSummaryTests.swift; sourceTree = "<group>"; };
@@ -2977,6 +2979,7 @@
 				78151DCE21AE7E0500692862 /* APIDiscussionTests.swift */,
 				7D54D6B22464705100409520 /* DiscussionDetailsViewControllerTests.swift */,
 				7DC4A554222EF87300FA03DC /* DiscussionEntryTests.swift */,
+				CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */,
 				7D6E580D255207100068D3C3 /* DiscussionListViewControllerTests.swift */,
 				7D54D6AE24646AF800409520 /* DiscussionParticipantTests.swift */,
 				7D5425D1246DDAFF00E166C0 /* DiscussionReplyViewControllerTests.swift */,
@@ -4474,6 +4477,7 @@
 				9F3107FA2371E02600502428 /* PageTests.swift in Sources */,
 				B19797AB23D77CC400032BC4 /* GoogleCloudAssignmentViewControllerTests.swift in Sources */,
 				7D81F3FC24F0128F00C482D2 /* TermsOfServiceViewControllerTests.swift in Sources */,
+				CF4E5E9025BAF91F008609C5 /* DiscussionHTMLTests.swift in Sources */,
 				7D86285B224C05BB003A37DC /* APIMediaCommentTests.swift in Sources */,
 				3B3467612130556000F9BC2E /* MockURLSession.swift in Sources */,
 				7DDC450D215BF14A003F3209 /* DynamicLabelTests.swift in Sources */,

--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -184,7 +184,7 @@ public enum DiscussionHTML {
 
     static func js(entry: DiscussionEntry, depth: UInt, maxDepth: UInt, overrideLiked: Bool? = nil) -> String {
         """
-        {attachment:\(js(file: entry.attachment)),
+        {attachment:\(entry.isRemoved ? "null" : js(file: entry.attachment)),
         author:\(js(participant: entry.author)),
         date:\(s(entry.updatedAt?.dateTimeString)),
         id:\(s(entry.id)),

--- a/Core/CoreTests/Discussions/DiscussionHTMLTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionHTMLTests.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+class DiscussionHTMLTests: CoreTestCase {
+    private var file: File!
+
+    override func setUp() {
+        super.setUp()
+
+        file = File(context: databaseClient)
+        file.displayName = "testfile.txt"
+        file.url = URL(string: "https://instructure.com")!
+    }
+
+    func testAttachmentRenderedForNonRemovedComment() {
+        let entry = DiscussionEntry(context: databaseClient)
+        entry.isRemoved = false
+        entry.attachment = file
+
+        let result = DiscussionHTML.js(entry: entry, depth: 1, maxDepth: 1)
+        XCTAssertTrue(result.contains("attachment:{displayName:'testfile.txt',url:'https://instructure.com'},"))
+    }
+
+    func testAttachmentNotRenderedForRemovedComment() {
+        let entry = DiscussionEntry(context: databaseClient)
+        entry.isRemoved = true
+        entry.attachment = file
+
+        let result = DiscussionHTML.js(entry: entry, depth: 1, maxDepth: 1)
+        XCTAssertTrue(result.contains("attachment:null,"))
+    }
+}


### PR DESCRIPTION
refs: MBL-15047
affects: Student, Teacher
release note: Fixed attachments being visible on deleted discussion entries.

test plan:
- Attachment icon shouldn't be visible on a deleted discussion entry.
- See ticket for test environment.