### PR TITLE
Make today button visible on all schedule pages

### DIFF
--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleView.swift
@@ -31,7 +31,9 @@ public struct K5ScheduleView: View {
                             initialPageIndex: viewModel.defaultWeekIndex,
                             currentPageIndex: $currentPageIndex.animation(animation),
                             pagerProxy: pagerProxy) { pageIndex in
-                K5ScheduleWeekView(viewModel: viewModel.weekModels[pageIndex])
+                K5ScheduleWeekView(viewModel: viewModel.weekModels[pageIndex], todayPressed: {
+                    pagerProxy.scrollToPage(viewModel.defaultWeekIndex, animated: false)
+                })
             }
             Divider()
             pageSwitcherButtons

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleView.swift
@@ -32,7 +32,7 @@ public struct K5ScheduleView: View {
                             currentPageIndex: $currentPageIndex.animation(animation),
                             pagerProxy: pagerProxy) { pageIndex in
                 K5ScheduleWeekView(viewModel: viewModel.weekModels[pageIndex], todayPressed: {
-                    pagerProxy.scrollToPage(viewModel.defaultWeekIndex, animated: false)
+                    pagerProxy.scrollToPage(viewModel.defaultWeekIndex, animated: true)
                 })
             }
             Divider()

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
@@ -26,9 +26,11 @@ public struct K5ScheduleWeekView: View {
     @State private var isTodayCellVisible = false
     // If we animate the today button during the first render cycle it causes glitches in List Section headers.
     @State private var didAppear = false
+    private let todayPressed: () -> Void
 
-    public init(viewModel: K5ScheduleWeekViewModel) {
+    public init(viewModel: K5ScheduleWeekViewModel, todayPressed: @escaping () -> Void) {
         self.viewModel = viewModel
+        self.todayPressed = todayPressed
     }
 
     public var body: some View {
@@ -85,6 +87,7 @@ public struct K5ScheduleWeekView: View {
             withAnimation {
                 scrollProxy.scrollTo(viewModel.todayViewId, anchor: .top)
             }
+            todayPressed()
         }, label: {
             Text("Today", bundle: .core)
                 .font(.regular17)
@@ -138,10 +141,10 @@ struct K5ScheduleWeekView_Previews: PreviewProvider {
         // swiftlint:disable:next redundant_discardable_let
         let _ = K5Preview.setupK5Mode()
 
-        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[0])
-        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[1])
+        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[0], todayPressed: {})
+        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[1], todayPressed: {})
 
-        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[0])
+        K5ScheduleWeekView(viewModel: K5Preview.Data.Schedule.weeks[0], todayPressed: {})
             .previewDevice(PreviewDevice(stringLiteral: "iPad (8th generation)"))
             .environment(\.containerSize, CGSize(width: 500, height: 0))
     }

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
@@ -36,22 +36,7 @@ public struct K5ScheduleWeekView: View {
             List {
                 let dayModels = viewModel.days
                 ForEach(dayModels) { dayModel in
-                    Section(header: header(for: dayModel)) {
-                        K5ScheduleDayView(viewModel: dayModel)
-                            .listRowInsets(EdgeInsets(top: 0, leading: horizontalPadding, bottom: 0, trailing: horizontalPadding))
-                            .padding(.bottom, dayModels.last == dayModel ? 24 : 0)
-                    }
-                    .onAppear {
-                        if viewModel.isTodayModel(dayModel) {
-                            updateTodayCellVisibility(to: true)
-                        }
-                    }
-                    .onDisappear {
-                        if viewModel.isTodayModel(dayModel) {
-                            updateTodayCellVisibility(to: false)
-                        }
-                    }
-                    .id(dayModel.weekday)
+                    dayCell(for: dayModel, isLastDay: dayModels.last == dayModel)
                 }
             }
             // This removes the gray highlight from list items on tap
@@ -73,6 +58,28 @@ public struct K5ScheduleWeekView: View {
         }
     }
 
+    @ViewBuilder
+    private func dayCell(for dayModel: K5ScheduleDayViewModel, isLastDay: Bool) -> some View {
+        let section = Section(header: header(for: dayModel)) {
+            K5ScheduleDayView(viewModel: dayModel)
+                .listRowInsets(EdgeInsets(top: 0, leading: horizontalPadding, bottom: 0, trailing: horizontalPadding))
+                .padding(.bottom, isLastDay ? 24 : 0)
+        }
+        .id(dayModel.weekday)
+
+        if viewModel.isTodayModel(dayModel) {
+            section
+                .onAppear {
+                    setTodayCellVisible(to: true)
+                }
+                .onDisappear {
+                    setTodayCellVisible(to: false)
+                }
+        } else {
+            section
+        }
+    }
+
     private func todayButton(scrollProxy: CompatibleScrollViewProxy) -> some View {
         Button(action: {
             withAnimation {
@@ -85,7 +92,7 @@ public struct K5ScheduleWeekView: View {
                 .padding(.trailing, horizontalPadding)
                 .padding(.top, 55)
         })
-        .hidden(!viewModel.isTodayButtonAvailable || isTodayCellVisible)
+        .hidden(isTodayCellVisible)
     }
 
     private func header(for model: K5ScheduleDayViewModel) -> some View {
@@ -113,7 +120,7 @@ public struct K5ScheduleWeekView: View {
         return background.overlay(content, alignment: .topLeading).accessibilityElement(children: .combine)
     }
 
-    private func updateTodayCellVisibility(to isVisible: Bool) {
+    private func setTodayCellVisible(to isVisible: Bool) {
         if didAppear {
             withAnimation {
                 isTodayCellVisible = isVisible

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleWeekView.swift
@@ -23,6 +23,7 @@ public struct K5ScheduleWeekView: View {
     @Environment(\.horizontalPadding) private var horizontalPadding
     private var isCompact: Bool { containerSize.width < 500 }
     @ObservedObject private var viewModel: K5ScheduleWeekViewModel
+    // In case this isn't the current week we don't update this variable so the Today button will be always visible
     @State private var isTodayCellVisible = false
     // If we animate the today button during the first render cycle it causes glitches in List Section headers.
     @State private var didAppear = false

--- a/Core/Core/SwiftUIViews/HorizontalPager/HorizontalPagerProxy.swift
+++ b/Core/Core/SwiftUIViews/HorizontalPager/HorizontalPagerProxy.swift
@@ -24,6 +24,7 @@ import Combine
 public struct HorizontalPagerProxy {
     public let scrollToNextPageSubject = PassthroughSubject<Void, Never>()
     public let scrollToPreviousPageSubject = PassthroughSubject<Void, Never>()
+    public let scrollToPageSubject = PassthroughSubject<(pageIndex: Int, animated: Bool), Never>()
 
     public func scrollToNextPage() {
         scrollToNextPageSubject.send()
@@ -31,5 +32,9 @@ public struct HorizontalPagerProxy {
 
     public func scrollToPreviousPage() {
         scrollToPreviousPageSubject.send()
+    }
+
+    public func scrollToPage(_ pageIndex: Int, animated: Bool) {
+        scrollToPageSubject.send((pageIndex, animated))
     }
 }


### PR DESCRIPTION
refs: MBL-15608
affects: Student
release note: none

test plan: Today button should be visible on all week pages of the schedule tab, not just on the current week.