### PR TITLE
Add empty state announcement to date picker cell.

### DIFF
--- a/Core/Core/SwiftUIViews/OptionalDatePicker.swift
+++ b/Core/Core/SwiftUIViews/OptionalDatePicker.swift
@@ -82,9 +82,10 @@ public struct OptionalDatePicker<Label: View>: View {
                 withAnimation(.default) { selection = initial }
             }, content: {
                 label
-                Spacer()
+                Spacer().accessibility(hidden: true)
                 placeholder
                     .font(.medium16).foregroundColor(.textDark)
+                    .accessibility(label: Text("No date selected", bundle: .core))
             })
         }
     }


### PR DESCRIPTION
refs: MBL-15445
affects: Teacher
release note: none

test plan:
- As the teacher edit an assignment.
- Turn on VoiceOver.
- Focus on Due, Available from and Available until buttons and observe that it now announces that there is no date selected.