### PR TITLE
Fix syllabus summary not displaying assignments if there's one with unpublished workflowstate

### DIFF
--- a/Core/Core/Planner/CalendarEvent.swift
+++ b/Core/Core/Planner/CalendarEvent.swift
@@ -24,7 +24,7 @@ public enum CalendarEventType: String, Codable {
 }
 
 public enum CalendarEventWorkflowState: String, Codable {
-    case active, deleted, locked, published
+    case active, deleted, locked, published, unpublished
 }
 
 final public class CalendarEvent: NSManagedObject, WriteableModel {


### PR DESCRIPTION
refs: MBL-15214
affects: Teacher, Student
release note: none

test plan:
- Have a course in which there's an assignment with workflowState = unpublished
- Go to course syllabus summary
- Assignments should be listed