### PR TITLE
Add entity to be able to decode two different data types in APIPlannable response.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -848,6 +848,8 @@
 		CF60CC5F26496EDE00C1C173 /* K5GradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF60CC5E26496EDE00C1C173 /* K5GradesViewModel.swift */; };
 		CF60CC6226497BC100C1C173 /* Refreshable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF60CC6126497BC100C1C173 /* Refreshable.swift */; };
 		CF62AE472640539E004F062D /* FileSubmissionsStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF62AE462640539E004F062D /* FileSubmissionsStatus.swift */; };
+		CF7C3696267A3CEE00ACAC79 /* TypeSafeCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C3695267A3CEE00ACAC79 /* TypeSafeCodable.swift */; };
+		CF7C3699267A3E3400ACAC79 /* TypeSafeCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C3698267A3E3400ACAC79 /* TypeSafeCodableTests.swift */; };
 		CF7C6D9F25E5130200363203 /* GroupContextCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6D9E25E5130200363203 /* GroupContextCardView.swift */; };
 		CF7C6DA325E5139D00363203 /* GroupContextCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6DA225E5139D00363203 /* GroupContextCardViewModel.swift */; };
 		CF7C6DAD25E56A0000363203 /* GroupContextCardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C6DAC25E56A0000363203 /* GroupContextCardTests.swift */; };
@@ -1993,6 +1995,8 @@
 		CF60CC5E26496EDE00C1C173 /* K5GradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesViewModel.swift; sourceTree = "<group>"; };
 		CF60CC6126497BC100C1C173 /* Refreshable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refreshable.swift; sourceTree = "<group>"; };
 		CF62AE462640539E004F062D /* FileSubmissionsStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSubmissionsStatus.swift; sourceTree = "<group>"; };
+		CF7C3695267A3CEE00ACAC79 /* TypeSafeCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeSafeCodable.swift; sourceTree = "<group>"; };
+		CF7C3698267A3E3400ACAC79 /* TypeSafeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeSafeCodableTests.swift; sourceTree = "<group>"; };
 		CF7C6D9E25E5130200363203 /* GroupContextCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardView.swift; sourceTree = "<group>"; };
 		CF7C6DA225E5139D00363203 /* GroupContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModel.swift; sourceTree = "<group>"; };
 		CF7C6DAC25E56A0000363203 /* GroupContextCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardTests.swift; sourceTree = "<group>"; };
@@ -3283,6 +3287,7 @@
 				7D80AC1E212B738500C40ECE /* APITests.swift */,
 				B11AAC3A237A1EB4002BC41F /* APIURLTests.swift */,
 				3B3467D52135B99700F9BC2E /* IDTests.swift */,
+				CF7C3698267A3E3400ACAC79 /* TypeSafeCodableTests.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -3349,6 +3354,7 @@
 				7D8262EA212B1A7B00BD268D /* APIRequestable.swift */,
 				B11AAC3C237A2428002BC41F /* APIURL.swift */,
 				3B3467D32135B7B700F9BC2E /* ID.swift */,
+				CF7C3695267A3CEE00ACAC79 /* TypeSafeCodable.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -4952,6 +4958,7 @@
 				3B158CBC22E267FF0039A568 /* PageViewSessionTests.swift in Sources */,
 				7DF9BF082152AEF10099026B /* UIColorExtensionsTests.swift in Sources */,
 				B191D5E8226E2CBA00D02948 /* CacheManagerTests.swift in Sources */,
+				CF7C3699267A3E3400ACAC79 /* TypeSafeCodableTests.swift in Sources */,
 				B1CA3348233948870015CBB4 /* UserTests.swift in Sources */,
 				D9DE56E9255454D300CF8B22 /* SyllabusEditorViewTests.swift in Sources */,
 				B19792FF2176A0F00000369C /* TabTests.swift in Sources */,
@@ -5550,6 +5557,7 @@
 				7DA260B823F72352005D2121 /* GetQuiz.swift in Sources */,
 				7DA2605923F722D9005D2121 /* Quiz.swift in Sources */,
 				CFFA6CF02655628100B47380 /* TopBarItemViewModel.swift in Sources */,
+				CF7C3696267A3CEE00ACAC79 /* TypeSafeCodable.swift in Sources */,
 				7D531D44254B105700CBFCA6 /* AssignmentAssigneePicker.swift in Sources */,
 				CF7C6DA325E5139D00363203 /* GroupContextCardViewModel.swift in Sources */,
 				7DA260BD23F72352005D2121 /* GetSubmissions.swift in Sources */,

--- a/Core/Core/API/TypeSafeCodable.swift
+++ b/Core/Core/API/TypeSafeCodable.swift
@@ -1,0 +1,64 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public typealias CodableEquatable = Codable & Equatable
+
+/**
+ The purpose of this entity is to allow two different data types to be coded/decoded to/from a single entity. Useful if a JSON property has different data types based on the context.
+ Example: `APIPlannable`'s `submissions` property can be either a `Bool` or a custom structure depending on if the plannable is an announcement or an assignment.
+ */
+public struct TypeSafeCodable<T1: CodableEquatable, T2: CodableEquatable>: CodableEquatable {
+    public let value1: T1?
+    public let value2: T2?
+
+    public init(value1: T1?, value2: T2?) {
+        self.value1 = value1
+        self.value2 = value2
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        if let type1Value = try? container.decode(T1.self) {
+            value1 = type1Value
+            value2 = nil
+
+        } else if let type2Value = try? container.decode(T2.self) {
+            value1 = nil
+            value2 = type2Value
+
+        } else {
+            value1 = nil
+            value2 = nil
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var singleEncoder = encoder.singleValueContainer()
+
+        if let value1 = value1 {
+            try singleEncoder.encode(value1)
+
+        } else if let value2 = value2 {
+            try singleEncoder.encode(value2)
+
+        } else {
+            try singleEncoder.encodeNil()
+        }
+    }
+}

--- a/Core/Core/Dashboard/K5/Model/DueItems/GetK5HomeroomDueItemCount.swift
+++ b/Core/Core/Dashboard/K5/Model/DueItems/GetK5HomeroomDueItemCount.swift
@@ -36,7 +36,7 @@ public class GetK5HomeroomDueItemCount: CollectionUseCase {
         for plannable in plannables {
             let model: K5HomeroomDueItemCount = client.first(where: #keyPath(K5HomeroomDueItemCount.courseId), equals: plannable.course_id?.rawValue) ?? client.insert()
             model.courseId = plannable.course_id?.rawValue ?? ""
-            model.due += (plannable.submissions?.submitted == false ? 1 : 0)
+            model.due += (plannable.submissions?.value1?.submitted == false ? 1 : 0)
         }
     }
 }

--- a/Core/Core/Planner/APIPlannable.swift
+++ b/Core/Core/Planner/APIPlannable.swift
@@ -30,7 +30,7 @@ public struct APIPlannable: Codable, Equatable {
     let context_name: String?
     let plannable: plannable?
     public let plannable_date: Date
-    let submissions: Submissions?
+    let submissions: TypeSafeCodable<Submissions, Bool>?
 
     //  swiftlint:disable:next type_name
     public struct plannable: Codable, Equatable {
@@ -99,7 +99,7 @@ extension APIPlannable {
             context_name: context_name,
             plannable: plannable,
             plannable_date: plannable_date,
-            submissions: submissions
+            submissions: TypeSafeCodable(value1: submissions, value2: nil)
         )
     }
 }

--- a/Core/CoreTests/API/TypeSafeCodableTests.swift
+++ b/Core/CoreTests/API/TypeSafeCodableTests.swift
@@ -81,10 +81,10 @@ class TypeSafeCodableTests: XCTestCase {
     }
 }
 
-private struct TestDecodable: Codable {
+private struct TestDecodable: Codable, Equatable {
     public let submissions: TypeSafeCodable<Bool, Type2Decodable>?
 }
 
-private struct Type2Decodable: Codable {
+private struct Type2Decodable: Codable, Equatable {
     public let excused: String
 }

--- a/Core/CoreTests/API/TypeSafeCodableTests.swift
+++ b/Core/CoreTests/API/TypeSafeCodableTests.swift
@@ -1,0 +1,90 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+class TypeSafeCodableTests: XCTestCase {
+    private let type1JSON = """
+        {
+            "submissions": true
+        }
+    """
+    private let type2JSON = """
+        {
+            "submissions": {
+                "excused": "Nope"
+            }
+        }
+    """
+    private let type3JSON = """
+        {
+            "submissions": [
+                "excused"
+            ]
+        }
+    """
+
+    func testType1Decode() {
+        let testee = try? JSONDecoder().decode(TestDecodable.self, from: type1JSON.data(using: .utf8)!)
+        XCTAssertEqual(testee?.submissions?.value1, true)
+    }
+
+    func testType2Decode() {
+        let testee = try? JSONDecoder().decode(TestDecodable.self, from: type2JSON.data(using: .utf8)!)
+        XCTAssertEqual(testee?.submissions?.value2?.excused, "Nope")
+    }
+
+    func testType3Decode() {
+        let testee: TestDecodable?
+
+        do {
+            testee = try JSONDecoder().decode(TestDecodable.self, from: type3JSON.data(using: .utf8)!)
+        } catch {
+            XCTFail()
+            return
+        }
+
+        XCTAssertNotNil(testee)
+        XCTAssertNil(testee?.submissions?.value1)
+        XCTAssertNil(testee?.submissions?.value2)
+    }
+
+    func testType1Encode() {
+        let testee = TestDecodable(submissions: TypeSafeCodable<Bool, Type2Decodable>(value1: true, value2: nil))
+        XCTAssertEqual(String(data: try JSONEncoder().encode(testee), encoding: .utf8), "{\"submissions\":true}")
+    }
+
+    func testType2Encode() {
+        let testee = TestDecodable(submissions: TypeSafeCodable<Bool, Type2Decodable>(value1: nil, value2: Type2Decodable(excused: "yes")))
+        XCTAssertEqual(String(data: try JSONEncoder().encode(testee), encoding: .utf8), "{\"submissions\":{\"excused\":\"yes\"}}")
+    }
+
+    func testNilEncode() {
+        let testee = TestDecodable(submissions: TypeSafeCodable<Bool, Type2Decodable>(value1: nil, value2: nil))
+        XCTAssertEqual(String(data: try JSONEncoder().encode(testee), encoding: .utf8), "{\"submissions\":null}")
+    }
+}
+
+private struct TestDecodable: Codable {
+    public let submissions: TypeSafeCodable<Bool, Type2Decodable>?
+}
+
+private struct Type2Decodable: Codable {
+    public let excused: String
+}


### PR DESCRIPTION
refs: MBL-15498
affects: Student
release note: none

test plan: See ticket