### PR TITLE
Fix GetCourses API call overwriting permissions CoreData information.

### DIFF
--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -73,7 +73,8 @@ public class DiscussionListViewController: UIViewController, ColoredNavViewProto
         tableView.separatorColor = .borderMedium
 
         colors.refresh()
-        course?.refresh()
+        // We must force refresh because the GetCourses call deletes all existing Courses from the CoreData cache and since GetCourses response includes no permissions we lose that information.
+        course?.refresh(force: true)
         group?.refresh()
         topics.exhaust()
     }


### PR DESCRIPTION
refs: MBL-15212
affects: Teacher
release note: none

test plan:
- Go to Course/Discussions, note + button is visible in the top right corner
- Go back to Dashboard, pull to refresh
- Go back to Course/Discussions
- "+" button should still be visible