### PR TITLE
Move scrollview from K5 skeleton to child page to support more generic page contents

### DIFF
--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomMySubjectsView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomMySubjectsView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 public struct K5HomeroomMySubjectsView: View {
     public private(set) var subjectCards: [K5HomeroomSubjectCardViewModel]
 
+    @Environment(\.horizontalPadding) private var horizontalPadding
     @Environment(\.containerSize) private var containerSize
     // allow even an iPhoneSE2 to hold 2 cards next to each other in landscape
     private var isCompact: Bool { containerSize.width < 600 }
@@ -32,7 +33,7 @@ public struct K5HomeroomMySubjectsView: View {
                 .font(.bold20)
                 .foregroundColor(.licorice)
                 .padding(.bottom, 16)
-            let cardWidth = calculateCardWidth(containerWidth: containerSize.width)
+            let cardWidth = calculateCardWidth(containerWidth: containerSize.width - 2 * horizontalPadding)
             JustifiedGrid(itemCount: subjectCards.count, itemSize: CGSize(width: cardWidth, height: K5HomeroomSubjectCardView.Height), spacing: cardSpacing, width: containerSize.width) { cardIndex in
                 K5HomeroomSubjectCardView(viewModel: subjectCards[cardIndex], width: cardWidth)
             }.padding(.bottom, cardSpacing)

--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomMySubjectsView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomMySubjectsView.swift
@@ -21,9 +21,9 @@ import SwiftUI
 public struct K5HomeroomMySubjectsView: View {
     public private(set) var subjectCards: [K5HomeroomSubjectCardViewModel]
 
-    @Environment(\.containerWidth) private var containerWidth
+    @Environment(\.containerSize) private var containerSize
     // allow even an iPhoneSE2 to hold 2 cards next to each other in landscape
-    private var isCompact: Bool { containerWidth < 600 }
+    private var isCompact: Bool { containerSize.width < 600 }
     private let cardSpacing: CGFloat = 24
 
     public var body: some View {
@@ -32,8 +32,8 @@ public struct K5HomeroomMySubjectsView: View {
                 .font(.bold20)
                 .foregroundColor(.licorice)
                 .padding(.bottom, 16)
-            let cardWidth = calculateCardWidth(containerWidth: containerWidth)
-            JustifiedGrid(itemCount: subjectCards.count, itemSize: CGSize(width: cardWidth, height: K5HomeroomSubjectCardView.Height), spacing: cardSpacing, width: containerWidth) { cardIndex in
+            let cardWidth = calculateCardWidth(containerWidth: containerSize.width)
+            JustifiedGrid(itemCount: subjectCards.count, itemSize: CGSize(width: cardWidth, height: K5HomeroomSubjectCardView.Height), spacing: cardSpacing, width: containerSize.width) { cardIndex in
                 K5HomeroomSubjectCardView(viewModel: subjectCards[cardIndex], width: cardWidth)
             }.padding(.bottom, cardSpacing)
         }
@@ -72,10 +72,10 @@ struct K5HomeroomMySubjectsView_Previews: PreviewProvider {
     static var previews: some View {
         K5HomeroomMySubjectsView(subjectCards: cards)
             .previewDevice(PreviewDevice(stringLiteral: "iPad (8th generation)"))
-            .environment(\.containerWidth, 800)
+            .environment(\.containerSize, CGSize(width: 800, height: 0))
         K5HomeroomMySubjectsView(subjectCards: cards)
             .previewDevice(PreviewDevice(stringLiteral: "iPhone SE (2nd generation)"))
-            .environment(\.containerWidth, 370)
+            .environment(\.containerSize, CGSize(width: 370, height: 0))
     }
 }
 

--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
@@ -19,29 +19,35 @@
 import SwiftUI
 
 public struct K5HomeroomView: View {
+    @Environment(\.horizontalPadding) private var horizontalPadding
     @ObservedObject private var viewModel: K5HomeroomViewModel
-    private let containerHorizontalMargin: CGFloat
 
-    public init(viewModel: K5HomeroomViewModel, containerHorizontalMargin: CGFloat) {
+    public init(viewModel: K5HomeroomViewModel) {
         self.viewModel = viewModel
-        self.containerHorizontalMargin = containerHorizontalMargin
     }
 
     public var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Text(viewModel.welcomeText)
-                .foregroundColor(.licorice)
-                .font(.bold34)
-                .padding(.top)
-            ForEach(viewModel.announcements) {
-                K5HomeroomAnnouncementView(viewModel: $0)
-                    .padding(.vertical, 23)
-                Divider()
-                    .padding(.horizontal, -containerHorizontalMargin) // make sure the divider fills the parent view horizontally
+        ScrollView(.vertical, showsIndicators: false) {
+            CircleRefresh { endRefreshing in
+                viewModel.refresh(completion: endRefreshing)
             }
 
-            K5HomeroomMySubjectsView(subjectCards: viewModel.subjectCards)
-                .padding(.top, 23)
+            VStack(alignment: .leading, spacing: 0) {
+                Text(viewModel.welcomeText)
+                    .foregroundColor(.licorice)
+                    .font(.bold34)
+                    .padding(.top)
+                ForEach(viewModel.announcements) {
+                    K5HomeroomAnnouncementView(viewModel: $0)
+                        .padding(.vertical, 23)
+                    Divider()
+                        .padding(.horizontal, -horizontalPadding) // make sure the divider fills the parent view horizontally
+                }
+
+                K5HomeroomMySubjectsView(subjectCards: viewModel.subjectCards)
+                    .padding(.top, 23)
+            }
+            .padding(.horizontal, horizontalPadding)
         }
     }
 }
@@ -50,7 +56,7 @@ public struct K5HomeroomView: View {
 
 struct K5HomeroomView_Previews: PreviewProvider {
     static var previews: some View {
-        K5HomeroomView(viewModel: K5HomeroomViewModel(), containerHorizontalMargin: 0).previewLayout(.sizeThatFits)
+        K5HomeroomView(viewModel: K5HomeroomViewModel()).previewLayout(.sizeThatFits)
     }
 }
 

--- a/Core/Core/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Dashboard/K5/View/K5DashboardView.swift
@@ -23,18 +23,16 @@ public struct K5DashboardView: View {
     @Environment(\.viewController) private var controller
 
     @ObservedObject private var viewModel = K5DashboardViewModel()
-    private var horizontalMargin: CGFloat { UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16 }
 
     public var body: some View {
         GeometryReader { geometry in
+            let padding: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
             VStack(spacing: 0) {
-                TopBarView(viewModel: viewModel.topBarViewModel, leftInset: horizontalMargin)
+                TopBarView(viewModel: viewModel.topBarViewModel, leftInset: padding)
                 Divider()
-                ScrollView(.vertical, showsIndicators: false) {
-                    content
-                        .padding(.horizontal, horizontalMargin)
-                        .environment(\.containerSize, CGSize(width: geometry.size.width - 2 * horizontalMargin, height: geometry.size.height))
-                }
+                content
+                    .environment(\.containerSize, geometry.size)
+                    .environment(\.horizontalPadding, padding)
             }
         }
         .navigationBarGlobal()
@@ -54,24 +52,12 @@ public struct K5DashboardView: View {
         VStack(spacing: 0) {
             switch viewModel.topBarViewModel.selectedItemIndex {
             case 0:
-                CircleRefresh { endRefreshing in
-                    viewModel.viewModels.homeroom.refresh(completion: endRefreshing)
-                }
-                K5HomeroomView(viewModel: viewModel.viewModels.homeroom, containerHorizontalMargin: horizontalMargin)
+                K5HomeroomView(viewModel: viewModel.viewModels.homeroom)
             case 1:
-                CircleRefresh { endRefreshing in
-                    viewModel.viewModels.schedule.refresh(completion: endRefreshing)
-                }
                 K5ScheduleView(viewModel: viewModel.viewModels.schedule)
             case 2:
-                CircleRefresh { endRefreshing in
-                    viewModel.viewModels.grades.refresh(completion: endRefreshing)
-                }
                 K5GradesView()
             case 3:
-                CircleRefresh { endRefreshing in
-                    viewModel.viewModels.resources.refresh(completion: endRefreshing)
-                }
                 K5ResourcesView()
             default:
                 SwiftUI.EmptyView()

--- a/Core/Core/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Dashboard/K5/View/K5DashboardView.swift
@@ -23,10 +23,10 @@ public struct K5DashboardView: View {
     @Environment(\.viewController) private var controller
 
     @ObservedObject private var viewModel = K5DashboardViewModel()
+    private var padding: CGFloat { UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16 }
 
     public var body: some View {
         GeometryReader { geometry in
-            let padding: CGFloat = UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16
             VStack(spacing: 0) {
                 TopBarView(viewModel: viewModel.topBarViewModel, leftInset: padding)
                 Divider()

--- a/Core/Core/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Dashboard/K5/View/K5DashboardView.swift
@@ -33,7 +33,7 @@ public struct K5DashboardView: View {
                 ScrollView(.vertical, showsIndicators: false) {
                     content
                         .padding(.horizontal, horizontalMargin)
-                        .environment(\.containerWidth, geometry.size.width - 2 * horizontalMargin)
+                        .environment(\.containerSize, CGSize(width: geometry.size.width - 2 * horizontalMargin, height: geometry.size.height))
                 }
             }
         }

--- a/Core/Core/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Dashboard/K5/View/K5DashboardView.swift
@@ -26,10 +26,10 @@ public struct K5DashboardView: View {
     private var padding: CGFloat { UIDevice.current.userInterfaceIdiom == .pad ? 32 : 16 }
 
     public var body: some View {
-        GeometryReader { geometry in
-            VStack(spacing: 0) {
-                TopBarView(viewModel: viewModel.topBarViewModel, leftInset: padding)
-                Divider()
+        VStack(spacing: 0) {
+            TopBarView(viewModel: viewModel.topBarViewModel, leftInset: padding)
+            Divider()
+            GeometryReader { geometry in
                 content
                     .environment(\.containerSize, geometry.size)
                     .environment(\.horizontalPadding, padding)

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleSubjectView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleSubjectView.swift
@@ -20,8 +20,8 @@ import SwiftUI
 
 public struct K5ScheduleSubjectView: View {
     private let viewModel: K5ScheduleSubjectViewModel
-    @Environment(\.containerWidth) private var containerWidth
-    private var isCompact: Bool { containerWidth < 500 }
+    @Environment(\.containerSize) private var containerSize
+    private var isCompact: Bool { containerSize.width < 500 }
 
     public init(viewModel: K5ScheduleSubjectViewModel) {
         self.viewModel = viewModel
@@ -138,7 +138,7 @@ struct K5ScheduleSubjectView_Previews: PreviewProvider {
             }
         }
         .previewDevice(PreviewDevice(stringLiteral: "iPad (8th generation)"))
-        .environment(\.containerWidth, 500)
+        .environment(\.containerSize, CGSize(width: 500, height: 0))
 
         VStack {
             ForEach(K5Preview.Data.Schedule.subjects) {

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/EnvironmentValues.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/EnvironmentValues.swift
@@ -30,6 +30,10 @@ struct ContainerSize: EnvironmentKey {
     public static var defaultValue: CGSize { .zero }
 }
 
+struct HorizontalPadding: EnvironmentKey {
+    public static var defaultValue: CGFloat { 0 }
+}
+
 extension EnvironmentValues {
     public var appEnvironment: AppEnvironment {
         get { self[AppEnvironment.self] }
@@ -47,5 +51,13 @@ extension EnvironmentValues {
     public var containerSize: CGSize {
         get { self[ContainerSize.self] }
         set { self[ContainerSize.self] = newValue }
+    }
+
+    /**
+     Useful for passing the expected horizontal padding to child views if padding cannot be set on the root view for some reason.
+     */
+    public var horizontalPadding: CGFloat {
+        get { self[HorizontalPadding.self] }
+        set { self[HorizontalPadding.self] = newValue }
     }
 }

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/EnvironmentValues.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/EnvironmentValues.swift
@@ -26,8 +26,8 @@ extension UIViewController: EnvironmentKey {
     public static var defaultValue: WeakViewController { WeakViewController() }
 }
 
-struct ContainerWidth: EnvironmentKey {
-    public static var defaultValue: CGFloat { 0 }
+struct ContainerSize: EnvironmentKey {
+    public static var defaultValue: CGSize { .zero }
 }
 
 extension EnvironmentValues {
@@ -41,8 +41,11 @@ extension EnvironmentValues {
         set { self[UIViewController.self] = newValue }
     }
 
-    public var containerWidth: CGFloat {
-        get { self[ContainerWidth.self] }
-        set { self[ContainerWidth.self] = newValue }
+    /**
+     This environment value can be used to pass a size read with GeometryReader down the view hierarchy.
+     */
+    public var containerSize: CGSize {
+        get { self[ContainerSize.self] }
+        set { self[ContainerSize.self] = newValue }
     }
 }


### PR DESCRIPTION
refs: MBL-15566
affects: Student
release note: none

test plan: No new functionality, only refactoring. K5 homeroom should work as before.