### PR TITLE
Hebrew character ע will prevent updating pages

### DIFF
--- a/Core/Core/Pages/GetPage.swift
+++ b/Core/Core/Pages/GetPage.swift
@@ -86,7 +86,7 @@ struct UpdatePage: UseCase {
         front_page: Bool? = nil
     ) {
         self.context = context
-        self.url = url?.removingPercentEncoding
+        self.url = url?.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
         self.body = PutPageRequest.Body(wiki_page: PutPageRequest.WikiPage(
             title: title, body: body, editing_roles: editing_roles, published: published, front_page: front_page
         ))

--- a/Core/CoreTests/Pages/GetPageTests.swift
+++ b/Core/CoreTests/Pages/GetPageTests.swift
@@ -25,6 +25,7 @@ class GetPageTests: CoreTestCase {
 
     func testEncodedString() {
         XCTAssertEqual(GetPage(context: context, url: "pipe-%7C-pipe").url, "pipe-|-pipe")
+        XCTAssertEqual(UpdatePage(context: context, url: "`").url, "%60")
     }
 
     func testCacheKey() {


### PR DESCRIPTION
refs: MBL-15710
affects: Teacher
release note: Fixed Hebrew character handling in page titles.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/141808293-0e9d60bd-0655-4933-98d4-7f2cf771e575.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/141808287-c0c2eeeb-394c-411d-b2ce-7e1a4a9580ab.png"></td>
</tr>
</table>

