### PR TITLE
Remove unused file which caused export-translations to fail

### DIFF
--- a/rn/Teacher/ios/Teacher/en.lproj/InfoPlist.strings
+++ b/rn/Teacher/ios/Teacher/en.lproj/InfoPlist.strings
@@ -1,1 +1,0 @@
-IDELocalizationWork Temporary File


### PR DESCRIPTION
refs: MBL-15468
affects: Teacher
release note: none

test plan: Export translations script should complete without errors.