### PR TITLE
Fix NightlyB build error by switching ParentUITests and ParentUnitTests test order.

### DIFF
--- a/TestPlans/NightlyTests.xctestplan
+++ b/TestPlans/NightlyTests.xctestplan
@@ -111,15 +111,15 @@
     {
       "target" : {
         "containerPath" : "container:..\/Parent\/Parent.xcodeproj",
-        "identifier" : "E8E1BE4923C6891F000E3A76",
-        "name" : "ParentUITests"
+        "identifier" : "3B36A2DE2322C26A00599A1E",
+        "name" : "ParentUnitTests"
       }
     },
     {
       "target" : {
         "containerPath" : "container:..\/Parent\/Parent.xcodeproj",
-        "identifier" : "3B36A2DE2322C26A00599A1E",
-        "name" : "ParentUnitTests"
+        "identifier" : "E8E1BE4923C6891F000E3A76",
+        "name" : "ParentUITests"
       }
     },
     {


### PR DESCRIPTION
refs: MBL-15468
affects: none
release note: none

test plan: