### PR TITLE
Fix course navigation a11y announcement

### DIFF
--- a/rn/Teacher/src/common/components/PickerPage.js
+++ b/rn/Teacher/src/common/components/PickerPage.js
@@ -61,7 +61,7 @@ export default class PickerPage extends Component<Props> {
                   source={icon('check', 'solid')}
                 />
               }
-              accessibilityTraits={key === selectedValue ? ['button', 'selected'] : 'button'}
+              accessibilityState={{ selected: (key === selectedValue ? true : false) }}
             />
           }
         />

--- a/rn/Teacher/src/common/components/PickerPage.js
+++ b/rn/Teacher/src/common/components/PickerPage.js
@@ -61,7 +61,7 @@ export default class PickerPage extends Component<Props> {
                   source={icon('check', 'solid')}
                 />
               }
-              accessibilityState={{ selected: (key === selectedValue ? true : false) }}
+              accessibilityState={{ selected: (key === selectedValue) }}
             />
           }
         />

--- a/rn/Teacher/src/common/components/__tests__/__snapshots__/PickerPage.test.js.snap
+++ b/rn/Teacher/src/common/components/__tests__/__snapshots__/PickerPage.test.js.snap
@@ -27,10 +27,11 @@ exports[`PickerPage renders the given options as rows 1`] = `
 
 exports[`PickerPage renders the given options as rows: a 1`] = `
 <ForwardRef
-  accessibilityTraits={
-    Array [
-      "button",
-    ]
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "selected": false,
+    }
   }
   onPress={[Function]}
   style={
@@ -104,11 +105,11 @@ exports[`PickerPage renders the given options as rows: a 1`] = `
 
 exports[`PickerPage renders the given options as rows: b 1`] = `
 <ForwardRef
-  accessibilityTraits={
-    Array [
-      "button",
-      "selected",
-    ]
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "selected": true,
+    }
   }
   onPress={[Function]}
   style={
@@ -217,10 +218,11 @@ exports[`PickerPage renders the given options as rows: b 1`] = `
 
 exports[`PickerPage renders the given options as rows: c 1`] = `
 <ForwardRef
-  accessibilityTraits={
-    Array [
-      "button",
-    ]
+  accessibilityRole="button"
+  accessibilityState={
+    Object {
+      "selected": false,
+    }
   }
   onPress={[Function]}
   style={

--- a/rn/Teacher/src/common/components/rows/Row.js
+++ b/rn/Teacher/src/common/components/rows/Row.js
@@ -44,7 +44,8 @@ export type RowProps = {
   identifier?: any, // Passed in as the first parameter to the onPress callback
   accessories?: any,
   accessibilityLabel?: ?string,
-  accessibilityTraits?: React$ElementProps<typeof View>,
+  accessibilityRole?: string,
+  accessibilityState?: any,
   titleProps?: { ellipsizeMode?: string, numberOfLines?: number, accessibilityLabel?: string },
   selected?: ?boolean,
   titleStyles?: any,
@@ -75,14 +76,16 @@ export default class Row extends Component<RowProps> {
       bottomBorder = style.bottomHairline
     }
 
-    let accessibilityTraits = typeof this.props.accessibilityTraits === 'string' ? [this.props.accessibilityTraits] : (this.props.accessibilityTraits || [])
-    if (this.props.onPress && !accessibilityTraits.includes('button')) {
-      accessibilityTraits.push('button')
+    let accessibilityRole = this.props.accessibilityRole
+
+    if (accessibilityRole === undefined && this.props.onPress) {
+      accessibilityRole = 'button'
     }
 
     let traits: {[string]: any} = {
-      accessibilityTraits,
+      accessibilityRole,
       accessibilityLabel: this.props.accessibilityLabel,
+      accessibilityState: this.props.accessibilityState,
     }
 
     if (this.props.accessible !== undefined) {

--- a/rn/Teacher/src/common/components/rows/RowWithSwitch.js
+++ b/rn/Teacher/src/common/components/rows/RowWithSwitch.js
@@ -39,14 +39,6 @@ export default class RowWithSwitch extends Component<RowWithSwitchProps, any> {
   }
 
   render () {
-    let traits = []
-    if (this.props.disabled) {
-      traits.push('disabled')
-    }
-    if (this.props.value) {
-      traits.push('selected')
-    }
-
     const accessories = <Switch {...this.props}
       testID={this.props.identifier}
       onValueChange={this.onValueChange}
@@ -56,8 +48,9 @@ export default class RowWithSwitch extends Component<RowWithSwitchProps, any> {
     return (
       <Row {...this.props}
         accessories={accessories}
+        accessibilityRole='switch'
         accessibilityLabel={accessibilityLabel}
-        accessibilityTraits={traits}
+        {...this.props.disabled && { accessibilityState: { disabled: true } } }
         onPress={() => { this.onValueChange(!this.props.value) }}
       />
     )

--- a/rn/Teacher/src/common/components/rows/RowWithSwitch.js
+++ b/rn/Teacher/src/common/components/rows/RowWithSwitch.js
@@ -20,6 +20,7 @@
 
 import React, { Component } from 'react'
 import {
+  AccessibilityInfo,
   Switch,
 } from 'react-native'
 import Row, { type RowProps } from './Row'
@@ -51,7 +52,11 @@ export default class RowWithSwitch extends Component<RowWithSwitchProps, any> {
         accessibilityRole='switch'
         accessibilityLabel={accessibilityLabel}
         {...this.props.disabled && { accessibilityState: { disabled: true } } }
-        onPress={() => { this.onValueChange(!this.props.value) }}
+        onPress={() => {
+          const newValue = !this.props.value
+          AccessibilityInfo.announceForAccessibility(newValue ? i18n('On') : i18n('Off'))
+          this.onValueChange(newValue)
+        }}
       />
     )
   }

--- a/rn/Teacher/src/common/components/rows/__tests__/RowWithSwitch.test.js
+++ b/rn/Teacher/src/common/components/rows/__tests__/RowWithSwitch.test.js
@@ -36,3 +36,15 @@ test('Render row with switch', () => {
   aRow.getInstance().onValueChange(true, 'test')
   expect(onValueChange).toHaveBeenLastCalledWith(true, 'test')
 })
+
+test('Render disabled row with switch', () => {
+  const onValueChange = jest.fn()
+  let aRow = renderer.create(
+    <RowWithSwitch
+      title='Row with a switch in it!'
+      onValueChange={onValueChange}
+      identifier='test'
+      disabled={true} />
+  )
+  expect(aRow.toJSON()).toMatchSnapshot()
+})

--- a/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/Row.test.js.snap
+++ b/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/Row.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Render the base row 1`] = `
 <View
+  accessibilityRole="button"
   accessible={true}
   focusable={true}
   onClick={[Function]}

--- a/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/RowWithDetail.test.js.snap
+++ b/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/RowWithDetail.test.js.snap
@@ -3,7 +3,6 @@
 exports[`Render row with detail label 1`] = `
 <View
   accessibilityLabel="Row with a switch in it!, this is a detail label"
-  accessibilityTraits={Array []}
   onPress={[Function]}
   style={
     Array [

--- a/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/RowWithSwitch.test.js.snap
+++ b/rn/Teacher/src/common/components/rows/__tests__/__snapshots__/RowWithSwitch.test.js.snap
@@ -1,8 +1,130 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Render disabled row with switch 1`] = `
+<View
+  accessibilityLabel="Row with a switch in it!, Off"
+  accessibilityRole="switch"
+  accessibilityState={
+    Object {
+      "disabled": true,
+    }
+  }
+  accessible={true}
+  focusable={true}
+  onClick={[Function]}
+  onResponderGrant={[Function]}
+  onResponderMove={[Function]}
+  onResponderRelease={[Function]}
+  onResponderTerminate={[Function]}
+  onResponderTerminationRequest={[Function]}
+  onStartShouldSetResponder={[Function]}
+  style={
+    Array [
+      undefined,
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Array [
+        Object {
+          "alignItems": "center",
+          "backgroundColor": "#FFFFFF",
+          "flex": 1,
+          "flexDirection": "row",
+          "minHeight": 54,
+          "paddingBottom": 12,
+          "paddingLeft": 16,
+          "paddingRight": 16,
+          "paddingTop": 12,
+        },
+        Object {
+          "backgroundColor": "#FFFFFF",
+        },
+        undefined,
+      ]
+    }
+  >
+    <View
+      style={
+        Array [
+          Object {
+            "flex": 1,
+            "flexDirection": "column",
+            "justifyContent": "center",
+          },
+          Object {
+            "marginLeft": 0,
+          },
+        ]
+      }
+    >
+      <Text
+        ellipsizeMode="tail"
+        numberOfLines={0}
+        style={
+          Array [
+            Object {
+              "color": "#2D3B45",
+              "fontSize": 16,
+            },
+            Array [
+              Object {
+                "color": "#2D3B45",
+                "fontWeight": "600",
+              },
+            ],
+          ]
+        }
+      >
+        Row with a switch in it!
+      </Text>
+    </View>
+    <View
+      style={
+        Object {
+          "flex": 0,
+        }
+      }
+    >
+      <View
+        style={
+          Object {
+            "alignItems": "center",
+            "flex": 1,
+            "flexDirection": "row",
+            "justifyContent": "flex-end",
+          }
+        }
+      >
+        <RCTSwitch
+          accessibilityRole="switch"
+          disabled={true}
+          identifier="test"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          testID="test"
+          title="Row with a switch in it!"
+          value={false}
+        />
+      </View>
+    </View>
+  </View>
+</View>
+`;
+
 exports[`Render row with switch 1`] = `
 <View
   accessibilityLabel="Row with a switch in it!, Off"
+  accessibilityRole="switch"
   accessible={true}
   focusable={true}
   onClick={[Function]}

--- a/rn/Teacher/src/modules/assignments/__tests__/__snapshots__/AssignmentListRow.test.js.snap
+++ b/rn/Teacher/src/modules/assignments/__tests__/__snapshots__/AssignmentListRow.test.js.snap
@@ -4,6 +4,7 @@ exports[`renders correctly 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -215,6 +216,7 @@ exports[`renders correctly assignment icon 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -426,6 +428,7 @@ exports[`renders correctly discussion icon 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -637,6 +640,7 @@ exports[`renders correctly not published icon 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -848,6 +852,7 @@ exports[`renders correctly published icon 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -1059,6 +1064,7 @@ exports[`renders correctly quiz icon 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -1270,6 +1276,7 @@ exports[`renders correctly with closed due dates 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -1481,6 +1488,7 @@ exports[`renders correctly with needs_grading_count 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -1720,6 +1728,7 @@ exports[`renders correctly with needs_grading_count and set to not_graded 1`] = 
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -1931,6 +1940,7 @@ exports[`renders correctly with open due dates 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}
@@ -2142,6 +2152,7 @@ exports[`renders correctly with selected props 1`] = `
 <View>
   <View>
     <View
+      accessibilityRole="button"
       accessible={true}
       focusable={true}
       onClick={[Function]}

--- a/rn/Teacher/src/modules/attachments/__tests__/__snapshots__/AttachmentRow.test.js.snap
+++ b/rn/Teacher/src/modules/attachments/__tests__/__snapshots__/AttachmentRow.test.js.snap
@@ -2,11 +2,7 @@
 
 exports[`AttachmentRow renders 1`] = `
 <TouchableHighlight
-  accessibilityTraits={
-    Array [
-      "button",
-    ]
-  }
+  accessibilityRole="button"
   accessible={false}
   onPress={[Function]}
   style={

--- a/rn/Teacher/src/modules/filter/Filter.js
+++ b/rn/Teacher/src/modules/filter/Filter.js
@@ -83,7 +83,7 @@ export default class Filter extends Component<FilterProps, FilterState> {
     return (
       <Row
         title={item.title()}
-        accessibilityState={{ selected: item.selected ? true : false }}
+        accessibilityState={{ selected: item.selected }}
         identifier={item.type}
         onPress={this.onFilterPress}
         border='bottom'

--- a/rn/Teacher/src/modules/filter/Filter.js
+++ b/rn/Teacher/src/modules/filter/Filter.js
@@ -80,11 +80,10 @@ export default class Filter extends Component<FilterProps, FilterState> {
   }
 
   renderRow = ({ item }: { item: SubmissionFilterOption }) => {
-    const traits = item.selected ? 'selected' : 'none'
     return (
       <Row
         title={item.title()}
-        accessibilityTraits={traits}
+        accessibilityState={{ selected: item.selected ? true : false }}
         identifier={item.type}
         onPress={this.onFilterPress}
         border='bottom'

--- a/rn/Teacher/src/modules/filter/__tests__/__snapshots__/Filter.test.js.snap
+++ b/rn/Teacher/src/modules/filter/__tests__/__snapshots__/Filter.test.js.snap
@@ -26,11 +26,11 @@ exports[`Filter renders the filter options 1`] = `
   <list>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -112,11 +112,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -198,11 +198,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -284,11 +284,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -370,11 +370,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -456,11 +456,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -542,11 +542,11 @@ exports[`Filter renders the filter options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -656,11 +656,11 @@ exports[`Filter renders with preselected options 1`] = `
   <list>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -744,11 +744,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -832,11 +832,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -920,11 +920,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1008,11 +1008,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": true,
+          }
         }
         onPress={[Function]}
         style={
@@ -1127,11 +1127,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1215,11 +1215,11 @@ exports[`Filter renders with preselected options 1`] = `
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1331,11 +1331,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
   <list>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1419,11 +1419,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1507,11 +1507,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1595,11 +1595,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1683,11 +1683,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": true,
+          }
         }
         onPress={[Function]}
         style={
@@ -1802,11 +1802,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={
@@ -1890,11 +1890,11 @@ exports[`Filter updates the selection when pressed for non prompt filter options
     </item>
     <item>
       <TouchableHighlight
-        accessibilityTraits={
-          Array [
-            "none",
-            "button",
-          ]
+        accessibilityRole="button"
+        accessibilityState={
+          Object {
+            "selected": false,
+          }
         }
         onPress={[Function]}
         style={

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/CourseSelect.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/CourseSelect.test.js.snap
@@ -54,11 +54,7 @@ exports[`CourseSelect renders 1`] = `
       </View>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -178,11 +174,7 @@ exports[`CourseSelect renders 1`] = `
       </View>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -295,11 +287,7 @@ exports[`CourseSelect renders 1`] = `
       </item>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -430,11 +418,7 @@ exports[`CourseSelect renders and then selects a course and then dismisses 1`] =
       </View>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -554,11 +538,7 @@ exports[`CourseSelect renders and then selects a course and then dismisses 1`] =
       </View>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -671,11 +651,7 @@ exports[`CourseSelect renders and then selects a course and then dismisses 1`] =
       </item>
       <item>
         <TouchableHighlight
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [

--- a/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
+++ b/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
@@ -53,7 +53,6 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -181,11 +180,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Survey"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -326,12 +321,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -433,11 +423,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group, Changed"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -593,11 +579,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -698,11 +680,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -821,12 +799,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -929,11 +902,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -1070,11 +1039,7 @@ exports[`QuizEdit changes assignment group 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -1212,12 +1177,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -1322,11 +1282,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -1427,11 +1383,7 @@ exports[`QuizEdit changes assignment group 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -1553,11 +1505,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -1680,11 +1628,7 @@ exports[`QuizEdit changes assignment group 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -1891,7 +1835,6 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -2019,11 +1962,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Survey"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -2189,12 +2128,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Picker>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -2296,11 +2230,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -2437,11 +2367,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -2542,11 +2468,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -2665,12 +2587,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -2773,11 +2690,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -2914,11 +2827,7 @@ exports[`QuizEdit changes quiz type 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -3056,12 +2965,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -3166,11 +3070,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -3271,11 +3171,7 @@ exports[`QuizEdit changes quiz type 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -3397,11 +3293,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -3524,11 +3416,7 @@ exports[`QuizEdit changes quiz type 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -3735,7 +3623,6 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -3863,11 +3750,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -4008,12 +3891,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -4115,11 +3993,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -4256,11 +4130,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -4361,11 +4231,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -4484,12 +4350,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -4592,11 +4453,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -4733,11 +4590,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -4875,12 +4728,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -4985,11 +4833,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -5090,12 +4934,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -5451,11 +5290,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -5578,11 +5413,7 @@ exports[`QuizEdit clears "hide correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -5789,7 +5620,6 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -5917,11 +5747,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -6062,12 +5888,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -6169,11 +5990,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -6310,11 +6127,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -6415,11 +6228,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -6538,12 +6347,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -6646,11 +6450,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -6787,11 +6587,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -6929,12 +6725,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -7039,11 +6830,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -7144,12 +6931,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -7505,11 +7287,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -7632,11 +7410,7 @@ exports[`QuizEdit clears "show correct answers at" date 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -7880,7 +7654,6 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -8008,11 +7781,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -8153,12 +7922,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -8260,11 +8024,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -8401,11 +8161,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -8506,11 +8262,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -8629,12 +8381,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -8737,11 +8484,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -8878,11 +8621,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -9020,12 +8759,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -9130,11 +8864,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -9235,11 +8965,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -9361,11 +9087,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -9488,11 +9210,7 @@ exports[`QuizEdit hides modal when save finishes 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -9699,7 +9417,6 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -9827,11 +9544,7 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -9972,12 +9685,7 @@ exports[`QuizEdit renders 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -10079,11 +9787,7 @@ exports[`QuizEdit renders 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -10220,11 +9924,7 @@ exports[`QuizEdit renders 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -10325,11 +10025,7 @@ exports[`QuizEdit renders 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -10448,12 +10144,7 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -10556,11 +10247,7 @@ exports[`QuizEdit renders 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -10697,11 +10384,7 @@ exports[`QuizEdit renders 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -10839,12 +10522,7 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -10949,11 +10627,7 @@ exports[`QuizEdit renders 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -11054,11 +10728,7 @@ exports[`QuizEdit renders 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -11180,11 +10850,7 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -11307,11 +10973,7 @@ exports[`QuizEdit renders 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -11555,7 +11217,6 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -11683,11 +11344,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -11828,12 +11485,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -11935,11 +11587,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -12076,11 +11724,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -12181,11 +11825,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -12304,12 +11944,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -12412,11 +12047,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -12553,11 +12184,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -12695,12 +12322,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -12805,11 +12427,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -12910,11 +12528,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -13036,11 +12650,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -13163,11 +12773,7 @@ exports[`QuizEdit saving invalid due dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -13426,7 +13032,6 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -13582,11 +13187,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -13727,12 +13328,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -13834,11 +13430,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -13975,11 +13567,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -14080,11 +13668,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -14203,12 +13787,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -14311,11 +13890,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -14452,11 +14027,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -14594,12 +14165,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -14704,11 +14270,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -14809,11 +14371,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -14935,11 +14493,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -15062,11 +14616,7 @@ exports[`QuizEdit saving invalid name displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -15310,7 +14860,6 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -15438,11 +14987,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -15583,12 +15128,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -15690,11 +15230,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -15831,11 +15367,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -15936,11 +15468,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -16059,12 +15587,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -16167,11 +15690,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -16308,11 +15827,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -16450,12 +15965,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -16560,11 +16070,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -16665,12 +16171,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -17132,11 +16633,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -17259,11 +16756,7 @@ exports[`QuizEdit saving invalid viewing dates displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -17507,7 +17000,6 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -17635,11 +17127,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -17780,12 +17268,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -17887,11 +17370,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -18028,11 +17507,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -18133,11 +17608,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -18256,12 +17727,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -18364,11 +17830,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -18505,11 +17967,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -18647,12 +18105,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -18757,11 +18210,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -18862,11 +18311,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -18988,11 +18433,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -19115,12 +18556,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -19224,11 +18660,7 @@ exports[`QuizEdit saving password displays banner 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Access Code, text field"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         accessible={false}
         onPress={[Function]}
         style={
@@ -19476,7 +18908,6 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -19604,11 +19035,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -19749,12 +19176,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -19856,11 +19278,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -20010,11 +19428,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -20115,11 +19529,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -20238,12 +19648,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -20346,11 +19751,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -20487,11 +19888,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -20629,12 +20026,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -20739,11 +20131,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -20844,11 +20232,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -20970,11 +20354,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -21097,11 +20477,7 @@ exports[`QuizEdit shows Assignment Group picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -21345,7 +20721,6 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -21473,11 +20848,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -21618,12 +20989,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -21725,11 +21091,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -21866,11 +21228,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -21971,11 +21329,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -22094,12 +21448,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -22202,11 +21551,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -22343,11 +21688,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -22485,12 +21826,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -22595,11 +21931,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -22700,11 +22032,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -22826,11 +22154,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -22953,11 +22277,7 @@ exports[`QuizEdit shows modal while saving 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -23164,7 +22484,6 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -23292,11 +22611,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -23462,12 +22777,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Picker>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -23569,11 +22879,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -23710,11 +23016,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -23815,11 +23117,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -23938,12 +23236,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -24046,11 +23339,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -24187,11 +23476,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -24329,12 +23614,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -24439,11 +23719,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -24544,11 +23820,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -24670,11 +23942,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -24797,11 +24065,7 @@ exports[`QuizEdit shows quiz time picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -25008,7 +24272,6 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -25136,11 +24399,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -25281,12 +24540,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -25388,11 +24642,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -25529,11 +24779,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -25634,11 +24880,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -25757,12 +24999,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -25865,11 +25102,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -26006,11 +25239,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -26148,12 +25377,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -26258,11 +25482,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -26363,11 +25583,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -26489,12 +25705,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -26598,12 +25809,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Lock Questions After Answering, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -26723,11 +25929,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -26934,7 +26136,6 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -27062,11 +26263,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -27207,12 +26404,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -27314,11 +26506,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -27455,11 +26643,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -27560,11 +26744,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -27683,12 +26863,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -27791,11 +26966,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -27932,11 +27103,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -28074,12 +27241,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -28184,11 +27346,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -28289,11 +27447,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -28415,12 +27569,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -28524,11 +27673,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Lock Questions After Answering, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -28648,11 +27793,7 @@ exports[`QuizEdit toggles "Lock Questions After Answering 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -28859,7 +28000,6 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -28987,11 +28127,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -29132,12 +28268,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -29239,11 +28370,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -29380,11 +28507,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -29485,11 +28608,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -29608,12 +28727,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -29716,11 +28830,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -29857,11 +28967,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -29999,12 +29105,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -30109,11 +29210,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -30214,11 +29311,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -30340,12 +29433,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -30449,11 +29537,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Lock Questions After Answering, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -30573,11 +29657,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -30784,7 +29864,6 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -30912,11 +29991,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -31057,12 +30132,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -31164,11 +30234,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -31305,11 +30371,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -31410,11 +30472,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -31533,12 +30591,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -31641,11 +30694,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -31782,11 +30831,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -31924,12 +30969,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -32034,11 +31074,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -32139,11 +31175,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -32265,11 +31297,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -32392,11 +31420,7 @@ exports[`QuizEdit toggles "Show One Question at a Time" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -32603,7 +31627,6 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -32731,11 +31754,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -32876,12 +31895,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -32983,11 +31997,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -33124,11 +32134,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -33229,11 +32235,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -33352,12 +32354,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -33460,11 +32457,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -33601,11 +32594,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -33743,12 +32732,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -33853,11 +32837,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -33958,11 +32938,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -34084,11 +33060,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -34211,12 +33183,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -34320,11 +33287,7 @@ exports[`QuizEdit toggles "access code" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Access Code, text field"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         accessible={false}
         onPress={[Function]}
         style={
@@ -34544,7 +33507,6 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -34672,11 +33634,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -34817,12 +33775,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -34924,11 +33877,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -35065,11 +34014,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -35170,11 +34115,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -35293,12 +34234,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -35401,11 +34337,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -35542,11 +34474,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -35684,12 +34612,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -35794,11 +34717,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -35899,11 +34818,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -36025,11 +34940,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -36152,11 +35063,7 @@ exports[`QuizEdit toggles "access code" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -36363,7 +35270,6 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -36491,11 +35397,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -36636,12 +35538,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -36743,11 +35640,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -36884,11 +35777,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -36989,11 +35878,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -37112,12 +35997,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -37220,11 +36100,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -37361,11 +36237,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -37503,12 +36375,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -37613,11 +36480,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -37718,12 +36581,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -38125,11 +36983,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -38252,11 +37106,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -38463,7 +37313,6 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -38591,11 +37440,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -38736,12 +37581,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -38843,11 +37683,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -38984,11 +37820,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -39089,11 +37921,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -39212,12 +38040,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -39320,11 +38143,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -39461,11 +38280,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -39603,12 +38418,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -39713,11 +38523,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -39818,12 +38624,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -40218,11 +39019,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -40345,11 +39142,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -40556,7 +39349,6 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -40684,11 +39476,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -40829,12 +39617,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -40936,11 +39719,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -41077,11 +39856,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -41182,11 +39957,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -41305,12 +40076,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -41413,11 +40179,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -41554,11 +40316,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -41696,12 +40454,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -41806,11 +40559,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -41911,11 +40660,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -42037,11 +40782,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -42164,11 +40905,7 @@ exports[`QuizEdit toggles "let students see responses" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -42375,7 +41112,6 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -42503,11 +41239,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -42648,12 +41380,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -42755,11 +41482,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -42896,11 +41619,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -43001,11 +41720,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -43124,12 +41839,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -43232,11 +41942,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -43373,11 +42079,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -43515,12 +42217,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -43625,11 +42322,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -43730,11 +42423,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -43856,12 +42545,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -43965,11 +42649,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Lock Questions After Answering, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -44089,11 +42769,7 @@ exports[`QuizEdit toggles "one question at a time" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -44300,7 +42976,6 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -44428,11 +43103,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -44573,12 +43244,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -44680,11 +43346,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -44821,11 +43483,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -44926,11 +43584,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -45049,12 +43703,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -45157,11 +43806,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -45298,11 +43943,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -45440,12 +44081,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -45550,12 +44186,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -45656,11 +44287,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -45782,11 +44409,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -45909,11 +44532,7 @@ exports[`QuizEdit toggles "only once after each attempt" 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -46120,7 +44739,6 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -46248,11 +44866,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -46393,12 +45007,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -46500,11 +45109,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -46641,11 +45246,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -46746,11 +45347,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -46869,12 +45466,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -46977,11 +45569,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -47118,11 +45706,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -47260,12 +45844,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -47370,11 +45949,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -47475,11 +46050,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -47601,11 +46172,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -47728,11 +46295,7 @@ exports[`QuizEdit toggles "only once after each attempt" 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -47939,7 +46502,6 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -48067,11 +46629,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -48212,12 +46770,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -48319,11 +46872,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -48460,11 +47009,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -48565,11 +47110,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -48688,12 +47229,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -48796,11 +47332,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -48937,11 +47469,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -49079,12 +47607,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -49189,11 +47712,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -49294,12 +47813,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -49701,11 +48215,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -49828,11 +48338,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -50039,7 +48545,6 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -50167,11 +48672,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -50312,12 +48813,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -50419,11 +48915,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -50560,11 +49052,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -50665,11 +49153,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -50788,12 +49272,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -50896,11 +49375,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -51037,11 +49512,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -51179,12 +49650,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -51289,11 +49755,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -51394,12 +49856,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -51794,11 +50251,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -51921,11 +50374,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -52132,7 +50581,6 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -52260,11 +50708,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -52405,12 +50849,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -52512,11 +50951,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -52653,11 +51088,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -52758,11 +51189,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -52881,12 +51308,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -52989,11 +51411,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -53130,11 +51548,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -53272,12 +51686,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -53382,11 +51791,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -53487,11 +51892,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -53613,11 +52014,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -53740,11 +52137,7 @@ exports[`QuizEdit toggles "show correct answers" options 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -53951,7 +52344,6 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -54079,11 +52471,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -54224,12 +52612,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -54331,11 +52714,7 @@ exports[`QuizEdit toggles publish 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -54472,11 +52851,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -54577,11 +52952,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -54700,12 +53071,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -54808,11 +53174,7 @@ exports[`QuizEdit toggles publish 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -54949,11 +53311,7 @@ exports[`QuizEdit toggles publish 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -55091,12 +53449,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -55201,11 +53554,7 @@ exports[`QuizEdit toggles publish 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -55306,11 +53655,7 @@ exports[`QuizEdit toggles publish 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -55432,11 +53777,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -55559,11 +53900,7 @@ exports[`QuizEdit toggles publish 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -55770,7 +54107,6 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -55898,11 +54234,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -56043,11 +54375,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -56149,11 +54477,7 @@ exports[`QuizEdit toggles publish 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -56290,11 +54614,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -56395,11 +54715,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -56518,12 +54834,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -56626,11 +54937,7 @@ exports[`QuizEdit toggles publish 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -56767,11 +55074,7 @@ exports[`QuizEdit toggles publish 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -56909,12 +55212,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -57019,11 +55317,7 @@ exports[`QuizEdit toggles publish 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -57124,11 +55418,7 @@ exports[`QuizEdit toggles publish 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -57250,11 +55540,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -57377,11 +55663,7 @@ exports[`QuizEdit toggles publish 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -57588,7 +55870,6 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -57716,11 +55997,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -57861,12 +56138,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -57968,11 +56240,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -58109,12 +56377,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -58215,11 +56478,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -58338,12 +56597,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -58446,11 +56700,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -58587,11 +56837,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -58729,12 +56975,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -58839,11 +57080,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -58944,11 +57181,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -59070,11 +57303,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -59197,11 +57426,7 @@ exports[`QuizEdit toggles shuffle answers 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -59408,7 +57633,6 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -59536,11 +57760,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -59681,12 +57901,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -59788,11 +58003,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -59929,11 +58140,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -60034,11 +58241,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -60157,12 +58360,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -60265,11 +58463,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -60406,11 +58600,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -60548,12 +58738,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -60658,11 +58843,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -60763,11 +58944,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -60889,11 +59066,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -61016,11 +59189,7 @@ exports[`QuizEdit toggles shuffle answers 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -61227,7 +59396,6 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -61355,11 +59523,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -61500,12 +59664,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -61607,11 +59766,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -61748,11 +59903,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -61853,12 +60004,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -61959,11 +60105,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Length in minutes, text field"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         accessible={false}
         onPress={[Function]}
         style={
@@ -62100,12 +60242,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -62208,11 +60345,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -62349,11 +60482,7 @@ exports[`QuizEdit toggles time limit 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -62491,12 +60620,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -62601,11 +60725,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -62706,11 +60826,7 @@ exports[`QuizEdit toggles time limit 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -62832,11 +60948,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -62959,11 +61071,7 @@ exports[`QuizEdit toggles time limit 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -63170,7 +61278,6 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -63298,11 +61405,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -63443,12 +61546,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -63550,11 +61648,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -63691,11 +61785,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -63796,11 +61886,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -63920,12 +62006,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -64028,11 +62109,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -64169,11 +62246,7 @@ exports[`QuizEdit toggles time limit 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -64311,12 +62384,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -64421,11 +62489,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -64526,11 +62590,7 @@ exports[`QuizEdit toggles time limit 2`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -64652,11 +62712,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -64779,11 +62835,7 @@ exports[`QuizEdit toggles time limit 2`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -64990,7 +63042,6 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -65118,11 +63169,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -65263,12 +63310,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -65370,11 +63412,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -65511,11 +63549,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -65616,11 +63650,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -65739,12 +63769,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -65847,11 +63872,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -65988,11 +64009,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -66130,12 +64147,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -66240,11 +64252,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -66345,12 +64353,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -66752,11 +64755,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -66879,11 +64878,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -67090,7 +65085,6 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <View
         accessibilityLabel="Title, text field"
-        accessibilityTraits={Array []}
         accessible={false}
         onPress={[Function]}
         style={
@@ -67218,11 +65212,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Quiz Type, Graded Quiz"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="button"
         onPress={[Function]}
         style={
           Array [
@@ -67363,12 +65353,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Publish, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -67470,11 +65455,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Assignment Group"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -67611,11 +65592,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </View>
       <TouchableHighlight
         accessibilityLabel="Shuffle Answers, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -67716,11 +65693,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </TouchableHighlight>
       <TouchableHighlight
         accessibilityLabel="Time Limit, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -67839,12 +65812,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Allow Multiple Attempts, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -67947,11 +65915,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Quiz Score to Keep, Latest"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           onPress={[Function]}
           style={
             Array [
@@ -68088,11 +66052,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Allowed Attempts, text field"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="button"
           accessible={false}
           onPress={[Function]}
           style={
@@ -68230,12 +66190,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Let Students See Their Quiz Responses, On"
-        accessibilityTraits={
-          Array [
-            "selected",
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -68340,11 +66295,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       <View>
         <TouchableHighlight
           accessibilityLabel="Only Once After Each Attempt, Off"
-          accessibilityTraits={
-            Array [
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -68445,12 +66396,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
         </TouchableHighlight>
         <TouchableHighlight
           accessibilityLabel="Let Students See the Correct Answer, On"
-          accessibilityTraits={
-            Array [
-              "selected",
-              "button",
-            ]
-          }
+          accessibilityRole="switch"
           onPress={[Function]}
           style={
             Array [
@@ -68852,11 +66798,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Show One Question at a Time, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [
@@ -68979,11 +66921,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
       </Text>
       <TouchableHighlight
         accessibilityLabel="Require an Access Code, Off"
-        accessibilityTraits={
-          Array [
-            "button",
-          ]
-        }
+        accessibilityRole="switch"
         onPress={[Function]}
         style={
           Array [


### PR DESCRIPTION
refs: MBL-14991
affects: Teacher, Student
release note: Improved accessibility.

test plan:
- Enable voice over and navigate to the course navigation menu.
- When swiping to each item VoiceOver should announce that the item is a button.