### PR TITLE
Add grading_periods include to react courses request to be in sync with the native API call and mocks.

### DIFF
--- a/rn/Teacher/src/canvas-api/apis/courses.js
+++ b/rn/Teacher/src/canvas-api/apis/courses.js
@@ -30,7 +30,7 @@ export function getCourses (): ApiPromise<Course[]> {
   }
   const courses = paginate('courses', {
     params: {
-      include: [ 'course_image', 'current_grading_period_scores', 'favorites', 'needs_grading_count', 'observed_users', 'sections', 'syllabus_body', 'tabs', 'term', 'total_scores' ],
+      include: [ 'course_image', 'current_grading_period_scores', 'grading_periods', 'favorites', 'needs_grading_count', 'observed_users', 'sections', 'syllabus_body', 'tabs', 'term', 'total_scores' ],
       state,
       per_page: 10,
     },


### PR DESCRIPTION
refs: MBL-15697
affects: Student, Teacher
release note: none

test plan:
- Course picker should work when composing a new message in Inbox.
- The following tests shouldn't fail:
  - StudentUITests/InboxTests/testCanMessageEntireClass
  - StudentUITests/InboxTests/testCanMessageMultiple