### PR TITLE
Disable pairing if self registration is disallowed

### DIFF
--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -182,11 +182,17 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
 
     private func refreshTermsOfService() {
         termsOfServiceRequest = env.api.makeRequest(GetAccountTermsOfServiceRequest()) { [weak self] response, _, _ in
-            defer { self?.termsOfServiceRequest = nil }
-            guard let self_registration = response?.self_registration_type else { return }
+            self?.termsOfServiceRequest = nil
+            let isPairingAllowed: Bool
+
+            if let self_registration = response?.self_registration_type {
+                isPairingAllowed = [APISelfRegistrationType.all, .observer].contains(self_registration)
+            } else {
+                isPairingAllowed = false
+            }
 
             performUIUpdate {
-                self?.isPairingWithObserverAllowed = [APISelfRegistrationType.all, .observer].contains(self_registration)
+                self?.isPairingWithObserverAllowed = isPairingAllowed
             }
         }
     }

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -134,8 +134,8 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
             + [Row(NSLocalizedString("Subscribe to Calendar Feed", bundle: .core, comment: ""), hasDisclosure: false) { [weak self] in
                     guard let url = self?.profile.first?.calendarURL else { return }
                     self?.env.loginDelegate?.openExternalURL(url)
-                }]
-            ),
+               },
+            ]),
 
             Section(NSLocalizedString("Legal", bundle: .core, comment: ""), rows: [
                 Row(NSLocalizedString("Privacy Policy", bundle: .core, comment: "")) { [weak self] in
@@ -161,11 +161,13 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
     private var pairWithObserverButton: [Any] {
         guard isPairingWithObserverAllowed else { return [] }
 
-        return [Row(NSLocalizedString("Pair with Observer", bundle: .core, comment: "")) { [weak self] in
-            guard let self = self else { return }
-            let vc = PairWithObserverViewController.create()
-            self.env.router.show(vc, from: self, options: .modal(.formSheet, isDismissable: true, embedInNav: true, addDoneButton: true))
-        }]
+        return [
+            Row(NSLocalizedString("Pair with Observer", bundle: .core, comment: "")) { [weak self] in
+                guard let self = self else { return }
+                let vc = PairWithObserverViewController.create()
+                self.env.router.show(vc, from: self, options: .modal(.formSheet, isDismissable: true, embedInNav: true, addDoneButton: true))
+            },
+        ]
     }
 
     private var k5DashboardSwitch: [Any] {

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -37,6 +37,12 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
     }
 
     let tableView = UITableView(frame: .zero, style: .grouped)
+    private var isPairingWithObserverAllowed = false {
+        didSet {
+            reloadData()
+        }
+    }
+    private var termsOfServiceRequest: APITask?
 
     public static func create(onElementaryViewToggleChanged: (() -> Void)? = nil) -> ProfileSettingsViewController {
         let viewController = ProfileSettingsViewController()
@@ -82,6 +88,7 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
         let force = sender != nil
         channels.exhaust(while: { _ in true })
         profile.refresh(force: force)
+        refreshTermsOfService()
     }
 
     func reloadData() {
@@ -122,17 +129,13 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
                         self.env.router.show(vc, from: self)
                     }
                 }
-            }).sorted(by: { $0.title < $1.title }) + [
-                Row(NSLocalizedString("Pair with Observer", bundle: .core, comment: "")) { [weak self] in
-                    guard let sself = self else { return }
-                    let vc = PairWithObserverViewController.create()
-                    sself.env.router.show(vc, from: sself, options: .modal(.formSheet, isDismissable: true, embedInNav: true, addDoneButton: true))
-                },
-                Row(NSLocalizedString("Subscribe to Calendar Feed", bundle: .core, comment: ""), hasDisclosure: false) { [weak self] in
+            }).sorted(by: { $0.title < $1.title })
+            + pairWithObserverButton
+            + [Row(NSLocalizedString("Subscribe to Calendar Feed", bundle: .core, comment: ""), hasDisclosure: false) { [weak self] in
                     guard let url = self?.profile.first?.calendarURL else { return }
                     self?.env.loginDelegate?.openExternalURL(url)
-                },
-            ]),
+                }]
+            ),
 
             Section(NSLocalizedString("Legal", bundle: .core, comment: ""), rows: [
                 Row(NSLocalizedString("Privacy Policy", bundle: .core, comment: "")) { [weak self] in
@@ -149,10 +152,20 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
                 },
             ]),
         ]
-        if !channels.pending && !profile.pending {
+        if !channels.pending && !profile.pending && termsOfServiceRequest == nil {
             tableView.refreshControl?.endRefreshing()
         }
         tableView.reloadData()
+    }
+
+    private var pairWithObserverButton: [Any] {
+        guard isPairingWithObserverAllowed else { return [] }
+
+        return [Row(NSLocalizedString("Pair with Observer", bundle: .core, comment: "")) { [weak self] in
+            guard let self = self else { return }
+            let vc = PairWithObserverViewController.create()
+            self.env.router.show(vc, from: self, options: .modal(.formSheet, isDismissable: true, embedInNav: true, addDoneButton: true))
+        }]
     }
 
     private var k5DashboardSwitch: [Any] {
@@ -163,6 +176,17 @@ public class ProfileSettingsViewController: UIViewController, PageViewEventViewC
             self?.onElementaryViewToggleChanged?()
         }
         return [row]
+    }
+
+    private func refreshTermsOfService() {
+        termsOfServiceRequest = env.api.makeRequest(GetAccountTermsOfServiceRequest()) { [weak self] response, _, _ in
+            defer { self?.termsOfServiceRequest = nil }
+            guard let self_registration = response?.self_registration_type else { return }
+
+            performUIUpdate {
+                self?.isPairingWithObserverAllowed = [APISelfRegistrationType.all, .observer].contains(self_registration)
+            }
+        }
     }
 }
 

--- a/Core/Core/TermsOfService/APIAccountTermsOfService.swift
+++ b/Core/Core/TermsOfService/APIAccountTermsOfService.swift
@@ -18,12 +18,19 @@
 
 import Foundation
 
+public enum APISelfRegistrationType: String, Codable {
+    case all
+    case none
+    case observer
+}
+
 public struct APIAccountTermsOfService: Codable, Equatable {
     let account_id: ID
     let content: String?
     let id: ID?
     let passive: Bool?
     let terms_type: String?
+    let self_registration_type: APISelfRegistrationType?
 }
 
 #if DEBUG
@@ -33,14 +40,16 @@ extension APIAccountTermsOfService {
         content: String? = "content",
         id: ID? = nil,
         passive: Bool? = false,
-        terms_type: String? = nil
+        terms_type: String? = nil,
+        self_registration_type: APISelfRegistrationType? = nil
     ) -> APIAccountTermsOfService {
         return APIAccountTermsOfService(
             account_id: account_id,
             content: content,
             id: id,
             passive: passive,
-            terms_type: terms_type
+            terms_type: terms_type,
+            self_registration_type: self_registration_type
         )
     }
 }

--- a/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
+++ b/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
@@ -42,6 +42,7 @@ class ProfileSettingsViewControllerTests: CoreTestCase {
         ]
         api.mock(vc.profile, value: APIProfile.make())
         api.mock(vc.channels, value: channels)
+        api.mock(GetAccountTermsOfServiceRequest(), value: .make(self_registration_type: .all))
 
         load()
 


### PR DESCRIPTION
refs: MBL-15532
affects: Student
release note: none

test plan: See ticket. Pairing option in settings should only be visible if self registration is set to all or observer on the canvas account.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/130920407-22702b53-7734-4970-8708-a4117f4ae84e.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/130920418-045073f6-ef51-4d29-80ea-a9a5d033fdfe.png"></td>
</tr>
</table>