### PR TITLE
Fix inactive students are listed in the not submitted tab

### DIFF
--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -290,7 +290,9 @@ public class GetSubmissions: CollectionUseCase {
             case .late:
                 return NSPredicate(key: #keyPath(Submission.late), equals: true)
             case .notSubmitted:
-                return NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil)
+                let notSubmitted = NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil)
+                let notInactive = NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive")
+                return NSCompoundPredicate(andPredicateWithSubpredicates: [notSubmitted, notInactive])
             case .needsGrading:
                 return NSPredicate(format: """
                     %K != nil AND (%K == 'pending_review' OR (

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -204,7 +204,10 @@ public class GetSubmissions: CollectionUseCase {
         predicate: NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: assignmentID),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
-            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            NSCompoundPredicate(orPredicateWithSubpredicates: [
+                NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
+                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            ]),
         ] + filter.map { $0.predicate }),
         order: order
     ) }

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -204,6 +204,7 @@ public class GetSubmissions: CollectionUseCase {
         predicate: NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: assignmentID),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
+            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
         ] + filter.map { $0.predicate }),
         order: [ shuffled ?
             NSSortDescriptor(key: #keyPath(Submission.shuffleOrder), ascending: true) :
@@ -290,9 +291,7 @@ public class GetSubmissions: CollectionUseCase {
             case .late:
                 return NSPredicate(key: #keyPath(Submission.late), equals: true)
             case .notSubmitted:
-                let notSubmitted = NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil)
-                let notInactive = NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive")
-                return NSCompoundPredicate(andPredicateWithSubpredicates: [notSubmitted, notInactive])
+                return NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil)
             case .needsGrading:
                 return NSPredicate(format: """
                     %K != nil AND (%K == 'pending_review' OR (

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -223,13 +223,19 @@ class GetSubmissionsTests: CoreTestCase {
         XCTAssertEqual(useCase.scope.predicate, NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: "1"),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
-            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            NSCompoundPredicate(orPredicateWithSubpredicates: [
+                NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
+                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            ]),
         ]))
         useCase.filter = [.late]
         XCTAssertEqual(useCase.scope.predicate, NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: "1"),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
-            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            NSCompoundPredicate(orPredicateWithSubpredicates: [
+                NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
+                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            ]),
             NSPredicate(key: #keyPath(Submission.late), equals: true),
         ]))
     }

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -219,11 +219,13 @@ class GetSubmissionsTests: CoreTestCase {
         XCTAssertEqual(useCase.scope.predicate, NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: "1"),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
+            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
         ]))
         useCase.filter = [.late]
         XCTAssertEqual(useCase.scope.predicate, NSCompoundPredicate(andPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Submission.assignmentID), equals: "1"),
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
+            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
             NSPredicate(key: #keyPath(Submission.late), equals: true),
         ]))
     }

--- a/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -31,6 +31,7 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         api.mock(controller.enrollments, value: [
             .make(id: "1", course_id: "1", course_section_id: "1", user_id: "1"),
             .make(id: "2", course_id: "1", course_section_id: "2", user_id: "2"),
+            .make(id: "3", course_id: "1", course_section_id: "2", enrollment_state: .inactive, user_id: "3"),
         ])
         api.mock(controller.sections, value: [
             .make(id: "1", name: "One"),
@@ -47,6 +48,12 @@ class SubmissionListViewControllerTests: TeacherTestCase {
                 submission_history: [],
                 user: .make(id: "2", name: "Alice", sortable_name: "Alice"),
                 user_id: "2"
+            ),
+            .make(
+                submission_history: [],
+                user: .make(id: "3", name: "Christine", sortable_name: "Christine"),
+                user_id: "3",
+                workflow_state: .unsubmitted
             ),
         ])
     }
@@ -69,6 +76,9 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         XCTAssertEqual(cell?.nameLabel.text, "Bob")
         XCTAssertEqual(cell?.statusLabel.text, "Submitted")
         XCTAssertEqual(cell?.needsGradingView.isHidden, false)
+
+        cell = controller.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) as? SubmissionListCell
+        XCTAssertNil(cell)
 
         controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: IndexPath(row: 0, section: 0))
         XCTAssert(router.lastRoutedTo("/courses/1/assignments/1/submissions/2"))


### PR DESCRIPTION
affects: Teacher
release note: Hide inactive students on the Submissions page
test plan: See ticket.