### PR TITLE
Fix K5 dashboard not resizing to full screen when tab bar icon is tapped

### DIFF
--- a/CanvasCore/CanvasCore/Helm/FullScreenPrimaryHelmSplitViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/FullScreenPrimaryHelmSplitViewController.swift
@@ -161,6 +161,8 @@ public class FullScreenPrimaryHelmSplitViewController: HelmSplitViewController {
     func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
         if navigationController.viewControllers.count != 1 {
             state = .divided
+        } else if navigationController.viewControllers.count == 1 { // if the nav controller pops to root then willShow won't trigger the fullscreen mode
+            state = .fullScreen
         }
     }
 


### PR DESCRIPTION
refs: MBL-15553
affects: Student
release note: none

test plan:
- Launch the app on iPad or a landscape capable iPhone with a K5 account.
- Enter Course > Assignment.
- Note that assignment details are visible on the right side of the split view.
- Tap on the Homeroom icon on the bottom tab bar.
- K5 dashboard should resize to full screen.