### PR TITLE
Not submitted indication discrepancy

### DIFF
--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -75,7 +75,6 @@ public class GradeCircleView: UIView {
             gradeCircle.color = circleColor
         }
 
-        circleComplete.tintColor = circleColor
         circleComplete.isAccessibilityElement = true
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case
@@ -94,7 +93,10 @@ public class GradeCircleView: UIView {
         let isPassFail = assignment.gradingType == .pass_fail
         circlePoints.isHidden = isPassFail
         circleLabel.isHidden = isPassFail
-        circleComplete.isHidden = isPassFail ? submission.grade == "incomplete" : true
+        let isFail = isPassFail && submission.grade == "incomplete"
+        circleComplete.image = isFail ? .xLine : .checkSolid
+        circleComplete.tintColor = isFail ? .borderLight : circleColor
+        circleComplete.isHidden = !isPassFail
 
         // Update grade circle
         if let score = submission.score, let pointsPossible = assignment.pointsPossible {

--- a/Core/CoreTests/UIViews/GradeCircleViewTests.swift
+++ b/Core/CoreTests/UIViews/GradeCircleViewTests.swift
@@ -60,10 +60,12 @@ class GradeCircleViewTests: XCTestCase {
         XCTAssertTrue(view.circlePoints.isHidden)
         XCTAssertTrue(view.circleLabel.isHidden)
         XCTAssertFalse(view.circleComplete.isHidden)
+        XCTAssertTrue(view.circleComplete.image == UIImage.checkSolid)
 
         a.submission?.grade = "incomplete"
         view.update(a)
-        XCTAssertTrue(view.circleComplete.isHidden)
+        XCTAssertFalse(view.circleComplete.isHidden)
+        XCTAssertTrue(view.circleComplete.image == UIImage.xLine)
     }
 
     func testItShowsCorrectViewsForNonPassFail() {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -268,6 +268,7 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
         return (
             features.first(where: { $0.name == "assignment_attempts" })?.enabled != true ||
             assignment?.allowedAttempts == 0 ||
+            assignment?.allowedAttempts == -1 ||
             assignment?.attemptPossible == false ||
             assignment?.lockStatus == .before ||
             assignment?.submissionTypes.contains(.online_quiz) == true // attempts show up elsewhere

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16087"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -241,6 +242,7 @@
                                                                 </userDefinedRuntimeAttributes>
                                                             </view>
                                                         </subviews>
+                                                        <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.attemptsView"/>
                                                         <constraints>
                                                             <constraint firstItem="nad-l4-oX0" firstAttribute="leading" secondItem="U3Y-Im-VWs" secondAttribute="leading" id="4Ni-oD-Pnm"/>
                                                             <constraint firstAttribute="bottom" secondItem="nad-l4-oX0" secondAttribute="bottom" id="8SQ-3P-5u0"/>

--- a/Student/StudentUITests/Assignments/AssignmentDetailsTests.swift
+++ b/Student/StudentUITests/Assignments/AssignmentDetailsTests.swift
@@ -23,7 +23,7 @@ import XCTest
 
 class AssignmentDetailsTests: CoreUITestCase {
     lazy var course = mock(course: .make())
-    
+
     override func setUp() {
         super.setUp()
         mockBaseRequests()
@@ -295,13 +295,13 @@ class AssignmentDetailsTests: CoreUITestCase {
         XCTAssertEqual(AssignmentDetails.gradeDisplayGrade.label(), "Excused")
         XCTAssertEqual(AssignmentDetails.gradeCircleOutOf.label(), "Out of 100 pts")
     }
-    
+
     func testShowsAnyAttemptsCell() {
         let assignment = mock(assignment: .make(allowed_attempts: 1))
         show("/courses/\(course.id)/assignments/\(assignment.id)")
         XCTAssertTrue(AssignmentDetails.attemptsView.waitToExist().isVisible)
     }
-    
+
     func testHidesUnlimitedAttemptsCell() {
         let assignment = mock(assignment: .make(allowed_attempts: -1))
         show("/courses/\(course.id)/assignments/\(assignment.id)")

--- a/Student/StudentUITests/Assignments/AssignmentDetailsTests.swift
+++ b/Student/StudentUITests/Assignments/AssignmentDetailsTests.swift
@@ -23,10 +23,14 @@ import XCTest
 
 class AssignmentDetailsTests: CoreUITestCase {
     lazy var course = mock(course: .make())
+    
+    override func setUp() {
+        super.setUp()
+        mockBaseRequests()
+    }
 
     func testUnsubmittedUpload() {
         // FLAKY: color cache doesn't always get updated
-        mockBaseRequests()
         mockData(GetCustomColorsRequest(), value: APICustomColors(custom_colors: [
             Context(.course, id: course.id.value).canvasContextID: "#123456",
         ]))
@@ -60,7 +64,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testUnsubmittedDiscussion() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             description: "Say it like you mean it",
             discussion_topic: APIDiscussionTopic.make(
@@ -92,7 +95,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testSubmittedDiscussion() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission: APISubmission.make(
                 discussion_entries: [ APIDiscussionEntry.make(
@@ -110,7 +112,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testResubmitAssignmentButton() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission: APISubmission.make(),
             submission_types: [ .online_upload ]
@@ -120,7 +121,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testSubmitAssignmentButton() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .online_upload ]
         ))
@@ -129,7 +129,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShows() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .none ]
         ))
@@ -139,7 +138,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShowsForNotGraded() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .not_graded ]
         ))
@@ -149,7 +147,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShowsWhenExcused() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission: .make(excused: true),
             submission_types: [.online_text_entry]
@@ -160,7 +157,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoLockSection() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .online_upload ]
         ))
@@ -171,7 +167,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShowsWhenLockAtLessThanNow() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             allowed_extensions: ["png"],
             locked_for_user: true,
@@ -189,7 +184,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShowsWhenUnLockAtGreaterThanNow() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             allowed_extensions: ["png"],
             locked_for_user: true,
@@ -208,7 +202,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testNoSubmitAssignmentButtonShowsUserNotStudentEnrollment() {
-        mockBaseRequests()
         mockData(GetCourseRequest(courseID: course.id.value), value: APICourse.make(enrollments: []))
         let assignment = mock(assignment: .make(
             submission_types: [ .online_upload ]
@@ -219,7 +212,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testTappingSubmitButtonShowsFileUploadOption() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .online_upload, .online_url ]
         ))
@@ -230,7 +222,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testCancelSubmitAction() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .online_upload, .online_url ]
         ))
@@ -241,7 +232,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testGradeCellShowsSubmittedTextWhenNotGraded() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission: APISubmission.make(submission_type: .online_upload, workflow_state: .pending_review)
         ))
@@ -251,7 +241,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testGradeCellShowsDialWhenGraded() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             points_possible: 100,
             submission: APISubmission.make(
@@ -265,7 +254,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testDisplayGradeAs() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             grading_type: .percent,
             points_possible: 10,
@@ -281,7 +269,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testGradeCellShowsLatePenalty() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             due_at: Date(timeIntervalSinceNow: -10000), // less than 1 day should deduct 5 points
             points_possible: 100,
@@ -299,7 +286,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testGradeCellShowsExcused() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             points_possible: 100,
             submission: .make(excused: true)
@@ -309,9 +295,21 @@ class AssignmentDetailsTests: CoreUITestCase {
         XCTAssertEqual(AssignmentDetails.gradeDisplayGrade.label(), "Excused")
         XCTAssertEqual(AssignmentDetails.gradeCircleOutOf.label(), "Out of 100 pts")
     }
+    
+    func testShowsAnyAttemptsCell() {
+        let assignment = mock(assignment: .make(allowed_attempts: 1))
+        show("/courses/\(course.id)/assignments/\(assignment.id)")
+        XCTAssertTrue(AssignmentDetails.attemptsView.waitToExist().isVisible)
+    }
+    
+    func testHidesUnlimitedAttemptsCell() {
+        let assignment = mock(assignment: .make(allowed_attempts: -1))
+        show("/courses/\(course.id)/assignments/\(assignment.id)")
+        AssignmentDetails.name.waitToExist()
+        XCTAssertFalse(AssignmentDetails.attemptsView.exists)
+    }
 
     func testViewSubmissionButtonWorksWithNoSubmission() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             points_possible: 10
         ))
@@ -322,7 +320,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testSubmissionButtonNavigatesToSubmission() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             points_possible: 10,
             submission: APISubmission.make(submission_type: .online_upload, workflow_state: .submitted)
@@ -333,7 +330,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testGradeCellNavigatesToSubmission() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             grading_type: .percent,
             points_possible: 10,
@@ -349,7 +345,6 @@ class AssignmentDetailsTests: CoreUITestCase {
     }
 
     func testSubmitUrlSubmission() {
-        mockBaseRequests()
         let assignment = mock(assignment: .make(
             submission_types: [ .online_url ]
         ))

--- a/TestsFoundation/TestsFoundation/CoreUIElements/Assignments/Assignments.swift
+++ b/TestsFoundation/TestsFoundation/CoreUIElements/Assignments/Assignments.swift
@@ -20,25 +20,26 @@ import XCTest
 
 public enum AssignmentDetails: String, ElementWrapper {
     case allowedExtensions
+    case attemptsView
+    case circleComplete
     case due
+    case fileSubmissionButton
     case gradeCell
     case gradeCircle
-    case circleComplete
     case gradeCircleOutOf
     case gradeDisplayGrade
     case gradeLatePenalty
-    case name
-    case points
-    case status
-    case submissionTypes
-    case submittedText
-    case submitAssignmentButton
-    case viewSubmissionButton
-    case fileSubmissionButton
     case lockIcon
     case lockSection
+    case name
+    case points
     case replyButton // parent
+    case status
+    case submissionTypes
+    case submitAssignmentButton
+    case submittedText
     case viewAllSubmissionsButton // teacher
+    case viewSubmissionButton
 
     public static func description(_ description: String) -> Element {
         return app.find(label: description)

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -520,6 +520,7 @@ open class CoreUITestCase: XCTestCase {
         mockData(GetEnabledFeatureFlagsRequest(context: .course(course.id.value)), value: [
             "rce_enhancements",
             "new_gradebook",
+            "assignment_attempts",
         ])
         mockEncodableRequest("courses/\(course.id)/external_tools?include_parents=true&per_page=100", value: [String]())
         mockEncodableRequest("courses/\(course.id)/external_tools?include_parents=true", value: [String]())


### PR DESCRIPTION
Fix progress circle for incomplete submissions, hide attempts section for unlimited attempts on the assignment details page.

refs: MBL-15081
affects: Student
release note: Fix submission status for incomplete assignments

test plan:
- set up an assignment with the grade display set to complete/incomplete
- set the submission attempts to unlimited
- save and publish the assignment
- in the Student app find the assignment and open its details
- attempts section should not be visible
- after submission and an incomplete grade a gray X and the "Incomplete" should be visible in the grade section