### PR TITLE
Move FileAnnotations inside DocViewerAnnotataionProvider

### DIFF
--- a/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
@@ -38,7 +38,12 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         }
     }
 
-    init(documentProvider: PDFDocumentProvider!, fileAnnotationProvider: PDFFileAnnotationProvider, metadata: APIDocViewerMetadata, annotations: [APIDocViewerAnnotation], api: API, sessionID: String) {
+    init(documentProvider: PDFDocumentProvider!,
+         fileAnnotationProvider: PDFFileAnnotationProvider,
+         metadata: APIDocViewerMetadata,
+         annotations: [APIDocViewerAnnotation],
+         api: API, sessionID: String) {
+
         self.api = api
         self.sessionID = sessionID
         self.fileAnnotationProvider = fileAnnotationProvider
@@ -108,7 +113,7 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
     }
 
     override func annotationsForPage(at pageIndex: PageIndex) -> [Annotation]? {
-        // First, fetch the annotations from the file annotation provider. Use `annotationsForPage(at:)` because this is the function that actually loads the annotations.
+        // First, fetch the annotations from the file annotation provider.
         let fileAnnotations = fileAnnotationProvider.annotationsForPage(at: pageIndex) ?? []
         // Then ask `super` to retrieve the custom annotations from cache.
         let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -103,9 +103,9 @@ public class DocViewerViewController: UIViewController {
             document.defaultAnnotationUsername = annotationMeta.user_name
             document.didCreateDocumentProviderBlock = { [weak self] documentProvider in
                 guard let self = self, let fileAnnotationProvider = documentProvider.annotationManager.fileAnnotationProvider else { return }
-                let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, metadata: metadata, annotations: annotations, api: self.session.api, sessionID: sessionID)
+                let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, fileAnnotationProvider: fileAnnotationProvider, metadata: metadata, annotations: annotations, api: self.session.api, sessionID: sessionID)
                 provider.docViewerDelegate = self
-                documentProvider.annotationManager.annotationProviders = [provider, fileAnnotationProvider, provider]
+                documentProvider.annotationManager.annotationProviders = [provider]
                 self.annotationProvider = provider
             }
         }

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -103,7 +103,12 @@ public class DocViewerViewController: UIViewController {
             document.defaultAnnotationUsername = annotationMeta.user_name
             document.didCreateDocumentProviderBlock = { [weak self] documentProvider in
                 guard let self = self, let fileAnnotationProvider = documentProvider.annotationManager.fileAnnotationProvider else { return }
-                let provider = DocViewerAnnotationProvider(documentProvider: documentProvider, fileAnnotationProvider: fileAnnotationProvider, metadata: metadata, annotations: annotations, api: self.session.api, sessionID: sessionID)
+                let provider = DocViewerAnnotationProvider(documentProvider: documentProvider,
+                                                           fileAnnotationProvider: fileAnnotationProvider,
+                                                           metadata: metadata,
+                                                           annotations: annotations,
+                                                           api: self.session.api,
+                                                           sessionID: sessionID)
                 provider.docViewerDelegate = self
                 documentProvider.annotationManager.annotationProviders = [provider]
                 self.annotationProvider = provider

--- a/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
@@ -45,8 +45,10 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
         let document = Document(url: Bundle(for: DocViewerAnnotationProviderTests.self).url(forResource: "instructure", withExtension: "pdf")!)
         let metadata = APIDocViewerAnnotationsMetadata(enabled: enabled, user_id: "1", user_name: "a", permissions: permissions)
         let documentProvider = document.documentProviders.first!
+        let fileAnnotationProvider = documentProvider.annotationManager.fileAnnotationProvider!
         let provider = DocViewerAnnotationProvider(
             documentProvider: documentProvider,
+            fileAnnotationProvider: fileAnnotationProvider,
             metadata: APIDocViewerMetadata(
                 annotations: metadata,
                 panda_push: nil,


### PR DESCRIPTION
refs: MBL-15223
affects: Teacher
release note: Fixed annotation orientation on rotated submissions

test plan: see ticket, only new annotations will save correctly (check green arrows at bottom)