### PR TITLE
Remove unsupported quiz field from update request.

### DIFF
--- a/rn/Teacher/src/canvas-api/apis/quizzes.js
+++ b/rn/Teacher/src/canvas-api/apis/quizzes.js
@@ -54,6 +54,7 @@ export function updateQuiz (quiz: Quiz, courseID: string): ApiPromise<Quiz> {
     ...quiz,
     one_question_at_a_time: quiz.one_question_at_a_time || 0, // silly Canvas
   }
+  delete params.important_dates // API sends this to the app but doesn't accept in PUT
   const url = `courses/${courseID}/quizzes/${quiz.id}`
   return httpClient.put(url, { quiz: params })
 }


### PR DESCRIPTION
refs: MBL-15560
affects: Teacher
release note: Fixed error on saving quiz details.

test plan: Editing a quiz should no longer return an error.