### PR TITLE
Filter people list cell's role to show a role only one time

### DIFF
--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -252,7 +252,8 @@ class PeopleListCell: UITableViewCell {
         avatarView.name = user?.name ?? ""
         avatarView.url = user?.avatarURL
         nameLabel.text = user.flatMap { User.displayName($0.name, pronouns: $0.pronouns) }
-        let roles = user?.enrollments?.compactMap { $0.formattedRole }.sorted() ?? []
+        var roles = user?.enrollments?.compactMap { $0.formattedRole } ?? []
+        roles = Set(roles).sorted()
         rolesLabel.text = ListFormatter.localizedString(from: roles)
         rolesLabel.isHidden = roles.isEmpty
     }

--- a/Core/CoreTests/People/PeopleListViewControllerTests.swift
+++ b/Core/CoreTests/People/PeopleListViewControllerTests.swift
@@ -35,7 +35,7 @@ class PeopleListViewControllerTests: CoreTestCase {
                 name: "Jane",
                 sortable_name: "jane doe",
                 short_name: "jane",
-                enrollments: [ .make(id: "2", role: "StudentEnrollment"), .make(id: "3", role: "Custom") ],
+                enrollments: [ .make(id: "2", role: "StudentEnrollment"), .make(id: "3", role: "Custom"), .make(id: "4", role: "StudentEnrollment"), ],
                 pronouns: "She/Her"
             ),
         ])


### PR DESCRIPTION
refs: MBL-15227
affects: Student, Teacher
release note: none

test plan:
- Assign an observer both to a course and to a user inside the course
- Go to Course > People
- The role "Observer" under the user's name should be written once

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/108716105-fcc0e980-751b-11eb-8d6c-810c81fe8657.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/108716117-ffbbda00-751b-11eb-90e3-3f9d127ef12f.png"></td>
</tr>
</table>
