### PR TITLE
Remove unused brew tap.

### DIFF
--- a/scripts/build_automation/bitrise_workflows/tests.yml
+++ b/scripts/build_automation/bitrise_workflows/tests.yml
@@ -63,8 +63,6 @@ workflows:
             #!/bin/zsh
             set -euxo pipefail
 
-            brew tap mxcl/made
-
             brew reinstall swiftlint jq
 
             rm -rf "$BITRISE_SOURCE_DIR/Pods/Target Support Files/yoga"


### PR DESCRIPTION
refs: none
affects: none
release note: none

test plan: Nightly tests shouldn't fail while setting up dependencies.