### PR TITLE
Fix add assignee screen buttons

### DIFF
--- a/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
@@ -112,6 +112,9 @@ extension HelmSplitViewController: UISplitViewControllerDelegate {
 
         if let nav = primaryViewController as? UINavigationController, nav.viewControllers.count >= 2 {
             var newDeets = nav.viewControllers[nav.viewControllers.count - 1]
+            // If there's a presented controller it will cause glitches so it's better to remove it.
+            // Presenting it again on the details view controller or self doesn't work at this point.
+            newDeets.dismissModal(animated: false)
             nav.popViewController(animated: true)
 
             if let helmVC = newDeets as? HelmViewController {

--- a/CanvasCore/CanvasCore/Helm/HelmViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmViewController.swift
@@ -459,7 +459,7 @@ extension UIViewController {
         if navigationItem.rightBarButtonItems?.count ?? 0 == 0 {
             button.style = .done
             navigationItem.rightBarButtonItem = button
-        } else {
+        } else if navigationItem.leftBarButtonItems?.count ?? 0 == 0 {
             navigationItem.leftBarButtonItem = button
         }
     }

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -811,6 +811,7 @@
 		B1F614AE243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F614AD243D0BE700F1FBA3 /* ModuleItemSequenceViewControllerTests.swift */; };
 		B1F6D6BA22EB675000CDD44D /* SessionDefaultsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */; };
 		CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */; };
+		CF12DFC826D63937000BE452 /* CompatibleNavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */; };
 		CF22C94325F2874A00C2E012 /* UIAccessibilityAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */; };
 		CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */; };
 		CF326B352563D4D3005ABAAA /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF326B342563D4D3005ABAAA /* HelpView.swift */; };
@@ -2005,6 +2006,7 @@
 		B1F6D6B722EB672500CDD44D /* SessionDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaults.swift; sourceTree = "<group>"; };
 		B1F6D6B922EB675000CDD44D /* SessionDefaultsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaultsTests.swift; sourceTree = "<group>"; };
 		CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
+		CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleNavBarItems.swift; sourceTree = "<group>"; };
 		CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncement.swift; sourceTree = "<group>"; };
 		CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncementTests.swift; sourceTree = "<group>"; };
 		CF326B342563D4D3005ABAAA /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
@@ -4648,6 +4650,7 @@
 			children = (
 				E8D7E6EA24D9D0EB00D6CCD0 /* AvoidKeyboardArea.swift */,
 				7DBD150525477CEB00750F52 /* Badge.swift */,
+				CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */,
 				CFEC7F4F26B92FBB008B9F77 /* Hidden.swift */,
 				E8809F3324E4775F006DBE0A /* TestIdentifier.swift */,
 			);
@@ -5948,6 +5951,7 @@
 				7DA25FF423F72260005D2121 /* ExperimentalFeaturesViewController.swift in Sources */,
 				7D7F71DA241C41BC00D6F9CB /* APIDate.swift in Sources */,
 				7D81F3F724F0112700C482D2 /* APIAccountTermsOfService.swift in Sources */,
+				CF12DFC826D63937000BE452 /* CompatibleNavBarItems.swift in Sources */,
 				7DA260D023F72359005D2121 /* CircleProgressView.swift in Sources */,
 				7DA25FBD23F72136005D2121 /* APIMediaComment.swift in Sources */,
 				7DA25FF723F7226E005D2121 /* DocViewerAnnotationStateManager.swift in Sources */,

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -45,7 +45,7 @@ public struct AssignmentDetailsView: View {
             .navigationBarItems(trailing: Button(action: { env.router.route(
                 to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
                 from: controller,
-                options: .modal(.formSheet, isDismissable: false, embedInNav: false)
+                options: .modal(.formSheet, isDismissable: false, embedInNav: true)
             ) }, label: {
                 Text("Edit", bundle: .core).fontWeight(.regular)
             }))

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -41,15 +41,15 @@ public struct AssignmentDetailsView: View {
         states
             .navigationBarStyle(.color(course.first?.color))
             .navigationTitle(NSLocalizedString("Assignment Details", comment: ""), subtitle: course.first?.name)
-
-            .navigationBarItems(trailing: Button(action: { env.router.route(
-                to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
-                from: controller,
-                options: .modal(.formSheet, isDismissable: false, embedInNav: true)
-            ) }, label: {
-                Text("Edit", bundle: .core).fontWeight(.regular)
-            }))
-
+            .compatibleNavBarItems(trailing: {
+                Button(action: { env.router.route(
+                    to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
+                    from: controller,
+                    options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+                ) }, label: {
+                    Text("Edit", bundle: .core).fontWeight(.regular)
+                })
+            })
             .onAppear {
                 assignment.refresh()
                 course.refresh()

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -50,19 +50,20 @@ public struct AssignmentEditorView: View {
     public var body: some View {
         form
             .navigationBarTitle(Text("Edit Assignment", bundle: .core), displayMode: .inline)
-            .navigationBarItems(
-                leading: Button(action: {
+            .compatibleNavBarItems(leading: {
+                Button(action: {
                     env.router.dismiss(controller)
                 }, label: {
                     Text("Cancel", bundle: .core).fontWeight(.regular)
                 })
-                    .identifier("screen.dismiss"),
-                trailing: Button(action: save, label: {
+                    .identifier("screen.dismiss")
+            }, trailing: {
+                Button(action: save, label: {
                     Text("Done", bundle: .core).bold()
                 })
                     .disabled(isLoading || isSaving)
                     .identifier("AssignmentEditor.doneButton")
-            )
+            })
 
             .alert(item: $alert) { alert in
                 switch alert {

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -48,34 +48,32 @@ public struct AssignmentEditorView: View {
     }
 
     public var body: some View {
-        NavigationView {
-            form
-                .navigationBarTitle(Text("Edit Assignment", bundle: .core), displayMode: .inline)
-                .navigationBarItems(
-                    leading: Button(action: {
-                        env.router.dismiss(controller)
-                    }, label: {
-                        Text("Cancel", bundle: .core).fontWeight(.regular)
-                    })
+        form
+            .navigationBarTitle(Text("Edit Assignment", bundle: .core), displayMode: .inline)
+            .navigationBarItems(
+                leading: Button(action: {
+                    env.router.dismiss(controller)
+                }, label: {
+                    Text("Cancel", bundle: .core).fontWeight(.regular)
+                })
                     .identifier("screen.dismiss"),
-                    trailing: Button(action: save, label: {
-                        Text("Done", bundle: .core).bold()
-                    })
+                trailing: Button(action: save, label: {
+                    Text("Done", bundle: .core).bold()
+                })
                     .disabled(isLoading || isSaving)
                     .identifier("AssignmentEditor.doneButton")
-                )
+            )
 
-                .alert(item: $alert) { alert in
-                    switch alert {
-                    case .error(let error):
-                        return Alert(title: Text(error.localizedDescription))
-                    case .removeOverride(let override):
-                        return AssignmentOverridesEditor.alert(toRemove: override, from: $overrides)
-                    }
+            .alert(item: $alert) { alert in
+                switch alert {
+                case .error(let error):
+                    return Alert(title: Text(error.localizedDescription))
+                case .removeOverride(let override):
+                    return AssignmentOverridesEditor.alert(toRemove: override, from: $overrides)
                 }
+            }
 
-                .onAppear(perform: load)
-        }.animation(.none)
+            .onAppear(perform: load)
     }
 
     enum AlertItem: Identifiable {

--- a/Core/Core/SwiftUIViews/CompatibleScrollViewReader.swift
+++ b/Core/Core/SwiftUIViews/CompatibleScrollViewReader.swift
@@ -21,6 +21,7 @@ import SwiftUI
 /**
  The purpose os this View is to be able to use ScrollViewReader on iOS 13 without any `if #available` statements. Acts as a ScrollViewReader on iOS 14, does nothing below that since there's no support from Apple.
  */
+@available(iOS, obsoleted: 14)
 public struct CompatibleScrollViewReader<Content: View>: View {
     private let content: (CompatibleScrollViewProxy) -> Content
 

--- a/Core/Core/ViewModifiers/CompatibleNavBarItems.swift
+++ b/Core/Core/ViewModifiers/CompatibleNavBarItems.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension View {
+
+    @available(iOS, obsoleted: 14)
+    @ViewBuilder
+    public func compatibleNavBarItems<T>(trailing: () -> T) -> some View where T: View {
+        if #available(iOS 14, *) {
+            self.toolbar {
+                ToolbarItem(placement: .navigationBarTrailing, content: trailing)
+            }
+        } else {
+            self.navigationBarItems(trailing: trailing())
+        }
+    }
+}

--- a/Core/Core/ViewModifiers/CompatibleNavBarItems.swift
+++ b/Core/Core/ViewModifiers/CompatibleNavBarItems.swift
@@ -31,4 +31,17 @@ extension View {
             self.navigationBarItems(trailing: trailing())
         }
     }
+
+    @available(iOS, obsoleted: 14)
+    @ViewBuilder
+    public func compatibleNavBarItems<L, T>(leading: () -> L, trailing: () -> T) -> some View where L: View, T: View {
+        if #available(iOS 14, *) {
+            self.toolbar {
+                ToolbarItem(placement: .navigationBarLeading, content: leading)
+                ToolbarItem(placement: .navigationBarTrailing, content: trailing)
+            }
+        } else {
+            self.navigationBarItems(leading: leading(), trailing: trailing())
+        }
+    }
 }

--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -58,13 +58,11 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
   }
 
   editAssignment = () => {
-    if (this.props.quizID) {
-      let route = `/courses/${this.props.courseID}/quizzes/${this.props.quizID}/edit`
-      this.props.navigator.show(route, { modal: true })
-      return
-    }
     let route = `/courses/${this.props.courseID}/assignments/${this.props.assignmentID}/edit`
-    this.props.navigator.show(route, { embedInNavigationController: false, modal: true })
+    if (this.props.quizID) {
+      route = `/courses/${this.props.courseID}/quizzes/${this.props.quizID}/edit`
+    }
+    this.props.navigator.show(route, { modal: true })
   }
 
   renderRow (date: AssignmentDate, dates: AssignmentDates) {

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
@@ -115,7 +115,7 @@ test('routes to assignment edit', () => {
   ).toJSON()
   const editButton: any = explore(tree).selectRightBarButton('assignment-due-dates.edit-btn')
   editButton.action()
-  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/1/edit', { embedInNavigationController: false, modal: true })
+  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/1/edit', { modal: true })
 })
 
 test('routes to quiz edit', () => {


### PR DESCRIPTION
refs: MBL-15585
affects: Teacher
release note: Fixed edit assignment dialog navigation issues.

test plan:
- Open assignment details
- Tap on edit
- Close the edit dialog either with cancel or done
- Edit button should work again from assignment details
---
- Open assignment details
- Tap on due dates section
- Tap on edit
- Edit dialog should have a cancel and done button
 ---
- Open assignment details on a big enough iPhone to support master-detail split view
- Tap on edit
- Rotate the phone to landscape
- Layout should still be usable

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/130790982-d027474d-e45f-4fff-94a1-263af5ca7b20.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/130791070-6148e19f-0ba3-4406-86cb-de90ba24b16b.png"></td>
</tr>
</table>
