### PR TITLE
Make K5 top navbar scroll to the selected item

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -819,6 +819,8 @@
 		CF4BDB6026453BD900A91952 /* K5DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */; };
 		CF4E5E9025BAF91F008609C5 /* DiscussionHTMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */; };
 		CF4E5E9925C8455A008609C5 /* NSPredicateExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4E5E9825C8455A008609C5 /* NSPredicateExtensionsTests.swift */; };
+		CF575E1A265E920D00F8515F /* CompatibleScrollViewReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF575E19265E920D00F8515F /* CompatibleScrollViewReader.swift */; };
+		CF575E20265E9D5200F8515F /* ScrollViewWithReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF575E1F265E9D5200F8515F /* ScrollViewWithReader.swift */; };
 		CF5C5B422534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */; };
 		CF5F602A25DBD70E00E7E0ED /* WeakViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5F602925DBD70E00E7E0ED /* WeakViewController.swift */; };
 		CF5F602E25DBD7D800E7E0ED /* EnvironmentValues.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5F602D25DBD7D800E7E0ED /* EnvironmentValues.swift */; };
@@ -1951,6 +1953,8 @@
 		CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5DashboardViewModel.swift; sourceTree = "<group>"; };
 		CF4E5E8F25BAF91F008609C5 /* DiscussionHTMLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionHTMLTests.swift; sourceTree = "<group>"; };
 		CF4E5E9825C8455A008609C5 /* NSPredicateExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPredicateExtensionsTests.swift; sourceTree = "<group>"; };
+		CF575E19265E920D00F8515F /* CompatibleScrollViewReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleScrollViewReader.swift; sourceTree = "<group>"; };
+		CF575E1F265E9D5200F8515F /* ScrollViewWithReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollViewWithReader.swift; sourceTree = "<group>"; };
 		CF5C5B412534B9CB009871B9 /* GroupPeopleListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupPeopleListViewControllerTests.swift; sourceTree = "<group>"; };
 		CF5F602925DBD70E00E7E0ED /* WeakViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeakViewController.swift; sourceTree = "<group>"; };
 		CF5F602D25DBD7D800E7E0ED /* EnvironmentValues.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnvironmentValues.swift; sourceTree = "<group>"; };
@@ -4366,6 +4370,7 @@
 				CF7CEAEB26035BE500967EA0 /* ChangeObserver.swift */,
 				7D7BA23824DB57BD00B1A68B /* CircleProgress.swift */,
 				7D2FA37E255EEC3F00C9552F /* CircleRefresh.swift */,
+				CF575E19265E920D00F8515F /* CompatibleScrollViewReader.swift */,
 				EB66DB9426451CAE002D3325 /* CustomTextField.swift */,
 				7D89A2C82509326B009D0FD2 /* DisclosureIndicator.swift */,
 				7D89A2CA250A6B3B009D0FD2 /* EditorForm.swift */,
@@ -4376,6 +4381,7 @@
 				7DD6FB3525081CD900DB5286 /* OptionalDatePicker.swift */,
 				7D0A28DC251952A2004FB3B6 /* RemoteImage.swift */,
 				7D1E85652567294A00D093C5 /* ScaleButtonStyle.swift */,
+				CF575E1F265E9D5200F8515F /* ScrollViewWithReader.swift */,
 				E8A8FA8D24D328C3000B27DF /* SearchBar.swift */,
 				7D4B2744253E3A5700A98DE3 /* TextEditor.swift */,
 				7DCA32112541DB8B00458651 /* WebSession.swift */,
@@ -5317,11 +5323,13 @@
 				7D4F44FA241BF26700233B92 /* APIConference.swift in Sources */,
 				D9E1BABD258163DC0034C01E /* ContextCardSubmissionsView.swift in Sources */,
 				7DA2607F23F722FA005D2121 /* Persistency.swift in Sources */,
+				CF575E20265E9D5200F8515F /* ScrollViewWithReader.swift in Sources */,
 				7DA25F9B23F72136005D2121 /* APIActivity.swift in Sources */,
 				7D2E812F25632C34008C568F /* SubmissionBreakdown.swift in Sources */,
 				7D0A28DA25194CE6004FB3B6 /* Avatar.swift in Sources */,
 				7DA260D423F72359005D2121 /* DynamicButton.swift in Sources */,
 				7DA260A323F7234C005D2121 /* IPC.swift in Sources */,
+				CF575E1A265E920D00F8515F /* CompatibleScrollViewReader.swift in Sources */,
 				7D06A2B32469B7D100D76267 /* DiscussionReplyViewController.swift in Sources */,
 				7DA2605323F722D9005D2121 /* Module.swift in Sources */,
 				B102EEB6243B862C002E04F0 /* ModuleItemSequenceViewController.swift in Sources */,

--- a/Core/Core/SwiftUIViews/CompatibleScrollViewReader.swift
+++ b/Core/Core/SwiftUIViews/CompatibleScrollViewReader.swift
@@ -1,0 +1,51 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+/**
+ The purpose os this View is to be able to use ScrollViewReader on iOS 13 without any `if #available` statements. Acts as a ScrollViewReader on iOS 14, does nothing below that since there's no support from Apple.
+ */
+public struct CompatibleScrollViewReader<Content: View>: View {
+    private let content: (CompatibleScrollViewProxy) -> Content
+
+    public init(content: @escaping (CompatibleScrollViewProxy) -> Content) {
+        self.content = content
+    }
+
+    @ViewBuilder
+    public var body: some View {
+        if #available(iOS 14, *) {
+            ScrollViewReader(content: content)
+        } else {
+            content(IOS13ScrollViewReaderProxy())
+        }
+    }
+}
+
+public protocol CompatibleScrollViewProxy {
+    func scrollTo<ID: Hashable>(_ id: ID, anchor: UnitPoint?)
+}
+
+/** Since there's no such thing on iOS 13 as a manually scrollable swiftui scrollview we just provide a mock implementation that does nothing. */
+private struct IOS13ScrollViewReaderProxy: CompatibleScrollViewProxy {
+    func scrollTo<ID: Hashable>(_ id: ID, anchor: UnitPoint?) {}
+}
+
+@available(iOSApplicationExtension 14.0, *)
+extension ScrollViewProxy: CompatibleScrollViewProxy {}

--- a/Core/Core/SwiftUIViews/ScrollViewWithReader.swift
+++ b/Core/Core/SwiftUIViews/ScrollViewWithReader.swift
@@ -1,0 +1,39 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public struct ScrollViewWithReader<Content>: View where Content: View {
+    private let contentBuilder: (CompatibleScrollViewProxy) -> Content
+    private let axes: Axis.Set
+    private let showsIndicators: Bool
+
+    public var body: some View {
+        CompatibleScrollViewReader { proxy in
+            ScrollView(axes, showsIndicators: showsIndicators) {
+                contentBuilder(proxy)
+            }
+        }
+    }
+
+    public init(_ axes: Axis.Set = .vertical, showsIndicators: Bool = true, @ViewBuilder contentBuilder: @escaping (CompatibleScrollViewProxy) -> Content) {
+        self.axes = axes
+        self.showsIndicators = showsIndicators
+        self.contentBuilder = contentBuilder
+    }
+}

--- a/Core/Core/SwiftUIViews/TopBar/View/TopBarView.swift
+++ b/Core/Core/SwiftUIViews/TopBar/View/TopBarView.swift
@@ -27,13 +27,17 @@ public struct TopBarView: View {
     }
 
     public var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
+        ScrollViewWithReader(.horizontal, showsIndicators: false) { scrollViewProxy in
             HStack(spacing: 0) {
                 ForEach(0..<viewModel.items.count) { index in
                     TopBarItemView(viewModel: viewModel.items[index]) {
                         viewModel.selectedItemIndex = index
+                        withAnimation {
+                            scrollViewProxy.scrollTo(index, anchor: nil)
+                        }
                     }
                     .anchorPreference(key: ViewBoundsPreferenceKey.self, value: .bounds, transform: { [ViewBoundsPreferenceData(viewId: index, bounds: $0)] })
+                    .id(index)
                 }
             }
             .overlayPreferenceValue(ViewBoundsPreferenceKey.self) { boundsPreferences in


### PR DESCRIPTION
refs: MBL-15374
affects: Student
release note: none

test plan: Items should scroll to screen on iOS 14 when selected if a part of them is off-screen.