### PR TITLE
Delete old submissions after a fresh list is fetched from API.

### DIFF
--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -232,6 +232,11 @@ public class GetSubmissions: CollectionUseCase {
         ]
     }
 
+    public func reset(context: NSManagedObjectContext) {
+        let oldSubmissions: [Submission] = context.fetch(NSPredicate(key: #keyPath(Submission.assignmentID), equals: assignmentID), sortDescriptors: nil)
+        context.delete(oldSubmissions)
+    }
+
     public enum Filter: RawRepresentable, Equatable {
         case late, notSubmitted, needsGrading, graded
         case scoreAbove(Double)

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -317,4 +317,16 @@ class GetSubmissionsTests: CoreTestCase {
         XCTAssertEqual(fetchedSubmissions[2].id, "1")
         XCTAssertEqual(fetchedSubmissions[3].id, "3")
     }
+
+    func testDeletesOldSubmissions() {
+        Submission.save(.make(attempt: 0, workflow_state: .unsubmitted), in: databaseClient)
+        XCTAssertEqual((databaseClient.fetch() as [Submission]).count, 1)
+
+        let testee = GetSubmissions(context: .course("1"), assignmentID: "1", filter: [.needsGrading], shuffled: false)
+        // Simulate Store executing these after API fetch completes
+        testee.reset(context: databaseClient)
+        testee.write(response: [.make(attempt: 1, workflow_state: .submitted)], urlResponse: nil, to: databaseClient)
+
+        XCTAssertEqual((databaseClient.fetch() as [Submission]).count, 1)
+    }
 }


### PR DESCRIPTION
refs: MBL-15304
affects: Teacher
release note: Fixed empty submissions appearing in SpeedGrader next to a real submission.

test plan:
- Create a submission with students assigned.
- Start the app and go to the new assignment's detail page.
- Make a submission with a student via web or app.
- Go back to teacher app, refresh assignment page. 1 need grading should appear.
- Tap on the need grading circle and then on the submission.
- There should be only one submission in the SpeedGrader.