### PR TITLE
Add K5 feature flag.

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -39,13 +39,16 @@ open class AppEnvironment {
     public var currentSession: LoginSession?
     public var pageViewLogger: PageViewEventViewControllerLoggingProtocol = PresenterPageViewLogger()
     public var userDefaults: SessionDefaults?
-    public var isK5Enabled = false {
+    /** This flag indicates that the logged in user requested K5 mode. The app might not follow this if the K5 feature flag is turned off. */
+    public var shouldUseK5Mode = false {
         didSet {
             UITabBar.updateFontAppearance(useK5Fonts: isK5Enabled)
             UIBarButtonItem.updateFontAppearance(useK5Fonts: isK5Enabled)
             UISegmentedControl.updateFontAppearance()
         }
     }
+    /** This flag indicates if K5 mode is turned on and should be used. */
+    public var isK5Enabled: Bool { shouldUseK5Mode && ExperimentalFeature.K5Dashboard.isEnabled }
     public weak var loginDelegate: LoginDelegate?
     public weak var window: UIWindow?
     open var isTest: Bool { false }
@@ -74,7 +77,7 @@ open class AppEnvironment {
         userDefaults = nil
         Logger.shared.database = database
         refreshWidgets()
-        isK5Enabled = false
+        shouldUseK5Mode = false
     }
 
     public static var shared = AppEnvironment()

--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -28,6 +28,7 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case favoriteGroups = "favorite_groups"
     case nativeStudentInbox = "native_student_inbox"
     case nativeTeacherInbox = "native_teacher_inbox"
+    case K5Dashboard = "enable_K5_dashboard"
 
     public var isEnabled: Bool {
         get { UserDefaults.standard.bool(forKey: userDefaultsKey) }

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -64,11 +64,29 @@ class AppEnvironmentTests: CoreTestCase {
     }
 
     func testResetsK5FlagOnLogout() {
+        ExperimentalFeature.K5Dashboard.isEnabled = true
         let env = AppEnvironment()
         let session = LoginSession.make(accessToken: "token")
         env.userDidLogin(session: session)
-        env.isK5Enabled = true
+        env.shouldUseK5Mode = true
+        XCTAssertTrue(env.isK5Enabled)
         env.userDidLogout(session: session)
+        XCTAssertFalse(env.shouldUseK5Mode)
+        XCTAssertFalse(env.isK5Enabled)
+    }
+
+    func testK5ModeDependsOnFeatureFlag() {
+        let env = AppEnvironment()
+        XCTAssertFalse(env.shouldUseK5Mode)
+        XCTAssertFalse(env.isK5Enabled)
+
+        env.shouldUseK5Mode = true
+        XCTAssertFalse(env.isK5Enabled)
+
+        ExperimentalFeature.K5Dashboard.isEnabled = true
+        XCTAssertTrue(env.isK5Enabled)
+
+        env.shouldUseK5Mode = false
         XCTAssertFalse(env.isK5Enabled)
     }
 }

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -70,7 +70,7 @@ class CoreTestCase: XCTestCase {
         Analytics.shared.handler = analytics
         environment.app = .student
         environment.window = window
-        environment.isK5Enabled = false
+        environment.shouldUseK5Mode = false
         window.rootViewController = mainViewController
         window.makeKeyAndVisible()
     }

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -31,7 +31,8 @@ class CourseTests: CoreTestCase {
     func testDefaultK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1"))
-        environment.isK5Enabled = true
+        environment.shouldUseK5Mode = true
+        ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#394B58"))
     }
@@ -39,7 +40,8 @@ class CourseTests: CoreTestCase {
     func testK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1", course_color: "#0DEAD0"))
-        environment.isK5Enabled = true
+        environment.shouldUseK5Mode = true
+        ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#0DEAD0"))
     }

--- a/Core/CoreTests/Planner/PlannableTests.swift
+++ b/Core/CoreTests/Planner/PlannableTests.swift
@@ -83,7 +83,8 @@ class PlannableTests: CoreTestCase {
     }
 
     func testK5Color() {
-        environment.isK5Enabled = true
+        ExperimentalFeature.K5Dashboard.isEnabled = true
+        environment.shouldUseK5Mode = true
         Course.make(from: .make(id: "2", course_color: "#0DEAD0"))
         Course.make(from: .make(id: "0", course_color: nil))
         ContextColor.make(canvasContextID: "course_2", color: .blue)

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -88,7 +88,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         NotificationManager.shared.subscribeToPushChannel()
 
         GetUserProfile().fetch(environment: environment, force: true) { apiProfile, urlResponse, _ in
-            self.environment.isK5Enabled = (apiProfile?.k5_user == true)
+            self.environment.shouldUseK5Mode = (apiProfile?.k5_user == true)
             if urlResponse?.isUnauthorized == true, !session.isFakeStudent {
                 DispatchQueue.main.async { self.userDidLogout(session: session) }
             }
@@ -322,7 +322,7 @@ extension StudentAppDelegate {
 
 extension StudentAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
     func changeUser() {
-        environment.isK5Enabled = false
+        environment.shouldUseK5Mode = false
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {
             window.rootViewController = LoginNavigationController.create(loginDelegate: self, app: .student)


### PR DESCRIPTION
refs: MBL-15511
affects: Student
release note: none

test plan: K5 mode should be turned on only if the account is K5 capable and the experimental feature flag is on.