### PR TITLE
Improve helplink parsing

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="17709" systemVersion="19H524" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20G165" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -489,12 +489,12 @@
         <relationship name="todos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Todo" inverseName="group" inverseEntity="Todo"/>
     </entity>
     <entity name="HelpLink" representedClassName="Core.HelpLink" syncable="YES">
-        <attribute name="availableToRaw" attributeType="String" defaultValueString="unenrolled"/>
-        <attribute name="id" attributeType="String"/>
+        <attribute name="availableToRaw" optional="YES" attributeType="String" defaultValueString="unenrolled"/>
+        <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="position" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="subtext" optional="YES" attributeType="String"/>
-        <attribute name="text" attributeType="String"/>
-        <attribute name="url" attributeType="URI"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
     </entity>
     <entity name="K5HomeroomDueItemCount" representedClassName="Core.K5HomeroomDueItemCount" syncable="YES">
         <attribute name="courseId" attributeType="String"/>

--- a/Core/Core/Profile/APIHelpLinks.swift
+++ b/Core/Core/Profile/APIHelpLinks.swift
@@ -28,12 +28,34 @@ public struct APIHelpLinks: Codable {
 
 // https://canvas.instructure.com/doc/api/accounts.html#HelpLink
 public struct APIHelpLink: Codable {
-    let id: String
-    let text: String
+
+    let id: String?
+    let text: String?
     let subtext: String?
     // let type: 'default' | 'custom'
-    let available_to: [HelpLinkEnrollment]
-    let url: URL
+    let available_to: [HelpLinkEnrollment]?
+    let url: URL?
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decodeIfPresent(String.self, forKey: .id)
+        text = try container.decodeIfPresent(String.self, forKey: .text)
+        subtext = try container.decodeIfPresent(String.self, forKey: .subtext)
+        available_to = try container.decodeIfPresent([HelpLinkEnrollment].self, forKey: .available_to)
+        do {
+            url = try container.decode(URL.self, forKey: .url)
+        } catch( _) {
+            url = nil
+        }
+    }
+
+    public init(id: String?, text: String?, subtext: String?, available_to: [HelpLinkEnrollment]?, url: URL?) {
+        self.id = id
+        self.text = text
+        self.subtext = subtext
+        self.available_to = available_to
+        self.url = url
+    }
 }
 
 public enum HelpLinkEnrollment: String, Codable {
@@ -63,11 +85,11 @@ extension APIHelpLinks {
 
 extension APIHelpLink {
     public static func make(
-        id: String = "instructor_question",
-        text: String = "Ask Your Instructor a Question",
+        id: String? = "instructor_question",
+        text: String? = "Ask Your Instructor a Question",
         subtext: String? = "Questions are submitted to your instructor",
-        available_to: [HelpLinkEnrollment] = [ .student ],
-        url: URL = URL(string: "#teacher_feedback")!
+        available_to: [HelpLinkEnrollment]? = [ .student ],
+        url: URL? = URL(string: "#teacher_feedback")!
     ) -> APIHelpLink {
         return APIHelpLink(
             id: id,

--- a/Core/Core/Profile/Help/Controller/GetAccountHelpLinks.swift
+++ b/Core/Core/Profile/Help/Controller/GetAccountHelpLinks.swift
@@ -53,7 +53,7 @@ public class GetAccountHelpLinks: CollectionUseCase {
 
         var position = 0
         for link in links.custom_help_links.isEmpty ? links.default_help_links : links.custom_help_links {
-            let predicate = NSPredicate(format: "%K == %@", #keyPath(HelpLink.id), link.id)
+            let predicate = NSPredicate(format: "%K == %@", #keyPath(HelpLink.id), link.id ?? "")
             let model: HelpLink = client.fetch(predicate).first ?? client.insert()
             model.availableTo = link.available_to
             model.id = link.id

--- a/Core/Core/Profile/Help/Model/HelpLink.swift
+++ b/Core/Core/Profile/Help/Model/HelpLink.swift
@@ -19,15 +19,23 @@
 import CoreData
 
 public class HelpLink: NSManagedObject {
-    @NSManaged public var availableToRaw: String
-    @NSManaged public var id: String
+    @NSManaged public var availableToRaw: String?
+    @NSManaged public var id: String?
     @NSManaged public var position: Int
     @NSManaged public var subtext: String?
-    @NSManaged public var text: String
+    @NSManaged public var text: String?
     @NSManaged public var url: URL?
 
-    public var availableTo: [HelpLinkEnrollment] {
-        get { return availableToRaw.components(separatedBy: ",").compactMap { HelpLinkEnrollment(rawValue: $0) } }
-        set { availableToRaw = newValue.map { $0.rawValue } .joined(separator: ",") }
+    public var availableTo: [HelpLinkEnrollment]? {
+        get {
+            guard let availableToRaw = availableToRaw else { return nil }
+            return availableToRaw.components(separatedBy: ",").compactMap { HelpLinkEnrollment(rawValue: $0) }
+        }
+        set {
+            guard let newValue = newValue else {
+                availableToRaw = nil
+                return
+            }
+            availableToRaw = newValue.map { $0.rawValue } .joined(separator: ",") }
     }
 }

--- a/Core/Core/Profile/Help/View/HelpItemView.swift
+++ b/Core/Core/Profile/Help/View/HelpItemView.swift
@@ -24,7 +24,7 @@ struct HelpItemView: View {
             tapAction(model)
         }, label: {
             VStack(alignment: .leading, spacing: 5) {
-                Text(model.text)
+                Text(model.text ?? "")
                     .font(.semibold16)
                     .foregroundColor(.textDarkest)
                     .testID()

--- a/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
@@ -62,7 +62,7 @@ struct SideMenuBottomSection: View {
         VStack(spacing: 0) {
 
             if let root = helpLinks.first, helpLinks.count > 1 {
-                SideMenuItem(id: "help", image: .questionLine, title: Text("\(root.text)", bundle: .core), badgeValue: 0).onTapGesture {
+                SideMenuItem(id: "help", image: .questionLine, title: Text("\(root.text ?? "")", bundle: .core), badgeValue: 0).onTapGesture {
                     showHelpMenu()
                 }
             }

--- a/Core/CoreTests/Profile/GetAccountHelpLinksTests.swift
+++ b/Core/CoreTests/Profile/GetAccountHelpLinksTests.swift
@@ -65,6 +65,20 @@ class GetAccountHelpLinksTests: CoreTestCase {
         XCTAssertEqual(student[2].availableTo, [.student])
     }
 
+    func testNilCustom() {
+        GetAccountHelpLinks(for: .student).write(response: .make(custom_help_links: [
+            .make(id: nil, text: nil, subtext: nil, available_to: [.student], url: nil),
+        ]), urlResponse: nil, to: databaseClient)
+
+        let student: [HelpLink] = databaseClient.fetch(scope: GetAccountHelpLinks(for: .student).scope)
+        XCTAssertEqual(student.count, 2)
+        XCTAssertNil(student[1].id)
+        XCTAssertNil(student[1].text)
+        XCTAssertNil(student[1].subtext)
+        XCTAssertEqual(student[1].availableTo, [.student])
+        XCTAssertNil(student[1].url)
+    }
+
     func testAvailableTo() {
         GetAccountHelpLinks(for: .student).write(response: .make(custom_help_links: [
             .make(id: "1", text: "Parent", subtext: nil, available_to: [.observer, .unenrolled], url: URL(string: "/")!),


### PR DESCRIPTION
refs: MBL-15604
affects: Student, Teacher
release note: Improved handling of help links.
test plan:
- Have a malformed help item set up (eg. url with a space on the end)
- Open the side menu
- Help should show up despite the error
- The malformed item should also show up, but might not display texts nor navigate