### PR TITLE
Fix annotation saving error not getting displayed in case of poor network connection

### DIFF
--- a/Core/Core/DocViewer/APIDocViewer.swift
+++ b/Core/Core/DocViewer/APIDocViewer.swift
@@ -232,11 +232,14 @@ struct GetDocViewerAnnotationsRequest: APIRequestable {
 
     static var decoder: JSONDecoder = {
         let decoder = JSONDecoder()
-        let formatter = ISO8601DateFormatter()
-        formatter.formatOptions = [ .withInternetDateTime, .withFractionalSeconds ]
+        let formatter1 = ISO8601DateFormatter()
+        formatter1.formatOptions = [ .withInternetDateTime, .withFractionalSeconds ]
+        // This is mainly to support mocking because when the mock encodes APIDocViewerAnnotations it doesn't add franctions so response parsing fails.
+        let formatter2 = ISO8601DateFormatter()
+        formatter2.formatOptions = [ .withInternetDateTime]
         decoder.dateDecodingStrategy = .custom { decoder in
             let dateStr = try decoder.singleValueContainer().decode(String.self)
-            guard let date = formatter.date(from: dateStr) else {
+            guard let date = (formatter1.date(from: dateStr) ?? formatter2.date(from: dateStr)) else {
                 throw APIDocViewerError.badDateFormat(dateStr)
             }
             return date

--- a/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
@@ -26,23 +26,28 @@ protocol DocViewerAnnotationProviderDelegate: AnyObject {
 }
 
 class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
-    let api: API
-    var apiAnnotations: [String: APIDocViewerAnnotation] = [:]
-    weak var docViewerDelegate: DocViewerAnnotationProviderDelegate?
-    let sessionID: String
-    let fileAnnotationProvider: PDFFileAnnotationProvider
+    public weak var docViewerDelegate: DocViewerAnnotationProviderDelegate?
 
+    var apiAnnotations: [String: APIDocViewerAnnotation] = [:]
     var requestsInFlight = 0 {
         didSet {
-            self.docViewerDelegate?.annotationSaveStateChanges(saving: requestsInFlight != 0)
+            // If we have a failed upload don't communicate success even if subsequent upload succeed.
+            guard uploadDidFail == false else { return }
+            docViewerDelegate?.annotationSaveStateChanges(saving: requestsInFlight != 0)
         }
     }
 
-    init(documentProvider: PDFDocumentProvider!,
-         fileAnnotationProvider: PDFFileAnnotationProvider,
-         metadata: APIDocViewerMetadata,
-         annotations: [APIDocViewerAnnotation],
-         api: API, sessionID: String) {
+    private let api: API
+    private let sessionID: String
+    private let fileAnnotationProvider: PDFFileAnnotationProvider
+    private var uploadDidFail = false
+
+    public init(documentProvider: PDFDocumentProvider!,
+                fileAnnotationProvider: PDFFileAnnotationProvider,
+                metadata: APIDocViewerMetadata,
+                annotations: [APIDocViewerAnnotation],
+                api: API,
+                sessionID: String) {
 
         self.api = api
         self.sessionID = sessionID
@@ -69,7 +74,7 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         setAnnotations(allAnnotations, append: false)
     }
 
-    func getReplies (to: Annotation) -> [DocViewerCommentReplyAnnotation] {
+    public func getReplies (to: Annotation) -> [DocViewerCommentReplyAnnotation] {
         return allAnnotations
             .compactMap { $0 as? DocViewerCommentReplyAnnotation }
             .filter { $0.inReplyToName == to.name }
@@ -80,7 +85,18 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
             }
     }
 
-    override func add(_ annotations: [Annotation], options: [AnnotationManager.ChangeBehaviorKey: Any]? = nil) -> [Annotation]? {
+    public override func annotationsForPage(at pageIndex: PageIndex) -> [Annotation]? {
+        // First, fetch the annotations from the file annotation provider.
+        let fileAnnotations = fileAnnotationProvider.annotationsForPage(at: pageIndex) ?? []
+        // Then ask `super` to retrieve the custom annotations from cache.
+        let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []
+        // Merge annotations loaded from the file annotation provider with our custom ones.
+        return fileAnnotations + docViewerAnnotations
+    }
+
+    // MARK: - Annotation Change Callbacks From PSPDFKit
+
+    public override func add(_ annotations: [Annotation], options: [AnnotationManager.ChangeBehaviorKey: Any]? = nil) -> [Annotation]? {
         super.add(annotations, options: options)
         var added: [Annotation] = []
         for annotation in annotations {
@@ -95,7 +111,7 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         return added
     }
 
-    override func remove(_ annotations: [Annotation], options: [AnnotationManager.ChangeBehaviorKey: Any]? = nil) -> [Annotation]? {
+    public override func remove(_ annotations: [Annotation], options: [AnnotationManager.ChangeBehaviorKey: Any]? = nil) -> [Annotation]? {
         super.remove(annotations, options: options)
         var removed: [Annotation] = []
         for annotation in annotations {
@@ -112,14 +128,11 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         return removed
     }
 
-    override func annotationsForPage(at pageIndex: PageIndex) -> [Annotation]? {
-        // First, fetch the annotations from the file annotation provider.
-        let fileAnnotations = fileAnnotationProvider.annotationsForPage(at: pageIndex) ?? []
-        // Then ask `super` to retrieve the custom annotations from cache.
-        let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []
-        // Merge annotations loaded from the file annotation provider with our custom ones.
-        return fileAnnotations + docViewerAnnotations
+    public override func didChange(_ annotation: Annotation, keyPaths: [String], options: [String: Any]? = nil) {
+        syncAnnotation(annotation)
     }
+
+    // MARK: - API Sync
 
     private func put(_ body: APIDocViewerAnnotation) {
         requestsInFlight += 1
@@ -130,6 +143,7 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
             } else if let error = error as? APIDocViewerError, error == APIDocViewerError.tooBig {
                 self?.docViewerDelegate?.annotationDidExceedLimit(annotation: body)
             } else {
+                self?.uploadDidFail = true
                 self?.docViewerDelegate?.annotationDidFailToSave(error: error ?? APIDocViewerError.noData)
             }
         } }
@@ -145,11 +159,20 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         } }
     }
 
-    override func didChange(_ annotation: Annotation, keyPaths: [String], options: [String: Any]? = nil) {
-        syncAnnotation(annotation)
+    // MARK: - User Triggered Events
+
+    public func syncAllAnnotations() {
+        uploadDidFail = false
+
+        if allAnnotations.count == 0 {
+            requestsInFlight = 0
+        }
+        allAnnotations.forEach(syncAnnotation)
     }
 
-    func syncAnnotation(_ annotation: Annotation) {
+    // MARK: - Private Methods
+
+    private func syncAnnotation(_ annotation: Annotation) {
         guard let apiAnnotation = annotation.apiAnnotation() else { return }
 
         if let inkAnnotation = annotation as? InkAnnotation, (inkAnnotation.lines?.count ??  0) > 120 {
@@ -164,12 +187,5 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
             return // don't save to network if empty comment reply or free text
         }
         put(apiAnnotation)
-    }
-
-    func syncAllAnnotations() {
-        if allAnnotations.count == 0 {
-            requestsInFlight = 0
-        }
-        allAnnotations.forEach(syncAnnotation)
     }
 }

--- a/Core/CoreTests/DocViewer/APIDocViewerTests.swift
+++ b/Core/CoreTests/DocViewer/APIDocViewerTests.swift
@@ -44,7 +44,7 @@ class APIDocViewerTests: XCTestCase {
         let data2 = """
             {"data":[{"id":"1","user_name":"a","page":1,"type":"text","created_at":"\(dateStr2)"}]}
         """.data(using: .utf8)!
-        XCTAssertThrowsError(try GetDocViewerAnnotationsRequest(sessionID: "{}").decode(data2))
+        XCTAssertNoThrow(try GetDocViewerAnnotationsRequest(sessionID: "{}").decode(data2))
     }
 
     func testPutDocViewerAnnotationRequest() {
@@ -80,7 +80,7 @@ class APIDocViewerTests: XCTestCase {
         let data2 = """
             {"id":"1","user_name":"a","page":1,"type":"text","created_at":"\(dateStr2)"}
         """.data(using: .utf8)!
-        XCTAssertThrowsError(try PutDocViewerAnnotationRequest(body: annotation, sessionID: "{}").decode(data2))
+        XCTAssertNoThrow(try PutDocViewerAnnotationRequest(body: annotation, sessionID: "{}").decode(data2))
     }
 
     func testDeleteDocViewerAnnotationRequest() {


### PR DESCRIPTION
refs: MBL-15225
affects: Teacher
release note: Fixed annotation saving error not getting displayed in case of poor network connection.

test plan:
- Setup Charles proxy.
- Add a breakpoint in Breakpoints Settings... menu to this path /2018-03-07/sessions/* check only the request checkbox.
- Log in to the teacher app, go to an assignment which can be annotated.
- Draw a line.
- Charles proxy will pop up a dialog, ignore it yet.
- Draw a second line.
- In Charles, abort the first request and execute the second.
- Go back to app, SpeedGrader should display the annotation save failed message.
- Disable breakpoints in Charles.
- Hit try again in the app, wait until save finishes.
- Close and re-open the assignment.
- Both lines should be visible.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/136382963-8bd6c4b4-57b3-4052-979b-dbb6aecf47f2.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/136382980-c76359ca-fde8-4ad5-9165-11128ba86bc2.png"></td>
</tr>
</table>