### PR TITLE
Use can_submit parameter for getAssigmnents as default

### DIFF
--- a/Core/Core/Assignments/APIAssignment.swift
+++ b/Core/Core/Assignments/APIAssignment.swift
@@ -25,6 +25,7 @@ public struct APIAssignment: Codable, Equatable {
     let all_dates: [APIAssignmentDate]?
     let anonymize_students: Bool?
     let assignment_group_id: ID?
+    let can_submit: Bool?
     let course_id: ID
     let description: String?
     let discussion_topic: APIDiscussionTopic?
@@ -99,6 +100,7 @@ extension APIAssignment {
         all_dates: [APIAssignmentDate]? = nil,
         anonymize_students: Bool? = nil,
         assignment_group_id: ID? = nil,
+        can_submit: Bool? = true,
         course_id: ID = "1",
         description: String? = "<p>Do the following:</p>...",
         discussion_topic: APIDiscussionTopic? = nil,
@@ -145,6 +147,7 @@ extension APIAssignment {
             all_dates: all_dates,
             anonymize_students: anonymize_students,
             assignment_group_id: assignment_group_id,
+            can_submit: can_submit,
             course_id: course_id,
             description: description,
             discussion_topic: discussion_topic,
@@ -262,7 +265,7 @@ public struct GetAssignmentRequest: APIRequestable {
     }
 
     public enum GetAssignmentInclude: String {
-        case submission, overrides, score_statistics
+        case submission, overrides, score_statistics, can_submit, observed_users
     }
 
     public var path: String {
@@ -272,9 +275,9 @@ public struct GetAssignmentRequest: APIRequestable {
 
     public var query: [APIQueryItem] {
         var query: [APIQueryItem] = []
-        var include = self.include.map { $0.rawValue }
-        include.append("observed_users")
-        query.append(.array("include", include))
+        var include = self.include
+        include.append(.can_submit)
+        query.append(.array("include", include.map { $0.rawValue }))
         if AppEnvironment.shared.app == .teacher || allDates == true {
             query.append(.value("all_dates", "true"))
         }

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -27,6 +27,7 @@ public class Assignment: NSManagedObject {
     @NSManaged public var assignmentGroup: AssignmentGroup?
     @NSManaged public var assignmentGroupID: String?
     @NSManaged public var assignmentGroupPosition: Int
+    @NSManaged public var canSubmit: Bool
     @NSManaged public var canUnpublish: Bool
     @NSManaged public var courseID: String
     @NSManaged public var details: String?
@@ -141,6 +142,7 @@ extension Assignment {
         allowedExtensions = item.allowed_extensions ?? []
         anonymizeStudents = item.anonymize_students == true
         assignmentGroupID = item.assignment_group_id?.value
+        canSubmit = item.can_submit == true
         canUnpublish = item.unpublishable == true
         courseID = item.course_id.value
         details = item.description

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -33,6 +33,7 @@
         <attribute name="assignmentGroupPosition" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="assignmentGroupSectionName" optional="YES" transient="YES" attributeType="String"/>
         <attribute name="cacheKey" optional="YES" attributeType="String"/>
+        <attribute name="canSubmit" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="canUnpublish" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="courseID" attributeType="String"/>
         <attribute name="details" optional="YES" attributeType="String"/>
@@ -916,7 +917,7 @@
         <element name="AccountNotification" positionX="-540" positionY="-18" width="128" height="133"/>
         <element name="Activity" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="AlertThreshold" positionX="-540" positionY="-27" width="128" height="118"/>
-        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="763"/>
+        <element name="Assignment" positionX="-507.2109375" positionY="194.3515625" width="128" height="779"/>
         <element name="AssignmentDate" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="AssignmentGroup" positionX="-540" positionY="-27" width="128" height="120"/>
         <element name="AssignmentOverride" positionX="-540" positionY="-18" width="128" height="193"/>

--- a/Core/CoreTests/Assignments/APIAssignmentTests.swift
+++ b/Core/CoreTests/Assignments/APIAssignmentTests.swift
@@ -24,16 +24,16 @@ class APIAssignmentRequestableTests: XCTestCase {
         let request = GetAssignmentRequest(courseID: "1", assignmentID: "2", include: [])
         XCTAssertEqual(request.path, "courses/1/assignments/2")
         XCTAssertEqual(request.queryItems, [
-            URLQueryItem(name: "include[]", value: "observed_users"),
+            URLQueryItem(name: "include[]", value: "can_submit"),
         ])
         let allDates = GetAssignmentRequest(courseID: "1", assignmentID: "2", allDates: true, include: [])
         XCTAssertEqual(allDates.queryItems, [
-            URLQueryItem(name: "include[]", value: "observed_users"),
+            URLQueryItem(name: "include[]", value: "can_submit"),
             URLQueryItem(name: "all_dates", value: "true"),
         ])
         let notAllDates = GetAssignmentRequest(courseID: "1", assignmentID: "2", allDates: false, include: [])
         XCTAssertEqual(notAllDates.queryItems, [
-            URLQueryItem(name: "include[]", value: "observed_users"),
+            URLQueryItem(name: "include[]", value: "can_submit"),
         ])
     }
 
@@ -42,7 +42,7 @@ class APIAssignmentRequestableTests: XCTestCase {
         XCTAssertEqual(request.path, "courses/1/assignments/2")
         XCTAssertEqual(request.queryItems, [
             URLQueryItem(name: "include[]", value: "submission"),
-            URLQueryItem(name: "include[]", value: "observed_users"),
+            URLQueryItem(name: "include[]", value: "can_submit"),
         ])
     }
 

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -46,7 +46,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     let env = AppEnvironment.shared
     var studentID = ""
 
-    lazy var assignment = env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID)) {  [weak self] in
+    lazy var assignment = env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID, include: [.observed_users])) {  [weak self] in
         self?.update()
     }
     lazy var course = env.subscribe(GetCourse(courseID: courseID)) {  [weak self] in

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -276,7 +276,8 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
             assignment?.lockedForUser == true ||
             assignment?.isSubmittable == false ||
             assignment?.submission?.excused == true ||
-            assignment?.isMasteryPathAssignment == true
+            assignment?.isMasteryPathAssignment == true ||
+            assignment?.canSubmit == false
     }
 
     func attemptsIsHidden() -> Bool {

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -420,6 +420,11 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         XCTAssertTrue(presenter.submitAssignmentButtonIsHidden())
     }
 
+    func testSubmitAssignmentButtonHiddenForCantSubmit() {
+        Assignment.make(from: .make(can_submit: false, submission_types: [ .online_text_entry ]))
+        XCTAssertTrue(presenter.submitAssignmentButtonIsHidden())
+    }
+
     func setupIsHiddenTest(lockStatus: LockStatus, lockedForUser: Bool = true) {
         switch lockStatus {
         case .unlocked:


### PR DESCRIPTION
Use can_submit parameter for getAssigmnents as default
use observed_users only in parent app

refs: MBL-14703
affects: Student, Parent
release note: Fixed submit button availability for soft concluded enrollments.

test plan:
see ticket, check parent, if assignments are valid