### PR TITLE
Recent Activity page in course filters all courses' activities

### DIFF
--- a/Core/Core/Notifications/GetActivities.swift
+++ b/Core/Core/Notifications/GetActivities.swift
@@ -23,7 +23,10 @@ public class GetActivities: CollectionUseCase {
 
     public typealias Model = Activity
 
-    public init() {}
+    private let context: Context?
+    public init(context: Context? = nil) {
+        self.context = context
+    }
 
     public var cacheKey: String? {
         return "get-activities"
@@ -34,8 +37,15 @@ public class GetActivities: CollectionUseCase {
                                #keyPath(Activity.typeRaw), ActivityType.conference.rawValue,
                                #keyPath(Activity.typeRaw), ActivityType.collaboration.rawValue,
                                #keyPath(Activity.typeRaw), ActivityType.assessmentRequest.rawValue)
+        var contextFilter: NSPredicate {
+            guard let contextID = context?.canvasContextID  else {
+                return NSPredicate(value: true)
+            }
+            return NSPredicate(format: "%K == %@", #keyPath(Activity.canvasContextIDRaw), contextID)
+        }
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [pred, contextFilter])
         let order = [ NSSortDescriptor(key: #keyPath(Activity.updatedAt), ascending: false), ]
-        return Scope(predicate: pred, order: order, sectionNameKeyPath: nil)
+        return Scope(predicate: predicate, order: order, sectionNameKeyPath: nil)
     }
 
     public var request: GetActivitiesRequest {

--- a/Core/CoreTests/Notifications/GetActivitiesTests.swift
+++ b/Core/CoreTests/Notifications/GetActivitiesTests.swift
@@ -38,8 +38,10 @@ class GetActivitiesTests: CoreTestCase {
                                #keyPath(Activity.typeRaw), ActivityType.conference.rawValue,
                                #keyPath(Activity.typeRaw), ActivityType.collaboration.rawValue,
                                #keyPath(Activity.typeRaw), ActivityType.assessmentRequest.rawValue)
+        let contextFilter = NSPredicate(value: true)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [pred, contextFilter])
         let order = [ NSSortDescriptor(key: #keyPath(Activity.updatedAt), ascending: false), ]
-        let expected = Scope(predicate: pred, order: order, sectionNameKeyPath: nil)
+        let expected = Scope(predicate: predicate, order: order, sectionNameKeyPath: nil)
         XCTAssertEqual(useCase.scope, expected)
     }
 

--- a/Core/CoreTests/Notifications/GetActivitiesTests.swift
+++ b/Core/CoreTests/Notifications/GetActivitiesTests.swift
@@ -45,6 +45,20 @@ class GetActivitiesTests: CoreTestCase {
         XCTAssertEqual(useCase.scope, expected)
     }
 
+    func testScopeForCourse() {
+        let contextID = "course_1234"
+        useCase = GetActivities(context: Context(.course, id: "1234"))
+        let pred = NSPredicate(format: "%K != %@ && %K != %@ && %K != %@",
+                               #keyPath(Activity.typeRaw), ActivityType.conference.rawValue,
+                               #keyPath(Activity.typeRaw), ActivityType.collaboration.rawValue,
+                               #keyPath(Activity.typeRaw), ActivityType.assessmentRequest.rawValue)
+        let contextFilter = NSPredicate(format: "%K == %@", #keyPath(Activity.canvasContextIDRaw), contextID)
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [pred, contextFilter])
+        let order = [ NSSortDescriptor(key: #keyPath(Activity.updatedAt), ascending: false), ]
+        let expected = Scope(predicate: predicate, order: order, sectionNameKeyPath: nil)
+        XCTAssertEqual(useCase.scope, expected)
+    }
+
     func testRequest() {
         XCTAssertNotNil(useCase.request)
     }

--- a/Student/Student/Notifications/ActivityStreamViewController.swift
+++ b/Student/Student/Notifications/ActivityStreamViewController.swift
@@ -28,7 +28,7 @@ class ActivityStreamViewController: UIViewController, PageViewEventViewControlle
     }
 
     let env = AppEnvironment.shared
-    lazy var activities = env.subscribe(GetActivities()) { [weak self] in
+    lazy var activities = env.subscribe(GetActivities(context: context)) { [weak self] in
         self?.update()
     }
 
@@ -54,9 +54,11 @@ class ActivityStreamViewController: UIViewController, PageViewEventViewControlle
     }()
 
     var courseCache: [String: Info] = [:]
+    var context: Context?
 
-    static func create() -> ActivityStreamViewController {
+    static func create(context: Context? = nil) -> ActivityStreamViewController {
         let vc = loadFromStoryboard()
+        vc.context = context
         return vc
     }
 

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -70,8 +70,9 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
         return GroupNavigationViewController.create(context: context)
     },
 
-    "/:context/:contextID/activity_stream": { _, _, _ in
-        return ActivityStreamViewController.create()
+    "/:context/:contextID/activity_stream": { url, _, _ in
+        guard let context = Context(path: url.path) else { return nil }
+        return ActivityStreamViewController.create(context: context)
     },
 
     "/:context/:contextID/announcements": { url, _, _ in


### PR DESCRIPTION
refs: MBL-15594
affects: Student
release note: Show course related recent activities.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/131867768-2008cd3e-7275-448d-a415-9cb335bd41c5.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/131867755-92a5087b-076c-4ce9-8373-66e18e77edd4.png"></td>
</tr>
</table>