### PR TITLE
Don't check can_submit in case of LTI tools

### DIFF
--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -142,7 +142,7 @@ extension Assignment {
         allowedExtensions = item.allowed_extensions ?? []
         anonymizeStudents = item.anonymize_students == true
         assignmentGroupID = item.assignment_group_id?.value
-        canSubmit = item.can_submit == true
+        canSubmit = !(item.can_submit == false)
         canUnpublish = item.unpublishable == true
         courseID = item.course_id.value
         details = item.description

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -291,7 +291,7 @@ class AssignmentDetailsPresenter: PageViewLoggerPresenterProtocol {
             assignment?.isSubmittable == false ||
             assignment?.submission?.excused == true ||
             assignment?.isMasteryPathAssignment == true ||
-            assignment?.canSubmit == false
+            (assignment?.canSubmit == false && (assignment?.isLTIAssignment != true))
     }
 
     func attemptsIsHidden() -> Bool {


### PR DESCRIPTION
refs: MBL-15414
affects: Student
release note: Fixed External tools button not showing

test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/117959500-5fa46e80-b31c-11eb-86fc-e0f9c26745a6.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/117959528-66cb7c80-b31c-11eb-9c93-adc5bd80eac9.png"></td>
</tr>
</table>