### PR TITLE
Add a11y identifier for eye icon

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -63,6 +63,7 @@ struct SubmissionHeader: View {
                     .padding(16)
             })
                 .identifier("SpeedGrader.postPolicyButton")
+                .accessibility(label: Text("Post settings"))
 
             Button(action: dismiss, label: {
                 Text("Done")


### PR DESCRIPTION
refs: MBL-15124
affects: Teacher
release note: none

test plan: See ticket ( submission header eye icon identifier)