### PR TITLE
K5 dashboard toggle in settings

### DIFF
--- a/CanvasCore/CanvasCore/ReactNativeModules/NativeLoginManager.swift
+++ b/CanvasCore/CanvasCore/ReactNativeModules/NativeLoginManager.swift
@@ -55,7 +55,7 @@ extension NativeLoginManager {
                 "primary_email": entry.userEmail,
             ],
             "isFakeStudent": entry.isFakeStudent,
-            "isK5Enabled": AppEnvironment.shared.isK5Enabled,
+            "isK5Enabled": AppEnvironment.shared.k5.isK5Enabled,
         ]
         if let actAsUserID = entry.actAsUserID {
             body["actAsUserID"] = actAsUserID

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -870,6 +870,7 @@
 		CF9FE7FF2673B770004BDE58 /* font_balsamiq_regular.css in Resources */ = {isa = PBXBuildFile; fileRef = CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */; };
 		CFAE973925ECFF8F00DF2102 /* APIUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */; };
 		CFB3A1E4269C8D4A00429B3E /* K5State.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB3A1E3269C8D4A00429B3E /* K5State.swift */; };
+		CFB3A1E8269D8B0600429B3E /* K5StateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB3A1E7269D8B0600429B3E /* K5StateTests.swift */; };
 		CFB3C4BE25A8A86E003F9AB9 /* ContextCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB3C4BD25A8A86E003F9AB9 /* ContextCardViewModel.swift */; };
 		CFB50C4C2564330600E4AD72 /* HelpLinkRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB50C4B2564330600E4AD72 /* HelpLinkRouteTests.swift */; };
 		CFB50C51256439D100E4AD72 /* HelpViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB50C50256439D100E4AD72 /* HelpViewTests.swift */; };
@@ -2033,6 +2034,7 @@
 		CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = font_balsamiq_regular.css; sourceTree = "<group>"; };
 		CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIUserTests.swift; sourceTree = "<group>"; };
 		CFB3A1E3269C8D4A00429B3E /* K5State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5State.swift; sourceTree = "<group>"; };
+		CFB3A1E7269D8B0600429B3E /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
 		CFB3C4BD25A8A86E003F9AB9 /* ContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCardViewModel.swift; sourceTree = "<group>"; };
 		CFB50C4B2564330600E4AD72 /* HelpLinkRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpLinkRouteTests.swift; sourceTree = "<group>"; };
 		CFB50C50256439D100E4AD72 /* HelpViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpViewTests.swift; sourceTree = "<group>"; };
@@ -3432,6 +3434,7 @@
 				B191D5E7226E2CBA00D02948 /* CacheManagerTests.swift */,
 				7D52D8AC2301C0A400684932 /* ExperimentalFeatureTests.swift */,
 				7D63F791215D8EEC00151E49 /* GetBrandVariablesTests.swift */,
+				CFB3A1E7269D8B0600429B3E /* K5StateTests.swift */,
 				3B158CB722E241130039A568 /* KeychainTests.swift */,
 				7DAFB46421A4693B00311275 /* LocalizationManagerTests.swift */,
 				B1F3780922498AF1000B7CAA /* MDMManagerTests.swift */,
@@ -5138,6 +5141,7 @@
 				9FE84DDC214FE5C500B95A68 /* GetGroupsTests.swift in Sources */,
 				7D7F71E224200AB100D6F9CB /* ConferenceListViewControllerTests.swift in Sources */,
 				B11AEBBD24082E2F00B736D6 /* PlannerFilterViewControllerTests.swift in Sources */,
+				CFB3A1E8269D8B0600429B3E /* K5StateTests.swift in Sources */,
 				B1A32BE22159A3100071B41E /* APIAssignmentTests.swift in Sources */,
 				7DC7046A24ABA3C100CD1C46 /* ObserverAlertTests.swift in Sources */,
 				7D4F44FD241BFB2300233B92 /* APIConferenceTests.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -869,6 +869,7 @@
 		CF9DFB602584F3EE004E27A5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9DFB5F2584F3EE004E27A5 /* ColorExtensions.swift */; };
 		CF9FE7FF2673B770004BDE58 /* font_balsamiq_regular.css in Resources */ = {isa = PBXBuildFile; fileRef = CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */; };
 		CFAE973925ECFF8F00DF2102 /* APIUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */; };
+		CFB3A1E4269C8D4A00429B3E /* K5State.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB3A1E3269C8D4A00429B3E /* K5State.swift */; };
 		CFB3C4BE25A8A86E003F9AB9 /* ContextCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB3C4BD25A8A86E003F9AB9 /* ContextCardViewModel.swift */; };
 		CFB50C4C2564330600E4AD72 /* HelpLinkRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB50C4B2564330600E4AD72 /* HelpLinkRouteTests.swift */; };
 		CFB50C51256439D100E4AD72 /* HelpViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFB50C50256439D100E4AD72 /* HelpViewTests.swift */; };
@@ -2031,6 +2032,7 @@
 		CF9DFB5F2584F3EE004E27A5 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = font_balsamiq_regular.css; sourceTree = "<group>"; };
 		CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIUserTests.swift; sourceTree = "<group>"; };
+		CFB3A1E3269C8D4A00429B3E /* K5State.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5State.swift; sourceTree = "<group>"; };
 		CFB3C4BD25A8A86E003F9AB9 /* ContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCardViewModel.swift; sourceTree = "<group>"; };
 		CFB50C4B2564330600E4AD72 /* HelpLinkRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpLinkRouteTests.swift; sourceTree = "<group>"; };
 		CFB50C50256439D100E4AD72 /* HelpViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpViewTests.swift; sourceTree = "<group>"; };
@@ -2326,6 +2328,7 @@
 				B17F23B02137981B00771F86 /* Clock.swift */,
 				7D52D8AA2301BA5100684932 /* ExperimentalFeature.swift */,
 				7D63F789215D46AB00151E49 /* GetBrandVariables.swift */,
+				CFB3A1E3269C8D4A00429B3E /* K5State.swift */,
 				3B158CB522E230510039A568 /* Keychain.swift */,
 				7DAFB46221A361C400311275 /* LocalizationManager.swift */,
 				B1BEB2CA22458B5E00E893A4 /* MDMManager.swift */,
@@ -5643,6 +5646,7 @@
 				B12AB4A32457500F009872C4 /* MasteryPath.swift in Sources */,
 				CFE7E362267CD47A00F8EB7B /* UISplitViewControllerExtensions.swift in Sources */,
 				B14707B42437BC1C00CE1DBD /* ExternalURLViewController.swift in Sources */,
+				CFB3A1E4269C8D4A00429B3E /* K5State.swift in Sources */,
 				7DA260E223F72359005D2121 /* KeyboardTransitioning.swift in Sources */,
 				7DA2600923F7227A005D2121 /* NSErrorExtensions.swift in Sources */,
 				CFFA6CF42656478A00B47380 /* TopBarViewModel.swift in Sources */,

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -38,7 +38,11 @@ open class AppEnvironment {
     public var router: Router
     public var currentSession: LoginSession?
     public var pageViewLogger: PageViewEventViewControllerLoggingProtocol = PresenterPageViewLogger()
-    public var userDefaults: SessionDefaults?
+    public var userDefaults: SessionDefaults? {
+        didSet {
+            k5.sessionDefaults = userDefaults
+        }
+    }
     public let k5 = K5State()
     public weak var loginDelegate: LoginDelegate?
     public weak var window: UIWindow?

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -39,16 +39,7 @@ open class AppEnvironment {
     public var currentSession: LoginSession?
     public var pageViewLogger: PageViewEventViewControllerLoggingProtocol = PresenterPageViewLogger()
     public var userDefaults: SessionDefaults?
-    /** This flag indicates that the logged in user requested K5 mode. The app might not follow this if the K5 feature flag is turned off. */
-    public var shouldUseK5Mode = false {
-        didSet {
-            UITabBar.updateFontAppearance(useK5Fonts: isK5Enabled)
-            UIBarButtonItem.updateFontAppearance(useK5Fonts: isK5Enabled)
-            UISegmentedControl.updateFontAppearance()
-        }
-    }
-    /** This flag indicates if K5 mode is turned on and should be used. */
-    public var isK5Enabled: Bool { shouldUseK5Mode && ExperimentalFeature.K5Dashboard.isEnabled }
+    public let k5 = K5State()
     public weak var loginDelegate: LoginDelegate?
     public weak var window: UIWindow?
     open var isTest: Bool { false }
@@ -77,7 +68,7 @@ open class AppEnvironment {
         userDefaults = nil
         Logger.shared.database = database
         refreshWidgets()
-        shouldUseK5Mode = false
+        k5.userDidLogout()
     }
 
     public static var shared = AppEnvironment()

--- a/Core/Core/AppEnvironment/K5State.swift
+++ b/Core/Core/AppEnvironment/K5State.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public class K5State {
+    /** This flag indicates that the logged in user requested K5 mode. The app might not follow this if the K5 feature flag is turned off. */
+    public var shouldUseK5Mode = false {
+        didSet {
+            UITabBar.updateFontAppearance(useK5Fonts: isK5Enabled)
+            UIBarButtonItem.updateFontAppearance(useK5Fonts: isK5Enabled)
+            UISegmentedControl.updateFontAppearance()
+        }
+    }
+    /** This flag indicates if K5 mode is turned on and should be used. */
+    public var isK5Enabled: Bool { shouldUseK5Mode && ExperimentalFeature.K5Dashboard.isEnabled }
+
+    public func userDidLogout() {
+        shouldUseK5Mode = false
+    }
+}

--- a/Core/Core/AppEnvironment/K5State.swift
+++ b/Core/Core/AppEnvironment/K5State.swift
@@ -17,8 +17,8 @@
 //
 
 public class K5State {
-    /** This flag indicates that the logged in user requested K5 mode. The app might not follow this if the K5 feature flag is turned off. */
-    public var shouldUseK5Mode = false {
+    /** This flag indicates that the logged in user is under a K5 enabled account. The app might not follow this if the K5 feature flag is turned off. */
+    public private(set) var isK5Account = false {
         didSet {
             UITabBar.updateFontAppearance(useK5Fonts: isK5Enabled)
             UIBarButtonItem.updateFontAppearance(useK5Fonts: isK5Enabled)
@@ -26,9 +26,17 @@ public class K5State {
         }
     }
     /** This flag indicates if K5 mode is turned on and should be used. */
-    public var isK5Enabled: Bool { shouldUseK5Mode && ExperimentalFeature.K5Dashboard.isEnabled }
+    public var isK5Enabled: Bool { isK5Account && ExperimentalFeature.K5Dashboard.isEnabled }
+
+    public func userDidLogin(profile: APIProfile?) {
+        isK5Account = (profile?.k5_user == true)
+    }
+
+    public func userDidLogin(isK5Account: Bool) {
+        self.isK5Account = isK5Account
+    }
 
     public func userDidLogout() {
-        shouldUseK5Mode = false
+        isK5Account = false
     }
 }

--- a/Core/Core/AppEnvironment/K5State.swift
+++ b/Core/Core/AppEnvironment/K5State.swift
@@ -26,7 +26,8 @@ public class K5State {
         }
     }
     /** This flag indicates if K5 mode is turned on and should be used. */
-    public var isK5Enabled: Bool { isK5Account && ExperimentalFeature.K5Dashboard.isEnabled }
+    public var isK5Enabled: Bool { isK5Account && isRemoteFeatureFlagEnabled }
+    public var isRemoteFeatureFlagEnabled: Bool { ExperimentalFeature.K5Dashboard.isEnabled }
 
     public func userDidLogin(profile: APIProfile?) {
         isK5Account = (profile?.k5_user == true)

--- a/Core/Core/AppEnvironment/K5State.swift
+++ b/Core/Core/AppEnvironment/K5State.swift
@@ -25,9 +25,13 @@ public class K5State {
             UISegmentedControl.updateFontAppearance()
         }
     }
-    /** This flag indicates if K5 mode is turned on and should be used. */
-    public var isK5Enabled: Bool { isK5Account && isRemoteFeatureFlagEnabled }
     public var isRemoteFeatureFlagEnabled: Bool { ExperimentalFeature.K5Dashboard.isEnabled }
+    public var isElementaryViewEnabled: Bool { sessionDefaults?.isElementaryViewEnabled ?? false }
+    /** External dependency. */
+    public var sessionDefaults: SessionDefaults?
+
+    /** This flag indicates if K5 mode is turned on and should be used. */
+    public var isK5Enabled: Bool { isK5Account && isRemoteFeatureFlagEnabled && isElementaryViewEnabled }
 
     public func userDidLogin(profile: APIProfile?) {
         isK5Account = (profile?.k5_user == true)

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -53,6 +53,11 @@ public struct SessionDefaults {
         }
     }
 
+    public var isK5DashboardEnabled: Bool {
+        get { (self["isK5DashboardEnabled"] as? Bool) ?? true }
+        set { self["isK5DashboardEnabled"] = newValue }
+    }
+
     public var landingPath: String? {
         mutating get {
             if let landingPath = self["landingPath"] as? String {

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -53,9 +53,9 @@ public struct SessionDefaults {
         }
     }
 
-    public var isK5DashboardEnabled: Bool {
-        get { (self["isK5DashboardEnabled"] as? Bool) ?? true }
-        set { self["isK5DashboardEnabled"] = newValue }
+    public var isElementaryViewEnabled: Bool {
+        get { (self["isElementaryViewEnabled"] as? Bool) ?? true }
+        set { self["isElementaryViewEnabled"] = newValue }
     }
 
     public var landingPath: String? {

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -56,7 +56,7 @@ final public class Course: NSManagedObject, WriteableModel {
     }
 
     public var color: UIColor {
-        if AppEnvironment.shared.isK5Enabled {
+        if AppEnvironment.shared.k5.isK5Enabled {
             return UIColor(hexString: courseColor) ?? UIColor(hexString: "#394B58")!
         } else {
             return contextColor?.color ?? .ash

--- a/Core/Core/Extensions/UIFontExtensions.swift
+++ b/Core/Core/Extensions/UIFontExtensions.swift
@@ -107,7 +107,7 @@ public extension UIFont {
     }
 
     static func monospacedApplicationFont(ofSize fontSize: CGFloat, weight: UIFont.Weight) -> UIFont {
-        if AppEnvironment.shared.isK5Enabled {
+        if AppEnvironment.shared.k5.isK5Enabled {
             return applicationFont(ofSize: fontSize, weight: weight)
         } else {
             return .monospacedDigitSystemFont(ofSize: fontSize, weight: weight)
@@ -115,7 +115,7 @@ public extension UIFont {
     }
 
     static func applicationFont(ofSize fontSize: CGFloat, weight: UIFont.Weight) -> UIFont {
-        if AppEnvironment.shared.isK5Enabled {
+        if AppEnvironment.shared.k5.isK5Enabled {
             let fontName: String
             switch weight {
             case .bold, .heavy:

--- a/Core/Core/Extensions/UINavigationBarExtensions.swift
+++ b/Core/Core/Extensions/UINavigationBarExtensions.swift
@@ -65,7 +65,7 @@ extension UINavigationBar {
         updateFontAppearance()
     }
 
-    public func updateFontAppearance(useK5Fonts: Bool = AppEnvironment.shared.isK5Enabled) {
+    public func updateFontAppearance(useK5Fonts: Bool = AppEnvironment.shared.k5.isK5Enabled) {
         if useK5Fonts {
             titleTextAttributes?[NSAttributedString.Key.font] = UIFont.scaledNamedFont(.bold17)
         }

--- a/Core/Core/Planner/Plannable.swift
+++ b/Core/Core/Planner/Plannable.swift
@@ -126,7 +126,7 @@ extension Plannable {
     public var color: UIColor {
         guard let canvasContextID = canvasContextIDRaw else { return .ash }
 
-        if AppEnvironment.shared.isK5Enabled,
+        if AppEnvironment.shared.k5.isK5Enabled,
            let context = Context(canvasContextID: canvasContextID),
            context.contextType == .course {
             if let course: Course = managedObjectContext?.first(where: #keyPath(Course.id), equals: context.id) {

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -192,7 +192,6 @@ extension ProfileSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.toggle.isOn = switchRow.value
             cell.onToggleChange = { toggle in
                 switchRow.value = toggle.isOn
-                switchRow.onSelect(toggle.isOn)
             }
             cell.backgroundColor = .backgroundGroupedCell
             cell.textLabel?.text = switchRow.title
@@ -210,7 +209,6 @@ extension ProfileSettingsViewController: UITableViewDataSource, UITableViewDeleg
         } else if let switchCell = tableView.cellForRow(at: indexPath) as? SwitchTableViewCell, let switchRow = row as? Switch {
             let newValue = !switchCell.toggle.isOn
             switchCell.toggle.setOn(newValue, animated: true)
-            switchRow.onSelect(newValue)
             switchRow.value = newValue
         }
 
@@ -253,8 +251,12 @@ private struct Row {
 
 private class Switch {
     let title: String
-    var value: Bool
-    let onSelect: (_ value: Bool) -> Void
+    var value: Bool {
+        didSet {
+            onSelect(value)
+        }
+    }
+    private let onSelect: (_ value: Bool) -> Void
 
     init(_ title: String, initialValue: Bool = false, onSelect: @escaping (_ value: Bool) -> Void) {
         self.title = title

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -155,8 +155,8 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
     private var k5DashboardSwitch: [Any] {
         guard AppEnvironment.shared.k5.isK5Account, AppEnvironment.shared.k5.isRemoteFeatureFlagEnabled else { return [] }
 
-        let row = Switch(NSLocalizedString("Elementary View", bundle: .core, comment: ""), initialValue: AppEnvironment.shared.userDefaults?.isK5DashboardEnabled ?? false) { isOn in
-            AppEnvironment.shared.userDefaults?.isK5DashboardEnabled = isOn
+        let row = Switch(NSLocalizedString("Elementary View", bundle: .core, comment: ""), initialValue: AppEnvironment.shared.userDefaults?.isElementaryViewEnabled ?? false) { isOn in
+            AppEnvironment.shared.userDefaults?.isElementaryViewEnabled = isOn
         }
         return [row]
     }

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -38,7 +38,7 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
 
     let tableView = UITableView(frame: .zero, style: .grouped)
 
-    public static func create(onElementaryViewToggleChanged: @escaping () -> Void) -> ProfileSettingsViewController {
+    public static func create(onElementaryViewToggleChanged: (() -> Void)? = nil) -> ProfileSettingsViewController {
         let viewController = ProfileSettingsViewController()
         viewController.onElementaryViewToggleChanged = onElementaryViewToggleChanged
         return viewController

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 public class ProfileSettingsViewController: UIViewController, PageViewEventViewControllerLoggingProtocol {
     let env = AppEnvironment.shared
     private var sections: [Section] = []
+    private var onElementaryViewToggleChanged: (() -> Void)?
 
     private var landingPage: LandingPage {
         get { return LandingPage(rawValue: env.userDefaults?.landingPath ?? "/") ?? .dashboard }
@@ -37,8 +38,10 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
 
     let tableView = UITableView(frame: .zero, style: .grouped)
 
-    public static func create() -> ProfileSettingsViewController {
-        return ProfileSettingsViewController()
+    public static func create(onElementaryViewToggleChanged: @escaping () -> Void) -> ProfileSettingsViewController {
+        let viewController = ProfileSettingsViewController()
+        viewController.onElementaryViewToggleChanged = onElementaryViewToggleChanged
+        return viewController
     }
 
     public override func loadView() {
@@ -155,8 +158,9 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
     private var k5DashboardSwitch: [Any] {
         guard AppEnvironment.shared.k5.isK5Account, AppEnvironment.shared.k5.isRemoteFeatureFlagEnabled else { return [] }
 
-        let row = Switch(NSLocalizedString("Elementary View", bundle: .core, comment: ""), initialValue: AppEnvironment.shared.userDefaults?.isElementaryViewEnabled ?? false) { isOn in
+        let row = Switch(NSLocalizedString("Elementary View", bundle: .core, comment: ""), initialValue: AppEnvironment.shared.userDefaults?.isElementaryViewEnabled ?? false) { [weak self] isOn in
             AppEnvironment.shared.userDefaults?.isElementaryViewEnabled = isOn
+            self?.onElementaryViewToggleChanged?()
         }
         return [row]
     }

--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -96,7 +96,7 @@ public class RichContentEditorViewController: UIViewController {
                 --color-textDarkest: \(UIColor.textDarkest.hexString);
 
                 font-size: \(UIFont.scaledNamedFont(.regular16).pointSize)px;
-                font-family: \(AppEnvironment.shared.isK5Enabled ? "BalsamiqSans-Regular" : "system-ui");
+                font-family: \(AppEnvironment.shared.k5.isK5Enabled ? "BalsamiqSans-Regular" : "system-ui");
             }
             </style>
             <div id="content" contenteditable=\"true\" placeholder=\"\(placeholder)\" aria-label=\"\(a11yLabel)\"></div>

--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -150,7 +150,7 @@ open class CoreWebView: WKWebView {
         var font = "system-ui"
         var fontCSS = ""
 
-        if AppEnvironment.shared.isK5Enabled {
+        if AppEnvironment.shared.k5.isK5Enabled {
             font = "BalsamiqSans-Regular"
             fontCSS = Self.BalsamiqRegularCSSFontFace
         }

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -68,10 +68,23 @@ class AppEnvironmentTests: CoreTestCase {
         let env = AppEnvironment()
         let session = LoginSession.make(accessToken: "token")
         env.userDidLogin(session: session)
+        env.userDefaults?.isElementaryViewEnabled = true
         env.k5.userDidLogin(isK5Account: true)
         XCTAssertTrue(env.k5.isK5Enabled)
         env.userDidLogout(session: session)
         XCTAssertFalse(env.k5.isK5Account)
         XCTAssertFalse(env.k5.isK5Enabled)
+    }
+
+    func testUpdatesK5SessionDependency() {
+        let session = LoginSession.make()
+        let env = AppEnvironment()
+        XCTAssertNil(env.k5.sessionDefaults)
+
+        env.userDidLogin(session: session)
+        XCTAssertNotNil(env.k5.sessionDefaults)
+
+        env.userDidLogout(session: session)
+        XCTAssertNil(env.k5.sessionDefaults)
     }
 }

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -68,25 +68,25 @@ class AppEnvironmentTests: CoreTestCase {
         let env = AppEnvironment()
         let session = LoginSession.make(accessToken: "token")
         env.userDidLogin(session: session)
-        env.k5.shouldUseK5Mode = true
+        env.k5.userDidLogin(isK5Account: true)
         XCTAssertTrue(env.k5.isK5Enabled)
         env.userDidLogout(session: session)
-        XCTAssertFalse(env.k5.shouldUseK5Mode)
+        XCTAssertFalse(env.k5.isK5Account)
         XCTAssertFalse(env.k5.isK5Enabled)
     }
 
     func testK5ModeDependsOnFeatureFlag() {
         let env = AppEnvironment()
-        XCTAssertFalse(env.k5.shouldUseK5Mode)
+        XCTAssertFalse(env.k5.isK5Account)
         XCTAssertFalse(env.k5.isK5Enabled)
 
-        env.k5.shouldUseK5Mode = true
+        env.k5.userDidLogin(isK5Account: true)
         XCTAssertFalse(env.k5.isK5Enabled)
 
         ExperimentalFeature.K5Dashboard.isEnabled = true
         XCTAssertTrue(env.k5.isK5Enabled)
 
-        env.k5.shouldUseK5Mode = false
+        env.k5.userDidLogin(isK5Account: false)
         XCTAssertFalse(env.k5.isK5Enabled)
     }
 }

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -68,25 +68,25 @@ class AppEnvironmentTests: CoreTestCase {
         let env = AppEnvironment()
         let session = LoginSession.make(accessToken: "token")
         env.userDidLogin(session: session)
-        env.shouldUseK5Mode = true
-        XCTAssertTrue(env.isK5Enabled)
+        env.k5.shouldUseK5Mode = true
+        XCTAssertTrue(env.k5.isK5Enabled)
         env.userDidLogout(session: session)
-        XCTAssertFalse(env.shouldUseK5Mode)
-        XCTAssertFalse(env.isK5Enabled)
+        XCTAssertFalse(env.k5.shouldUseK5Mode)
+        XCTAssertFalse(env.k5.isK5Enabled)
     }
 
     func testK5ModeDependsOnFeatureFlag() {
         let env = AppEnvironment()
-        XCTAssertFalse(env.shouldUseK5Mode)
-        XCTAssertFalse(env.isK5Enabled)
+        XCTAssertFalse(env.k5.shouldUseK5Mode)
+        XCTAssertFalse(env.k5.isK5Enabled)
 
-        env.shouldUseK5Mode = true
-        XCTAssertFalse(env.isK5Enabled)
+        env.k5.shouldUseK5Mode = true
+        XCTAssertFalse(env.k5.isK5Enabled)
 
         ExperimentalFeature.K5Dashboard.isEnabled = true
-        XCTAssertTrue(env.isK5Enabled)
+        XCTAssertTrue(env.k5.isK5Enabled)
 
-        env.shouldUseK5Mode = false
-        XCTAssertFalse(env.isK5Enabled)
+        env.k5.shouldUseK5Mode = false
+        XCTAssertFalse(env.k5.isK5Enabled)
     }
 }

--- a/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
+++ b/Core/CoreTests/AppEnvironment/AppEnvironmentTests.swift
@@ -74,19 +74,4 @@ class AppEnvironmentTests: CoreTestCase {
         XCTAssertFalse(env.k5.isK5Account)
         XCTAssertFalse(env.k5.isK5Enabled)
     }
-
-    func testK5ModeDependsOnFeatureFlag() {
-        let env = AppEnvironment()
-        XCTAssertFalse(env.k5.isK5Account)
-        XCTAssertFalse(env.k5.isK5Enabled)
-
-        env.k5.userDidLogin(isK5Account: true)
-        XCTAssertFalse(env.k5.isK5Enabled)
-
-        ExperimentalFeature.K5Dashboard.isEnabled = true
-        XCTAssertTrue(env.k5.isK5Enabled)
-
-        env.k5.userDidLogin(isK5Account: false)
-        XCTAssertFalse(env.k5.isK5Enabled)
-    }
 }

--- a/Core/CoreTests/AppEnvironment/K5StateTests.swift
+++ b/Core/CoreTests/AppEnvironment/K5StateTests.swift
@@ -1,0 +1,72 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import TestsFoundation
+@testable import Core
+
+class K5StateTests: CoreTestCase {
+
+    func testK5AccountStateUpdates() {
+        let testee = K5State()
+        XCTAssertFalse(testee.isK5Account)
+
+        testee.userDidLogin(isK5Account: true)
+        XCTAssertTrue(testee.isK5Account)
+
+        testee.userDidLogin(isK5Account: false)
+        XCTAssertFalse(testee.isK5Account)
+
+        testee.userDidLogin(profile: nil)
+        XCTAssertFalse(testee.isK5Account)
+
+        testee.userDidLogin(profile: APIProfile.make(k5_user: nil))
+        XCTAssertFalse(testee.isK5Account)
+
+        testee.userDidLogin(profile: APIProfile.make(k5_user: false))
+        XCTAssertFalse(testee.isK5Account)
+
+        testee.userDidLogin(profile: APIProfile.make(k5_user: true))
+        XCTAssertTrue(testee.isK5Account)
+    }
+
+    func testLogoutUpdatesK5AccountState() {
+        let testee = K5State()
+        testee.userDidLogin(isK5Account: true)
+        XCTAssertTrue(testee.isK5Account)
+
+        testee.userDidLogout()
+        XCTAssertFalse(testee.isK5Account)
+    }
+
+    func testK5ModeDependsOnFeatureFlag() {
+        let testee = K5State()
+        XCTAssertFalse(testee.isK5Account)
+        XCTAssertFalse(testee.isK5Enabled)
+
+        testee.userDidLogin(isK5Account: true)
+        XCTAssertFalse(testee.isK5Enabled)
+
+        ExperimentalFeature.K5Dashboard.isEnabled = true
+        XCTAssertTrue(testee.isK5Enabled)
+
+        testee.userDidLogin(isK5Account: false)
+        XCTAssertFalse(testee.isK5Enabled)
+    }
+}
+

--- a/Core/CoreTests/AppEnvironment/K5StateTests.swift
+++ b/Core/CoreTests/AppEnvironment/K5StateTests.swift
@@ -68,5 +68,29 @@ class K5StateTests: CoreTestCase {
         testee.userDidLogin(isK5Account: false)
         XCTAssertFalse(testee.isK5Enabled)
     }
-}
 
+    func testFontAppearanceUpdated() {
+        ExperimentalFeature.K5Dashboard.isEnabled = true
+        AppEnvironment.shared.k5.userDidLogin(isK5Account: false)
+
+        let oldTabFont = UITabBarItem.appearance().titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let oldTabBadgeFont = UITabBarItem.appearance().badgeTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let oldBarButtonItemFont = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let oldSegmentedControlNormalFont = UISegmentedControl.appearance().titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let oldSegmentedControlSelectedFont = UISegmentedControl.appearance().titleTextAttributes(for: .selected)![NSAttributedString.Key.font] as! UIFont?
+
+        AppEnvironment.shared.k5.userDidLogin(isK5Account: true)
+
+        let newTabFont = UITabBarItem.appearance().titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let newTabBadgeFont = UITabBarItem.appearance().badgeTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let newBarButtonItemFont = UIBarButtonItem.appearance(whenContainedInInstancesOf: [UINavigationBar.self]).titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let newSegmentedControlNormalFont = UISegmentedControl.appearance().titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?
+        let newSegmentedControlSelectedFont = UISegmentedControl.appearance().titleTextAttributes(for: .selected)![NSAttributedString.Key.font] as! UIFont?
+
+        XCTAssertNotEqual(oldTabFont, newTabFont)
+        XCTAssertNotEqual(oldTabBadgeFont, newTabBadgeFont)
+        XCTAssertNotEqual(oldBarButtonItemFont, newBarButtonItemFont)
+        XCTAssertNotEqual(oldSegmentedControlNormalFont, newSegmentedControlNormalFont)
+        XCTAssertNotEqual(oldSegmentedControlSelectedFont, newSegmentedControlSelectedFont)
+    }
+}

--- a/Core/CoreTests/AppEnvironment/K5StateTests.swift
+++ b/Core/CoreTests/AppEnvironment/K5StateTests.swift
@@ -22,6 +22,12 @@ import TestsFoundation
 
 class K5StateTests: CoreTestCase {
 
+    override func setUp() {
+        super.setUp()
+        ExperimentalFeature.K5Dashboard.isEnabled = false
+        environment.userDefaults?.isElementaryViewEnabled = false
+    }
+
     func testK5AccountStateUpdates() {
         let testee = K5State()
         XCTAssertFalse(testee.isK5Account)
@@ -54,15 +60,20 @@ class K5StateTests: CoreTestCase {
         XCTAssertFalse(testee.isK5Account)
     }
 
-    func testK5ModeDependsOnFeatureFlag() {
+    func testK5ModeDepencies() {
         let testee = K5State()
+        testee.sessionDefaults = environment.userDefaults
         XCTAssertFalse(testee.isK5Account)
         XCTAssertFalse(testee.isK5Enabled)
+        XCTAssertFalse(testee.isElementaryViewEnabled)
 
         testee.userDidLogin(isK5Account: true)
         XCTAssertFalse(testee.isK5Enabled)
 
         ExperimentalFeature.K5Dashboard.isEnabled = true
+        XCTAssertFalse(testee.isK5Enabled)
+
+        environment.userDefaults?.isElementaryViewEnabled = true
         XCTAssertTrue(testee.isK5Enabled)
 
         testee.userDidLogin(isK5Account: false)
@@ -71,6 +82,7 @@ class K5StateTests: CoreTestCase {
 
     func testFontAppearanceUpdated() {
         ExperimentalFeature.K5Dashboard.isEnabled = true
+        environment.userDefaults?.isElementaryViewEnabled = true
         AppEnvironment.shared.k5.userDidLogin(isK5Account: false)
 
         let oldTabFont = UITabBarItem.appearance().titleTextAttributes(for: .normal)![NSAttributedString.Key.font] as! UIFont?

--- a/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
+++ b/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
@@ -42,8 +42,8 @@ class SessionDefaultsTests: XCTestCase {
         XCTAssertTrue(defaults.hasSetPSPDFKitLastUsedValues)
     }
 
-    func testEnableK5DashboardDefault() {
+    func testElementaryViewEnabledDefaultValue() {
         defaults.reset()
-        XCTAssertTrue(defaults.isK5DashboardEnabled)
+        XCTAssertTrue(defaults.isElementaryViewEnabled)
     }
 }

--- a/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
+++ b/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
@@ -41,4 +41,9 @@ class SessionDefaultsTests: XCTestCase {
         defaults.hasSetPSPDFKitLastUsedValues = true
         XCTAssertTrue(defaults.hasSetPSPDFKitLastUsedValues)
     }
+
+    func testEnableK5DashboardDefault() {
+        defaults.reset()
+        XCTAssertTrue(defaults.isK5DashboardEnabled)
+    }
 }

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -70,7 +70,7 @@ class CoreTestCase: XCTestCase {
         Analytics.shared.handler = analytics
         environment.app = .student
         environment.window = window
-        environment.shouldUseK5Mode = false
+        environment.k5.userDidLogout()
         window.rootViewController = mainViewController
         window.makeKeyAndVisible()
     }

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -31,7 +31,7 @@ class CourseTests: CoreTestCase {
     func testDefaultK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1"))
-        environment.shouldUseK5Mode = true
+        environment.k5.shouldUseK5Mode = true
         ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#394B58"))
@@ -40,7 +40,7 @@ class CourseTests: CoreTestCase {
     func testK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1", course_color: "#0DEAD0"))
-        environment.shouldUseK5Mode = true
+        environment.k5.shouldUseK5Mode = true
         ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#0DEAD0"))

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -31,7 +31,7 @@ class CourseTests: CoreTestCase {
     func testDefaultK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1"))
-        environment.k5.shouldUseK5Mode = true
+        environment.k5.userDidLogin(isK5Account: true)
         ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#394B58"))
@@ -40,7 +40,7 @@ class CourseTests: CoreTestCase {
     func testK5Color() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1", course_color: "#0DEAD0"))
-        environment.k5.shouldUseK5Mode = true
+        environment.k5.userDidLogin(isK5Account: true)
         ExperimentalFeature.K5Dashboard.isEnabled = true
 
         XCTAssertEqual(a.color, UIColor(hexString: "#0DEAD0"))

--- a/Core/CoreTests/Planner/PlannableTests.swift
+++ b/Core/CoreTests/Planner/PlannableTests.swift
@@ -84,7 +84,7 @@ class PlannableTests: CoreTestCase {
 
     func testK5Color() {
         ExperimentalFeature.K5Dashboard.isEnabled = true
-        environment.k5.shouldUseK5Mode = true
+        environment.k5.userDidLogin(isK5Account: true)
         Course.make(from: .make(id: "2", course_color: "#0DEAD0"))
         Course.make(from: .make(id: "0", course_color: nil))
         ContextColor.make(canvasContextID: "course_2", color: .blue)

--- a/Core/CoreTests/Planner/PlannableTests.swift
+++ b/Core/CoreTests/Planner/PlannableTests.swift
@@ -84,7 +84,7 @@ class PlannableTests: CoreTestCase {
 
     func testK5Color() {
         ExperimentalFeature.K5Dashboard.isEnabled = true
-        environment.shouldUseK5Mode = true
+        environment.k5.shouldUseK5Mode = true
         Course.make(from: .make(id: "2", course_color: "#0DEAD0"))
         Course.make(from: .make(id: "0", course_color: nil))
         ContextColor.make(canvasContextID: "course_2", color: .blue)

--- a/Core/CoreTests/Planner/PlannableTests.swift
+++ b/Core/CoreTests/Planner/PlannableTests.swift
@@ -85,6 +85,8 @@ class PlannableTests: CoreTestCase {
     func testK5Color() {
         ExperimentalFeature.K5Dashboard.isEnabled = true
         environment.k5.userDidLogin(isK5Account: true)
+        environment.k5.sessionDefaults = environment.userDefaults
+        environment.userDefaults?.isElementaryViewEnabled = true
         Course.make(from: .make(id: "2", course_color: "#0DEAD0"))
         Course.make(from: .make(id: "0", course_color: nil))
         ContextColor.make(canvasContextID: "course_2", color: .blue)

--- a/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
+++ b/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
@@ -25,7 +25,7 @@ class ProfileSettingsViewControllerTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
-        vc = ProfileSettingsViewController.create()
+        vc = ProfileSettingsViewController.create(onElementaryViewToggleChanged: {})
     }
 
     func load() {

--- a/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
+++ b/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
@@ -25,7 +25,7 @@ class ProfileSettingsViewControllerTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
-        vc = ProfileSettingsViewController.create(onElementaryViewToggleChanged: {})
+        vc = ProfileSettingsViewController.create()
     }
 
     func load() {

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -358,7 +358,9 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
     },
 
     "/profile/settings": { _, _, _ in
-        return ProfileSettingsViewController.create()
+        return ProfileSettingsViewController.create(onElementaryViewToggleChanged: {
+            HelmManager.shared.reload()
+        })
     },
 
     "/support/problem": { _, _, _ in

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -88,7 +88,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         NotificationManager.shared.subscribeToPushChannel()
 
         GetUserProfile().fetch(environment: environment, force: true) { apiProfile, urlResponse, _ in
-            self.environment.k5.shouldUseK5Mode = (apiProfile?.k5_user == true)
+            self.environment.k5.userDidLogin(profile: apiProfile)
             if urlResponse?.isUnauthorized == true, !session.isFakeStudent {
                 DispatchQueue.main.async { self.userDidLogout(session: session) }
             }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -88,7 +88,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         NotificationManager.shared.subscribeToPushChannel()
 
         GetUserProfile().fetch(environment: environment, force: true) { apiProfile, urlResponse, _ in
-            self.environment.shouldUseK5Mode = (apiProfile?.k5_user == true)
+            self.environment.k5.shouldUseK5Mode = (apiProfile?.k5_user == true)
             if urlResponse?.isUnauthorized == true, !session.isFakeStudent {
                 DispatchQueue.main.async { self.userDidLogout(session: session) }
             }
@@ -322,7 +322,7 @@ extension StudentAppDelegate {
 
 extension StudentAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
     func changeUser() {
-        environment.shouldUseK5Mode = false
+        environment.k5.userDidLogout()
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {
             window.rootViewController = LoginNavigationController.create(loginDelegate: self, app: .student)

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -45,7 +45,7 @@ class StudentTabBarController: UITabBarController {
     func dashboardTab() -> UIViewController {
         let split: HelmSplitViewController
 
-        if AppEnvironment.shared.isK5Enabled {
+        if AppEnvironment.shared.k5.isK5Enabled {
             let primary = HelmNavigationController(rootViewController: CoreHostingController(K5DashboardView()))
             let secondary = HelmNavigationController(rootViewController: EmptyViewController())
             split = FullScreenPrimaryHelmSplitViewController(primary: primary, secondary: secondary)


### PR DESCRIPTION
refs: MBL-15526
affects: Student
release note: none

test plan: K5 mode should be controlled by the switch in the settings menu on K5 accounts. The switch shouldn't be visible for non-k5 users or teachers or when the K5 remote/experimental feature flag is turned off.