### PR TITLE
Add a11y label to mail button.

### DIFF
--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
@@ -79,6 +79,7 @@ class SubmissionListViewController: UIViewController, ColoredNavViewProtocol {
 
         postPolicyButton.accessibilityIdentifier = "SubmissionsList.postPolicyButton"
         postPolicyButton.accessibilityLabel = NSLocalizedString("Grade post policy", comment: "")
+        messageUsersButton.accessibilityLabel = NSLocalizedString("Send message to users", comment: "")
 
         tableView.backgroundColor = .backgroundLightest
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)


### PR DESCRIPTION
refs: MBL-15521
affects: Teacher
release note: none

test plan: The mail button on the assignment submission list screen should have a valid a11y identifier.