### PR TITLE
Disable pop gesture recogniser in K5 dashboard.

### DIFF
--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -50,6 +50,8 @@ class StudentTabBarController: UITabBarController {
 
         if AppEnvironment.shared.k5.isK5Enabled {
             let primary = HelmNavigationController(rootViewController: CoreHostingController(K5DashboardView()))
+            // This causes issues with hosted SwiftUI views. If appears at multiple places maybe worth disabling globally in HelmNavigationController.
+            primary.interactivePopGestureRecognizer?.isEnabled = false
             let secondary = HelmNavigationController(rootViewController: EmptyViewController())
             split = FullScreenPrimaryHelmSplitViewController(primary: primary, secondary: secondary)
             tabBarTitle = NSLocalizedString("Homeroom", comment: "Homeroom tab title")


### PR DESCRIPTION
refs: MBL-15622
affects: Student
release note: none

test plan:
- Login with a K5 user
- Go to schedule
- Swipe to the previous week by starting the swipe on the left side of the screen like you do when you want to go back a screen in a navigation controller
- Go to grades tab, tap a course
- Observe app getting frozen
- Repeat the left swipe for more undefined behavior