### PR TITLE
Limit comment box size and enable scrolling.

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -24,6 +24,7 @@ struct CommentEditor: View {
 
     @Binding var text: String
     let action: () -> Void
+    let containerHeight: CGFloat
 
     var body: some View {
         HStack(alignment: .bottom) {
@@ -33,7 +34,7 @@ struct CommentEditor: View {
                         .font(.regular16).foregroundColor(.textDark)
                         .accessibility(hidden: true)
                 }
-                TextEditor(text: $text)
+                Core.TextEditor(text: $text, maxHeight: containerHeight / 2)
                     .font(.regular16).foregroundColor(.textDarkest)
                     .accessibility(label: Text("Comment"))
                     .identifier("SubmissionComments.commentTextView")

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -96,7 +96,7 @@ struct SubmissionCommentList: View {
                         .frame(height: geometry.size.height)
                         .transition(.move(edge: .bottom))
                 case nil:
-                    toolbar
+                    toolbar(containerHeight: geometry.size.height)
                         .transition(.opacity)
                 }
             }
@@ -121,7 +121,7 @@ struct SubmissionCommentList: View {
         }
     }
 
-    var toolbar: some View {
+    func toolbar(containerHeight: CGFloat) -> some View {
         HStack(spacing: 0) {
             Button(action: { showMediaOptions = true }, label: {
                 Image.addSolid.size(18)
@@ -138,7 +138,7 @@ struct SubmissionCommentList: View {
                         .cancel(),
                     ])
                 }
-            CommentEditor(text: $comment, action: sendComment)
+            CommentEditor(text: $comment, action: sendComment, containerHeight: containerHeight)
                 .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 16))
         }
             .background(Color.backgroundLight)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -223,7 +223,7 @@ struct SubmissionGrader: View {
                     snapDrawerTo(.min)
                 })
                 VStack(spacing: 0) {
-                    SubmissionGrades(assignment: assignment, submission: submission)
+                    SubmissionGrades(assignment: assignment, containerHeight: geometry.size.height, submission: submission)
                         .clipped()
                     Spacer().frame(height: bottomInset)
                 }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -21,6 +21,7 @@ import Core
 
 struct SubmissionGrades: View {
     let assignment: Assignment
+    let containerHeight: CGFloat
     @ObservedObject var submission: Submission
 
     @Environment(\.appEnvironment) var env
@@ -161,7 +162,7 @@ struct SubmissionGrades: View {
                         rubricCommentID = nil
                         rubricAssessments[id] = .init(comments: rubricComment, points: points, rating_id: ratingID)
                     }
-                })
+                }, containerHeight: containerHeight)
                     .padding(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                     .background(Color.backgroundLight)
             }

--- a/rn/Teacher/ios/TeacherUITests/SpeedGrader/SpeedGraderCommentUITests.swift
+++ b/rn/Teacher/ios/TeacherUITests/SpeedGrader/SpeedGraderCommentUITests.swift
@@ -89,6 +89,16 @@ class SpeedGraderCommentUITests: MiniCanvasUITestCase {
         waitUntil { submission.api.submission_comments?.isEmpty == false }
     }
 
+    func testLongTextCommentNotBlockingSendButton() {
+        let longText = Array(repeating: "Test sentence to be repeated. ", count: 100).reduce(into: "") { $0 += $1 }
+
+        showSubmission()
+        SpeedGrader.Segment.comments.tap()
+        SubmissionComments.commentTextView.pasteText(longText)
+        waitUntil { SubmissionComments.commentTextView.value() == longText }
+        XCTAssertTrue(SubmissionComments.addCommentButton.isVisible)
+    }
+
     func testNewAudioComment() throws {
         try XCTSkipIf(true, "recordButton.tap() doesn't start recording on bitrise")
         showSubmission()


### PR DESCRIPTION
refs: MBL-15291
affects: Teacher
release note: Fixed long comments in SpeedGrader pushing send button out of screen.

test plan:
- Start SpeedGrader on a submission where free form rubric comments are enabled.
- Enter a long text (or 1 character and new lines).
- Text box shouldn't grow so large that it pushes the send button out of screen, scrolling should work in text box.
- Repeat the same on the submission comments tab.