### PR TITLE
Fix nil self being used for alert dismissal.

### DIFF
--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -292,7 +292,7 @@ extension SubmissionButtonPresenter: AudioRecorderDelegate, UIImagePickerControl
             let success = UIAlertController(title: NSLocalizedString("Successfully submitted!", bundle: .student, comment: ""), message: nil, preferredStyle: .alert)
             self?.show(success) {
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-                    self?.env.router.dismiss(success)
+                    env.router.dismiss(success)
                 }
             }
         }


### PR DESCRIPTION
refs: MBL-15630
affects: Student
release note: Fixed app getting frozen after a successful media submission.

test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/133631765-8bf280a2-9911-425a-b45e-b6f6e4011921.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/133631778-22665dda-3f14-4e43-8000-7485d93a16a3.PNG"></td>
</tr>
</table>
