### PR TITLE
hide a11y label for pickerbutton, when drawer is fully open

### DIFF
--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -82,6 +82,7 @@ class SubmissionDetailsViewController: UIViewController, SubmissionDetailsViewPr
         _ = setDrawerPositionOnce
         drawerContentViewController?.view.accessibilityElementsHidden = drawer?.height == 0
         contentView?.accessibilityElementsHidden = drawer?.height != 0
+        pickerButton?.accessibilityElementsHidden = drawer?.height == drawer?.maxDrawerHeight
     }
 
     func reload() {


### PR DESCRIPTION
refs: MBL-15104
affects: Student
release note: none

test plan: submissions->open drawer to max, navigation to date is no longer possible