### PR TITLE
Groups in soft-concluded courses show up on dashboard and give error

### DIFF
--- a/Core/Core/Groups/GetGroups.swift
+++ b/Core/Core/Groups/GetGroups.swift
@@ -67,13 +67,15 @@ public class GetDashboardGroups: CollectionUseCase {
 
     public var cacheKey: String? { "users/self/groups" }
     public var request: GetGroupsRequest { GetGroupsRequest(context: .currentUser) }
-    public var scope: Scope { .where(
-        #keyPath(Group.showOnDashboard), equals: true,
-        sortDescriptors: [
-            NSSortDescriptor(key: #keyPath(Group.name), ascending: true, naturally: true),
-            NSSortDescriptor(key: #keyPath(Group.id), ascending: true, naturally: true),
-        ]
-    ) }
+    public var scope: Scope {
+        let showOnDashboard = NSPredicate(key: #keyPath(Group.showOnDashboard), equals: true)
+        let accessRestrictedByDate = NSPredicate(key: #keyPath(Group.course.accessRestrictedByDate), equals: false)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [showOnDashboard, accessRestrictedByDate])
+        return Scope(predicate: predicate,
+                     order: [NSSortDescriptor(key: #keyPath(Group.name), ascending: true, naturally: true),
+                             NSSortDescriptor(key: #keyPath(Group.id), ascending: true, naturally: true),
+                     ])
+    }
 }
 
 class GetGroupsInCategory: CollectionUseCase {

--- a/Core/CoreTests/Groups/GetGroupsTests.swift
+++ b/Core/CoreTests/Groups/GetGroupsTests.swift
@@ -115,4 +115,15 @@ class GetDashboardGroupsTest: CoreTestCase {
         let groups: [Group] = databaseClient.fetch()
         XCTAssert(groups.contains(notMember))
     }
+
+    func testItDoesNotShowRestrictedCourseGroups() {
+        let course: Course = .make(from: .make(access_restricted_by_date: true))
+        let group = Group.make(from: .make(id: "1", name: "Old Name"), showOnDashboard: true, course: course)
+        let getGroup = GetDashboardGroups()
+        var groups: [Group] = databaseClient.fetch(.all, sortDescriptors: getGroup.scope.order)
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups.first, group)
+        groups = databaseClient.fetch(getGroup.scope.predicate, sortDescriptors: getGroup.scope.order)
+        XCTAssertEqual(groups.count, 0)
+    }
 }

--- a/TestsFoundation/TestsFoundation/Fixtures/Model/GroupFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Model/GroupFixture.swift
@@ -25,10 +25,12 @@ extension Group {
     public static func make(
         from api: APIGroup = .make(),
         showOnDashboard: Bool = false,
+        course: Course = .make(),
         in context: NSManagedObjectContext = singleSharedTestDatabase.viewContext
     ) -> Group {
         let model = Group.save(api, in: context)
         model.showOnDashboard = showOnDashboard
+        model.course = course
         try! context.save()
         return model
     }


### PR DESCRIPTION
refs: MBL-15336
affects: Student
release note: Hide concluded course groups on the dashboard.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/121877299-c39ac800-cd0a-11eb-80fe-2f8ba8688121.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/121877313-c5fd2200-cd0a-11eb-8b64-98cdbfa9cab7.png"></td>
</tr>
</table>
