### PR TITLE
Release Canvas iOS Student 6.11.0

### DIFF
--- a/Student/GradesWidget/Info.plist
+++ b/Student/GradesWidget/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>6.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>14325</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/Student/Student/Info.plist
+++ b/Student/Student/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSCrossWebsiteTrackingUsageDescription</key>
-	<string>Canvas uses cookies to load media embedded in rich content.</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
@@ -19,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>$(MARKETING_VERSION)</string>
+	<string>6.11.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSpokenName</key>
@@ -56,7 +54,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>14325</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<true/>
 	<key>ITSEncryptionExportComplianceCode</key>
@@ -83,6 +81,8 @@
 	</dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Attach photos and videos to messages and discussion posts or turn them in as assignment submissions.</string>
+	<key>NSCrossWebsiteTrackingUsageDescription</key>
+	<string>Canvas uses cookies to load media embedded in rich content.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Help us find schools near you.</string>
 	<key>NSMicrophoneUsageDescription</key>

--- a/Student/SubmitAssignment/Info.plist
+++ b/Student/SubmitAssignment/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.0.1</string>
+	<string>6.11.0</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>14325</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionAttributes</key>


### PR DESCRIPTION
Inbox tab - Allow students and teachers to be able to select multiple conversations by long-tapping and be able to delete multiple conversations at once. Allow students and teachers to delete specific conversations by doing a swiping gesture and showing a delete button.