### PR TITLE
Filter out invited only users from submissions list.

### DIFF
--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -205,7 +205,7 @@ public class GetSubmissions: CollectionUseCase {
         NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
         NSCompoundPredicate(orPredicateWithSubpredicates: [
             NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
-            NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+            NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
         ]),
     ]}
 

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -225,7 +225,7 @@ class GetSubmissionsTests: CoreTestCase {
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
-                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+                NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
             ]),
         ]))
 
@@ -234,7 +234,7 @@ class GetSubmissionsTests: CoreTestCase {
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
-                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+                NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
             ]),
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSCompoundPredicate(andPredicateWithSubpredicates: []),
@@ -247,7 +247,7 @@ class GetSubmissionsTests: CoreTestCase {
             NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
-                NSPredicate(format: "ANY %K != %@", #keyPath(Submission.enrollments.stateRaw), "inactive"),
+                NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
             ]),
             NSPredicate(key: #keyPath(Submission.late), equals: true),
         ]))


### PR DESCRIPTION
refs: MBL-15406
affects: Teacher
release note: Fixed invited but not accepted users showing up in submissions list.

test plan:
- Invite a user to a course which has an active assignment but don't accept the invitation with it.
- Start teacher app, enter the assignment's submissions list.
- Invited user shouldn't be visible in this list.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/123277019-037d5e80-d506-11eb-8f82-ca9eed9f249c.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/123276905-e779bd00-d505-11eb-98ba-b1aca4889c91.png"></td>
</tr>
</table>