### PR TITLE
Improve discussion reply button's accessibility label.

### DIFF
--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -286,7 +286,8 @@ public enum DiscussionHTML {
         return h('div', { style: 'display:flex; margin:24px 0 16px 0;' },
             h('a', {
                 style: '\(Styles.font(.semibold, 16))text-decoration:none',
-                href: `${id}/reply`
+                href: `${id}/reply`,
+                'aria-label': \(s(NSLocalizedString("Reply to main discussion", bundle: .core, comment: "")))
             },
                 \(s(NSLocalizedString("Reply", bundle: .core, comment: "")))
             )
@@ -348,7 +349,8 @@ public enum DiscussionHTML {
             !topic.lockedForUser && topic.canReply && h(Fragment, null,
                 h('a', {
                     href: `${topic.id}/entries/${entry.id}/replies`,
-                    class: \(s(.reply))
+                    class: \(s(.reply)),
+                    'aria-label': \(s(NSLocalizedString("Reply to thread", bundle: .core, comment: "")))
                 },
                     \(s(NSLocalizedString("Reply", bundle: .core, comment: "")))
                 ),


### PR DESCRIPTION
refs: MBL-15004
affects: Student, Teacher
release note: Improved accessibility.

test plan:
- Go to a discussion with replies with VoiceOver activated.
- Notice each reply button just says "reply" and doesn't indicate if you are replying to the main discussion or a thread.