### PR TITLE
Remove xcbeautify brew dependency from test yml as it's already pre-installed on Bitrise stack.

### DIFF
--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -64,9 +64,8 @@ workflows:
             set -euxo pipefail
 
             brew tap mxcl/made
-            brew tap thii/xcbeautify https://github.com/thii/xcbeautify.git
 
-            brew reinstall swiftlint jq xcbeautify
+            brew reinstall swiftlint jq
 
             rm -rf "$BITRISE_SOURCE_DIR/Pods/Target Support Files/yoga"
     - &yarn-install-root


### PR DESCRIPTION
refs: none
affects: none
release note: none

test plan:
- Nightly test runs shouldn't fail