### PR TITLE
Addonly_active_users parameter

### DIFF
--- a/Core/Core/Notifications/APIActivity.swift
+++ b/Core/Core/Notifications/APIActivity.swift
@@ -85,8 +85,8 @@ public struct GetActivitiesRequest: APIRequestable {
         return "\(context.pathComponent)/activity_stream"
     }
 
-    public var query: [APIQueryItem] {
-        [ .value("only_active_courses", "true"),
-          .perPage(perPage), ]
-    }
+    public var query: [APIQueryItem] {[
+        .value("only_active_courses", "true"),
+        .perPage(perPage),
+    ]}
 }

--- a/Core/Core/Notifications/APIActivity.swift
+++ b/Core/Core/Notifications/APIActivity.swift
@@ -86,6 +86,7 @@ public struct GetActivitiesRequest: APIRequestable {
     }
 
     public var query: [APIQueryItem] {
-        [ .perPage(perPage) ]
+        [ .value("only_active_courses", "true"),
+          .perPage(perPage) ]
     }
 }

--- a/Core/Core/Notifications/APIActivity.swift
+++ b/Core/Core/Notifications/APIActivity.swift
@@ -87,6 +87,6 @@ public struct GetActivitiesRequest: APIRequestable {
 
     public var query: [APIQueryItem] {
         [ .value("only_active_courses", "true"),
-          .perPage(perPage) ]
+          .perPage(perPage), ]
     }
 }

--- a/Core/CoreTests/Notifications/APIActivityTests.swift
+++ b/Core/CoreTests/Notifications/APIActivityTests.swift
@@ -23,7 +23,7 @@ class APIActivityTests: XCTestCase {
     func testGetActivitiesRequest() {
         let request = GetActivitiesRequest()
         XCTAssertEqual(request.path, "users/self/activity_stream")
-        XCTAssertEqual(request.queryItems, [])
-        XCTAssertEqual(GetActivitiesRequest(perPage: 100).queryItems, [URLQueryItem(name: "per_page", value: "100")])
+        XCTAssertEqual(request.queryItems, [URLQueryItem(name: "only_active_courses", value: "true")])
+        XCTAssertEqual(GetActivitiesRequest(perPage: 100).queryItems[1], URLQueryItem(name: "per_page", value: "100"))
     }
 }


### PR DESCRIPTION
refs: MBL-13735
affects: Student
release note: Fixed activity stream showing unplublished courses.

test plan: See ticket