### PR TITLE
Resources screen - Important Info section

### DIFF
--- a/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
+++ b/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
@@ -60,9 +60,8 @@ public struct K5ResourcesView: View {
                 .font(.bold20)
                 .padding(.bottom)
                 .accessibility(addTraits: .isHeader)
-            let shouldShowTitle = viewModel.homeroomInfos.count > 1
             ForEach(viewModel.homeroomInfos) { info in
-                if shouldShowTitle {
+                if viewModel.showInfoTitle {
                     HStack {
                         Image.coursesLine
                             .accessibility(hidden: true)

--- a/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
+++ b/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
@@ -60,9 +60,8 @@ public struct K5ResourcesView: View {
                 .font(.bold20)
                 .padding(.bottom)
                 .accessibility(addTraits: .isHeader)
-            let infosWithContent = viewModel.homeroomInfos.filter { !$0.htmlContent.isEmpty }
-            let shouldShowTitle = infosWithContent.count > 1
-            ForEach(infosWithContent) { info in
+            let shouldShowTitle = viewModel.homeroomInfos.count > 1
+            ForEach(viewModel.homeroomInfos) { info in
                 if shouldShowTitle {
                     HStack {
                         Image.coursesLine
@@ -76,7 +75,7 @@ public struct K5ResourcesView: View {
                     .frameToFit()
                     .padding(.horizontal, -16) // Removes padding in CSS
 
-                if info != infosWithContent.last {
+                if info != viewModel.homeroomInfos.last {
                     Divider().padding(.bottom)
                 }
             }

--- a/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
+++ b/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
@@ -62,12 +62,14 @@ public struct K5ResourcesView: View {
                 .accessibility(addTraits: .isHeader)
 
             ForEach(viewModel.homeroomInfos) { info in
-                HStack {
-                    Image.coursesLine
-                        .accessibility(hidden: true)
-                    Text(info.homeroomName)
-                        .foregroundColor(.licorice)
-                        .font(.bold17)
+                if viewModel.homeroomInfos.count > 1 {
+                    HStack {
+                        Image.coursesLine
+                            .accessibility(hidden: true)
+                        Text(info.homeroomName)
+                            .foregroundColor(.licorice)
+                            .font(.bold17)
+                    }
                 }
                 WebView(html: info.htmlContent)
                     .frameToFit()

--- a/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
+++ b/Core/Core/Dashboard/K5/View/Resources/K5ResourcesView.swift
@@ -60,9 +60,10 @@ public struct K5ResourcesView: View {
                 .font(.bold20)
                 .padding(.bottom)
                 .accessibility(addTraits: .isHeader)
-
-            ForEach(viewModel.homeroomInfos) { info in
-                if viewModel.homeroomInfos.count > 1 {
+            let infosWithContent = viewModel.homeroomInfos.filter { !$0.htmlContent.isEmpty }
+            let shouldShowTitle = infosWithContent.count > 1
+            ForEach(infosWithContent) { info in
+                if shouldShowTitle {
                     HStack {
                         Image.coursesLine
                             .accessibility(hidden: true)
@@ -75,7 +76,7 @@ public struct K5ResourcesView: View {
                     .frameToFit()
                     .padding(.horizontal, -16) // Removes padding in CSS
 
-                if info != viewModel.homeroomInfos.last {
+                if info != infosWithContent.last {
                     Divider().padding(.bottom)
                 }
             }

--- a/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
@@ -43,7 +43,7 @@ public class K5ResourcesViewModel: ObservableObject {
 
         let homeroomCourses = courses.all.filter { $0.isHomeroomCourse }
         homeroomInfos = homeroomCourses.compactMap {
-            guard let name = $0.name, let syllabus = $0.syllabusBody else { return nil }
+            guard let name = $0.name, let syllabus = $0.syllabusBody, !syllabus.isEmpty else { return nil }
             return K5ResourcesHomeroomInfoViewModel(homeroomName: name, htmlContent: syllabus)
         }
         let nonHomeroomCourses = courses.all.filter { !$0.isHomeroomCourse }

--- a/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
@@ -23,6 +23,10 @@ public class K5ResourcesViewModel: ObservableObject {
     @Published public var applications: [K5ResourcesApplicationViewModel] = []
     @Published public var contacts: [K5ResourcesContactViewModel] = []
 
+    public var showInfoTitle: Bool {
+        return homeroomInfos.count > 1
+    }
+
     private lazy var courses = AppEnvironment.shared.subscribe(GetCourses(enrollmentState: nil)) { [weak self] in
         self?.coursesRefreshed()
     }


### PR DESCRIPTION
refs: MBL-15574
affects: Student
release note: none
test plan:
- set up a user with a single homeroom enrollment
- homeroom name should not show on the resources page

- set up a user with multiple homeroom enrollments
- all homeroom syllabuses should be presented
- homeroom names should show as titles