### PR TITLE
Use API order for announcements

### DIFF
--- a/Core/Core/Discussions/DiscussionTopic.swift
+++ b/Core/Core/Discussions/DiscussionTopic.swift
@@ -76,6 +76,13 @@ public final class DiscussionTopic: NSManagedObject, WriteableModel {
     }
 
     @discardableResult
+    public static func save(_ item: APIDiscussionTopic, apiPosition: Int = 0, in context: NSManagedObjectContext) -> DiscussionTopic {
+        let model = save(item, in: context)
+        model.position = apiPosition
+        return model
+    }
+
+    @discardableResult
     public static func save(_ item: APIDiscussionTopic, in context: NSManagedObjectContext) -> DiscussionTopic {
         let predicate = NSPredicate(format: "%K == %@", #keyPath(DiscussionTopic.id), item.id.value)
         let model: DiscussionTopic = context.fetch(predicate).first ?? context.insert()

--- a/Core/Core/Discussions/GetDiscussions.swift
+++ b/Core/Core/Discussions/GetDiscussions.swift
@@ -36,8 +36,14 @@ class GetAnnouncements: CollectionUseCase {
             NSPredicate(key: #keyPath(DiscussionTopic.isAnnouncement), equals: true),
             NSPredicate(key: #keyPath(DiscussionTopic.canvasContextID), equals: context.canvasContextID),
         ]),
-        orderBy: #keyPath(DiscussionTopic.postedAt), ascending: false
+        orderBy: #keyPath(DiscussionTopic.position), ascending: true
     ) }
+
+    func write(response: [APIDiscussionTopic]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        response?.enumerated().forEach {
+            Model.save($0.element, apiPosition: $0.offset, in: client)
+        }
+    }
 }
 
 class GetDiscussionTopics: CollectionUseCase {

--- a/Core/CoreTests/Discussions/DiscussionTopicTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionTopicTests.swift
@@ -38,4 +38,11 @@ class DiscussionTopicTests: CoreTestCase {
         let topics: [DiscussionTopic] =  databaseClient.fetch()
         XCTAssertEqual(topics.count, 1)
     }
+
+    func testSavePosition() {
+        let api = APIDiscussionTopic.make()
+        DiscussionTopic.save(api, apiPosition: 99, in: databaseClient)
+        let topics: [DiscussionTopic] =  databaseClient.fetch()
+        XCTAssertEqual(topics.first!.position, 99)
+    }
 }


### PR DESCRIPTION
refs: MBL-15324
affects: Teacher, Student
release note: Fix imported Announcement ordering

test plan: see ticket
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72031065/123276933-eea0cb00-d505-11eb-8711-ebe11f75d68b.png"></td>
<td><img src="https://user-images.githubusercontent.com/72031065/123276212-3ffc8a80-d505-11eb-9717-66079b2ca2ab.png"></td>
</tr>
</table>
