### PR TITLE
Move docviewer and annotations view to the front to prevent overlapping.

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -98,6 +98,7 @@ struct SubmissionGrader: View {
                             }
                             Spacer().frame(height: bottomInset)
                         }
+                            .zIndex(1)
                         Divider()
                         VStack(spacing: 0) {
                             tools(bottomInset: bottomInset, isDrawer: false)


### PR DESCRIPTION
refs: MBL-15238
affects: Teacher
release note: Fixed SpeedGrader annotations not working correctly on iPad landscape mode.

test plan:
See ticket.