### PR TITLE
Fix announcement position being reset when updating a single announcement.

### DIFF
--- a/Core/Core/Discussions/DiscussionTopic.swift
+++ b/Core/Core/Discussions/DiscussionTopic.swift
@@ -134,7 +134,14 @@ public final class DiscussionTopic: NSManagedObject, WriteableModel {
             : "1 \((item.last_reply_at ?? item.created_at ?? .distantPast).isoString()) \(model.id)"
         model.orderSection = item.pinned == true ? 0 : item.locked == true ? 2 : 1
         model.pinned = item.pinned == true
-        model.position = item.pinned == true ? item.position ?? 0 : Int.max
+
+        // In case of announcements we use the API's natural ordering. When we fetch a single instance
+        // we don't want to overwrite the previously set position in save(_:apiPosition:in:). Also, announcements
+        // cannot be pinned.
+        if !model.isAnnouncement {
+            model.position = item.pinned == true ? item.position ?? 0 : Int.max
+        }
+
         model.postedAt = item.delayed_post_at ?? item.posted_at
         model.published = item.published
         model.requireInitialPost = item.require_initial_post == true


### PR DESCRIPTION
refs: MBL-15631
affects: Student, Teacher
release note: Fixed announcements list getting out of order after reading one.

test plan:

Student App:
- Go to announcements
- Open an announcements which is not at the bottom of the list
- Do a pull to refresh on the announcement detail page
- Go back to announcements list
- Announcements order shouldn't have changed

Teacher App:
- Go to announcements
- Open an announcements which is not at the bottom of the list
- Go back to announcements list
- Announcements order shouldn't have changed

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/135054113-384fe6d5-52be-4aa9-aff9-ba8b3f9eddd9.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/135054127-7c31afc6-3a12-4bdc-aefd-491eebb6114f.png"></td>
</tr>
</table>
