### PR TITLE
Add alert for logout, while file is uploading in background

### DIFF
--- a/Core/Core/Files/FilePicker/FilePickerViewController.swift
+++ b/Core/Core/Files/FilePicker/FilePickerViewController.swift
@@ -158,7 +158,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         if inProgress {
             navigationController?.setToolbarHidden(false, animated: true)
             navigationItem.leftBarButtonItems = []
-            navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Done", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(close))
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Dismiss", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(close))
             navigationItem.rightBarButtonItem?.accessibilityIdentifier = "FilePicker.closeButton"
             let cancelButton = UIBarButtonItem(title: cancelButtonTitle, style: .plain, target: self, action: #selector(cancelClicked))
             cancelButton.accessibilityIdentifier = "FilePicker.cancelButton"

--- a/Core/Core/Files/UploadManager.swift
+++ b/Core/Core/Files/UploadManager.swift
@@ -102,6 +102,19 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
         return Store(env: environment, database: database, useCase: useCase, eventHandler: eventHandler)
     }
 
+    public func isUploading(completionHandler: @escaping (Bool) -> Void) {
+        if let validSession = validSession {
+            validSession.getAllTasks { tasks in
+              let runningTaskCount = tasks
+                .filter { $0.state == .running }
+                .count
+                completionHandler(runningTaskCount > 0)
+            }
+        } else {
+            completionHandler(false)
+        }
+    }
+
     @discardableResult
     public func add(url: URL, batchID: String? = nil) throws -> File {
         let file: File = viewContext.insert()

--- a/Core/Core/Files/UploadManager.swift
+++ b/Core/Core/Files/UploadManager.swift
@@ -105,9 +105,9 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
     public func isUploading(completionHandler: @escaping (Bool) -> Void) {
         if let validSession = validSession {
             validSession.getAllTasks { tasks in
-              let runningTaskCount = tasks
-                .filter { $0.state == .running }
-                .count
+                let runningTaskCount = tasks
+                    .filter { $0.state == .running }
+                    .count
                 completionHandler(runningTaskCount > 0)
             }
         } else {

--- a/Core/Core/Profile/ProfileViewController.swift
+++ b/Core/Core/Profile/ProfileViewController.swift
@@ -405,7 +405,7 @@ extension ProfileViewController: UIImagePickerControllerDelegate, UINavigationCo
 
     public func showUploadAlert(completionHandler: @escaping () -> Void) {
         let title = NSLocalizedString("Upload in progress", bundle: .core, comment: "")
-        let message = NSLocalizedString("Are you sure you want to log out?", bundle: .core, comment: "")
+        let message = NSLocalizedString("One of your submissions is still being uploaded. Logging out might interrupt it.\nAre you sure you want to log out?", bundle: .core, comment: "")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { _ in
             completionHandler()

--- a/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
+++ b/Core/CoreTests/Files/FilePicker/FilePickerViewControllerTests.swift
@@ -138,7 +138,7 @@ class FilePickerViewControllerTests: CoreTestCase, FilePickerControllerDelegate 
         }
 
         let doneItem = controller.navigationItem.rightBarButtonItem
-        XCTAssertEqual(doneItem?.title, "Done")
+        XCTAssertEqual(doneItem?.title, "Dismiss")
         XCTAssertNoThrow(doneItem?.target?.perform(doneItem?.action))
     }
 

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -202,9 +202,7 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
             submitMediaRecording(controller)
         } else {
             let context = FileUploadContext.submission(courseID: assignment.courseID, assignmentID: assignment.id, comment: nil)
-            env.router.dismiss(controller) {
-                UploadManager.shared.upload(batch: self.batchID, to: context)
-            }
+            UploadManager.shared.upload(batch: self.batchID, to: context)
         }
     }
 

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -242,11 +242,6 @@ class SubmissionButtonPresenterTests: StudentTestCase {
         XCTAssertEqual(filePicker?.sources, [.files, .library, .camera, .documentScan])
     }
 
-    func testSubmitFiles() {
-        presenter.submit(filePicker)
-        XCTAssert(filePicker == router.dismissed)
-    }
-
     func testRetryFileUpload() {
         XCTAssertNoThrow(presenter.retry(filePicker))
     }


### PR DESCRIPTION
refs: MBL-15258
affects: Student
release note: Added file upload warning when logging out

test plan: Have a file upload assignment, upload a large file
* on submission, the dialog should not dismiss automatically
* while the file is still uplaoding in the background, navigate to the menu and try to log out
* a warning message should appear