### PR TITLE
Add a11y announcement on successful reply post. Scroll discussion view to the new reply after posting.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,8 @@
 		B1F614AE243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F614AD243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift */; };
 		B1F6D6BA22EB675000CDD44D /* SessionDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */; };
 		CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */; };
+		CF22C94325F2874A00C2E012 /* UIAccessibilityAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */; };
+		CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */; };
 		CF326B352563D4D3005ABAAA /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF326B342563D4D3005ABAAA /* HelpView.swift */; };
 		CF4E5E9025BAF91F008609C5 /* DiscussionHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */; };
 		CF4E5E9925C8455A008609C5 /* NSPredicateExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E5E9825C8455A008609C5 /* NSPredicateExtensionsTests.swift */; };
@@ -1874,6 +1876,8 @@
 		B1F6D6B722EB672500CDD44D /* SessionDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaults.swift; sourceTree = "<group>"; };
 		B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaultsTests.swift; sourceTree = "<group>"; };
 		CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
+		CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncement.swift; sourceTree = "<group>"; };
+		CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncementTests.swift; sourceTree = "<group>"; };
 		CF326B342563D4D3005ABAAA /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionHTMLTests.swift; sourceTree = "<group>"; };
 		CF4E5E9825C8455A008609C5 /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
@@ -2008,6 +2012,7 @@
 		2C964830211E2F1A002C3255 /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				CF22C94125F286E000C2E012 /* Accessibility */,
 				7DB92CA824C5FD4A004A6C16 /* AccountNotifications */,
 				9FBFE6D122412B71002B3796 /* ActAsUser */,
 				3BC3E01B2315A0B300E15C6D /* Analytics */,
@@ -2072,6 +2077,7 @@
 		2C96483B211E2F1A002C3255 /* CoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				CF22C94D25F60FC600C2E012 /* Accessibility */,
 				7D148643230B48F3003944A2 /* AccountNotifications */,
 				7D3A1EED227BEFB20094531E /* ActAsUser */,
 				3BC3E01E2315A2A700E15C6D /* Analytics */,
@@ -3828,6 +3834,22 @@
 			path = ModuleItems;
 			sourceTree = "<group>";
 		};
+		CF22C94125F286E000C2E012 /* Accessibility */ = {
+			isa = PBXGroup;
+			children = (
+				CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */,
+			);
+			path = Accessibility;
+			sourceTree = "<group>";
+		};
+		CF22C94D25F60FC600C2E012 /* Accessibility */ = {
+			isa = PBXGroup;
+			children = (
+				CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */,
+			);
+			path = Accessibility;
+			sourceTree = "<group>";
+		};
 		CF5F602825DBD6EE00E7E0ED /* UIKitSwiftUIBridging */ = {
 			isa = PBXGroup;
 			children = (
@@ -4550,6 +4572,7 @@
 				9FA690F223C7A683009D12D9 /* GetConversationCoursesTests.swift in Sources */,
 				7DE6A7092319B05700A5B796 /* APIErrorReportTests.swift in Sources */,
 				9FD504EA2180BE2900B395BA /* APIFileTests.swift in Sources */,
+				CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */,
 				7D64A979236760A1004EAEDF /* CourseSectionTests.swift in Sources */,
 				3BD364AF225E36FC006CEBD8 /* CalendarEventItemTests.swift in Sources */,
 				3BA9FF752332B05700196A06 /* APIGradingPeriodTests.swift in Sources */,
@@ -5237,6 +5260,7 @@
 				7DA25F8A23F7211E005D2121 /* GetPlannables.swift in Sources */,
 				7DA2602C23F722C2005D2121 /* LoginStartSessionCell.swift in Sources */,
 				7DA2602623F722B3005D2121 /* LogEventListPresenter.swift in Sources */,
+				CF22C94325F2874A00C2E012 /* UIAccessibilityAnnouncement.swift in Sources */,
 				7DA25FCF23F72136005D2121 /* APITab.swift in Sources */,
 				7DA260D523F72359005D2121 /* DynamicLabel.swift in Sources */,
 				7D4F44FF241BFCF300233B92 /* Conference.swift in Sources */,

--- a/Core/Core/Accessibility/UIAccessibilityAnnouncement.swift
+++ b/Core/Core/Accessibility/UIAccessibilityAnnouncement.swift
@@ -1,0 +1,70 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public extension UIAccessibility {
+
+    /**
+     Announces the received string via VoiceOver. If the announcement is interrupted by anything this method will retry until the announcement succeeds.
+     Doesn't support queueing so if an announcement is already in progress and this method is invoked, then this method will return without doing anything.
+     - parameters:
+        - announcement: The string to be read by VoiceOver.
+        - announcementHandler: This parameter is only used for testing purposes, use its default value otherwise.
+        - isVoiceOverRunning: This parameter is only used for testing purposes, use its default value otherwise.
+     */
+    static func announce(_ announcement: String,
+                         announcementHandler: @escaping (UIAccessibility.Notification, Any?) -> Void = UIAccessibility.post(notification:argument:),
+                         isVoiceOverRunning: () -> Bool = UIAccessibility.isVoiceOverRunning) {
+        guard isVoiceOverRunning(), _announcementHandler == nil else { return }
+        _announcementHandler = announcementHandler
+        observeAnnouncementFinishedNofitication(announcement)
+        _announcementHandler?(.announcement, announcement)
+    }
+
+    /**
+     This is a helper method for testing purposes. The reason behind is that you can't pass around a reference of a method getter only of a function, so we wrap the UIAccessibility.isVoiceOverRunning property into a function and use this to mock the value of this property while testing the `announce` method.
+     */
+    static func isVoiceOverRunning() -> Bool {
+        UIAccessibility.isVoiceOverRunning
+    }
+
+    private static func observeAnnouncementFinishedNofitication(_ announcement: String) {
+        guard _announcementFinishedObserver == nil else { return }
+        _announcementFinishedObserver = NotificationCenter.default.addObserver(forName: announcementDidFinishNotification, object: nil, queue: .main) { notification in
+            guard
+                let announced = notification.userInfo?[announcementStringValueUserInfoKey] as? String,
+                let isSuccessful = notification.userInfo?[announcementWasSuccessfulUserInfoKey] as? Bool,
+                announced == announcement
+            else {
+                return
+            }
+
+            if isSuccessful {
+                if let announcementFinishedObserver = _announcementFinishedObserver {
+                    NotificationCenter.default.removeObserver(announcementFinishedObserver)
+                }
+                _announcementFinishedObserver = nil
+                _announcementHandler = nil
+            } else {
+                _announcementHandler?(.announcement, announcement)
+            }
+        }
+    }
+}
+
+private var _announcementFinishedObserver: Any?
+private var _announcementHandler: ((UIAccessibility.Notification, Any?) -> Void)?

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -405,8 +405,11 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
 
     private func findNewReplyFromCurrentUser() {
         let firstInsertedMessageIndex: Int? = {
+            let currentDate = Date()
             for change in entries.changes {
-                if case .insertRow(let insertIndex) = change {
+                if case .insertRow(let insertIndex) = change,
+                   let entryDate = entries[insertIndex]?.createdAt,
+                   currentDate.timeIntervalSince(entryDate) < 5 { // We check the date because pull-to-refresh and TTL expiration also cause insert type context changes.
                     return insertIndex.row
                 }
             }
@@ -479,11 +482,13 @@ extension DiscussionDetailsViewController: CoreWebViewLinkDelegate {
             return true
         }
         let path = Array(url.pathComponents.dropFirst(5))
+        // Reply to main discussion
         if path.count == 1, path[0] == "reply" {
             Analytics.shared.logEvent(isAnnouncement ? "announcement_replied" : "discussion_topic_replied")
             env.router.route(to: url, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             return true
         }
+        // Reply to thread
         if path.count == 3, path[0] == "entries", !path[1].isEmpty, path[2] == "replies" {
             env.router.route(to: url, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             return true

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -52,7 +52,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
     var showEntryID: String?
     var showRepliesToEntryID: String?
     var topicID = ""
-    private(set) var newReplyIDFromCurrentUser: String?
+    private var newReplyIDFromCurrentUser: String?
 
     var assignment: Store<GetAssignment>?
     lazy var colors = env.subscribe(GetCustomColors()) { [weak self] in
@@ -62,7 +62,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         self?.updateNavBar()
     }
     lazy var entries = env.subscribe(GetDiscussionView(context: context, topicID: topicID)) { [weak self] in
-        self?.findNewReplyFromCurrentUser()
+        self?.newReplyIDFromCurrentUser = self?.findNewReplyIDFromCurrentUser()
         self?.update()
     }
     lazy var group = env.subscribe(GetGroup(groupID: context.id)) { [weak self] in
@@ -403,7 +403,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         scrollViewDidScroll(scrollView) // read initial
     }
 
-    private func findNewReplyFromCurrentUser() {
+    func findNewReplyIDFromCurrentUser() -> String? {
         let firstInsertedMessageIndex: Int? = {
             let currentDate = Date()
             for change in entries.changes {
@@ -420,8 +420,10 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         if let firstInsertedMessageIndex = firstInsertedMessageIndex,
            let currentUserID = env.currentSession?.actAsUserID ?? env.currentSession?.userID,
            entries.all[firstInsertedMessageIndex].userID == currentUserID {
-            newReplyIDFromCurrentUser = entries.all[firstInsertedMessageIndex].id
+            return entries.all[firstInsertedMessageIndex].id
         }
+
+        return nil
     }
 
     private func focusOnNewReplyIfNecessary() {

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -281,7 +281,7 @@ public class DiscussionReplyViewController: UIViewController, ErrorViewControlle
             return
         }
 
-        UIAccessibility.post(notification: .announcement, argument: NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
+        UIAccessibility.announce(NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
         env.router.dismiss(self)
     }
 }

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -281,7 +281,9 @@ public class DiscussionReplyViewController: UIViewController, ErrorViewControlle
             return
         }
 
-        UIAccessibility.announce(NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
+            UIAccessibility.announce(NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
+        }
         env.router.dismiss(self)
     }
 }

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -280,9 +280,10 @@ public class DiscussionReplyViewController: UIViewController, ErrorViewControlle
             showError(error)
             return
         }
+
+        UIAccessibility.post(notification: .announcement, argument: NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
         env.router.dismiss(self)
     }
-
 }
 
 extension DiscussionReplyViewController: FilePickerDelegate, QLPreviewControllerDataSource {

--- a/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
+++ b/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
@@ -1,0 +1,47 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+import XCTest
+
+class UIAccessibilityAnnouncementTests: XCTestCase {
+
+    func testAnnouncementRetryIfInterrupted() {
+        let announcementReceived = expectation(description: "Announcement request received")
+        announcementReceived.expectedFulfillmentCount = 2
+
+        UIAccessibility.announce("Test Announcement", announcementHandler: { notificationType, announcementString in
+            announcementReceived.fulfill()
+            XCTAssertEqual(notificationType, .announcement)
+            XCTAssertEqual(announcementString as? String, "Test Announcement")
+        }, isVoiceOverRunning: {
+            true
+        })
+
+        // Simulate that announcement gets interrupted by a system sound, this should trigger a retry
+        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: false])
+
+        // Simulate that announcement was successfully announced
+        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: true])
+
+        // After successful announcement no more retries should occur
+        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: false])
+
+        wait(for: [announcementReceived], timeout: 1)
+    }
+}

--- a/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
+++ b/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
@@ -34,14 +34,22 @@ class UIAccessibilityAnnouncementTests: XCTestCase {
         })
 
         // Simulate that announcement gets interrupted by a system sound, this should trigger a retry
-        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: false])
+        postAnnouncementNotification(isSuccessful: false)
 
         // Simulate that announcement was successfully announced
-        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: true])
+        postAnnouncementNotification(isSuccessful: true)
 
         // After successful announcement no more retries should occur
-        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: [UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement", UIAccessibility.announcementWasSuccessfulUserInfoKey: false])
+        postAnnouncementNotification(isSuccessful: false)
 
         wait(for: [announcementReceived], timeout: 1)
+    }
+
+    private func postAnnouncementNotification(isSuccessful: Bool) {
+        let userInfo: [String : Any] = [
+            UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement",
+            UIAccessibility.announcementWasSuccessfulUserInfoKey: isSuccessful,
+        ]
+        NotificationCenter.default.post(name: UIAccessibility.announcementDidFinishNotification, object: nil, userInfo: userInfo)
     }
 }

--- a/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
+++ b/Core/CoreTests/Accessibility/UIAccessibilityAnnouncementTests.swift
@@ -46,7 +46,7 @@ class UIAccessibilityAnnouncementTests: XCTestCase {
     }
 
     private func postAnnouncementNotification(isSuccessful: Bool) {
-        let userInfo: [String : Any] = [
+        let userInfo: [String: Any] = [
             UIAccessibility.announcementStringValueUserInfoKey: "Test Announcement",
             UIAccessibility.announcementWasSuccessfulUserInfoKey: isSuccessful,
         ]

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -431,9 +431,9 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
             parentEntry.replies.append(newEntry)
         }
 
-        waitUntil(1) { controller.newReplyIDFromCurrentUser == "5" }
+        waitUntil(2) { controller.newReplyIDFromCurrentUser == "5" }
         waitForWebView()
-        waitUntil(1) { controller.newReplyIDFromCurrentUser == nil }
+        waitUntil(2) { controller.newReplyIDFromCurrentUser == nil }
     }
 
     func testDoesntDetectOldReplyFromUser() {

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -418,42 +418,43 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
 
     func testDetectsNewReplyFromUser() {
         controller.view.layoutIfNeeded()
-        controller.viewWillAppear(false)
 
-        XCTAssertNil(controller.newReplyIDFromCurrentUser)
+        let newDiscussionNotification = expectation(description: "New discussion detected")
+        controller.entries.eventHandler = { [weak self] in
+            XCTAssertEqual(self?.controller.findNewReplyIDFromCurrentUser(), "5")
+            newDiscussionNotification.fulfill()
+        }
 
         // Simulate reply to thread, this will generate a context change of 1 insert and 1 update
         databaseClient.performAndWait {
-            let newAPIEntry = APIDiscussionEntry.make(id: 5, user_id: 1, parent_id: 1, message: "New reply from the current user")
+            let newAPIEntry = APIDiscussionEntry.make(id: 5, user_id: 1, parent_id: 1, created_at: Date(), message: "New reply from the current user")
 
             let parentEntry: DiscussionEntry = databaseClient.first(where: #keyPath(DiscussionEntry.id), equals: "1")!
             let newEntry = DiscussionEntry.save(newAPIEntry, topicID: "1", parent: parentEntry, unreadIDs: nil, forcedIDs: nil, entryRatings: nil, in: databaseClient)
             parentEntry.replies.append(newEntry)
         }
 
-        waitUntil(2) { controller.newReplyIDFromCurrentUser == "5" }
-        waitForWebView()
-        waitUntil(2) { controller.newReplyIDFromCurrentUser == nil }
+        wait(for: [newDiscussionNotification], timeout: 1)
     }
 
     func testDoesntDetectOldReplyFromUser() {
         controller.view.layoutIfNeeded()
-        controller.viewWillAppear(false)
 
-        XCTAssertNil(controller.newReplyIDFromCurrentUser)
+        let newDiscussionNotification = expectation(description: "New discussion detected")
+        controller.entries.eventHandler = { [weak self] in
+            XCTAssertNil(self?.controller.findNewReplyIDFromCurrentUser())
+            newDiscussionNotification.fulfill()
+        }
 
         // Simulate reply to thread, this will generate a context change of 1 insert and 1 update
         databaseClient.performAndWait {
-            let newAPIEntry = APIDiscussionEntry.make(id: 5, user_id: 1, parent_id: 1, created_at: Date().addSeconds(-6), message: "New reply from the current user")
+            let newAPIEntry = APIDiscussionEntry.make(id: 5, user_id: 1, parent_id: 1, created_at: Date().addSeconds(-6), message: "Old reply from the current user")
 
             let parentEntry: DiscussionEntry = databaseClient.first(where: #keyPath(DiscussionEntry.id), equals: "1")!
             let newEntry = DiscussionEntry.save(newAPIEntry, topicID: "1", parent: parentEntry, unreadIDs: nil, forcedIDs: nil, entryRatings: nil, in: databaseClient)
             parentEntry.replies.append(newEntry)
         }
 
-        RunLoop.current.run(until: Date() + 0.1) // Wait until CoreData notification reaches the view
-        XCTAssertNil(controller.newReplyIDFromCurrentUser)
-        waitForWebView()
-        XCTAssertNil(controller.newReplyIDFromCurrentUser)
+        wait(for: [newDiscussionNotification], timeout: 1)
     }
 }


### PR DESCRIPTION
refs: MBL-15074
affects: Teacher, Student
release note: Discussion screen now scrolls to your new reply if you add one.

test plan:
- Add a new reply to a discussion with VoiceOver enabled.
- App should announce "reply sent" on successful posting.
- Discussion list should scroll to the new reply.