### PR TITLE
Make submission order deterministic in case of group submissions.

### DIFF
--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -205,10 +205,7 @@ public class GetSubmissions: CollectionUseCase {
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: assignmentID),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
         ] + filter.map { $0.predicate }),
-        order: [ shuffled ?
-            NSSortDescriptor(key: #keyPath(Submission.shuffleOrder), ascending: true) :
-            NSSortDescriptor(key: #keyPath(Submission.sortableName), naturally: true),
-        ]
+        order: order
     ) }
 
     public func scopeKeepingIDs(_ ids: [String]) -> Scope { Scope(
@@ -220,11 +217,20 @@ public class GetSubmissions: CollectionUseCase {
                 NSPredicate(format: "%K IN %@", #keyPath(Submission.userID), ids),
             ]),
         ]),
-        order: [ shuffled ?
-            NSSortDescriptor(key: #keyPath(Submission.shuffleOrder), ascending: true) :
-            NSSortDescriptor(key: #keyPath(Submission.sortableName), naturally: true),
-        ]
+        order: order
     ) }
+
+    private var order: [NSSortDescriptor] {
+        if shuffled {
+            return [NSSortDescriptor(key: #keyPath(Submission.shuffleOrder), ascending: true)]
+        }
+
+        return [
+            NSSortDescriptor(key: #keyPath(Submission.sortableName), naturally: true), // In case of a group submission this is the name of the group
+            NSSortDescriptor(key: #keyPath(Submission.user.sortableName), naturally: true),
+            NSSortDescriptor(key: #keyPath(Submission.userID), naturally: true),
+        ]
+    }
 
     public enum Filter: RawRepresentable, Equatable {
         case late, notSubmitted, needsGrading, graded

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -295,4 +295,22 @@ class GetSubmissionsTests: CoreTestCase {
         XCTAssertEqual(Filter.user("1").name, "Me")
         XCTAssertEqual(Filter.section([ "2", "1" ]).name, "One and Two")
     }
+
+    func testGroupSubmissionWithIndividualGradesOrder() {
+        let date = Date()
+        let group = APISubmissionGroup(id: nil, name: "Group 1")
+        Submission.save([
+            APISubmission.make(group: group, id: "1", submission_history: [], submitted_at: date, user: .make(id: "B2", sortable_name: "B"), user_id: "B2"),
+            APISubmission.make(group: group, id: "2", submission_history: [], submitted_at: date, user: .make(id: "B1", sortable_name: "B"), user_id: "B1"),
+            APISubmission.make(group: group, id: "3", submission_history: [], submitted_at: date, user: .make(id: "C", sortable_name: "C"), user_id: "C"),
+            APISubmission.make(group: group, id: "4", submission_history: [], submitted_at: date, user: .make(id: "A", sortable_name: "A"), user_id: "A"),
+        ], in: databaseClient)
+
+        let testee = GetSubmissions(context: .course("1"), assignmentID: "1")
+        let fetchedSubmissions: [Submission] = databaseClient.fetch(scope: testee.scope)
+        XCTAssertEqual(fetchedSubmissions[0].id, "4")
+        XCTAssertEqual(fetchedSubmissions[1].id, "2")
+        XCTAssertEqual(fetchedSubmissions[2].id, "1")
+        XCTAssertEqual(fetchedSubmissions[3].id, "3")
+    }
 }

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -213,7 +213,11 @@ class GetSubmissionsTests: CoreTestCase {
         let useCase = GetSubmissions(context: .course("1"), assignmentID: "1")
         XCTAssertEqual(useCase.cacheKey, "courses/1/assignments/1/submissions")
         XCTAssertEqual(useCase.request.assignmentID, "1")
-        XCTAssertEqual(useCase.scope.order, [NSSortDescriptor(key: #keyPath(Submission.sortableName), naturally: true)])
+        XCTAssertEqual(useCase.scope.order, [
+            NSSortDescriptor(key: #keyPath(Submission.sortableName), naturally: true),
+            NSSortDescriptor(key: #keyPath(Submission.user.sortableName), naturally: true),
+            NSSortDescriptor(key: #keyPath(Submission.userID), naturally: true),
+        ])
         useCase.shuffled = true
         XCTAssertEqual(useCase.scope.order, [NSSortDescriptor(key: #keyPath(Submission.shuffleOrder), ascending: true)])
         XCTAssertEqual(useCase.scope.predicate, NSCompoundPredicate(andPredicateWithSubpredicates: [


### PR DESCRIPTION
refs: MBL-15288
affects: Teacher
release note: Fixed submission order changing while grading group submissions in SpeedGrader.

test plan: See ticket.