### PR TITLE
Confused action buttons on edit assignment dialog

### DIFF
--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -45,7 +45,7 @@ public struct AssignmentDetailsView: View {
             .navigationBarItems(trailing: Button(action: { env.router.route(
                 to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
                 from: controller,
-                options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+                options: .modal(.formSheet, isDismissable: false, embedInNav: false)
             ) }, label: {
                 Text("Edit", bundle: .core).fontWeight(.regular)
             }))

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -48,32 +48,34 @@ public struct AssignmentEditorView: View {
     }
 
     public var body: some View {
-        form
-            .navigationBarTitle(Text("Edit Assignment", bundle: .core), displayMode: .inline)
-            .navigationBarItems(
-                leading: Button(action: {
-                    env.router.dismiss(controller)
-                }, label: {
-                    Text("Cancel", bundle: .core).fontWeight(.regular)
-                })
+        NavigationView {
+            form
+                .navigationBarTitle(Text("Edit Assignment", bundle: .core), displayMode: .inline)
+                .navigationBarItems(
+                    leading: Button(action: {
+                        env.router.dismiss(controller)
+                    }, label: {
+                        Text("Cancel", bundle: .core).fontWeight(.regular)
+                    })
                     .identifier("screen.dismiss"),
-                trailing: Button(action: save, label: {
-                    Text("Done", bundle: .core).bold()
-                })
+                    trailing: Button(action: save, label: {
+                        Text("Done", bundle: .core).bold()
+                    })
                     .disabled(isLoading || isSaving)
                     .identifier("AssignmentEditor.doneButton")
-            )
+                )
 
-            .alert(item: $alert) { alert in
-                switch alert {
-                case .error(let error):
-                    return Alert(title: Text(error.localizedDescription))
-                case .removeOverride(let override):
-                    return AssignmentOverridesEditor.alert(toRemove: override, from: $overrides)
+                .alert(item: $alert) { alert in
+                    switch alert {
+                    case .error(let error):
+                        return Alert(title: Text(error.localizedDescription))
+                    case .removeOverride(let override):
+                        return AssignmentOverridesEditor.alert(toRemove: override, from: $overrides)
+                    }
                 }
-            }
 
-            .onAppear(perform: load)
+                .onAppear(perform: load)
+        }.animation(.none)
     }
 
     enum AlertItem: Identifiable {

--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -58,10 +58,12 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
   }
 
   editAssignment = () => {
-    let route = `/courses/${this.props.courseID}/assignments/${this.props.assignmentID}/edit`
     if (this.props.quizID) {
-      route = `/courses/${this.props.courseID}/quizzes/${this.props.quizID}/edit`
+      let route = `/courses/${this.props.courseID}/quizzes/${this.props.quizID}/edit`
+      this.props.navigator.show(route, { modal: true })
+      return
     }
+    let route = `/courses/${this.props.courseID}/assignments/${this.props.assignmentID}/edit`
     this.props.navigator.show(route, { embedInNavigationController: false, modal: true })
   }
 

--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -62,7 +62,7 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
     if (this.props.quizID) {
       route = `/courses/${this.props.courseID}/quizzes/${this.props.quizID}/edit`
     }
-    this.props.navigator.show(route, { modal: true })
+    this.props.navigator.show(route, { embedInNavigationController: false, modal: true })
   }
 
   renderRow (date: AssignmentDate, dates: AssignmentDates) {

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
@@ -115,7 +115,7 @@ test('routes to assignment edit', () => {
   ).toJSON()
   const editButton: any = explore(tree).selectRightBarButton('assignment-due-dates.edit-btn')
   editButton.action()
-  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/1/edit', { modal: true })
+  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/1/edit', { embedInNavigationController: false, modal: true })
 })
 
 test('routes to quiz edit', () => {


### PR DESCRIPTION
refs: MBL-15479
affects: Teacher
release note: Fix navigation bar buttons on the assignment editor screen.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/124758930-61ab3800-df2f-11eb-97e0-bb81ca9affab.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/124758890-548e4900-df2f-11eb-8b0f-61551ad36188.png"></td>
</tr>
</table>
