### PR TITLE
Fix GetCourses API call overwriting permissions CoreData information.

### DIFF
--- a/Core/Core/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Discussions/AnnouncementListViewController.swift
@@ -72,7 +72,8 @@ public class AnnouncementListViewController: UIViewController, ColoredNavViewPro
         tableView.separatorColor = .borderMedium
 
         colors.refresh()
-        course?.refresh()
+        // We must force refresh because the GetCourses call deletes all existing Courses from the CoreData cache and since GetCourses response includes no permissions we lose that information.
+        course?.refresh(force: true)
         group?.refresh()
         topics.exhaust()
     }


### PR DESCRIPTION
refs: MBL-15211
affects: Teacher
release note: none

test plan:
- Go to Course/Announcements, note + button is visible in the top right corner
- Go back to Dashboard, pull to refresh
- Go back to Course/Announcements
- "+" button should still be visible