### PR TITLE
Fix SpeedGrader comment field content disappearing and other layout issues

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		CF12DFC826D63937000BE452 /* CompatibleNavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */; };
 		CF22C94325F2874A00C2E012 /* UIAccessibilityAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */; };
 		CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */; };
+		CF29DF91272BD9F10046C04D /* DynamicHeightTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */; };
 		CF326B352563D4D3005ABAAA /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF326B342563D4D3005ABAAA /* HelpView.swift */; };
 		CF4BDB5C26453A3000A91952 /* K5DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4BDB5B26453A3000A91952 /* K5DashboardView.swift */; };
 		CF4BDB6026453BD900A91952 /* K5DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */; };
@@ -2025,6 +2026,7 @@
 		CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleNavBarItems.swift; sourceTree = "<group>"; };
 		CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncement.swift; sourceTree = "<group>"; };
 		CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncementTests.swift; sourceTree = "<group>"; };
+		CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightTextEditor.swift; sourceTree = "<group>"; };
 		CF326B342563D4D3005ABAAA /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
 		CF4BDB5B26453A3000A91952 /* K5DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5DashboardView.swift; sourceTree = "<group>"; };
 		CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5DashboardViewModel.swift; sourceTree = "<group>"; };
@@ -4648,6 +4650,7 @@
 				CF575E19265E920D00F8515F /* CompatibleScrollViewReader.swift */,
 				EB66DB9426451CAE002D3325 /* CustomTextField.swift */,
 				7D89A2C82509326B009D0FD2 /* DisclosureIndicator.swift */,
+				CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */,
 				7D89A2CA250A6B3B009D0FD2 /* EditorForm.swift */,
 				7D7D6D4F25100D11002B1485 /* EmptyPanda.swift */,
 				7D742F3C25563EFD00FD6CF1 /* FlowStack.swift */,
@@ -5666,6 +5669,7 @@
 				B1A7848C2441136C001A2B50 /* GetModuleItem.swift in Sources */,
 				7D159CEB242E556100A77A15 /* ModuleItemSubHeaderCell.swift in Sources */,
 				E8809F3424E4775F006DBE0A /* TestIdentifier.swift in Sources */,
+				CF29DF91272BD9F10046C04D /* DynamicHeightTextEditor.swift in Sources */,
 				CFC01CC62563FF5D00178E98 /* HelpLinkRoute.swift in Sources */,
 				7D531D51254CC18F00CBFCA6 /* DiscussionSectionsPicker.swift in Sources */,
 				CF5F602A25DBD70E00E7E0ED /* WeakViewController.swift in Sources */,

--- a/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
+++ b/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
@@ -1,0 +1,124 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+/**
+ This text editor starts as a one line height component, then as text is entered it grows until its maximum height is reached.
+ */
+@available(iOS 14, *)
+public struct DynamicHeightTextEditor: View {
+    @Binding private var text: String
+    /** The height of the TextEditor. Calculated by manually measuring the text's rendered size and adding paddings.*/
+    @State private var height: CGFloat
+    /** The measured available width. The initial value is just a placeholder until the view is actually rendered. */
+    @State private var width: CGFloat = 300
+    private let maxHeight: CGFloat
+    private let minHeight: CGFloat
+    private let placeholder: String?
+    /** This is required to measure the text's height with `NSString`'s `boundingRect` method. We can't use `Font` or get it from `Environment` because `SwiftUI.Font` cannot be converted into `UIFont.` */
+    private let font: UIFont
+    // These are estimated values. SwiftUI.TextEditor has some internal paddings which we cannot influence nor measure.
+    private let textEditorVerticalPadding: CGFloat = 7
+    private let textEditorHorizontalPadding: CGFloat = 5
+
+    public init(text: Binding<String>, maxLines: Int, font: UIFont, placeholder: String? = nil) {
+        let minHeight = font.lineHeight + 2 * textEditorVerticalPadding
+        self._text = text
+        self.minHeight = minHeight
+        self.maxHeight = CGFloat(maxLines) * font.lineHeight + 2 * textEditorVerticalPadding
+        self.placeholder = placeholder
+        self.font = font
+        self.height = minHeight
+        updateHeight()
+    }
+
+    public var body: some View {
+        GeometryReader { geometry in // Just to measure the available width
+            SwiftUI.TextEditor(text: $text)
+                .font(Font(font))
+                .foregroundColor(.textDarkest)
+                .frame(height: height)
+                .preference(key: ViewSizeKey.self, value: CGSize(width: geometry.size.width - 2 * textEditorHorizontalPadding, height: 0))
+                .overlay(placeholderView, alignment: .topLeading)
+        }
+        .frame(maxHeight: height) // height must be limited to the text height, otherwise the geometry reader fills all available space vertically
+        .onChange(of: text) { _ in updateHeight() }
+        .onAppear(perform: updateHeight)
+        .onPreferenceChange(ViewSizeKey.self, perform: { size in
+            self.width = size.width
+            updateHeight()
+        })
+    }
+
+    @ViewBuilder
+    private var placeholderView: some View {
+        if text.isEmpty, let placeholder = placeholder, #available(iOS 15, *) {
+            Text(placeholder)
+                .font(Font(font))
+                .foregroundColor(.textDark)
+                .padding(.top, textEditorVerticalPadding)
+                .padding(.leading, textEditorHorizontalPadding)
+                .accessibility(hidden: true)
+                .allowsHitTesting(false) // Make sure taps go through to the TextEditor, doesn't work on iOS 14
+        }
+    }
+
+    /**
+     This method renders the text offscreen to measure its height for the current width. This measured height will be the height of the TextEditor.
+     */
+    private func updateHeight() {
+        let sizeConstraint = CGSize(width: width, height: .greatestFiniteMagnitude)
+        var measuredTextHeight = NSString(string: text).boundingRect(with: sizeConstraint, options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil).height
+        measuredTextHeight += 2 * textEditorVerticalPadding
+        height = min(maxHeight, max(minHeight, measuredTextHeight))
+    }
+}
+
+#if DEBUG
+
+@available(iOSApplicationExtension 14, *)
+struct DynamicHeightTextEditor_Previews: PreviewProvider {
+    static var previews: some View {
+        DynamicHeightTextEditor(text: .constant(""), maxLines: 3, font: .scaledNamedFont(.regular14), placeholder: "Placeholder")
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+
+        DynamicHeightTextEditor(text: .constant("Placeholder"), maxLines: 3, font: .scaledNamedFont(.regular14), placeholder: "Placeholder")
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+
+        DynamicHeightTextEditor(text: .constant("1"), maxLines: 3, font: .scaledNamedFont(.regular14))
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+
+        DynamicHeightTextEditor(text: .constant("1\n2"), maxLines: 3, font: .scaledNamedFont(.regular14))
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+
+        DynamicHeightTextEditor(text: .constant("1\n2\n3"), maxLines: 3, font: .scaledNamedFont(.regular14))
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+
+        DynamicHeightTextEditor(text: .constant("1\n2\n3\n4\n5\n6\n7\n8\n9"), maxLines: 3, font: .scaledNamedFont(.regular14))
+        .previewLayout(.sizeThatFits)
+        .border(Color.red)
+    }
+}
+
+#endif

--- a/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
+++ b/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
@@ -57,3 +57,18 @@ public struct ViewBoundsKey: PreferenceKey {
         value.append(contentsOf: nextValue())
     }
 }
+
+// MARK: - Saving a Single View's Size
+
+/**
+ This key allows one to save a view's size to the preference store.
+ */
+public struct ViewSizeKey: PreferenceKey {
+    public typealias Value = CGSize
+
+    public static var defaultValue = CGSize.zero
+
+    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
+        value = nextValue()
+    }
+}

--- a/Core/Core/ViewModifiers/AvoidKeyboardArea.swift
+++ b/Core/Core/ViewModifiers/AvoidKeyboardArea.swift
@@ -30,7 +30,11 @@ struct AvoidKeyboardArea<Content: View>: View {
         let willHide = NotificationCenter.default.publisher(for: UIApplication.keyboardWillHideNotification).map { _ in
             CGFloat(0)
         }
-        return Publishers.MergeMany(willShow, willChange, willHide).eraseToAnyPublisher()
+        let willResignActive = NotificationCenter.default.publisher(for: UIApplication.willResignActiveNotification).map { _ in
+            CGFloat(0)
+        }
+
+        return Publishers.MergeMany(willShow, willChange, willHide, willResignActive).eraseToAnyPublisher()
     }
 
     let content: Content

--- a/Core/CoreTests/ViewModifiers/AvoidKeyboardAreaTests.swift
+++ b/Core/CoreTests/ViewModifiers/AvoidKeyboardAreaTests.swift
@@ -40,6 +40,16 @@ class AvoidKeyboardAreaTests: CoreTestCase {
         XCTAssertEqual(received, [100])
         NotificationCenter.default.post(name: UIApplication.keyboardWillHideNotification, object: nil, userInfo: [:])
         XCTAssertEqual(received, [100, 0])
+        NotificationCenter.default.post(name: UIApplication.keyboardWillChangeFrameNotification, object: nil, userInfo: [
+            UIResponder.keyboardFrameEndUserInfoKey: CGRect(x: 0, y: 0, width: 0, height: 150),
+        ])
+        XCTAssertEqual(received, [100, 0, 150])
+        NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil, userInfo: [:])
+        XCTAssertEqual(received, [100, 0, 150, 0])
+        NotificationCenter.default.post(name: UIApplication.keyboardWillShowNotification, object: nil, userInfo: [:])
+        XCTAssertEqual(received, [100, 0, 150, 0, 0])
+        NotificationCenter.default.post(name: UIApplication.keyboardWillChangeFrameNotification, object: nil, userInfo: [:])
+        XCTAssertEqual(received, [100, 0, 150, 0, 0, 0])
     }
 
     func testBody() {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -28,17 +28,23 @@ struct CommentEditor: View {
 
     var body: some View {
         HStack(alignment: .bottom) {
-            ZStack(alignment: .leading) {
-                if text.isEmpty {
-                    Text("Comment")
-                        .font(.regular16).foregroundColor(.textDark)
-                        .accessibility(hidden: true)
-                }
-                Core.TextEditor(text: $text, maxHeight: containerHeight / 2)
-                    .font(.regular16).foregroundColor(.textDarkest)
+            if #available(iOS 14, *) {
+                DynamicHeightTextEditor(text: $text, maxLines: 3, font: .scaledNamedFont(.regular16), placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
                     .accessibility(label: Text("Comment"))
                     .identifier("SubmissionComments.commentTextView")
-                    .padding(.vertical, 2)
+            } else {
+                ZStack(alignment: .leading) {
+                    if text.isEmpty {
+                        Text("Comment")
+                            .font(.regular16).foregroundColor(.textDark)
+                            .accessibility(hidden: true)
+                    }
+                    Core.TextEditor(text: $text, maxHeight: containerHeight / 2)
+                        .font(.regular16).foregroundColor(.textDarkest)
+                        .accessibility(label: Text("Comment"))
+                        .identifier("SubmissionComments.commentTextView")
+                        .padding(.vertical, 2)
+                }
             }
             Button(action: {
                 action()

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -26,6 +26,7 @@ struct SubmissionCommentList: View {
     @Binding var attempt: Int?
     @Binding var fileID: String?
     @Binding var showRecorder: MediaCommentType?
+    @Binding var comment: String
 
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
@@ -33,7 +34,6 @@ struct SubmissionCommentList: View {
     @ObservedObject var attempts: Store<LocalUseCase<Submission>>
     @ObservedObject var comments: Store<GetSubmissionComments>
 
-    @State var comment: String = ""
     @State var error: Text?
     @State var showMediaOptions = false
 
@@ -43,13 +43,15 @@ struct SubmissionCommentList: View {
         attempts: Store<LocalUseCase<Submission>>,
         attempt: Binding<Int?>,
         fileID: Binding<String?>,
-        showRecorder: Binding<MediaCommentType?>
+        showRecorder: Binding<MediaCommentType?>,
+        enteredComment: Binding<String>
     ) {
         self.assignment = assignment
         self.submission = submission
         self._attempt = attempt
         self._fileID = fileID
         self._showRecorder = showRecorder
+        self._comment = enteredComment
         self.attempts = attempts
         comments = AppEnvironment.shared.subscribe(GetSubmissionComments(
             context: .course(assignment.courseID),

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -35,6 +35,8 @@ struct SubmissionGrader: View {
     @State var showAttempts = false
     @State var tab: GraderTab = .grades
     @State var showRecorder: MediaCommentType?
+    /** This is mainly used by `SubmissionCommentList` but since it's re-created on rotation and app backgrounding the entered text is lost. */
+    @State var enteredComment: String = ""
 
     private var selected: Submission { attempts.first { attempt == $0.attempt } ?? submission }
     private var file: File? {
@@ -249,7 +251,8 @@ struct SubmissionGrader: View {
                         attempts: attempts,
                         attempt: drawerAttempt,
                         fileID: drawerFileID,
-                        showRecorder: $showRecorder
+                        showRecorder: $showRecorder,
+                        enteredComment: $enteredComment
                     )
                         .clipped()
                     if showRecorder != .video || drawerState == .min {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -41,6 +41,7 @@ struct SubmissionGrader: View {
     @State var showRecorder: MediaCommentType?
     /** This is mainly used by `SubmissionCommentList` but since it's re-created on rotation and app backgrounding the entered text is lost. */
     @State var enteredComment: String = ""
+    /** Used to work around an issue which caused the page to re-load after putting the app into background. See `layoutForWidth()` method for more. */
     @State private var lastPresentedLayout: Layout = .portrait
 
     private var selected: Submission { attempts.first { attempt == $0.attempt } ?? submission }
@@ -308,7 +309,7 @@ struct SubmissionGrader: View {
     private func layoutForWidth(_ width: CGFloat) -> Layout {
         // On iPads if the app is backgrounded then it changes the device orientation back and forth causing the UI to re-render and the submission to re-load.
         // To overcome this we force the last presented layout in case the app is in the background.
-        guard UIApplication.shared.applicationState == .active else {
+        guard UIApplication.shared.applicationState != .background else {
             return lastPresentedLayout
         }
         return width > 834 ? .landscape : .portrait


### PR DESCRIPTION
refs: MBL-15689
affects: Teacher
release note: Fixed entered submission comment disappearing upon rotation on iPads.

test plan:
- On iPad go to SpeedGrader.
- Enter a comment into the text field but don't send it, keep the keyboard on screen.
- Put the app into background then move it to foreground.
- Entered text shouldn't disappear.
- Repeat this for the other interface orientation as well.
---
- On iPad go to SpeedGrader.
- Enter a comment into the text field but don't send it, keep the keyboard on screen..
- Rotate the device to the other orientation.
- Entered text shouldn't disappear.
- Keyboard should disappear, its are should be filled back with our content.
---
- On iPad go to SpeedGrader on a submission which can be annotated.
- Put the app into background then move it to foreground.
- Submission content shouldn't reload.
---
- iPhone SpeedGrader should work as before.
---
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/139054009-4bf75596-f2f3-495a-b572-23d54729fd3a.jpeg"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/139053769-abec3272-d792-4582-b353-6c82d59b841f.PNG"></td>
</tr>
</table>