### PR TITLE
Student won't display in assignment list of students when inactive in another section

### DIFF
--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -206,6 +206,10 @@ public class GetSubmissions: CollectionUseCase {
         NSCompoundPredicate(orPredicateWithSubpredicates: [
             NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
             NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
+            NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(format: "ANY %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["active"]),
+                NSPredicate(format: "ANY %K != nil", #keyPath(Submission.enrollments.courseSectionID)),
+            ]),
         ]),
     ]}
 

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -226,6 +226,10 @@ class GetSubmissionsTests: CoreTestCase {
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
                 NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
+                NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "ANY %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["active"]),
+                    NSPredicate(format: "ANY %K != nil", #keyPath(Submission.enrollments.courseSectionID)),
+                ]),
             ]),
         ]))
 
@@ -235,6 +239,10 @@ class GetSubmissionsTests: CoreTestCase {
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
                 NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
+                NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "ANY %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["active"]),
+                    NSPredicate(format: "ANY %K != nil", #keyPath(Submission.enrollments.courseSectionID)),
+                ]),
             ]),
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSCompoundPredicate(andPredicateWithSubpredicates: []),
@@ -248,6 +256,10 @@ class GetSubmissionsTests: CoreTestCase {
             NSCompoundPredicate(orPredicateWithSubpredicates: [
                 NSPredicate(format: "%K.@count == 0", #keyPath(Submission.enrollments)),
                 NSPredicate(format: "NONE %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["inactive", "invited"]),
+                NSCompoundPredicate(andPredicateWithSubpredicates: [
+                    NSPredicate(format: "ANY %K IN %@", #keyPath(Submission.enrollments.stateRaw), ["active"]),
+                    NSPredicate(format: "ANY %K != nil", #keyPath(Submission.enrollments.courseSectionID)),
+                ]),
             ]),
             NSPredicate(key: #keyPath(Submission.late), equals: true),
         ]))


### PR DESCRIPTION
refs: MBL-15632
affects: Teacher
release note: Show inactive students' submissions while they are inactive in another course section.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/135981963-f4932939-a08f-4fb0-97e9-2370be33af7d.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/135981973-6cb3c6f4-d4ed-45f5-9094-08599b1e6506.png"></td>
</tr>
</table>
