### PR TITLE
Fix infinite refresh cycle of dashboard card.

### DIFF
--- a/Core/Core/Dashboard/CourseCard.swift
+++ b/Core/Core/Dashboard/CourseCard.swift
@@ -28,7 +28,7 @@ struct CourseCard: View {
     @Environment(\.viewController) var controller
 
     var a11yGrade: String {
-        guard let course = card.getCourse(), showGrade else { return "" }
+        guard let course = card.course, showGrade else { return "" }
         return course.displayGrade
     }
 
@@ -77,7 +77,7 @@ struct CourseCard: View {
 
     @ViewBuilder var customizeButton: some View {
         Button(action: {
-            guard let course = card.getCourse() else { return }
+            guard let course = card.course else { return }
             env.router.show(
                 CoreHostingController(CustomizeCourseView(course: course, hideColorOverlay: hideColorOverlay)),
                 from: controller,
@@ -95,7 +95,7 @@ struct CourseCard: View {
     }
 
     @ViewBuilder var gradePill: some View {
-        if showGrade, let course = card.getCourse() {
+        if showGrade, let course = card.course {
             HStack {
                 if course.hideTotalGrade {
                     Image.lockSolid.size(14)

--- a/Core/Core/Dashboard/DashboardCard.swift
+++ b/Core/Core/Dashboard/DashboardCard.swift
@@ -22,7 +22,6 @@ final class DashboardCard: NSManagedObject {
     typealias JSON = APIDashboardCard
 
     @NSManaged var contextColor: ContextColor?
-    @NSManaged var course: Course?
     @NSManaged var courseCode: String
     @NSManaged var enrollmentType: String
     @NSManaged var href: URL?
@@ -41,12 +40,7 @@ final class DashboardCard: NSManagedObject {
         enrollmentType.lowercased().contains("teacher")
     }
 
-    func getCourse() -> Course? {
-        if course == nil, let fetchedCourse: Course = managedObjectContext?.first(where: #keyPath(Course.id), equals: id) {
-            course = fetchedCourse
-        }
-        return course
-    }
+    var course: Course? { managedObjectContext?.first(where: #keyPath(Course.id), equals: id) }
 
     @discardableResult
     static func save(_ item: APIDashboardCard, position: Int, in context: NSManagedObjectContext) -> Self {

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -224,7 +224,6 @@
         <attribute name="syllabusBody" optional="YES" attributeType="String"/>
         <attribute name="termName" optional="YES" attributeType="String"/>
         <relationship name="contextColor" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContextColor" inverseName="course" inverseEntity="ContextColor"/>
-        <relationship name="dashboardCard" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DashboardCard" inverseName="course" inverseEntity="DashboardCard"/>
         <relationship name="enrollments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Enrollment" inverseName="course" inverseEntity="Enrollment"/>
         <relationship name="groups" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Group" inverseName="course" inverseEntity="Group"/>
         <relationship name="planner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Planner" inverseName="courses" inverseEntity="Planner"/>
@@ -260,7 +259,6 @@
         <attribute name="subtitle" attributeType="String"/>
         <attribute name="term" optional="YES" attributeType="String"/>
         <relationship name="contextColor" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContextColor" inverseName="card" inverseEntity="ContextColor"/>
-        <relationship name="course" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="dashboardCard" inverseEntity="Course"/>
     </entity>
     <entity name="DiscussionEntry" representedClassName="Core.DiscussionEntry" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>

--- a/Core/CoreTests/Dashboard/DashboardCardTests.swift
+++ b/Core/CoreTests/Dashboard/DashboardCardTests.swift
@@ -33,7 +33,7 @@ class DashboardCardTests: CoreTestCase {
         useCase.fetch()
         let card: DashboardCard? = databaseClient.fetch(scope: useCase.scope).first
         XCTAssertEqual(card?.color, .red)
-        XCTAssertEqual(card?.getCourse()?.id, "1")
+        XCTAssertEqual(card?.course?.id, "1")
         XCTAssertEqual(card?.shortName, "Course One")
     }
 


### PR DESCRIPTION
refs: MBL-15320
affects: Student, Teacher
release note: Fixed dashboard freezing on older iOS versions.

test plan:
- Start the app on an iPad (or simulator) running iOS 14.0 or 14.1 in portrait mode.
- Switch to Inbox tab.
- Rotate to landscape.
- Switch back to dashboard.
- App shouldn't freeze.