### PR TITLE
Use empty comment instead of nil

### DIFF
--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -471,7 +471,7 @@ public struct PutSubmissionGradeRequest: APIRequestable {
                 group_comment = forGroup
                 media_comment_id = mediaID
                 media_comment_type = type
-                text_comment = forGroup ? NSLocalizedString("This is a media comment", bundle: .core, comment: "") : nil
+                text_comment = forGroup ? NSLocalizedString("This is a media comment", bundle: .core, comment: "") : ""
                 file_ids = nil
             }
 
@@ -480,7 +480,7 @@ public struct PutSubmissionGradeRequest: APIRequestable {
                 file_ids = fileIDs
                 media_comment_id = nil
                 media_comment_type = nil
-                text_comment = nil
+                text_comment = ""
             }
         }
         public struct Submission: Codable, Equatable {

--- a/Core/CoreTests/Submissions/APISubmissionTests.swift
+++ b/Core/CoreTests/Submissions/APISubmissionTests.swift
@@ -63,7 +63,7 @@ class APISubmissionTests: CoreTestCase {
     func testPutSubmissionGradeRequestComment() {
         XCTAssertEqual(PutSubmissionGradeRequest.Body.Comment(text: "comment").text_comment, "comment")
         XCTAssertEqual(PutSubmissionGradeRequest.Body.Comment(mediaID: "1", type: .audio, forGroup: true).text_comment, "This is a media comment")
-        XCTAssertNil(PutSubmissionGradeRequest.Body.Comment(mediaID: "1", type: .audio).text_comment)
+        XCTAssertEqual(PutSubmissionGradeRequest.Body.Comment(mediaID: "1", type: .audio).text_comment, "")
     }
 
     func testGetSubmissionsRequest() {


### PR DESCRIPTION
refs: MBL-15466
affects: Teacher, Student
release note: Fixed submission file comments visibility

test plan: see ticket, it's a bit hard to understand: attach a file to a submission as a comment, then check on the web, if the file is visible