### PR TITLE
Remove options from side menu in K5 mode.

### DIFF
--- a/Core/Core/AppEnvironment/K5State.swift
+++ b/Core/Core/AppEnvironment/K5State.swift
@@ -26,11 +26,15 @@ public class K5State {
         }
     }
     public var isRemoteFeatureFlagEnabled: Bool { ExperimentalFeature.K5Dashboard.isEnabled }
+    /** Reflects the sate of the local switch in the options menu. */
     public var isElementaryViewEnabled: Bool { sessionDefaults?.isElementaryViewEnabled ?? false }
     /** External dependency. */
     public var sessionDefaults: SessionDefaults?
 
-    /** This flag indicates if K5 mode is turned on and should be used. */
+    /**
+     This flag indicates if K5 mode is turned on and should be used.
+     True if all of these flags are true: `isK5Account`, `isRemoteFeatureFlagEnabled`, `isElementaryViewEnabled`.
+     */
     public var isK5Enabled: Bool { isK5Account && isRemoteFeatureFlagEnabled && isElementaryViewEnabled }
 
     public func userDidLogin(profile: APIProfile?) {

--- a/Core/Core/Profile/SideMenu/SideMenuView.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuView.swift
@@ -19,6 +19,7 @@
 import SwiftUI
 
 public struct SideMenuView: View {
+    @Environment(\.appEnvironment) private var environment
     let enrollment: HelpLinkEnrollment
 
     public init(_ enrollment: HelpLinkEnrollment) {
@@ -33,7 +34,7 @@ public struct SideMenuView: View {
                     Divider()
                     SideMenuMainSection(enrollment)
                     Divider()
-                    if enrollment != .observer {
+                    if enrollment != .observer, !environment.k5.isK5Enabled {
                         SideMenuOptionsSection(enrollment: enrollment)
                         Divider()
                     }
@@ -46,8 +47,12 @@ public struct SideMenuView: View {
     }
 }
 
+#if DEBUG
+
 struct SideMenuView_Previews: PreviewProvider {
     static var previews: some View {
         SideMenuView(.student)
     }
 }
+
+#endif


### PR DESCRIPTION
refs: MBL-15462
affects: Student
release note: none

test plan: Show grades and color overlay switches should not be visible in the side menu in K5 mode.