### PR TITLE
Make assignment locked screen respect phone's timezone setting.

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -94,9 +94,11 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
 
         switch assignment.lockStatus {
         case .before:
-            return String.localizedStringWithFormat(NSLocalizedString("This assignment is locked until %@", comment: ""), (assignment.unlockAt ?? Date()).dateTimeString)
+            guard let unlockAt = assignment.unlockAt else { return "" }
+            return String.localizedStringWithFormat(NSLocalizedString("This assignment is locked until %@", comment: ""), unlockAt.dateTimeString)
         case .after:
-            return String.localizedStringWithFormat(NSLocalizedString("This assignment was locked %@", comment: ""), (assignment.lockAt ?? Date()).dateTimeString)
+            guard let lockAt = assignment.lockAt else { return "" }
+            return String.localizedStringWithFormat(NSLocalizedString("This assignment was locked %@", comment: ""), lockAt.dateTimeString)
         default:
             return assignment.lockExplanation ?? ""
         }

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -89,6 +89,18 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
             }
         }
     }
+    var lockExplanation: String {
+        guard let assignment = assignment else { return "" }
+
+        switch assignment.lockStatus {
+        case .before:
+            return String.localizedStringWithFormat(NSLocalizedString("This assignment is locked until %@", comment: ""), (assignment.unlockAt ?? Date()).dateTimeString)
+        case .after:
+            return String.localizedStringWithFormat(NSLocalizedString("This assignment was locked %@", comment: ""), (assignment.lockAt ?? Date()).dateTimeString)
+        default:
+            return assignment.lockExplanation ?? ""
+        }
+    }
 
     init(view: AssignmentDetailsViewProtocol, courseID: String, assignmentID: String, fragment: String? = nil) {
         self.view = view

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -308,7 +308,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
         showDescription(!presenter.descriptionIsHidden())
         submitAssignmentButton.isHidden = presenter.submitAssignmentButtonIsHidden()
 
-        lockedSubheaderWebView.loadHTMLString(assignment.lockExplanation ?? "")
+        lockedSubheaderWebView.loadHTMLString(presenter.lockExplanation)
         centerLockedIconContainerView()
 
         updateQuizSettings(quiz)

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -498,6 +498,32 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         try UploadManager.shared.viewContext.save()
         wait(for: [expectation], timeout: 0.1)
     }
+
+    func testLockExplanationBeforeUnlockDate() {
+        Assignment.make(from: APIAssignment.make(
+            locked_for_user: true,
+            lock_explanation: "This doesn't update with the phone's timezone",
+            unlock_at: Date().addDays(1)
+        ))
+        XCTAssertTrue(presenter.lockExplanation.hasPrefix("This assignment is locked until "))
+    }
+
+    func testLockExplanationAfterLockDate() {
+        Assignment.make(from: APIAssignment.make(
+            locked_for_user: true,
+            lock_at: Date().addDays(-1),
+            lock_explanation: "This doesn't update with the phone's timezone"
+        ))
+        XCTAssertTrue(presenter.lockExplanation.hasPrefix("This assignment was locked "))
+    }
+
+    func testLockExplanationBecauseModuleDependency() {
+        Assignment.make(from: APIAssignment.make(
+            locked_for_user: true,
+            lock_explanation: "This assignment is part of an unpublished module and is not available yet."
+        ))
+        XCTAssertEqual(presenter.lockExplanation, "This assignment is part of an unpublished module and is not available yet.")
+    }
 }
 
 class MockView: UIViewController, AssignmentDetailsViewProtocol {


### PR DESCRIPTION
refs: MBL-15221
affects: Student
release note: Assignment locked screen now respects the phone's timezone setting.

test plan:
- Create an assignment which will unlock in the future.
- In the app, observe the date on assignment details page.
- Go to iOS Settings, change timezone.
- Restart app, go to assignment details again.
- Unlock date should be updated based on the new timezone.