### PR TITLE
Allow inline media playback in CoreWebView

### DIFF
--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -56,6 +56,7 @@ open class CoreWebView: WKWebView {
     }
 
     public override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+        configuration.allowsInlineMediaPlayback = true
         configuration.processPool = CoreWebView.processPool
         super.init(frame: frame, configuration: configuration)
         setup()
@@ -63,6 +64,7 @@ open class CoreWebView: WKWebView {
 
     public init(customUserAgentName: String? = nil) {
         let configuration = WKWebViewConfiguration()
+        configuration.allowsInlineMediaPlayback = true
         configuration.processPool = CoreWebView.processPool
         if let customUserAgentName = customUserAgentName {
             configuration.applicationNameForUserAgent = customUserAgentName


### PR DESCRIPTION
This is part 1 of fixing MAT-83. The rest is up to the
studio team to add the `playsinline` attribute to their
video player.

refs: MAT-83
affects: student, teacher, parent
release note: none

test plan:
- narmstrong.instructure.com
  - username: s
- CS 1400 > Pages > Media Files
- There should be two videos
  - The first one was embedded via the UI and uses an iframe
  - The second one was embedded manually using a video tag
- The first video will not play inline because we need the
  studio team to add the `playsinline` attribute
- The second video should play inline because it has the
  `playsinline` attribute and this code change