### PR TITLE
Fix user file open logic being language dependent

### DIFF
--- a/Core/Core/Files/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/FileDetails/FileDetailsViewController.swift
@@ -127,7 +127,7 @@ public class FileDetailsViewController: UIViewController, CoreWebViewLinkDelegat
         guard let file = files.first else {
             if let error = files.error {
                 // If file download failed because of unauthorization error and we have a verifier token, then we modify the url and try to open the file in a webview.
-                if var url = originURL, url.containsVerifier, error.localizedDescription == "user not authorised to perform that action" {
+                if var url = originURL, url.containsVerifier, case .unauthorized = (error as? APIError) {
                     if !url.path.hasSuffix("download") {
                         url.path.append("/download")
                         url.queryItems?.append(URLQueryItem(name: "download_frd", value: "1"))

--- a/Core/CoreTests/API/APIErrorTests.swift
+++ b/Core/CoreTests/API/APIErrorTests.swift
@@ -68,4 +68,23 @@ class APIErrorTests: XCTestCase {
         XCTAssertEqual(from(response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 200, httpVersion: nil, headerFields: nil)), "default")
         XCTAssertEqual(from(response: HTTPURLResponse(url: URL(string: "/")!, statusCode: 400, httpVersion: nil, headerFields: nil)), "There was an unexpected error. Please try again.")
     }
+
+    func testUnauthorizedAPIError() {
+        let stringData = """
+        {
+            "status": "nicht berechtigt",
+            "errors": [{
+                "message": "Benutzer ist zu dieser Aktion nicht berechtigt."
+            }]
+        }
+        """
+        let data = stringData.data(using: .utf8)
+        let response = HTTPURLResponse(url: URL(string: "/")!, statusCode: 401, httpVersion: nil, headerFields: nil)
+
+        let error = APIError.from(data: data, response: response, error: NSError.instructureError("default"))
+
+        guard let apiError = error as? APIError else { XCTFail("Error is not an APIError"); return }
+        guard case .unauthorized = apiError else { XCTFail("Error is not an APIError.unauthorized"); return }
+        XCTAssertEqual(apiError.localizedDescription, "Benutzer ist zu dieser Aktion nicht berechtigt.")
+    }
 }


### PR DESCRIPTION
refs: MBL-15056
affects: Teacher, Student
release note: none

test plan: addition to the ticket, change language to a non-English one, files should open from
- global announcements ( MBL-14931 )
- discussions( MBL-15056)
- anywhere (?)