### PR TITLE
Fix big course image blocking tap action

### DIFF
--- a/Core/Core/Dashboard/CourseCard.swift
+++ b/Core/Core/Dashboard/CourseCard.swift
@@ -43,6 +43,8 @@ struct CourseCard: View {
                         card.imageURL.map { RemoteImage($0, width: width, height: 80) }?
                             .opacity(hideColorOverlay ? 1 : 0.4)
                             .clipped()
+                            // Fix big course image consuming tap events.
+                            .contentShape(Path(CGRect(x: 0, y: 0, width: width, height: 80)))
                     }
                     VStack(alignment: .leading, spacing: 2) {
                         HStack { Spacer() }


### PR DESCRIPTION
refs: MBL-15233
affects: Teacher, Student
release note: Fixed dashboard not opening the appropriate course in some cases.

test plan:
See ticket.