### PR TITLE
Fix profile image in SpeedGrader when grading a submission from an individual

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -26,7 +26,7 @@ struct SubmissionHeader: View {
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
-    var isGroupSubmission: Bool { !assignment.gradedIndividually && assignment.assignmentGroupID != nil }
+    var isGroupSubmission: Bool { !assignment.gradedIndividually && submission.groupID != nil }
     var groupName: String? { isGroupSubmission ? submission.groupName : nil }
     var routeToSubmitter: String? {
         if isGroupSubmission {

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SubmissionHeaderTests.swift
@@ -25,10 +25,11 @@ class SubmissionHeaderTests: TeacherTestCase {
     func testGroupSubmissionCheck() {
         let submission = Submission(context: databaseClient)
         let assignment = Assignment(context: databaseClient)
-        assignment.assignmentGroupID = "TestGroupID"
-        assignment.gradedIndividually = false
-
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
+
+        assignment.gradedIndividually = false
+        submission.groupID = "TestGroupID"
+
         XCTAssertTrue(testee.isGroupSubmission)
     }
 
@@ -40,33 +41,32 @@ class SubmissionHeaderTests: TeacherTestCase {
         assignment.gradedIndividually = false
         submission.groupName = "TestGroup Name"
         XCTAssertEqual(testee.groupName, nil)
-        assignment.assignmentGroupID = "TestGroupID"
+
+        submission.groupID = "TestGroupID"
         XCTAssertEqual(testee.groupName, "TestGroup Name")
     }
 
     func testRouteToGroupSubmitter() {
         let submission = Submission(context: databaseClient)
         let assignment = Assignment(context: databaseClient)
-
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
 
         assignment.gradedIndividually = false
-        assignment.assignmentGroupID = "TestGroupID"
         assignment.courseID = "testCourseID"
         submission.userID = "testUserID"
+        submission.groupID = "TestGroupID"
         XCTAssertNil(testee.routeToSubmitter)
     }
 
     func testRouteToIndividialInGroupSubmission() {
         let submission = Submission(context: databaseClient)
         let assignment = Assignment(context: databaseClient)
-
         let testee = SubmissionHeader(assignment: assignment, submission: submission)
 
         assignment.gradedIndividually = true
-        assignment.assignmentGroupID = "TestGroupID"
         assignment.courseID = "testCourseID"
         submission.userID = "testUserID"
+        submission.groupID = "TestGroupID"
         XCTAssertEqual(testee.routeToSubmitter, "/courses/testCourseID/users/testUserID")
     }
 }


### PR DESCRIPTION
refs: MBL-15253
affects: Teacher
release note: none

test plan:
- See ticket for account details on group submissions.
- Submission in SpeedGrader created by an individual should show the user's profile picture, tapping on it should open his/her context card
- In case a group submitted the assignment then the name of the group should show with the group logo, tapping on it should do nothing as it isn't supported yet
- In case a group submitted the assignment but individual grades is turned on then the user's profile picture should show with the context card on tap