### PR TITLE
Remove scanner for media recordings

### DIFF
--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -184,7 +184,8 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
         let mediaTypes = selectedSubmissionTypes.allowedMediaTypes
         filePicker.sources = [.files]
         if assignment.allowedExtensions.isEmpty == true || allowedUTIs.contains(where: { $0.isImage || $0.isVideo }) {
-            filePicker.sources.append(contentsOf: [.library, .camera, .documentScan])
+            filePicker.sources.append(contentsOf: [.library, .camera])
+            if !isMediaRecording { filePicker.sources.append(.documentScan) }
         }
         if isMediaRecording { filePicker.sources.append(.audio) }
         filePicker.utis = allowedUTIs

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -242,6 +242,13 @@ class SubmissionButtonPresenterTests: StudentTestCase {
         XCTAssertEqual(filePicker?.sources, [.files, .library, .camera, .documentScan])
     }
 
+    func testPickMediaRecordings() {
+        let a = Assignment.make(from: .make(allowed_extensions: [], submission_types: [ .online_upload, .media_recording ]))
+        presenter.pickFiles(for: a, selectedSubmissionTypes: [ .media_recording ])
+        let filePicker = (router.presented as? UINavigationController)?.viewControllers.first as? FilePickerViewController
+        XCTAssertEqual(filePicker?.sources, [.files, .library, .camera, .audio])
+    }
+
     func testRetryFileUpload() {
         XCTAssertNoThrow(presenter.retry(filePicker))
     }

--- a/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionRubric/RubricPresenterTests.swift
@@ -179,7 +179,7 @@ class RubricPresenterTests: StudentTestCase {
         ]))
         Course.make()
         let assignment = Assignment.make(from: .make(rubric: [
-            .make(id: "1", ratings:  [
+            .make(id: "1", ratings: [
                 .make(id: "1", points: 10),
                 .make(id: "2", points: 25),
             ]),
@@ -215,7 +215,7 @@ class RubricPresenterTests: StudentTestCase {
         ]))
         Course.make()
         Assignment.make(from: .make(rubric: [
-            .make(id: "1", ratings:  [
+            .make(id: "1", ratings: [
                 .make(id: "1", points: 10),
                 .make(id: "2", points: 25),
             ]),


### PR DESCRIPTION
refs: MBL-15312
affects: Student
release note: Disabled scanner for media recordings

test plan: see ticket (balintbartok sandbox has a media recording upload type assignment)
* scanner should not be available, when user selects media recording
* it should be available for file uploads as before

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72031065/117808083-bcd8eb00-b25c-11eb-92ce-329bc1c8e40d.png"></td>
<td><img src="https://user-images.githubusercontent.com/72031065/117807960-9ca92c00-b25c-11eb-815a-ddaf1719487f.png"></td>
</tr>
</table>

