### PR TITLE
Always show comments, when present

### DIFF
--- a/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
@@ -109,14 +109,13 @@ class RubricPresenter {
             ratings = ratings.sorted { $0.points < $1.points }
             var selected: RubricRating?
             var selectedIndex: Int?
-            var comments: String?
+            let comments = assessment?.comments
             var description = ""
             var isCustomAssessment = false
 
             if let index = ratings.firstIndex(where: { rating in assessment?.ratingID == rating.id && rating.points == assessment?.points }) {
                 selected = ratings[index]
                 selectedIndex = index
-                comments = assessment?.comments
                 description = selected?.desc ?? ""
             }
             var allRatings: [Double] = ratings.map { $0.points }
@@ -127,7 +126,6 @@ class RubricPresenter {
                 selectedIndex = allRatings.count - 1
                 description = NSLocalizedString("Custom Grade", comment: "")
                 allDescriptions.append(description)
-                comments = assessment.comments
                 isCustomAssessment = true
             }
 

--- a/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
@@ -214,6 +214,12 @@ class RubricPresenterTests: StudentTestCase {
             "1": .make(comments: "this is custom", points: nil, rating_id: "2"),
         ]))
         Course.make()
+        Assignment.make(from: .make(rubric: [
+            .make(id: "1", ratings:  [
+                .make(id: "1", points: 10),
+                .make(id: "2", points: 25),
+            ]),
+        ], rubric_settings: .make(free_form_criterion_comments: true)))
         ContextColor.make()
         presenter.update()
 

--- a/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
@@ -209,6 +209,17 @@ class RubricPresenterTests: StudentTestCase {
         XCTAssertEqual(models.first, expected.first)
     }
 
+    func testOnlyFreeFormCriterionComments() {
+        Submission.make(from: .make(rubric_assessment: [
+            "1": .make(comments: "this is custom", points: nil, rating_id: "2"),
+        ]))
+        Course.make()
+        ContextColor.make()
+        presenter.update()
+
+        XCTAssertEqual(models.first?.comment, "this is custom")
+    }
+
     func testRubricViewModelRatingBlurb() {
         let r = Rubric.make()
         let rating = RubricRating.make()


### PR DESCRIPTION
refs: MBL-15027
affects: Student
release note: Show rubric comments

test plan: see ticket, original sandbox is unavailable, use balintbartok / s / assignments->rubric