### PR TITLE
Fix SpeedGrader not scrolling while there's an annotation button selected.

### DIFF
--- a/Core/Core/DocViewer/DocViewer.swift
+++ b/Core/Core/DocViewer/DocViewer.swift
@@ -22,13 +22,11 @@ public struct DocViewer: UIViewControllerRepresentable {
     public let filename: String
     public let previewURL: URL?
     public let fallbackURL: URL
-    public let annotatingDidChange: ((Bool) -> Void)?
 
-    public init(filename: String, previewURL: URL?, fallbackURL: URL, annotatingDidChange: ((Bool) -> Void)? = nil) {
+    public init(filename: String, previewURL: URL?, fallbackURL: URL) {
         self.filename = filename
         self.previewURL = previewURL
         self.fallbackURL = fallbackURL
-        self.annotatingDidChange = annotatingDidChange
     }
 
     public func makeUIViewController(context: Self.Context) -> UIViewController { UIViewController() }
@@ -39,10 +37,7 @@ public struct DocViewer: UIViewControllerRepresentable {
             prev?.unembed()
             let next = DocViewerViewController.create(filename: filename, previewURL: previewURL, fallbackURL: fallbackURL)
             next.isAnnotatable = true
-            next.annotatingDidChange = annotatingDidChange
             uiViewController.embed(next, in: uiViewController.view)
-        } else {
-            prev?.annotatingDidChange = annotatingDidChange
         }
     }
 }

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -27,7 +27,6 @@ public class DocViewerViewController: UIViewController {
     let toolbar = UIToolbar()
     let toolbarContainer = FlexibleToolbarContainer()
 
-    public var annotatingDidChange: ((Bool) -> Void)?
     var annotationProvider: DocViewerAnnotationProvider?
     let env = AppEnvironment.shared
     public var fallbackURL: URL!
@@ -247,15 +246,6 @@ extension DocViewerViewController: PDFViewControllerDelegate, AnnotationStateMan
 
     public func pdfViewController(_ pdfController: PDFViewController, shouldShow controller: UIViewController, options: [String: Any]? = nil, animated: Bool) -> Bool {
         return !(controller is StampViewController)
-    }
-
-    public func annotationStateManager(
-        _ manager: AnnotationStateManager,
-        didChangeState oldState: Annotation.Tool?,
-        to newState: Annotation.Tool?,
-        variant oldVariant: Annotation.Variant?,
-        to newVariant: Annotation.Variant?) {
-        annotatingDidChange?(newState?.rawValue.isEmpty == false)
     }
     // swiftlint:enable function_parameter_count
 }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -160,11 +160,6 @@ class SpeedGraderViewController: UIViewController, PagesViewControllerDataSource
             index: index,
             assignment: assignment,
             submission: submissions.all[index],
-            isPagingEnabled: Binding(get: { [weak self] in
-                self?.pages.scrollView.isScrollEnabled ?? false
-            }, set: { [weak self] newValue in
-                self?.pages.scrollView.isScrollEnabled = newValue
-            }),
             handleRefresh: { [weak self] in
                 self?.submissions.refresh(force: true)
             }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -29,8 +29,6 @@ struct SubmissionGrader: View {
 
     @ObservedObject var attempts: Store<LocalUseCase<Submission>>
 
-    @Binding var isPagingEnabled: Bool
-
     @State var attempt: Int?
     @State var drawerState: DrawerState = .min
     @State var fileID: String?
@@ -48,7 +46,6 @@ struct SubmissionGrader: View {
         index: Int,
         assignment: Assignment,
         submission: Submission,
-        isPagingEnabled: Binding<Bool>,
         handleRefresh: (() -> Void)?
     ) {
         self.index = index
@@ -62,7 +59,6 @@ struct SubmissionGrader: View {
             ]),
             orderBy: #keyPath(Submission.attempt)
         ))
-        self._isPagingEnabled = isPagingEnabled
         self.handleRefresh = handleRefresh
     }
 
@@ -90,7 +86,6 @@ struct SubmissionGrader: View {
                                         assignment: assignment,
                                         submission: selected,
                                         fileID: fileID,
-                                        isPagingEnabled: $isPagingEnabled,
                                         handleRefresh: handleRefresh
                                     )
                                 }
@@ -124,7 +119,6 @@ struct SubmissionGrader: View {
                                     assignment: assignment,
                                     submission: selected,
                                     fileID: fileID,
-                                    isPagingEnabled: $isPagingEnabled,
                                     handleRefresh: handleRefresh
                                 )
                             }
@@ -178,7 +172,6 @@ struct SubmissionGrader: View {
                         fileID = nil
                     }
                     showAttempts = false
-                    isPagingEnabled = true
                 }), label: Text(verbatim: "")) {
                     ForEach(attempts.all, id: \.attempt) { attempt in
                         Text(attempt.submittedAt?.dateTimeString ?? "")

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
@@ -23,7 +23,6 @@ struct SubmissionViewer: View {
     let assignment: Assignment
     let submission: Submission
     let fileID: String?
-    @Binding var isPagingEnabled: Bool
     var handleRefresh: (() -> Void)?
 
     @Environment(\.appEnvironment) var env
@@ -49,9 +48,7 @@ struct SubmissionViewer: View {
             let file = submission.attachments?.first { fileID == $0.id } ??
                 submission.attachments?.sorted(by: File.idCompare).first
             if let file = file, let url = file.url, let previewURL = file.previewURL {
-                DocViewer(filename: file.filename, previewURL: previewURL, fallbackURL: url) {
-                    isPagingEnabled = !$0
-                }
+                DocViewer(filename: file.filename, previewURL: previewURL, fallbackURL: url)
             } else if let id = file?.id {
                 FileViewer(fileID: id)
             }


### PR DESCRIPTION
refs: MBL-15230
affects: Teacher
release note: Fixed SpeedGrader not scrolling to next submission while an annotation button is active.

test plan:
- Launch the app on an iPad in landscape mode
- Enter SpeedGrader
- Select an annotation type, pen for example
- Try to scroll to the next submission by initiating the scroll from the right grade panel