### PR TITLE
User viewing people in a course shows their enrollment roles from other courses

### DIFF
--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -252,7 +252,7 @@ class PeopleListCell: UITableViewCell {
         avatarView.name = user?.name ?? ""
         avatarView.url = user?.avatarURL
         nameLabel.text = user.flatMap { User.displayName($0.name, pronouns: $0.pronouns) }
-        let courseEnrollments = user?.enrollments.filter { $0.canvasContextID?.contains(user?.courseID ?? "") ?? false }
+        let courseEnrollments = user?.enrollments.filter { $0.course?.id == user?.courseID }
         var roles = courseEnrollments?.compactMap { $0.formattedRole } ?? []
         roles = Set(roles).sorted()
         rolesLabel.text = ListFormatter.localizedString(from: roles)

--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -252,7 +252,8 @@ class PeopleListCell: UITableViewCell {
         avatarView.name = user?.name ?? ""
         avatarView.url = user?.avatarURL
         nameLabel.text = user.flatMap { User.displayName($0.name, pronouns: $0.pronouns) }
-        var roles = user?.enrollments.compactMap { $0.formattedRole } ?? []
+        let courseEnrollments = user?.enrollments.filter { $0.canvasContextID?.contains(user?.courseID ?? "") ?? false }
+        var roles = courseEnrollments?.compactMap { $0.formattedRole } ?? []
         roles = Set(roles).sorted()
         rolesLabel.text = ListFormatter.localizedString(from: roles)
         rolesLabel.isHidden = roles.isEmpty

--- a/Core/Core/People/User.swift
+++ b/Core/Core/People/User.swift
@@ -50,7 +50,11 @@ extension User: WriteableModel {
         if let enrollments = item.enrollments {
             for item in enrollments {
                 let enrollment = context.insert() as Enrollment
-                enrollment.update(fromApiModel: item, course: nil, in: context)
+                var course: Course? = nil
+                if let courseID = item.course_id?.value {
+                    course = context.first(where: #keyPath(Course.id), equals: courseID)
+                }
+                enrollment.update(fromApiModel: item, course: course, in: context)
             }
         }
         return user

--- a/Core/Core/People/User.swift
+++ b/Core/Core/People/User.swift
@@ -50,7 +50,7 @@ extension User: WriteableModel {
         if let enrollments = item.enrollments {
             for item in enrollments {
                 let enrollment = context.insert() as Enrollment
-                var course: Course? = nil
+                var course: Course?
                 if let courseID = item.course_id?.value {
                     course = context.first(where: #keyPath(Course.id), equals: courseID)
                 }

--- a/Core/CoreTests/People/PeopleListViewControllerTests.swift
+++ b/Core/CoreTests/People/PeopleListViewControllerTests.swift
@@ -22,6 +22,7 @@ import XCTest
 
 class PeopleListViewControllerTests: CoreTestCase {
     let course1 = Context(.course, id: "1")
+    let course2 = Context(.course, id: "2")
     lazy var controller = PeopleListViewController.create(context: course1)
 
     override func setUp() {
@@ -36,6 +37,7 @@ class PeopleListViewControllerTests: CoreTestCase {
                 sortable_name: "jane doe",
                 short_name: "jane",
                 enrollments: [ .make(id: "2", course_id: "1", user_id: "2", role: "StudentEnrollment"),
+                               .make(id: "2", course_id: "2", user_id: "2", role: "TeacherEnrollment"),
                                .make(id: "3", course_id: "1", user_id: "2", role: "Custom"),
                                .make(id: "4", course_id: "1", user_id: "2", role: "StudentEnrollment"), ],
                 pronouns: "She/Her"

--- a/Core/CoreTests/People/PeopleListViewControllerTests.swift
+++ b/Core/CoreTests/People/PeopleListViewControllerTests.swift
@@ -35,7 +35,9 @@ class PeopleListViewControllerTests: CoreTestCase {
                 name: "Jane",
                 sortable_name: "jane doe",
                 short_name: "jane",
-                enrollments: [ .make(id: "2", user_id: "2", role: "StudentEnrollment"), .make(id: "3", user_id: "2", role: "Custom"), .make(id: "4", user_id: "2", role: "StudentEnrollment"), ],
+                enrollments: [ .make(id: "2", course_id: "1", user_id: "2", role: "StudentEnrollment"),
+                               .make(id: "3", course_id: "1", user_id: "2", role: "Custom"),
+                               .make(id: "4", course_id: "1", user_id: "2", role: "StudentEnrollment"), ],
                 pronouns: "She/Her"
             ),
         ])


### PR DESCRIPTION
refs: MBL-15435
affects: Student, Teacher
release note: Fix roles display on the People page. 
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/122892737-f1ed5880-d345-11eb-99a4-c2fe968116d9.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/122892686-e437d300-d345-11eb-8745-2553013785df.png"></td>
</tr>
</table>
