### PR TITLE
Add student annotation viewer to submissions screen.

### DIFF
--- a/Core/Core/DocViewer/APIDocViewer.swift
+++ b/Core/Core/DocViewer/APIDocViewer.swift
@@ -306,3 +306,29 @@ struct DeleteDocViewerAnnotationRequest: APIRequestable {
         HttpHeader.authorization: nil,
     ]
 }
+
+public struct CanvaDocsSessionRequest: APIRequestable {
+    public static let DraftAttempt = "draft"
+    public struct RequestBody: Encodable, Equatable {
+        let submission_attempt: String
+        let submission_id: String
+    }
+    public struct ResponseBody: Codable {
+        public let annotation_context_launch_id: String?
+        public let canvadocs_session_url: APIURL?
+    }
+    public typealias Response = ResponseBody
+    public typealias Body = RequestBody
+
+    public let body: Body?
+    public let method = APIMethod.post
+    public let path = "canvadoc_session"
+
+    /**
+     - parameters:
+        - attempt: Use `CanvaDocsSessionRequest.DraftAttempt` to create a new annotation context for a new submission, otherwise use the index of the submission attempt: "1", "2", ... to retrieve the context for that particular attempt.
+     */
+    public init(submissionId: String, attempt: String = DraftAttempt) {
+        self.body = RequestBody(submission_attempt: attempt, submission_id: submissionId)
+    }
+}

--- a/Core/CoreTests/DocViewer/APIDocViewerTests.swift
+++ b/Core/CoreTests/DocViewer/APIDocViewerTests.swift
@@ -91,4 +91,16 @@ class APIDocViewerTests: XCTestCase {
             HttpHeader.authorization: nil,
         ])
     }
+
+    func testCanvaDocSessionRequest() {
+        XCTAssertEqual(CanvaDocsSessionRequest.DraftAttempt, "draft")
+
+        let testee = CanvaDocsSessionRequest(submissionId: "1", attempt: "2")
+        XCTAssertEqual(testee.body, CanvaDocsSessionRequest.RequestBody(submission_attempt: "2", submission_id: "1"))
+        XCTAssertEqual(testee.method, .post)
+        XCTAssertEqual(testee.path, "canvadoc_session")
+
+        let defaultParamTestee = CanvaDocsSessionRequest(submissionId: "3")
+        XCTAssertEqual(defaultParamTestee.body, CanvaDocsSessionRequest.RequestBody(submission_attempt: "draft", submission_id: "3"))
+    }
 }

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
@@ -278,6 +278,24 @@ class SubmissionDetailsPresenterTests: StudentTestCase {
         XCTAssertEqual(ltiController.tools.url, submission.externalToolURL!)
     }
 
+    func testEmbedStudentAnnotation() {
+        Assignment.make()
+        Submission.make(from: .make(attempt: 1, submission_type: .student_annotation))
+
+        let request = CanvaDocsSessionRequest(submissionId: "1", attempt: "1")
+        let response = CanvaDocsSessionRequest.Response(annotation_context_launch_id: nil, canvadocs_session_url: APIURL(rawValue: URL(string: "https://instructure.com")!))
+        api.mock(request, value: response)
+
+        presenter.update()
+
+        XCTAssert(view.embedded is DocViewerViewController)
+
+        guard let docViewer = view.embedded as? DocViewerViewController else { return }
+        XCTAssertEqual(docViewer.filename, "")
+        XCTAssertEqual(docViewer.previewURL, URL(string: "https://instructure.com")!)
+        XCTAssertEqual(docViewer.fallbackURL, URL(string: "https://instructure.com")!)
+    }
+
     func testEmbedNothing() {
         Assignment.make()
         presenter.update()


### PR DESCRIPTION
refs: MBL-15674
affects: Student
release note: none

test plan:
- As a teacher create a new assignment with Student Annotation type, assign an image.
- As a student annotate the image on web.
- As teacher go to web based SpeedGrader and add further annotations on the submitted content.
- As a student log in to the iOS student app.
- Go to the student annotation assignment, enter Submission & Rubric screen.
- Assignment image should be visible with both student and teacher annotations.
- Submit multiple attempts to test the submission picker on this screen.