### PR TITLE
Fix iOS 14 datepicker on the calendar's new to do page

### DIFF
--- a/Core/Core/Planner/CreateTodoViewController.swift
+++ b/Core/Core/Planner/CreateTodoViewController.swift
@@ -95,6 +95,9 @@ public class CreateTodoViewController: UIViewController, ErrorViewController {
     }
 
     @IBAction func showDatePicker(_ sender: Any) {
+        if #available(iOS 13.4, *) {
+            datePicker.preferredDatePickerStyle = .wheels
+        }
         datePicker.datePickerMode = .dateAndTime
         let toolbar = UIToolbar()
         toolbar.sizeToFit()


### PR DESCRIPTION
refs: MBL-15329
affects: Student
release note: Fixed date picker for iOS 14 on the Calendar's new todo page.

test plan:
see ticket