### PR TITLE
MBL-15253 Fix group submission file not appearing

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -417,8 +417,8 @@
         <relationship name="discussionEntry" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DiscussionEntry" inverseName="attachment" inverseEntity="DiscussionEntry"/>
         <relationship name="discussionTopic" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DiscussionTopic" inverseName="attachments" inverseEntity="DiscussionTopic"/>
         <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="FolderItem" inverseName="file" inverseEntity="FolderItem"/>
-        <relationship name="submission" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Submission" inverseName="attachments" inverseEntity="Submission"/>
         <relationship name="submissionComment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SubmissionComment" inverseName="attachments" inverseEntity="SubmissionComment"/>
+        <relationship name="submissions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Submission" inverseName="attachments" inverseEntity="Submission"/>
         <relationship name="usageRights" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UsageRights" inverseName="file" inverseEntity="UsageRights"/>
     </entity>
     <entity name="Folder" representedClassName="Core.Folder" syncable="YES">
@@ -816,7 +816,7 @@
         <attribute name="userID" optional="YES" attributeType="String"/>
         <attribute name="workflowStateRaw" attributeType="String"/>
         <relationship name="assignment" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Assignment" inverseName="submissions" inverseEntity="Assignment"/>
-        <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="File" inverseName="submission" inverseEntity="File"/>
+        <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="File" inverseName="submissions" inverseEntity="File"/>
         <relationship name="discussionEntries" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="DiscussionEntry" inverseName="submission" inverseEntity="DiscussionEntry"/>
         <relationship name="enrollments" toMany="YES" deletionRule="Nullify" destinationEntity="Enrollment" inverseName="submissions" inverseEntity="Enrollment"/>
         <relationship name="list" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="SubmissionList" inverseName="submissionsRaw" inverseEntity="SubmissionList"/>

--- a/Core/Core/Files/File.swift
+++ b/Core/Core/Files/File.swift
@@ -66,7 +66,8 @@ final public class File: NSManagedObject {
     @NSManaged public var previewURL: URL?
     @NSManaged public var localFileURL: URL?
     @NSManaged public var discussionTopic: DiscussionTopic?
-    @NSManaged public var submission: Submission?
+    /** In case of a group assignment multiple students can have the same file submitted. */
+    @NSManaged public var submissions: Set<Submission>?
     @NSManaged public var uploadError: String?
     @NSManaged public var bytesSent: Int
     @NSManaged public var taskID: String?

--- a/Core/CoreTests/Files/FileTests.swift
+++ b/Core/CoreTests/Files/FileTests.swift
@@ -86,5 +86,9 @@ class FileTests: CoreTestCase {
 
         XCTAssertNotNil(submission1.attachments?.first)
         XCTAssertNotNil(submission2.attachments?.first)
+
+        databaseClient.delete(submission1)
+        try? databaseClient.save()
+        XCTAssertNotNil(submission2.attachments?.first)
     }
 }

--- a/Core/CoreTests/Files/FileTests.swift
+++ b/Core/CoreTests/Files/FileTests.swift
@@ -75,4 +75,16 @@ class FileTests: CoreTestCase {
         XCTAssertNil(file.courseID)
         XCTAssertNil(file.assignmentID)
     }
+
+    func testOneFileToMultipleSubmissions() {
+        let apiFile = APIFile.make()
+        let apiSubmission1 = APISubmission.make(assignment_id: "1", attachments: [apiFile], attempt: 0, user_id: "1")
+        let apiSubmission2 = APISubmission.make(assignment_id: "1", attachments: [apiFile], attempt: 0, user_id: "2")
+
+        let submission1 = Submission.save(apiSubmission1, in: databaseClient)
+        let submission2 = Submission.save(apiSubmission2, in: databaseClient)
+
+        XCTAssertNotNil(submission1.attachments?.first)
+        XCTAssertNotNil(submission2.attachments?.first)
+    }
 }


### PR DESCRIPTION
refs: MBL-15253
affects: Teacher
release note: Fixed submissions not appearing correctly in SpeedGrader for group assignments with individuals grades option turned on.

test plan: See second part of the ticket.