### PR TITLE
Improve VoiceOver announcement for grades on the grades list.

### DIFF
--- a/Core/Core/Grades/GradeFormatter.swift
+++ b/Core/Core/Grades/GradeFormatter.swift
@@ -59,6 +59,10 @@ public class GradeFormatter {
     public var pointsPossible: Double = 0
     public var placeholder = "-"
 
+    public static func a11yString(from assignment: Assignment, userID: String? = nil, style: Style = .medium) -> String? {
+        a11yString(from: string(from: assignment, userID: userID, style: style))
+    }
+
     public static func string(from assignment: Assignment, userID: String? = nil, style: Style = .medium) -> String? {
         let formatter = GradeFormatter()
         formatter.pointsPossible = assignment.pointsPossible ?? 0
@@ -71,6 +75,10 @@ public class GradeFormatter {
         return formatter.string(from: assignment.submission)
     }
 
+    public static func a11yString(from assignment: Assignment, submission: Submission, style: Style = .medium) -> String? {
+        a11yString(from: string(from: assignment, submission: submission, style: style))
+    }
+
     public static func string(from assignment: Assignment, submission: Submission, style: Style = .medium) -> String? {
         let formatter = GradeFormatter()
         formatter.pointsPossible = assignment.pointsPossible ?? 0
@@ -80,6 +88,19 @@ public class GradeFormatter {
             formatter.gradeStyle = .short
         }
         return formatter.string(from: submission)
+    }
+
+    private static func a11yString(from formattedGrade: String?) -> String? {
+        guard var formattedGrade = formattedGrade else { return nil }
+
+        formattedGrade = formattedGrade.replacingOccurrences(of: " / ", with: "/")
+        formattedGrade = formattedGrade.replacingOccurrences(of: "/", with: " " + NSLocalizedString("out of", comment: "5 out of 10") + " ")
+
+        return formattedGrade
+    }
+
+    public func a11yString(from submission: Submission?) -> String? {
+        GradeFormatter.a11yString(from: string(from: submission))
     }
 
     public func string(from submission: Submission?) -> String? {

--- a/Core/Core/Grades/GradeListViewController.swift
+++ b/Core/Core/Grades/GradeListViewController.swift
@@ -268,6 +268,7 @@ public class GradeListCell: UITableViewCell {
         gradeLabel.text = assignment.flatMap {
             GradeFormatter.string(from: $0, userID: userID, style: .medium)
         }
+        gradeLabel.accessibilityLabel = assignment.flatMap { GradeFormatter.a11yString(from: $0, userID: userID, style: .medium) }.flatMap { NSLocalizedString("Grade", comment: "") + ", " + $0 }
         dueLabel.text = assignment?.dueText
         statusLabel.isHidden = assignment?.isOnline != true
         let status = submission?.status ?? .notSubmitted

--- a/Core/CoreTests/Grades/GradeFormatterTests.swift
+++ b/Core/CoreTests/Grades/GradeFormatterTests.swift
@@ -38,6 +38,7 @@ class GradeFormatterTests: CoreTestCase {
             submission: .make(grade: "complete", score: 1)
         ))
         XCTAssertEqual(GradeFormatter.string(from: assignment), "Complete / 11")
+        XCTAssertEqual(GradeFormatter.a11yString(from: assignment), "Complete out of 11")
         XCTAssertEqual(GradeFormatter.string(from: assignment, style: .short), "Complete")
     }
 
@@ -48,6 +49,7 @@ class GradeFormatterTests: CoreTestCase {
             submissions: [.make(grade: "complete", score: 1, user_id: "1"), .make(grade: "incomplete", score: 0, user_id: "2")]
         ))
         XCTAssertEqual(GradeFormatter.string(from: assignment, userID: "2", style: .medium), "Incomplete / 10")
+        XCTAssertEqual(GradeFormatter.a11yString(from: assignment, userID: "2", style: .medium), "Incomplete out of 10")
         XCTAssertEqual(GradeFormatter.string(from: assignment, userID: "2", style: .short), "Incomplete")
     }
 
@@ -75,8 +77,10 @@ class GradeFormatterTests: CoreTestCase {
 
         formatter.gradeStyle = .medium
         XCTAssertEqual(formatter.string(from: submission), "Excused / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "Excused out of 10")
         submission.score = nil
         XCTAssertEqual(formatter.string(from: submission), "Excused / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "Excused out of 10")
     }
 
     func testPassFail() {
@@ -93,10 +97,13 @@ class GradeFormatterTests: CoreTestCase {
         formatter.gradeStyle = .medium
         submission.grade = "complete"
         XCTAssertEqual(formatter.string(from: submission), "Complete / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "Complete out of 10")
         submission.grade = "incomplete"
         XCTAssertEqual(formatter.string(from: submission), "Incomplete / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "Incomplete out of 10")
         submission.grade = "something else"
         XCTAssertEqual(formatter.string(from: submission), "- / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "- out of 10")
     }
 
     func testPoints() {
@@ -110,6 +117,7 @@ class GradeFormatterTests: CoreTestCase {
         formatter.gradeStyle = .medium
         formatter.pointsPossible = 10
         XCTAssertEqual(formatter.string(from: submission), "5 / 10")
+        XCTAssertEqual(formatter.a11yString(from: submission), "5 out of 10")
     }
 
     func testGPAScale() {
@@ -121,6 +129,7 @@ class GradeFormatterTests: CoreTestCase {
         formatter.gradeStyle = .medium
         submission.score = 5
         XCTAssertEqual(formatter.string(from: submission), "5 / 10 (50%)")
+        XCTAssertEqual(formatter.a11yString(from: submission), "5 out of 10 (50%)")
     }
 
     func testPercent() {
@@ -132,6 +141,7 @@ class GradeFormatterTests: CoreTestCase {
         formatter.gradeStyle = .medium
         submission.score = 5
         XCTAssertEqual(formatter.string(from: submission), "5 / 10 (50%)")
+        XCTAssertEqual(formatter.a11yString(from: submission), "5 out of 10 (50%)")
     }
 
     func testLetterGrade() {
@@ -143,6 +153,7 @@ class GradeFormatterTests: CoreTestCase {
         formatter.gradeStyle = .medium
         submission.score = 5
         XCTAssertEqual(formatter.string(from: submission), "5 / 10 (A)")
+        XCTAssertEqual(formatter.a11yString(from: submission), "5 out of 10 (A)")
     }
 
     func testNotGraded() {

--- a/Core/CoreTests/Grades/GradeListViewControllerTests.swift
+++ b/Core/CoreTests/Grades/GradeListViewControllerTests.swift
@@ -116,6 +116,7 @@ class GradeListViewControllerTests: CoreTestCase {
         var cell00 = controller.tableView.cellForRow(at: index00) as? GradeListCell
         XCTAssertEqual(cell00?.nameLabel.text, "Complex Numbers")
         XCTAssertEqual(cell00?.gradeLabel.text, "20 / 25")
+        XCTAssertEqual(cell00?.gradeLabel.accessibilityLabel, "Grade, 20 out of 25")
         XCTAssertEqual(cell00?.dueLabel.text, "Due Jan 1, 2020 at 12:00 AM")
         XCTAssertEqual(cell00?.statusLabel.text, "Late")
 


### PR DESCRIPTION
refs: MBL-15005
affects: Parent, Student
release note: Improved accessibility.

test plan:
- Go to grades list with VoiceOver enabled and tap on a row.
- VoiceOver should announce grades as: "grade, five out of ten" instead of "five slash ten"