### PR TITLE
Rubric fixes

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -825,6 +825,7 @@
 		CF7C6D9F25E5130200363203 /* GroupContextCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6D9E25E5130200363203 /* GroupContextCardView.swift */; };
 		CF7C6DA325E5139D00363203 /* GroupContextCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6DA225E5139D00363203 /* GroupContextCardViewModel.swift */; };
 		CF7C6DAD25E56A0000363203 /* GroupContextCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6DAC25E56A0000363203 /* GroupContextCardTests.swift */; };
+		CF7CEAEC26035BE500967EA0 /* ChangeObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7CEAEB26035BE500967EA0 /* ChangeObserver.swift */; };
 		CF80134C25B19DF200E5E744 /* SwiftUIExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80134B25B19DF200E5E744 /* SwiftUIExtensionsTests.swift */; };
 		CF80135125B1A03700E5E744 /* GetSubmissionSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */; };
 		CF8ADC562563D96400F3DBA9 /* HelpItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ADC552563D96400F3DBA9 /* HelpItemView.swift */; };
@@ -1888,6 +1889,7 @@
 		CF7C6D9E25E5130200363203 /* GroupContextCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardView.swift; sourceTree = "<group>"; };
 		CF7C6DA225E5139D00363203 /* GroupContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModel.swift; sourceTree = "<group>"; };
 		CF7C6DAC25E56A0000363203 /* GroupContextCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardTests.swift; sourceTree = "<group>"; };
+		CF7CEAEB26035BE500967EA0 /* ChangeObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeObserver.swift; sourceTree = "<group>"; };
 		CF80134B25B19DF200E5E744 /* SwiftUIExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIExtensionsTests.swift; sourceTree = "<group>"; };
 		CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSubmissionSummaryTests.swift; sourceTree = "<group>"; };
 		CF8ADC552563D96400F3DBA9 /* HelpItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpItemView.swift; sourceTree = "<group>"; };
@@ -4022,6 +4024,7 @@
 			children = (
 				CF5F602825DBD6EE00E7E0ED /* UIKitSwiftUIBridging */,
 				7D0A28D925194CE6004FB3B6 /* Avatar.swift */,
+				CF7CEAEB26035BE500967EA0 /* ChangeObserver.swift */,
 				7D7BA23824DB57BD00B1A68B /* CircleProgress.swift */,
 				7D2FA37E255EEC3F00C9552F /* CircleRefresh.swift */,
 				7D89A2C82509326B009D0FD2 /* DisclosureIndicator.swift */,
@@ -5199,6 +5202,7 @@
 				7DA2606C23F722D9005D2121 /* Activity.swift in Sources */,
 				3B4D89272450A8E9004ED120 /* ComposeReplyViewController.swift in Sources */,
 				7DA260F123F72391005D2121 /* FileUploadTarget.swift in Sources */,
+				CF7CEAEC26035BE500967EA0 /* ChangeObserver.swift in Sources */,
 				7DA25F9D23F72136005D2121 /* APIAssignmentGroup.swift in Sources */,
 				7DA2602E23F722C2005D2121 /* LoginStartViewController.swift in Sources */,
 				7DA2606223F722D9005D2121 /* SubmissionComment.swift in Sources */,

--- a/Core/Core/Assignments/APIRubric.swift
+++ b/Core/Core/Assignments/APIRubric.swift
@@ -49,9 +49,10 @@ public typealias APIRubricAssessmentMap = [String: APIRubricAssessment]
 public struct APIRubricAssessment: Codable, Equatable {
     public let comments: String?
     public let points: Double?
+    /** Use empty string to reset a rubric's rating to empty. */
     public let rating_id: String?
 
-    public init(comments: String? = nil, points: Double? = nil, rating_id: String? = nil) {
+    public init(comments: String? = nil, points: Double? = nil, rating_id: String = "") {
         self.comments = comments
         self.points = points
         self.rating_id = rating_id
@@ -101,7 +102,7 @@ extension APIRubricAssessment {
     public static func make(
         comments: String? = "You failed at punctuation!",
         points: Double? = 25.0,
-        rating_id: String? = "1"
+        rating_id: String = "1"
     ) -> APIRubricAssessment {
         return APIRubricAssessment(
             comments: comments,

--- a/Core/Core/Assignments/Rubric.swift
+++ b/Core/Core/Assignments/Rubric.swift
@@ -113,7 +113,7 @@ public final class RubricAssessment: NSManagedObject {
         model.comments = item.comments
         model.id = id
         model.points = item.points
-        model.ratingID = item.rating_id ?? "0"
+        model.ratingID = item.rating_id ?? ""
         model.submissionID = submissionID
         return model
     }

--- a/Core/Core/Submissions/GradeSubmission.swift
+++ b/Core/Core/Submissions/GradeSubmission.swift
@@ -78,7 +78,9 @@ public class GradeSubmission: APIUseCase {
         model.postedAt = item.posted_at
         model.score = item.score
         model.workflowState = item.workflow_state
-        if let rubricAssessmentMap = item.rubric_assessment {
+
+        // The API submission response doesn't include rubrics, so we save what we posted.
+        if let rubricAssessmentMap = rubricAssessment {
             let allPredicate = NSPredicate(format: "%K == %@", #keyPath(RubricAssessment.submissionID), item.id.value)
             let all: [RubricAssessment] = client.fetch(allPredicate)
             client.delete(all)

--- a/Core/Core/SwiftUIViews/ChangeObserver.swift
+++ b/Core/Core/SwiftUIViews/ChangeObserver.swift
@@ -23,6 +23,7 @@ public extension View {
     /**
      iOS 13 implementation of the `onChange` method which is iOS 14 only. On iOS 14 this method directly uses `onChange`.
      */
+    @available(iOS, deprecated: 14.0)
     func onDataChange<Value: Equatable>(of value: Value, perform action: @escaping (_ newValue: Value) -> Void) -> some View {
         SwiftUI.Group {
             if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {

--- a/Core/Core/SwiftUIViews/ChangeObserver.swift
+++ b/Core/Core/SwiftUIViews/ChangeObserver.swift
@@ -1,0 +1,61 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public extension View {
+
+    /**
+     iOS 13 implementation of the `onChange` method which is iOS 14 only. On iOS 14 this method directly uses `onChange`.
+     */
+    func onDataChange<Value: Equatable>(of value: Value, perform action: @escaping (_ newValue: Value) -> Void) -> some View {
+        SwiftUI.Group {
+            if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {
+                self.onChange(of: value, perform: action)
+            } else {
+                ChangeObserver(value: value, action: action) {
+                    self
+                }
+            }
+        }
+    }
+}
+
+private struct ChangeObserver<Content: View, Value: Equatable>: View {
+    let content: Content
+    let value: Value
+    let action: (Value) -> Void
+    @State private var oldValue: Value
+
+    var body: some View {
+        if oldValue != value {
+            DispatchQueue.main.async {
+                oldValue = value
+                self.action(self.value)
+            }
+        }
+        return content
+    }
+
+    init(value: Value, action: @escaping (Value) -> Void, content: @escaping () -> Content) {
+        self.value = value
+        self.action = action
+        self.content = content()
+        _oldValue = State(initialValue: value)
+    }
+}

--- a/Core/Core/SwiftUIViews/ChangeObserver.swift
+++ b/Core/Core/SwiftUIViews/ChangeObserver.swift
@@ -23,7 +23,7 @@ public extension View {
     /**
      iOS 13 implementation of the `onChange` method which is iOS 14 only. On iOS 14 this method directly uses `onChange`.
      */
-    @available(iOS, deprecated: 14.0)
+    @available(iOS, obsoleted: 14.0)
     func onDataChange<Value: Equatable>(of value: Value, perform action: @escaping (_ newValue: Value) -> Void) -> some View {
         SwiftUI.Group {
             if #available(iOS 14.0, macOS 11.0, tvOS 14.0, watchOS 7.0, *) {

--- a/Core/Core/SwiftUIViews/CircleProgress.swift
+++ b/Core/Core/SwiftUIViews/CircleProgress.swift
@@ -56,13 +56,14 @@ public struct CircleProgress: View {
                     .trim(from: 0, to: fillWidth)
                     .stroke(Color.accentColor, lineWidth: thickness)
                     .rotationEffect(fillRotate)
-                    .onReceive(timer) { _ in withAnimation(ease) {
-                        fillRotate += Angle(radians: fillWidth == 0.1 ? 0.5 * .pi : 1.5 * .pi)
-                        fillWidth = fillWidth == 0.1 ? 0.725 : 0.1
-                    } }
-
+                    .onReceive(timer) { _ in
+                        progressAnimation()
+                    }
                     .rotationEffect(rotate)
                     .onAppear {
+                        // Until the animation timer's first fire we still need to show some animation
+                        progressAnimation()
+
                         // This repeating animation caused other parts of the UI to animate their appearance repeatedly on iOS 14.0 and below.
                         if #available(iOS 14.1, *) {
                             withAnimation(Animation.linear(duration: 2.25).repeatForever(autoreverses: false)) {
@@ -79,6 +80,13 @@ public struct CircleProgress: View {
             .accentColor(color)
             .frame(width: size, height: size)
             .accessibility(label: Text("Loading", bundle: .core))
+    }
+
+    private func progressAnimation() {
+        withAnimation(ease) {
+            fillRotate += Angle(radians: fillWidth == 0.1 ? 0.5 * .pi : 1.5 * .pi)
+            fillWidth = fillWidth == 0.1 ? 0.725 : 0.1
+        }
     }
 }
 

--- a/Core/CoreTests/Submissions/GradeSubmissionTests.swift
+++ b/Core/CoreTests/Submissions/GradeSubmissionTests.swift
@@ -22,7 +22,7 @@ import XCTest
 class GradeSubmissionTests: CoreTestCase {
     func testGrading() throws {
         let model = Submission.make()
-        let useCase = GradeSubmission(courseID: "1", assignmentID: model.assignmentID, userID: model.userID)
+        let useCase = GradeSubmission(courseID: "1", assignmentID: model.assignmentID, userID: model.userID, rubricAssessment: [ "1": .make() ])
         api.mock(useCase, value: .make(
             entered_grade: "23",
             entered_score: 23,
@@ -33,7 +33,7 @@ class GradeSubmissionTests: CoreTestCase {
             late_policy_status: .late,
             missing: nil,
             points_deducted: 2,
-            rubric_assessment: [ "1": .make() ],
+            rubric_assessment: nil, // API response doesn't include this field, GradeSubmission saves rubric assessment received during init
             score: 23,
             workflow_state: .graded
         ))

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -25,11 +25,7 @@ struct RubricAssessor: View {
     let currentScore: Double
     @Binding var comment: String
     @Binding var commentID: String?
-    @Binding var assessments: APIRubricAssessmentMap {
-        didSet {
-            rubricAssessmentDidChange()
-        }
-    }
+    @Binding var assessments: APIRubricAssessmentMap
 
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
@@ -60,6 +56,9 @@ struct RubricAssessor: View {
         }
             .multilineTextAlignment(.leading)
             .padding(.horizontal, 16)
+            .onDataChange(of: assessments) { _ in
+                rubricAssessmentDidChange()
+            }
     }
 
     func RubricCriteriaAssessor(criteria: Rubric) -> some View { VStack(alignment: .leading, spacing: 0) {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -153,25 +153,29 @@ struct RubricAssessor: View {
         }
 
         if let comments = assessment?.comments, !comments.isEmpty {
-            HStack {
-                Text(comments)
-                    .font(.regular14).foregroundColor(.textDarkest)
-                    .padding(.horizontal, 12).padding(.vertical, 8)
-                    .background(CommentBackground()
-                        .fill(Color.backgroundLight)
-                    )
-                Spacer()
-                Button(action: { withAnimation(.default) {
-                    comment = comments
-                    commentID = criteria.id
-                } }, label: {
-                    Text("Edit")
-                        .font(.medium14).foregroundColor(.accentColor)
-                })
-            }
-                .padding(.top, 8)
+            freeFormRubricCommentBubbleWithEditButton(comments, criteriaID: criteria.id)
         }
     } }
+
+    func freeFormRubricCommentBubbleWithEditButton(_ comment: String, criteriaID: String) -> some View {
+        HStack {
+            Text(comment)
+                .font(.regular14).foregroundColor(.textDarkest)
+                .padding(.horizontal, 12).padding(.vertical, 8)
+                .background(CommentBackground()
+                    .fill(Color.backgroundLight)
+                )
+            Spacer()
+            Button(action: { withAnimation(.default) {
+                self.comment = comment
+                commentID = criteriaID
+            } }, label: {
+                Text("Edit")
+                    .font(.medium14).foregroundColor(.accentColor)
+            })
+        }
+            .padding(.top, 8)
+    }
 
     struct CircleToggle<Content: View>: View {
         let content: Content

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -97,7 +97,7 @@ struct RubricAssessor: View {
                 }
             }
 
-            let customGrade = (assignment.freeFormCriterionCommentsOnRubric || assessment?.rating_id == nil)
+            let customGrade = (assignment.freeFormCriterionCommentsOnRubric || assessment?.rating_id == nil || assessment?.rating_id == "")
                 ? assessment?.points : nil
             CircleToggle(isOn: Binding(get: { customGrade != nil }, set: { newValue in
                 if newValue {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -34,7 +34,7 @@ struct RubricAssessor: View {
     @State private var assessmentsChangedDuringUpload = false
 
     var body: some View {
-        HStack() {
+        HStack {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Rubric")
                     .font(.heavy24).foregroundColor(.textDarkest)
@@ -61,7 +61,7 @@ struct RubricAssessor: View {
             }
     }
 
-    func RubricCriteriaAssessor(criteria: Rubric) -> some View { VStack(alignment: .leading, spacing: 0) {
+    private func RubricCriteriaAssessor(criteria: Rubric) -> some View { VStack(alignment: .leading, spacing: 0) {
         let assessment = assessments[criteria.id] ?? submission.rubricAssessments?[criteria.id].map {
             APIRubricAssessment(comments: $0.comments, points: $0.points, rating_id: $0.ratingID)
         }
@@ -156,7 +156,7 @@ struct RubricAssessor: View {
         }
     } }
 
-    func freeFormRubricCommentBubbleWithEditButton(_ comment: String, criteriaID: String) -> some View {
+    private func freeFormRubricCommentBubbleWithEditButton(_ comment: String, criteriaID: String) -> some View {
         HStack {
             Text(comment)
                 .font(.regular14).foregroundColor(.textDarkest)
@@ -176,7 +176,7 @@ struct RubricAssessor: View {
             .padding(.top, 8)
     }
 
-    struct CircleToggle<Content: View>: View {
+    private struct CircleToggle<Content: View>: View {
         let content: Content
         @Binding var isOn: Bool
         let tooltip: String
@@ -236,7 +236,7 @@ struct RubricAssessor: View {
         }
     }
 
-    func promptCustomGrade(_ criteria: Rubric, assessment: APIRubricAssessment?) {
+    private func promptCustomGrade(_ criteria: Rubric, assessment: APIRubricAssessment?) {
         let format = NSLocalizedString("out_of_g_pts", bundle: .core, comment: "")
         let message = String.localizedStringWithFormat(format, criteria.points)
         let prompt = UIAlertController(title: NSLocalizedString("Customize Grade", comment: ""), message: message, preferredStyle: .alert)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -137,10 +137,10 @@ struct SubmissionGrades: View {
             if let id = rubricCommentID {
                 CommentEditor(text: $rubricComment, action: {
                     var points: Double?
-                    var ratingID: String?
+                    var ratingID = ""
                     if let assessment = rubricAssessments[id] {
                         points = assessment.points
-                        ratingID = assessment.rating_id
+                        ratingID = assessment.rating_id ?? ""
                     } else if let assessment = submission.rubricAssessments?[id] {
                         points = assessment.points
                         ratingID = assessment.ratingID

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -130,7 +130,6 @@ struct SubmissionGrades: View {
                             commentID: $rubricCommentID,
                             assessments: $rubricAssessments
                         )
-                            .onDisappear(perform: saveRubric)
                     }
                 }
             }
@@ -314,26 +313,6 @@ struct SubmissionGrades: View {
             grade: grade
         ).fetch { _, _, error in performUIUpdate {
             isSaving = false
-            if let error = error { showError(error) }
-        } }
-    }
-
-    func saveRubric() {
-        guard !rubricAssessments.isEmpty else { return }
-        let prevAssessments = submission.rubricAssessments // create map only once
-        var nextAssessments: APIRubricAssessmentMap = [:]
-        for criteria in assignment.rubric ?? [] {
-            nextAssessments[criteria.id] = rubricAssessments[criteria.id] ?? prevAssessments?[criteria.id].map {
-                APIRubricAssessment(comments: $0.comments, points: $0.points, rating_id: $0.ratingID)
-            }
-        }
-
-        GradeSubmission(
-            courseID: assignment.courseID,
-            assignmentID: assignment.id,
-            userID: submission.userID,
-            rubricAssessment: nextAssessments
-        ).fetch { _, _, error in performUIUpdate {
             if let error = error { showError(error) }
         } }
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -38,6 +38,13 @@ struct SubmissionGrades: View {
     @State var rubricCommentID: String?
     @State var rubricAssessments: APIRubricAssessmentMap = [:]
 
+    var isRubricScoreAvailable: Bool {
+        guard assignment.useRubricForGrading else { return false }
+        return rubricAssessments.contains { _, assessment in
+            assessment.points != nil
+        }
+    }
+
     var hasLateDeduction: Bool {
         submission.late &&
         (submission.pointsDeducted ?? 0) > 0 &&
@@ -80,8 +87,7 @@ struct SubmissionGrades: View {
                                     Text(GradeFormatter.longString(
                                         for: assignment,
                                         submission: submission,
-                                        rubricScore: assignment.useRubricForGrading && !rubricAssessments.isEmpty
-                                            ? currentRubricScore : nil,
+                                        rubricScore: isRubricScoreAvailable ? currentRubricScore : nil,
                                         final: false
                                     ))
                                 } else {


### PR DESCRIPTION
refs: MBL-15252
affects: Teacher
release note: Fixed grading issues when using rubrics in SpeedGrader.

test plan:
- See ticket.

In addition to that:
- Grade a submission with rubrics.
- Scroll two submissions away, then scroll back.
- Submission should still show your selected rubrics.
--
- Select a rubric on a submission, then de-select it.
- Close SpeedGrader, then re-open it.
- Rubric selection should be empty.
--
- Progress indicator circle should animate even if it's shown for less than 1 second.
--
- Rubric selection and comment should save upon adding them and not when the view is closed or the user scrolls to another submission.