### PR TITLE
Custom roles do not work with section filters

### DIFF
--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
@@ -49,7 +49,7 @@ class SubmissionListViewController: UIViewController, ColoredNavViewProtocol {
     lazy var course = env.subscribe(GetCourse(courseID: context.id)) { [weak self] in
         self?.updateNavBar()
     }
-    lazy var enrollments = env.subscribe(GetEnrollments(context: context, roles: [ .student ])) { [weak self] in
+    lazy var enrollments = env.subscribe(GetEnrollments(context: context)) { [weak self] in
         self?.update()
     }
     lazy var sections = env.subscribe(GetCourseSections(courseID: context.id)) { [weak self] in
@@ -170,7 +170,7 @@ class SubmissionListViewController: UIViewController, ColoredNavViewProtocol {
         self.filter = filter
         submissions.useCase.filter = filter
         submissions.setScope(submissions.useCase.scope)
-        update()
+        submissions.exhaust()
     }
 
     @objc func showFilters() {

--- a/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -102,7 +102,7 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         XCTAssertEqual(controller.filter, [ .section(["3"]), .notSubmitted ])
         cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? SubmissionListCell
         XCTAssertEqual(cell?.nameLabel.text, "Rebecca")
-        XCTAssertEqual(cell?.statusLabel.text, "Not submitted")
+        XCTAssertEqual(cell?.statusLabel.text?.lowercased(), "Not Submitted".lowercased())
         XCTAssertEqual(cell?.needsGradingView.isHidden, true)
 
         api.mock(controller.submissions, error: NSError.internalError())


### PR DESCRIPTION
refs: MBL-15382
affects: Teacher
release note: Fix assignment filter for custom roles.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/123268256-2d328780-d4fe-11eb-861a-489d38dc1e19.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/123268310-37548600-d4fe-11eb-8cb7-b86ece25be31.png"></td>
</tr>
</table>