### PR TITLE
Add Grade Slider tap feature

### DIFF
--- a/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
+++ b/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		E8F20FB924BFC27500F82129 /* TodoUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F20FB824BFC27500F82129 /* TodoUITests.swift */; };
 		E8F4B66424EEC912003FBAFD /* ContextCardE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4B66324EEC912003FBAFD /* ContextCardE2ETests.swift */; };
 		E8F4B66624EECA10003FBAFD /* ContextCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4B66524EECA10003FBAFD /* ContextCard.swift */; };
+		EB12071F2601F2C50038E875 /* GradeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB12071E2601F2C50038E875 /* GradeSlider.swift */; };
 		F9FDB9351C9FB4F9CF7E0F94 /* Pods_defaults_Teacher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE78272172F7D235E49A1D77 /* Pods_defaults_Teacher.framework */; };
 /* End PBXBuildFile section */
 
@@ -506,6 +507,7 @@
 		E8F4B66324EEC912003FBAFD /* ContextCardE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCardE2ETests.swift; sourceTree = "<group>"; };
 		E8F4B66524EECA10003FBAFD /* ContextCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCard.swift; sourceTree = "<group>"; };
 		E8F6CFFE23045A01004347D9 /* CoreUITests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		EB12071E2601F2C50038E875 /* GradeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSlider.swift; sourceTree = "<group>"; };
 		EE78272172F7D235E49A1D77 /* Pods_defaults_Teacher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_defaults_Teacher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -658,6 +660,7 @@
 			children = (
 				7D742F442556566F00FD6CF1 /* CommentEditor.swift */,
 				7D7126B02534B980000DEDE4 /* Drawer.swift */,
+				EB12071E2601F2C50038E875 /* GradeSlider.swift */,
 				7D742F372554D01400FD6CF1 /* RubricAssessor.swift */,
 				7D264DC62537A6E1007CDD90 /* SimilarityScore.swift */,
 				7DCA321925423CDF00458651 /* SpeedGraderViewController.swift */,
@@ -1532,6 +1535,7 @@
 				B15CA29D221F16C90014FB02 /* BundleExtensions.swift in Sources */,
 				7D7126C025374446000DEDE4 /* SubmissionGrades.swift in Sources */,
 				7D64A96023620A27004EAEDF /* DatePickerCollectionView.swift in Sources */,
+				EB12071F2601F2C50038E875 /* GradeSlider.swift in Sources */,
 				7D64A95E23620A27004EAEDF /* AttendanceViewController.swift in Sources */,
 				7D264DC72537A6E1007CDD90 /* SimilarityScore.swift in Sources */,
 				61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */,

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -1,0 +1,74 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct GradeSlider: View {
+    var value: Binding<Double>
+    var range: ClosedRange<Double>
+    var showTooltip: Bool
+    var tooltipText: Text
+    var score: Double
+    var possible: Double
+    var onEditingChanged: (Bool) -> Void = { _ in }
+
+    var body: some View {
+        GeometryReader { geometry in
+            Slider(value: value, in: range, onEditingChanged: onEditingChanged)
+                .gesture(DragGesture(minimumDistance: 0).onChanged { changeValue in
+                    let percent = min(max(0, Double(changeValue.location.x / geometry.size.width)), 1)
+                    let newValue = range.lowerBound + round(percent * (range.upperBound - range.lowerBound))
+                    value.wrappedValue = newValue
+                    onEditingChanged(true)
+                }.onEnded { _ in
+                    onEditingChanged(false)
+                })
+                .overlay(!showTooltip ? nil : GeometryReader { geometry in
+                    let x = CGFloat(score / max(possible, 0.01))
+                        * (geometry.size.width - 26) + 13 // center on slider thumb 26 wide
+                    tooltipText
+                        .foregroundColor(.textLightest)
+                        .padding(8)
+                        .background(TooltipBackground().fill(Color.backgroundDarkest))
+                        .position()
+                        .offset(x: x, y: -26)
+                }, alignment: .bottom)
+        }
+    }
+}
+
+struct TooltipBackground: Shape {
+    func path(in rect: CGRect) -> Path { Path { path in
+        let r: CGFloat = 5
+        let arrowHeight: CGFloat = 5
+        let arrowWidth: CGFloat = 10
+        path.move(to: CGPoint(x: r, y: 0)) // top left, almost
+        path.addLine(to: CGPoint(x: rect.maxX - r, y: 0))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: 0), tangent2End: CGPoint(x: rect.maxX, y: r), radius: r)
+        path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - r))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.maxY), tangent2End: CGPoint(x: rect.maxX - r, y: rect.maxY), radius: r)
+        path.addLine(to: CGPoint(x: rect.midX + arrowWidth / 2, y: rect.maxY))
+        path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY + arrowHeight))
+        path.addLine(to: CGPoint(x: rect.midX - arrowWidth / 2, y: rect.maxY))
+        path.addLine(to: CGPoint(x: r, y: rect.maxY))
+        path.addArc(tangent1End: CGPoint(x: 0, y: rect.maxY), tangent2End: CGPoint(x: 0, y: rect.maxY - r), radius: r)
+        path.addLine(to: CGPoint(x: 0, y: r))
+        path.addArc(tangent1End: CGPoint(x: 0, y: 0), tangent2End: CGPoint(x: r, y: 0), radius: r)
+        }
+    }
+}

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -116,7 +116,14 @@ struct SubmissionGrades: View {
                             .padding(.horizontal, 16).padding(.vertical, 12)
                     }
                     if !assignment.useRubricForGrading, assignment.gradingType == .points || assignment.gradingType == .percent {
-                        slider
+                        ZStack {
+                            // disables page swipe around the slider
+                            Rectangle()
+                                .contentShape(Rectangle())
+                                .foregroundColor(.clear)
+                                .gesture(DragGesture(minimumDistance: 0).onChanged {_ in})
+                            slider
+                        }
                     }
 
                     if assignment.rubric?.isEmpty == false {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -119,9 +119,8 @@ struct SubmissionGrades: View {
                         slider
                     }
 
-                    Divider().padding(.horizontal, 16)
-
                     if assignment.rubric?.isEmpty == false {
+                        Divider().padding(.horizontal, 16)
                         RubricAssessor(
                             assignment: assignment,
                             submission: submission,
@@ -167,49 +166,24 @@ struct SubmissionGrades: View {
             sliderExcused ? Text("Excused") :
             assignment.gradingType == .percent ? Text(round(score / max(possible, 0.01) * 100) / 100, number: .percent) :
             Text(round(score))
+
         HStack(spacing: 8) {
-            Text(0)
-
-            Slider(
-                value: Binding(get: { score }, set: sliderChangedValue),
-                in: 0...(assignment.pointsPossible ?? 0),
-                onEditingChanged: sliderChangedState
-            )
-                .overlay(!showTooltip ? nil : GeometryReader { geometry in
-                    let x = CGFloat(score / max(possible, 0.01))
-                        * (geometry.size.width - 26) + 13 // center on slider thumb 26 wide
-                    tooltipText
-                        .foregroundColor(.textLightest)
-                        .padding(8)
-                        .background(TooltipBackground().fill(Color.backgroundDarkest))
-                        .position()
-                        .offset(x: x, y: -26)
-                }, alignment: .bottom)
-
+            VStack {
+                Spacer()
+                Text(0)
+                Spacer()
+            }
+            GradeSlider(value: Binding(get: { score }, set: sliderChangedValue),
+                           range: 0...(assignment.pointsPossible ?? 0),
+                           showTooltip: showTooltip,
+                           tooltipText: tooltipText,
+                           score: score,
+                           possible: possible,
+                           onEditingChanged: sliderChangedState)
             Text(assignment.gradingType == .percent ? 100 : possible)
         }
-            .font(.medium14).foregroundColor(.textDarkest)
-            .padding(.horizontal, 16).padding(.vertical, 12)
-    }
-
-    struct TooltipBackground: Shape {
-        func path(in rect: CGRect) -> Path { Path { path in
-            let r: CGFloat = 5
-            let arrowHeight: CGFloat = 5
-            let arrowWidth: CGFloat = 10
-            path.move(to: CGPoint(x: r, y: 0)) // top left, almost
-            path.addLine(to: CGPoint(x: rect.maxX - r, y: 0))
-            path.addArc(tangent1End: CGPoint(x: rect.maxX, y: 0), tangent2End: CGPoint(x: rect.maxX, y: r), radius: r)
-            path.addLine(to: CGPoint(x: rect.maxX, y: rect.maxY - r))
-            path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.maxY), tangent2End: CGPoint(x: rect.maxX - r, y: rect.maxY), radius: r)
-            path.addLine(to: CGPoint(x: rect.midX + arrowWidth / 2, y: rect.maxY))
-            path.addLine(to: CGPoint(x: rect.midX, y: rect.maxY + arrowHeight))
-            path.addLine(to: CGPoint(x: rect.midX - arrowWidth / 2, y: rect.maxY))
-            path.addLine(to: CGPoint(x: r, y: rect.maxY))
-            path.addArc(tangent1End: CGPoint(x: 0, y: rect.maxY), tangent2End: CGPoint(x: 0, y: rect.maxY - r), radius: r)
-            path.addLine(to: CGPoint(x: 0, y: r))
-            path.addArc(tangent1End: CGPoint(x: 0, y: 0), tangent2End: CGPoint(x: r, y: 0), radius: r)
-        } }
+        .font(.medium14).foregroundColor(.textDarkest)
+        .padding(.horizontal, 16).padding(.vertical, 12)
     }
 
     func sliderChangedState(_ editing: Bool) {


### PR DESCRIPTION
Extract grade slider, make it tappable along the Slider track, align Slider min/max value Texts vertically, only show bottom divider when the rubrics section is available.

refs: MBL-15250
affects: Teacher
release note: Improved Grade Slider
test plan: see ticket