### PR TITLE
Add custom back button to discussion sections picker.

### DIFF
--- a/Core/Core/Discussions/DiscussionSectionsPicker.swift
+++ b/Core/Core/Discussions/DiscussionSectionsPicker.swift
@@ -24,6 +24,8 @@ struct DiscussionSectionsPicker: View {
 
     @ObservedObject var sections: Store<GetCourseSections>
 
+    @Environment(\.viewController) private var viewController
+
     init(courseID: String, selection: Binding<Set<CourseSection>>) {
         self.courseID = courseID
         sections = AppEnvironment.shared.subscribe(GetCourseSections(courseID: courseID))
@@ -61,6 +63,16 @@ struct DiscussionSectionsPicker: View {
         }
             .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
             .navigationBarTitle(Text("Sections", bundle: .core))
+            .navigationBarBackButtonHidden(true)
+            .navigationBarItems(leading:
+                                    Button(action: {
+                                        viewController.value.navigationController?.popViewController(animated: true)
+                                    }, label: {
+                                        HStack(spacing: 2) {
+                                            Image.arrowOpenLeftSolid.padding(.leading, -14)
+                                            Text("Back", bundle: .core).font(.regular17)
+                                        }
+                                    }))
 
             .onAppear(perform: load)
     }


### PR DESCRIPTION
refs: MBL-15556
affects: Student, Teacher
release note: none

test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/130811838-1f9dbc5d-b452-483b-93b2-035792d3ebdd.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/130811849-ce4dcc54-6d67-4dd6-9ae1-125ac71444a6.png"></td>
</tr>
</table>