### PR TITLE
Fix navigation bar buttons not working on dashboard due to infinite refresh cycle

### DIFF
--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -47,8 +47,8 @@ public final class Group: NSManagedObject, WriteableModel {
     public var color: UIColor { contextColor?.color ?? .ash }
 
     public func getCourse() -> Course? {
-        if let id = courseID, course == nil {
-            course = managedObjectContext?.first(where: #keyPath(Course.id), equals: id)
+        if let id = courseID, course == nil, let fetchedCourse: Course = managedObjectContext?.first(where: #keyPath(Course.id), equals: id) {
+            course = fetchedCourse
         }
         return course
     }


### PR DESCRIPTION
refs: MBL-15215
affects: Student
release note: none

test plan:
- Log into an account which is added to a group without a Course
- Tap on Edit and Hamburger buttons
- Dashboard edit page and side menu opens