### PR TITLE
Grade slider can give incorrect score if assignment is worth a decimal number

### DIFF
--- a/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
+++ b/rn/Teacher/ios/Teacher.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		E8F4B66424EEC912003FBAFD /* ContextCardE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4B66324EEC912003FBAFD /* ContextCardE2ETests.swift */; };
 		E8F4B66624EECA10003FBAFD /* ContextCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F4B66524EECA10003FBAFD /* ContextCard.swift */; };
 		EB12071F2601F2C50038E875 /* GradeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB12071E2601F2C50038E875 /* GradeSlider.swift */; };
+		EB71A24E261206CA0003241C /* GradeSliderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71A24D261206CA0003241C /* GradeSliderTests.swift */; };
 		F9FDB9351C9FB4F9CF7E0F94 /* Pods_defaults_Teacher.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EE78272172F7D235E49A1D77 /* Pods_defaults_Teacher.framework */; };
 /* End PBXBuildFile section */
 
@@ -508,6 +509,7 @@
 		E8F4B66524EECA10003FBAFD /* ContextCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCard.swift; sourceTree = "<group>"; };
 		E8F6CFFE23045A01004347D9 /* CoreUITests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB12071E2601F2C50038E875 /* GradeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSlider.swift; sourceTree = "<group>"; };
+		EB71A24D261206CA0003241C /* GradeSliderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSliderTests.swift; sourceTree = "<group>"; };
 		EE78272172F7D235E49A1D77 /* Pods_defaults_Teacher.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_defaults_Teacher.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -681,6 +683,7 @@
 			children = (
 				7DE062A525126E4D00DB49D4 /* SpeedGraderViewControllerTests.swift */,
 				CF56B71425F68CD3000DD32F /* SubmissionHeaderTests.swift */,
+				EB71A24D261206CA0003241C /* GradeSliderTests.swift */,
 			);
 			path = SpeedGrader;
 			sourceTree = "<group>";
@@ -1576,6 +1579,7 @@
 				7D64A98523689DD5004EAEDF /* DatePickerViewControllerTests.swift in Sources */,
 				3B1D37C9231085830017CCA2 /* PostGradesPresenterTests.swift in Sources */,
 				7DE062A625126E4D00DB49D4 /* SpeedGraderViewControllerTests.swift in Sources */,
+				EB71A24E261206CA0003241C /* GradeSliderTests.swift in Sources */,
 				B15CA26F221DDF230014FB02 /* TeacherTestCase.swift in Sources */,
 				B1992AAB2264D51200396A1F /* RoutesTests.swift in Sources */,
 				7D3DC0CB252432ED00B0EBC1 /* SubmissionListViewControllerTests.swift in Sources */,

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -32,8 +32,10 @@ struct GradeSlider: View {
             Slider(value: value, in: range, onEditingChanged: onEditingChanged)
                 .gesture(DragGesture(minimumDistance: 0).onChanged { changeValue in
                     let percent = min(max(0, Double(changeValue.location.x / geometry.size.width)), 1)
-                    let newValue = range.lowerBound + round(percent * (range.upperBound - range.lowerBound))
-                    value.wrappedValue = newValue
+                    let rangeSize = range.upperBound - range.lowerBound
+                    let roundingRule: FloatingPointRoundingRule = (percent * rangeSize) > rangeSize / 2 ? .up : .down
+                    let newValue = range.lowerBound + (percent * rangeSize).rounded(roundingRule)
+                    value.wrappedValue = min(max(newValue, range.lowerBound), range.upperBound)
                     onEditingChanged(true)
                 }.onEnded { _ in
                     onEditingChanged(false)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -31,11 +31,7 @@ struct GradeSlider: View {
         GeometryReader { geometry in
             Slider(value: value, in: range, onEditingChanged: onEditingChanged)
                 .gesture(DragGesture(minimumDistance: 0).onChanged { changeValue in
-                    let percent = min(max(0, Double(changeValue.location.x / geometry.size.width)), 1)
-                    let rangeSize = range.upperBound - range.lowerBound
-                    let roundingRule: FloatingPointRoundingRule = (percent * rangeSize) > rangeSize / 2 ? .up : .down
-                    let newValue = range.lowerBound + (percent * rangeSize).rounded(roundingRule)
-                    value.wrappedValue = min(max(newValue, range.lowerBound), range.upperBound)
+                    value.wrappedValue = grade(for: changeValue.location.x, in: geometry.size.width)
                     onEditingChanged(true)
                 }.onEnded { _ in
                     onEditingChanged(false)
@@ -51,6 +47,14 @@ struct GradeSlider: View {
                         .offset(x: x, y: -26)
                 }, alignment: .bottom)
         }
+    }
+    
+    func grade(for position: CGFloat, in width: CGFloat) -> Double {
+        let percent = min(max(0, Double(position / width)), 1)
+        let rangeSize = range.upperBound - range.lowerBound
+        let roundingRule: FloatingPointRoundingRule = (percent * rangeSize) > rangeSize / 2 ? .up : .down
+        let newValue = range.lowerBound + (percent * rangeSize).rounded(roundingRule)
+        return min(max(newValue, range.lowerBound), range.upperBound)
     }
 }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -48,7 +48,7 @@ struct GradeSlider: View {
                 }, alignment: .bottom)
         }
     }
-    
+
     func grade(for position: CGFloat, in width: CGFloat) -> Double {
         let percent = min(max(0, Double(position / width)), 1)
         let rangeSize = range.upperBound - range.lowerBound

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -52,7 +52,7 @@ struct GradeSlider: View {
     func grade(for position: CGFloat, in width: CGFloat) -> Double {
         let percent = min(max(0, Double(position / width)), 1)
         let rangeSize = range.upperBound - range.lowerBound
-        let roundingRule: FloatingPointRoundingRule = (percent * rangeSize) > rangeSize / 2 ? .up : .down
+        let roundingRule: FloatingPointRoundingRule = (percent * rangeSize) > rangeSize.rounded(.down) ? .up : .toNearestOrAwayFromZero
         let newValue = range.lowerBound + (percent * rangeSize).rounded(roundingRule)
         return min(max(newValue, range.lowerBound), range.upperBound)
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -201,9 +201,9 @@ struct SubmissionGrades: View {
 
     func sliderChangedState(_ editing: Bool) {
         withAnimation(.default) { showTooltip = editing }
-        sliderTimer?.invalidate()
-        sliderTimer = nil
         if editing == false, let value = sliderValue {
+            sliderTimer?.invalidate()
+            sliderTimer = nil
             if sliderCleared {
                 saveGrade("")
             } else if sliderExcused {
@@ -222,22 +222,19 @@ struct SubmissionGrades: View {
         guard previous != value || sliderTimer == nil else { return }
         sliderTimer?.invalidate()
         sliderTimer = nil
-        DispatchQueue.main.async {
-            if value == 0 {
-                sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
-                    sliderCleared = true
-                    sliderExcused = false
-                    UISelectionFeedbackGenerator().selectionChanged()
-                }
-            } else if value == assignment.pointsPossible ?? 0 {
-                sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
-                    sliderCleared = false
-                    sliderExcused = true
-                    UISelectionFeedbackGenerator().selectionChanged()
-                }
-            } else {
-                sliderCleared = false
+        sliderCleared = false
+        sliderExcused = false
+        if value == 0 {
+            sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+                sliderCleared = true
                 sliderExcused = false
+                UISelectionFeedbackGenerator().selectionChanged()
+            }
+        } else if value == assignment.pointsPossible ?? 0 {
+            sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+                sliderCleared = false
+                sliderExcused = true
+                UISelectionFeedbackGenerator().selectionChanged()
             }
         }
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -178,7 +178,7 @@ struct SubmissionGrades: View {
             sliderCleared ? Text("No Grade") :
             sliderExcused ? Text("Excused") :
             assignment.gradingType == .percent ? Text(round(score / max(possible, 0.01) * 100) / 100, number: .percent) :
-            Text(round(score))
+            Text(score)
 
         HStack(spacing: 8) {
             VStack {
@@ -211,32 +211,34 @@ struct SubmissionGrades: View {
             } else if assignment.gradingType == .percent {
                 saveGrade("\(round(value / max(assignment.pointsPossible ?? 0, 0.01) * 100))%")
             } else if assignment.gradingType == .points {
-                saveGrade(String(round(value)))
+                saveGrade(String(value))
             }
         }
     }
 
     func sliderChangedValue(_ value: Double) {
-        let previous = sliderValue.map { round($0) }
+        let previous = sliderValue.map { $0 }
         sliderValue = value
-        guard previous != round(value) || sliderTimer == nil else { return }
+        guard previous != value || sliderTimer == nil else { return }
         sliderTimer?.invalidate()
         sliderTimer = nil
-        if round(value) == 0 {
-            sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
-                sliderCleared = true
-                sliderExcused = false
-                UISelectionFeedbackGenerator().selectionChanged()
-            }
-        } else if round(value) == round(assignment.pointsPossible ?? 0) {
-            sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+        DispatchQueue.main.async {
+            if value == 0 {
+                sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+                    sliderCleared = true
+                    sliderExcused = false
+                    UISelectionFeedbackGenerator().selectionChanged()
+                }
+            } else if value == assignment.pointsPossible ?? 0 {
+                sliderTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+                    sliderCleared = false
+                    sliderExcused = true
+                    UISelectionFeedbackGenerator().selectionChanged()
+                }
+            } else {
                 sliderCleared = false
-                sliderExcused = true
-                UISelectionFeedbackGenerator().selectionChanged()
+                sliderExcused = false
             }
-        } else {
-            sliderCleared = false
-            sliderExcused = false
         }
     }
 

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
@@ -38,4 +38,16 @@ class GradeSliderTests: TeacherTestCase {
         grade = gradeSlider.grade(for: sliderWidth + 1, in: sliderWidth)
         XCTAssertEqual(grade, range.upperBound)
     }
+
+    func testSliderValueEvenRounding() throws {
+        let value = 5.0
+        let range: ClosedRange<Double> = 0...10
+        let sliderWidth: CGFloat = 320
+        let gradeSlider = GradeSlider(value: .constant(value), range: range, showTooltip: false, tooltipText: Text(""), score: value, possible: range.upperBound)
+        let halfRange = range.upperBound.rounded(.down) / 2
+        var grade = gradeSlider.grade(for: sliderWidth/2 + 1, in: sliderWidth)
+        XCTAssertEqual(grade, halfRange)
+        grade = gradeSlider.grade(for: sliderWidth/2 - 1, in: sliderWidth)
+        XCTAssertEqual(grade, halfRange)
+    }
 }

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
@@ -1,0 +1,41 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+@testable import Teacher
+import TestsFoundation
+
+class GradeSliderTests: TeacherTestCase {
+        
+    func testSliderValueRounding() throws {
+        let value = 9.0
+        let range: ClosedRange<Double> = 0...10.5
+        let sliderWidth: CGFloat = 320
+        let gradeSlider = GradeSlider(value: .constant(value), range: range, showTooltip: false, tooltipText: Text(""), score: value, possible: range.upperBound)
+        var grade = gradeSlider.grade(for: CGFloat(Double(sliderWidth) / range.upperBound * value), in: sliderWidth)
+        XCTAssertEqual(grade, value)
+        grade = gradeSlider.grade(for: sliderWidth, in: sliderWidth)
+        XCTAssertEqual(grade, range.upperBound)
+        grade = gradeSlider.grade(for: 0, in: sliderWidth)
+        XCTAssertEqual(grade, range.lowerBound)
+        grade = gradeSlider.grade(for: -1, in: sliderWidth)
+        XCTAssertEqual(grade, range.lowerBound)
+        grade = gradeSlider.grade(for: sliderWidth + 1, in: sliderWidth)
+        XCTAssertEqual(grade, range.upperBound)
+    }
+}

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/GradeSliderTests.swift
@@ -21,7 +21,7 @@ import SwiftUI
 import TestsFoundation
 
 class GradeSliderTests: TeacherTestCase {
-        
+
     func testSliderValueRounding() throws {
         let value = 9.0
         let range: ClosedRange<Double> = 0...10.5


### PR DESCRIPTION
refs: MBL-15292
affects: Teacher
release note: Fixed grade slider decimal value and hold features.

test plan:
- set up an assignment with decimal grade points (eg. 10.5)
- add a student submission
- move the grade slider to the maximum on the submission grading pane
- the slider should be able to take up even values and then the maximal decimal value
- the slider should support holding the slider button on the min/max values and toggle no mark/excused states accordingly.