### PR TITLE
Revert manual route constructing and use html url instead.

### DIFF
--- a/Core/Core/Quizzes/QuizListViewController.swift
+++ b/Core/Core/Quizzes/QuizListViewController.swift
@@ -104,10 +104,10 @@ public class QuizListViewController: UIViewController, ColoredNavViewProtocol {
         errorView.isHidden = quizzes.state != .error
         tableView.reloadData()
 
-        if !selectedFirstQuiz, quizzes.state != .loading, let quizID = quizzes.first?.id {
+        if !selectedFirstQuiz, quizzes.state != .loading, let url = quizzes.first?.htmlURL {
             selectedFirstQuiz = true
             if splitViewController?.isCollapsed == false, !isInSplitViewDetail {
-                env.router.route(to: "/courses/\(courseID)/quizzes/\(quizID)", from: self, options: .detail)
+                env.router.route(to: url, from: self, options: .detail)
             }
         }
     }
@@ -135,8 +135,8 @@ extension QuizListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let quizID = quizzes[indexPath]?.id else { return }
-        env.router.route(to: "/courses/\(courseID)/quizzes/\(quizID)", from: self, options: .detail)
+        guard let htmlURL = quizzes[indexPath]?.htmlURL else { return }
+        env.router.route(to: htmlURL, from: self, options: .detail)
     }
 }
 

--- a/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
+++ b/Student/Student/Assignments/AssignmentList/AssignmentListViewController.swift
@@ -220,9 +220,9 @@ extension AssignmentListViewController: UITableViewDataSource, UITableViewDelega
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let a = model.assignment(for: indexPath)
-        guard let courseID = courseID, let assignmentID = a?.id else { return }
-        env.router.route(to: "/courses/\(courseID)/assignments/\(assignmentID)", from: self, options: .detail)
+        let assignment = model.assignment(for: indexPath)
+        guard let url = assignment?.htmlUrl else { return }
+        env.router.route(to: url, from: self, options: .detail)
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -41,6 +41,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         setupFirebase()
         Core.Analytics.shared.handler = self
         CacheManager.resetAppIfNecessary()
+
         #if DEBUG
             UITestHelpers.setup(self)
         #endif

--- a/rn/Teacher/src/modules/assignments/AssignmentList.js
+++ b/rn/Teacher/src/modules/assignments/AssignmentList.js
@@ -199,10 +199,8 @@ export class AssignmentList extends Component<AssignmentListProps, State> {
     this.setState({ selectedRowID: assignment.id })
     if (assignment.discussion_topic && isTeacher()) {
       this.props.navigator.show(`/courses/${assignment.course_id}/discussion_topics/${assignment.discussion_topic.id}`)
-    } else if (assignment.quiz_id) {
-      this.props.navigator.show(`/courses/${assignment.course_id}/quizzes/${assignment.quiz_id}`)
     } else {
-      this.props.navigator.show(`/courses/${assignment.course_id}/assignments/${assignment.id}`)
+      this.props.navigator.show(assignment.html_url)
     }
   }
 

--- a/rn/Teacher/src/modules/assignments/__tests__/AssignmentList.test.js
+++ b/rn/Teacher/src/modules/assignments/__tests__/AssignmentList.test.js
@@ -170,7 +170,7 @@ describe('AssignmentList', () => {
     )
     let button = tree.find(`[testID="assignment-list.assignment-list-row.cell-${assignment.id}"]`)
     button.simulate('press')
-    expect(navigator.show).toHaveBeenCalledWith(`/courses/${assignment.course_id}/quizzes/${assignment.quiz_id}`)
+    expect(navigator.show).toHaveBeenCalledWith(assignment.html_url)
   })
 
   it('hides filter button without grading periods', () => {
@@ -263,14 +263,13 @@ describe('AssignmentList', () => {
     let traits = { window: { horizontal: 'regular' } }
     defaultProps.navigator.traitCollection = jest.fn(fn => fn(traits))
     defaultProps.assignmentGroups = [templates.assignmentGroup({
-      assignments: [templates.assignment()],
+      assignments: [templates.assignment({ html_url: '/courses/1/assignments/2' })],
     })]
     let screen = shallow(
       <AssignmentList {...defaultProps} />
     )
     screen.props().onTraitCollectionChange()
-    let assignment = defaultProps.assignmentGroups[0].assignments[0]
-    expect(defaultProps.navigator.show).toHaveBeenCalledWith(`/courses/${assignment.course_id}/assignments/${assignment.id}`)
+    expect(defaultProps.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/2')
   })
 
   it('does not select first item on regular horizontal trait collection when is modal', () => {


### PR DESCRIPTION
refs: MBL-15535
affects: Student, Teacher
release note: none

test plan: See linked ticket. Detail pages listed in MBL-15305 (except files) should open. New quiz won't launch on that test account since the LTI tool is broken there but the detail page should open.