### PR TITLE
Improve dashboard favourite button's a11y announcements

### DIFF
--- a/Core/Core/Courses/CourseListView.swift
+++ b/Core/Core/Courses/CourseListView.swift
@@ -168,7 +168,7 @@ public struct CourseListView: View {
                     icon.padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 12))
                 }
                     .buttonStyle(PlainButtonStyle())
-                    .accessibility(label: pending ? Text(verbatim: "Updating") : Text("favorite", bundle: .core))
+                    .accessibility(label: pending ? Text("Updating", bundle: .core) : Text("favorite", bundle: .core))
                     .accessibility(addTraits: (course.isFavorite && !pending) ? .isSelected : [])
 
                 Button(action: {

--- a/Core/Core/Courses/CourseListView.swift
+++ b/Core/Core/Courses/CourseListView.swift
@@ -168,8 +168,8 @@ public struct CourseListView: View {
                     icon.padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 12))
                 }
                     .buttonStyle(PlainButtonStyle())
-                    .accessibility(label: Text("favorite", bundle: .core))
-                    .accessibility(addTraits: course.isFavorite ? .isSelected : [])
+                    .accessibility(label: pending ? Text(verbatim: "Updating") : Text("favorite", bundle: .core))
+                    .accessibility(addTraits: (course.isFavorite && !pending) ? .isSelected : [])
 
                 Button(action: {
                     env.router.route(to: "/courses/\(course.id)", from: controller)


### PR DESCRIPTION
refs: MBL-14908
affects: Student, Teacher
release note: Improved accessibility features.

test plan:
- Enter edit Dashboard menu.
- Turn on VoiceOver.
- Toggle a course's favourite state.
- VoiceOver should announce the actual state correctly.