### PR TITLE
Resolving bug where the URL is further decoded with NSAttributedStrin…

### DIFF
--- a/Core/Core/API/APIURL.swift
+++ b/Core/Core/API/APIURL.swift
@@ -33,7 +33,13 @@ public struct APIURL: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let baseURL = AppEnvironment.shared.currentSession?.baseURL
         let container = try decoder.singleValueContainer()
-        let string = try container.decode(String.self)
+        var string = try container.decode(String.self)
+        if let data = string.data(using: .utf8) {
+            let decodedString = try? NSAttributedString(data: data, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil)
+            if let escapedString = decodedString?.string {
+                string = escapedString
+            }
+        }
         if let url = URL(string: string, relativeTo: baseURL) {
             rawValue = url
             return


### PR DESCRIPTION
…g to eliminate breaking characters such as '&amp' and the like.

Issue referenced: https://github.com/instructure/canvas-lms/issues/1849