### PR TITLE
MBL-15253 Fix group submission display

### DIFF
--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -33,8 +33,7 @@ public struct APISubmission: Codable, Equatable {
     var grade: String?
     var graded_at: Date?
     let grade_matches_current_submission: Bool
-    let group_id: ID?
-    let group_name: String?
+    let group: APISubmissionGroup?
     let id: ID
     let late: Bool?
     let late_policy_status: LatePolicyStatus?
@@ -54,6 +53,11 @@ public struct APISubmission: Codable, Equatable {
     var user: APIUser? // include[]=user
     let user_id: ID
     let workflow_state: SubmissionWorkflowState
+}
+
+public struct APISubmissionGroup: Codable, Equatable {
+    let id: ID?
+    let name: String?
 }
 
 // https://canvas.instructure.com/doc/api/submissions.html#SubmissionComment
@@ -147,8 +151,7 @@ extension APISubmission {
         grade: String? = nil,
         graded_at: Date? = nil,
         grade_matches_current_submission: Bool = true,
-        group_id: String? = nil,
-        group_name: String? = nil,
+        group: APISubmissionGroup? = nil,
         id: String = "1",
         late: Bool = false,
         late_policy_status: LatePolicyStatus? = nil,
@@ -183,8 +186,7 @@ extension APISubmission {
             grade: grade,
             graded_at: graded_at,
             grade_matches_current_submission: grade_matches_current_submission,
-            group_id: ID(group_id),
-            group_name: group_name,
+            group: group,
             id: ID(id),
             late: late,
             late_policy_status: late_policy_status,

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -148,8 +148,8 @@ extension Submission: WriteableModel {
         model.grade = item.grade
         model.gradedAt = item.graded_at
         model.gradeMatchesCurrentSubmission = item.grade_matches_current_submission
-        model.groupID = item.group_id?.value
-        model.groupName = item.group_name
+        model.groupID = item.group?.id?.value
+        model.groupName = item.group?.name
         model.id = item.id.value
         model.late = item.late == true
         model.latePolicyStatus = item.late_policy_status
@@ -158,7 +158,7 @@ extension Submission: WriteableModel {
         model.postedAt = item.posted_at
         model.previewUrl = item.preview_url
         model.score = item.score
-        model.sortableName = item.group_name ?? item.user?.sortable_name
+        model.sortableName = item.group?.name ?? item.user?.sortable_name
         model.submittedAt = item.submitted_at
         model.type = item.submission_type
         model.url = item.url

--- a/Core/CoreTests/Submissions/APISubmissionTests.swift
+++ b/Core/CoreTests/Submissions/APISubmissionTests.swift
@@ -136,4 +136,24 @@ class APISubmissionTests: CoreTestCase {
         )
         XCTAssertEqual(turnItInData.rawValue["submission_1"]?.status, "scored")
     }
+
+    func testSubmissionGroupDecode() {
+        let json = """
+            {
+                "id": "28302",
+                "assignment_id": "6799",
+                "grade_matches_current_submission": true,
+                "group": {
+                    "id": "284",
+                    "name": "Assignment 2"
+                },
+                "user_id": "12166",
+                "workflow_state": "submitted"
+            }
+        """
+
+        let testee = try? JSONDecoder().decode(APISubmission.self, from: json.data(using: .utf8)!)
+        XCTAssertEqual(testee?.group?.id?.value, "284")
+        XCTAssertEqual(testee?.group?.name, "Assignment 2")
+    }
 }

--- a/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
+++ b/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
@@ -91,6 +91,7 @@
 		B1992AAB2264D51200396A1F /* RoutesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1992AAA2264D51200396A1F /* RoutesTests.swift */; };
 		B1A5CDE62395836600BEA196 /* CanvasCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 497CA7321F82ACF400501613 /* CanvasCore.framework */; };
 		B1FF02D2240435B0004B7B1C /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FF02D1240435B0004B7B1C /* KeychainTests.swift */; };
+		CF56B71525F68CD3000DD32F /* SubmissionHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF56B71425F68CD3000DD32F /* SubmissionHeaderTests.swift */; };
 		D9DE56CB255030C800CF8B22 /* TeacherSyllabusTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9DE56CA255030C800CF8B22 /* TeacherSyllabusTabViewController.swift */; };
 		D9DE56ED255540C900CF8B22 /* TeacherSyllabusTabViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9DE56EC255540C900CF8B22 /* TeacherSyllabusTabViewController.swift */; };
 		E129D94B90ECDAF88591F8AC /* Pods_needs_pspdfkit_TeacherE2ETests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18305F11CBA93E3509A535AA /* Pods_needs_pspdfkit_TeacherE2ETests.framework */; };
@@ -483,6 +484,7 @@
 		B17E1DB4238DA8550022EE0E /* SpeedGraderUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderUITests.swift; sourceTree = "<group>"; };
 		B1992AAA2264D51200396A1F /* RoutesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutesTests.swift; sourceTree = "<group>"; };
 		B1FF02D1240435B0004B7B1C /* KeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainTests.swift; sourceTree = "<group>"; };
+		CF56B71425F68CD3000DD32F /* SubmissionHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionHeaderTests.swift; sourceTree = "<group>"; };
 		D063D27A1B3640208ABF74D4 /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
 		D082A88269C8C11CA67734AC /* Pods-needs-pspdfkit-TeacherUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-TeacherUITests.release.xcconfig"; path = "../../../Pods/Target Support Files/Pods-needs-pspdfkit-TeacherUITests/Pods-needs-pspdfkit-TeacherUITests.release.xcconfig"; sourceTree = "<group>"; };
 		D9DE56CA255030C800CF8B22 /* TeacherSyllabusTabViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherSyllabusTabViewController.swift; sourceTree = "<group>"; };
@@ -675,6 +677,7 @@
 			isa = PBXGroup;
 			children = (
 				7DE062A525126E4D00DB49D4 /* SpeedGraderViewControllerTests.swift */,
+				CF56B71425F68CD3000DD32F /* SubmissionHeaderTests.swift */,
 			);
 			path = SpeedGrader;
 			sourceTree = "<group>";
@@ -1562,6 +1565,7 @@
 				7D3DC0C7252432DD00B0EBC1 /* SubmissionFilterPickerViewControllerTests.swift in Sources */,
 				7D64A98123676E36004EAEDF /* RollCallSessionTests.swift in Sources */,
 				7D64A96D23626C22004EAEDF /* StatusCellTests.swift in Sources */,
+				CF56B71525F68CD3000DD32F /* SubmissionHeaderTests.swift in Sources */,
 				7D64A983236796CC004EAEDF /* AttendanceStatusControllerTests.swift in Sources */,
 				D9DE56ED255540C900CF8B22 /* TeacherSyllabusTabViewController.swift in Sources */,
 				7D64A96F23626F52004EAEDF /* StatusTests.swift in Sources */,

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -27,7 +27,7 @@ struct SubmissionHeader: View {
     @Environment(\.viewController) var controller
 
     var isGroupSubmission: Bool { !assignment.gradedIndividually && assignment.assignmentGroupID != nil }
-    var groupName: String? { isGroupSubmission ? assignment.name : nil }
+    var groupName: String? { isGroupSubmission ? assignment.name : nil } // TODO: Should be the name of the group instead of the assignment
     var routeToSubmitter: String? {
         if isGroupSubmission {
             return nil

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -27,6 +27,7 @@ struct SubmissionHeader: View {
     @Environment(\.viewController) var controller
 
     var isGroupSubmission: Bool { assignment.assignmentGroupID != nil }
+    var groupName: String? { submission.groupName }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -68,7 +69,7 @@ struct SubmissionHeader: View {
     @ViewBuilder var avatar: some View {
         if assignment.anonymizeStudents {
             Avatar.Anonymous(isGroup: isGroupSubmission)
-        } else if let name = submission.groupName {
+        } else if let name = groupName {
             Avatar(name: name, url: nil)
         } else {
             Avatar(name: submission.user?.name, url: submission.user?.avatarURL)
@@ -79,7 +80,7 @@ struct SubmissionHeader: View {
         if assignment.anonymizeStudents {
             return isGroupSubmission ? Text("Group") : Text("Student")
         }
-        return Text(submission.groupName ?? submission.user.flatMap {
+        return Text(groupName ?? submission.user.flatMap {
             User.displayName($0.name, pronouns: $0.pronouns)
         } ?? "")
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -26,6 +26,8 @@ struct SubmissionHeader: View {
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
+    private(set) var isGroupSubmission: Bool { submission.groupID != nil }
+
     var body: some View {
         HStack(spacing: 0) {
             Button(action: navigateToSubmitter, label: {
@@ -65,7 +67,7 @@ struct SubmissionHeader: View {
 
     @ViewBuilder var avatar: some View {
         if assignment.anonymizeStudents {
-            Avatar.Anonymous(isGroup: submission.groupID != nil)
+            Avatar.Anonymous(isGroup: isGroupSubmission)
         } else if let name = submission.groupName {
             Avatar(name: name, url: nil)
         } else {
@@ -75,7 +77,7 @@ struct SubmissionHeader: View {
 
     var nameText: Text {
         if assignment.anonymizeStudents {
-            return submission.groupID != nil ? Text("Group") : Text("Student")
+            return isGroupSubmission ? Text("Group") : Text("Student")
         }
         return Text(submission.groupName ?? submission.user.flatMap {
             User.displayName($0.name, pronouns: $0.pronouns)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -27,7 +27,7 @@ struct SubmissionHeader: View {
     @Environment(\.viewController) var controller
 
     var isGroupSubmission: Bool { !assignment.gradedIndividually && assignment.assignmentGroupID != nil }
-    var groupName: String? { isGroupSubmission ? assignment.name : nil } // TODO: Should be the name of the group instead of the assignment
+    var groupName: String? { isGroupSubmission ? submission.groupName : nil }
     var routeToSubmitter: String? {
         if isGroupSubmission {
             return nil

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -26,10 +26,15 @@ struct SubmissionHeader: View {
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
-    var isGroupSubmission: Bool { assignment.assignmentGroupID != nil }
+    var isGroupSubmission: Bool { !assignment.gradedIndividually && assignment.assignmentGroupID != nil }
     var groupName: String? { isGroupSubmission ? assignment.name : nil }
-    var routeToSubmitter: String { assignment.assignmentGroupID.flatMap { "/groups/\($0)/users" } ??
-        "/courses/\(assignment.courseID)/users/\(submission.userID)" } // TODO group route leads to 404
+    var routeToSubmitter: String {
+        if isGroupSubmission {
+            return assignment.assignmentGroupID.flatMap { "/groups/\($0)/users" } ?? ""// TODO group route leads to 404
+        } else {
+            return "/courses/\(assignment.courseID)/users/\(submission.userID)"
+        }
+    }
 
     var body: some View {
         HStack(spacing: 0) {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -76,8 +76,8 @@ struct SubmissionHeader: View {
     @ViewBuilder var avatar: some View {
         if assignment.anonymizeStudents {
             Avatar.Anonymous(isGroup: isGroupSubmission)
-        } else if let name = groupName {
-            Avatar(name: name, url: nil)
+        } else if isGroupSubmission {
+            Avatar.Anonymous(isGroup: true)
         } else {
             Avatar(name: submission.user?.name, url: submission.user?.avatarURL)
         }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -28,9 +28,9 @@ struct SubmissionHeader: View {
 
     var isGroupSubmission: Bool { !assignment.gradedIndividually && assignment.assignmentGroupID != nil }
     var groupName: String? { isGroupSubmission ? assignment.name : nil }
-    var routeToSubmitter: String {
+    var routeToSubmitter: String? {
         if isGroupSubmission {
-            return assignment.assignmentGroupID.flatMap { "/groups/\($0)/users" } ?? ""// TODO group route leads to 404
+            return nil
         } else {
             return "/courses/\(assignment.courseID)/users/\(submission.userID)"
         }
@@ -93,7 +93,7 @@ struct SubmissionHeader: View {
     }
 
     func navigateToSubmitter() {
-        guard !assignment.anonymizeStudents else { return }
+        guard !assignment.anonymizeStudents, let routeToSubmitter = routeToSubmitter else { return }
         env.router.route(
             to: routeToSubmitter,
             userInfo: [ "courseID": assignment.courseID ],

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -26,7 +26,7 @@ struct SubmissionHeader: View {
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
-    private(set) var isGroupSubmission: Bool { submission.groupID != nil }
+    var isGroupSubmission: Bool { assignment.assignmentGroupID != nil }
 
     var body: some View {
         HStack(spacing: 0) {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -28,6 +28,8 @@ struct SubmissionHeader: View {
 
     var isGroupSubmission: Bool { assignment.assignmentGroupID != nil }
     var groupName: String? { isGroupSubmission ? assignment.name : nil }
+    var routeToSubmitter: String { assignment.assignmentGroupID.flatMap { "/groups/\($0)/users" } ??
+        "/courses/\(assignment.courseID)/users/\(submission.userID)" } // TODO group route leads to 404
 
     var body: some View {
         HStack(spacing: 0) {
@@ -88,8 +90,7 @@ struct SubmissionHeader: View {
     func navigateToSubmitter() {
         guard !assignment.anonymizeStudents else { return }
         env.router.route(
-            to: submission.groupID.flatMap { "/groups/\($0)/users" } ??
-                "/courses/\(assignment.courseID)/users/\(submission.userID)",
+            to: routeToSubmitter,
             userInfo: [ "courseID": assignment.courseID ],
             from: controller,
             options: .modal(embedInNav: true, addDoneButton: true)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -27,7 +27,7 @@ struct SubmissionHeader: View {
     @Environment(\.viewController) var controller
 
     var isGroupSubmission: Bool { assignment.assignmentGroupID != nil }
-    var groupName: String? { submission.groupName }
+    var groupName: String? { isGroupSubmission ? assignment.name : nil }
 
     var body: some View {
         HStack(spacing: 0) {

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -41,4 +41,19 @@ class SubmissionHeaderTests: TeacherTestCase {
         assignment.assignmentGroupID = "TestGroupID"
         XCTAssertEqual(testee.groupName, "TestGroup Name")
     }
+
+    func testRouteToSubmitter() {
+        let submission = Submission(context: databaseClient)
+        let assignment = Assignment(context: databaseClient)
+
+        let testee = SubmissionHeader(assignment: assignment, submission: submission)
+
+        assignment.assignmentGroupID = "TestGroupID"
+        XCTAssertEqual(testee.routeToSubmitter, "/groups/TestGroupID/users")
+
+        assignment.assignmentGroupID = nil
+        assignment.courseID = "testCourseID"
+        submission.userID = "testUserID"
+        XCTAssertEqual(testee.routeToSubmitter, "/courses/testCourseID/users/testUserID")
+    }
 }

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -54,7 +54,7 @@ class SubmissionHeaderTests: TeacherTestCase {
         assignment.assignmentGroupID = "TestGroupID"
         assignment.courseID = "testCourseID"
         submission.userID = "testUserID"
-        XCTAssertEqual(testee.routeToSubmitter, "/groups/TestGroupID/users")
+        XCTAssertNil(testee.routeToSubmitter)
     }
 
     func testRouteToIndividialInGroupSubmission() {

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -1,0 +1,33 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+@testable import Teacher
+import XCTest
+
+class SubmissionHeaderTests: TeacherTestCase {
+
+    func testGroupSubmissionCheck() {
+        let submission = Submission(context: databaseClient)
+        let assignment = Assignment(context: databaseClient)
+        assignment.assignmentGroupID = "TestGroupID"
+
+        let testee = SubmissionHeader(assignment: assignment, submission: submission)
+        XCTAssertTrue(testee.isGroupSubmission)
+    }
+}

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -30,4 +30,15 @@ class SubmissionHeaderTests: TeacherTestCase {
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
         XCTAssertTrue(testee.isGroupSubmission)
     }
+
+    func testGroupName() {
+        let submission = Submission(context: databaseClient)
+        let assignment = Assignment(context: databaseClient)
+        let testee = SubmissionHeader(assignment: assignment, submission: submission)
+
+        assignment.name = "TestGroup Name"
+        XCTAssertEqual(testee.groupName, nil)
+        assignment.assignmentGroupID = "TestGroupID"
+        XCTAssertEqual(testee.groupName, "TestGroup Name")
+    }
 }

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -38,7 +38,7 @@ class SubmissionHeaderTests: TeacherTestCase {
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
 
         assignment.gradedIndividually = false
-        assignment.name = "TestGroup Name"
+        submission.groupName = "TestGroup Name"
         XCTAssertEqual(testee.groupName, nil)
         assignment.assignmentGroupID = "TestGroupID"
         XCTAssertEqual(testee.groupName, "TestGroup Name")

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -26,6 +26,7 @@ class SubmissionHeaderTests: TeacherTestCase {
         let submission = Submission(context: databaseClient)
         let assignment = Assignment(context: databaseClient)
         assignment.assignmentGroupID = "TestGroupID"
+        assignment.gradedIndividually = false
 
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
         XCTAssertTrue(testee.isGroupSubmission)
@@ -36,22 +37,34 @@ class SubmissionHeaderTests: TeacherTestCase {
         let assignment = Assignment(context: databaseClient)
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
 
+        assignment.gradedIndividually = false
         assignment.name = "TestGroup Name"
         XCTAssertEqual(testee.groupName, nil)
         assignment.assignmentGroupID = "TestGroupID"
         XCTAssertEqual(testee.groupName, "TestGroup Name")
     }
 
-    func testRouteToSubmitter() {
+    func testRouteToGroupSubmitter() {
         let submission = Submission(context: databaseClient)
         let assignment = Assignment(context: databaseClient)
 
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
 
+        assignment.gradedIndividually = false
         assignment.assignmentGroupID = "TestGroupID"
+        assignment.courseID = "testCourseID"
+        submission.userID = "testUserID"
         XCTAssertEqual(testee.routeToSubmitter, "/groups/TestGroupID/users")
+    }
 
-        assignment.assignmentGroupID = nil
+    func testRouteToIndividialInGroupSubmission() {
+        let submission = Submission(context: databaseClient)
+        let assignment = Assignment(context: databaseClient)
+
+        let testee = SubmissionHeader(assignment: assignment, submission: submission)
+
+        assignment.gradedIndividually = true
+        assignment.assignmentGroupID = "TestGroupID"
         assignment.courseID = "testCourseID"
         submission.userID = "testUserID"
         XCTAssertEqual(testee.routeToSubmitter, "/courses/testCourseID/users/testUserID")


### PR DESCRIPTION
refs: MBL-15253
affects: Teacher
release note: Fixed SpeedGrader displaying the submitter's name instead of the group name in case of group submissions.

test plan: See first part of the ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/110642982-dfdf1400-81b3-11eb-8363-4ee5242a7742.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/110642996-e40b3180-81b3-11eb-921a-723ff60120c1.png"></td>
</tr>
</table>