### PR TITLE
Fix annotation menu on read only documents

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -896,6 +896,7 @@
 		CF941B1E267B439600700DE9 /* K5ScheduleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF941B1D267B439600700DE9 /* K5ScheduleViewModelTests.swift */; };
 		CF9DFB602584F3EE004E27A5 /* ColorExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9DFB5F2584F3EE004E27A5 /* ColorExtensions.swift */; };
 		CF9FE7FF2673B770004BDE58 /* font_balsamiq_regular.css in Resources */ = {isa = PBXBuildFile; fileRef = CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */; };
+		CFABA2502742B8AE0096948F /* DocViewerAnnotationContextMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFABA24F2742B8AE0096948F /* DocViewerAnnotationContextMenuModel.swift */; };
 		CFAD79D826AEC02A0000A90D /* K5ScheduleEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAD79D726AEC02A0000A90D /* K5ScheduleEntryViewModel.swift */; };
 		CFAD79DB26AEFBCC0000A90D /* K5ScheduleEntryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAD79DA26AEFBCC0000A90D /* K5ScheduleEntryView.swift */; };
 		CFAE973925ECFF8F00DF2102 /* APIUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */; };
@@ -2127,6 +2128,7 @@
 		CF941B1D267B439600700DE9 /* K5ScheduleViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleViewModelTests.swift; sourceTree = "<group>"; };
 		CF9DFB5F2584F3EE004E27A5 /* ColorExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtensions.swift; sourceTree = "<group>"; };
 		CF9FE7FE2673B770004BDE58 /* font_balsamiq_regular.css */ = {isa = PBXFileReference; lastKnownFileType = text.css; path = font_balsamiq_regular.css; sourceTree = "<group>"; };
+		CFABA24F2742B8AE0096948F /* DocViewerAnnotationContextMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationContextMenuModel.swift; sourceTree = "<group>"; };
 		CFAD79D726AEC02A0000A90D /* K5ScheduleEntryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleEntryViewModel.swift; sourceTree = "<group>"; };
 		CFAD79DA26AEFBCC0000A90D /* K5ScheduleEntryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleEntryView.swift; sourceTree = "<group>"; };
 		CFAE973825ECFF8F00DF2102 /* APIUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIUserTests.swift; sourceTree = "<group>"; };
@@ -3105,6 +3107,7 @@
 				7DD694882195F7A200BA4984 /* DocViewerViewController.storyboard */,
 				7DD694862195F76C00BA4984 /* DocViewerViewController.swift */,
 				7D29D2FE218A4FEA0036437C /* PSPDFAnnotationExtension.swift */,
+				CFABA24F2742B8AE0096948F /* DocViewerAnnotationContextMenuModel.swift */,
 			);
 			path = DocViewer;
 			sourceTree = "<group>";
@@ -6147,6 +6150,7 @@
 				7DA260BA23F72352005D2121 /* GetQuizzes.swift in Sources */,
 				3B4D89342450A8F4004ED120 /* ConversationDetailViewController.swift in Sources */,
 				7DA2603623F722D9005D2121 /* SubmissionViewable.swift in Sources */,
+				CFABA2502742B8AE0096948F /* DocViewerAnnotationContextMenuModel.swift in Sources */,
 				7DA2603023F722C9005D2121 /* GoogleCloudAssignmentViewController.swift in Sources */,
 				D97020BD257FB554002B7B73 /* ContextCardView.swift in Sources */,
 				7DA2607923F722FA005D2121 /* AppBackgroundHelperProtocol.swift in Sources */,

--- a/Core/Core/DocViewer/DocViewerAnnotationContextMenuModel.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationContextMenuModel.swift
@@ -81,7 +81,7 @@ struct DocViewerAnnotationContextMenuModel {
                 return self.menuItems(for: annotation, suggestedMenuItems: menuItems, annotationMetadata: annotationMetadata)
             } else {
                 // Even if we can't annotate but the annotation has a comment added we should show the comment menu
-                // so the user can we previous comments and add new ones to the thread
+                // so the user can view previous comments and add new ones to the thread
                 if annotation.hasReplies == true {
                     return makeCommentOnlyMenu(for: annotation, annotationMetadata: annotationMetadata)
                 } else {

--- a/Core/Core/DocViewer/DocViewerAnnotationContextMenuModel.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationContextMenuModel.swift
@@ -1,0 +1,161 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import PSPDFKit
+import PSPDFKitUI
+
+struct DocViewerAnnotationContextMenuModel {
+    public typealias CommentTapHandler = (Annotation, Document, APIDocViewerAnnotationsMetadata) -> Void
+    public typealias DeleteTapHandler = (Annotation, Document) -> Void
+
+    private let globallyDisabledMenuItems: [String] = [
+        TextMenu.annotationMenuOpacity.rawValue,
+        TextMenu.annotationMenuThickness.rawValue,
+    ]
+    private var singleAnnotationDisabledMenuItems: [String] {
+        var result = globallyDisabledMenuItems
+        result.append(contentsOf: [
+            TextMenu.annotationMenuRemove.rawValue,
+            TextMenu.annotationMenuCopy.rawValue,
+            TextMenu.annotationMenuNote.rawValue,
+        ])
+        return result
+    }
+    private let commentTapHandler: CommentTapHandler
+    private let deleteTapHandler: DeleteTapHandler
+    private let env: AppEnvironment
+    private let isAnnotationEnabled: Bool
+    private let metadata: APIDocViewerMetadata?
+    private let pageView: PDFPageView
+    private let pdfController: PDFViewController
+    private var canAnnotate: Bool { isAnnotationEnabled && metadata?.annotations?.enabled == true }
+
+    public init(env: AppEnvironment,
+                isAnnotationEnabled: Bool,
+                metadata: APIDocViewerMetadata?,
+                pageView: PDFPageView,
+                pdfController: PDFViewController,
+                commentTapHandler: @escaping CommentTapHandler,
+                deleteTapHandler: @escaping DeleteTapHandler) {
+        self.env = env
+        self.isAnnotationEnabled = isAnnotationEnabled
+        self.metadata = metadata
+        self.pageView = pageView
+        self.pdfController = pdfController
+        self.commentTapHandler = commentTapHandler
+        self.deleteTapHandler = deleteTapHandler
+    }
+
+    public func shouldShow(_ menuItems: [MenuItem], for annotations: [Annotation]) -> [MenuItem] {
+        disableRotationOnFreeTextAnnotations(annotations)
+        updateInspectorMenuTitle(in: menuItems)
+
+        let isTappedOnEmptyArea = annotations.isEmpty
+
+        if isTappedOnEmptyArea {
+            // Only the teacher app should show the context menu when long tapped on an empty area
+            if env.app == .teacher, canAnnotate {
+                return filteredSuggestedMenuItems(menuItems)
+            } else {
+                return []
+            }
+
+        // Tap happened on a single annotation
+        } else if annotations.count == 1, let annotation = annotations.first, let annotationMetadata = metadata?.annotations {
+            if canAnnotate {
+                return self.menuItems(for: annotation, suggestedMenuItems: menuItems, annotationMetadata: annotationMetadata)
+            } else {
+                // Even if we can't annotate but the annotation has a comment added we should show the comment menu
+                // so the user can we previous comments and add new ones to the thread
+                if annotation.hasReplies == true {
+                    return makeCommentOnlyMenu(for: annotation, annotationMetadata: annotationMetadata)
+                } else {
+                    return []
+                }
+            }
+        } else {
+            if canAnnotate {
+                return filteredSuggestedMenuItems(menuItems)
+            } else {
+                return []
+            }
+        }
+    }
+
+    private func menuItems(for annotation: Annotation, suggestedMenuItems: [MenuItem], annotationMetadata: APIDocViewerAnnotationsMetadata) -> [MenuItem] {
+        // Annotations loaded from the pdf file shouldn't be modified
+        if annotation.isFileAnnotation {
+            return []
+        }
+
+        var newMenuItems: [MenuItem] = []
+
+        addCommentMenu(to: &newMenuItems, for: annotation, annotationMetadata: annotationMetadata)
+        add(suggestedMenus: suggestedMenuItems, to: &newMenuItems)
+        addDeleteMenu(to: &newMenuItems, for: annotation)
+
+        return newMenuItems
+    }
+
+    private func addCommentMenu(to menuItems: inout [MenuItem], for annotation: Annotation, annotationMetadata: APIDocViewerAnnotationsMetadata) {
+        if let document = pdfController.document {
+            menuItems.append(MenuItem(title: NSLocalizedString("Comments", bundle: .core, comment: "")) {
+                commentTapHandler(annotation, document, annotationMetadata)
+            })
+        }
+    }
+
+    private func addDeleteMenu(to menuItems: inout [MenuItem], for annotation: Annotation) {
+        if annotation.isDeletable, let document = pdfController.document {
+            menuItems.append(MenuItem(title: NSLocalizedString("Remove", bundle: .core, comment: ""), image: .trashLine, block: {
+                deleteTapHandler(annotation, document)
+            }, identifier: TextMenu.annotationMenuRemove.rawValue))
+        }
+    }
+
+    private func add(suggestedMenus: [MenuItem], to menuItems: inout [MenuItem]) {
+        menuItems.append(contentsOf: suggestedMenus.filter {
+            guard let identifier = $0.identifier else { return true }
+            return !singleAnnotationDisabledMenuItems.contains(identifier)
+        })
+    }
+
+    private func filteredSuggestedMenuItems(_ suggestedMenuItems: [MenuItem]) -> [MenuItem] {
+        suggestedMenuItems.filter {
+            guard let identifier = $0.identifier else { return true }
+            return !globallyDisabledMenuItems.contains(identifier)
+        }
+    }
+
+    private func makeCommentOnlyMenu(for annotation: Annotation, annotationMetadata: APIDocViewerAnnotationsMetadata) -> [MenuItem] {
+        var commentOnlyMenu: [MenuItem] = []
+        addCommentMenu(to: &commentOnlyMenu, for: annotation, annotationMetadata: annotationMetadata)
+        return commentOnlyMenu
+    }
+
+    private func updateInspectorMenuTitle(in menuItems: [MenuItem]) {
+        let inspectMenu = menuItems.first { $0.identifier == TextMenu.annotationMenuInspector.rawValue }
+        inspectMenu?.title = NSLocalizedString("Style", bundle: .core, comment: "")
+    }
+
+    private func disableRotationOnFreeTextAnnotations(_ annotations: [Annotation]) {
+        annotations.forEach {
+            (pageView.annotationView(for: $0) as? FreeTextAnnotationView)?.resizableView?.allowRotating = false
+        }
+    }
+}

--- a/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
@@ -41,17 +41,19 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
     private let sessionID: String
     private let fileAnnotationProvider: PDFFileAnnotationProvider
     private var uploadDidFail = false
+    private let isAnnotationEditingDisabled: Bool
 
     public init(documentProvider: PDFDocumentProvider!,
                 fileAnnotationProvider: PDFFileAnnotationProvider,
                 metadata: APIDocViewerMetadata,
                 annotations: [APIDocViewerAnnotation],
                 api: API,
-                sessionID: String) {
-
+                sessionID: String,
+                isAnnotationEditingDisabled: Bool) {
         self.api = api
         self.sessionID = sessionID
         self.fileAnnotationProvider = fileAnnotationProvider
+        self.isAnnotationEditingDisabled = isAnnotationEditingDisabled
 
         super.init(documentProvider: documentProvider)
 
@@ -60,7 +62,14 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         let allAnnotations = annotations.compactMap { (apiAnnotation: APIDocViewerAnnotation) -> Annotation? in
             apiAnnotations[apiAnnotation.id] = apiAnnotation
             if let id = apiAnnotation.inreplyto { hasReplies.insert(id) }
-            return Annotation.from(apiAnnotation, metadata: annotationsMetadata)
+
+            let pspdfAnnotation = Annotation.from(apiAnnotation, metadata: annotationsMetadata)
+
+            if isAnnotationEditingDisabled {
+                pspdfAnnotation?.flags.update(with: .readOnly)
+            }
+
+            return pspdfAnnotation
         }
         for annotation in allAnnotations {
             annotation.hasReplies = hasReplies.contains(annotation.name ?? "")
@@ -88,6 +97,8 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
     public override func annotationsForPage(at pageIndex: PageIndex) -> [Annotation]? {
         // First, fetch the annotations from the file annotation provider.
         let fileAnnotations = fileAnnotationProvider.annotationsForPage(at: pageIndex) ?? []
+        // Editing of annotations stored in the pdf file are always disabled
+        fileAnnotations.forEach { $0.flags.update(with: .readOnly) }
         // Then ask `super` to retrieve the custom annotations from cache.
         let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []
         // Merge annotations loaded from the file annotation provider with our custom ones.

--- a/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
@@ -98,7 +98,10 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         // First, fetch the annotations from the file annotation provider.
         let fileAnnotations = fileAnnotationProvider.annotationsForPage(at: pageIndex) ?? []
         // Editing of annotations stored in the pdf file are always disabled
-        fileAnnotations.forEach { $0.flags.update(with: .readOnly) }
+        fileAnnotations.forEach {
+            $0.flags.update(with: .readOnly)
+            $0.isFileAnnotation = true
+        }
         // Then ask `super` to retrieve the custom annotations from cache.
         let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []
         // Merge annotations loaded from the file annotation provider with our custom ones.

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -181,11 +181,6 @@ public class DocViewerViewController: UIViewController {
     }
 }
 
-private let disabledMenuItems: [String] = [
-    TextMenu.annotationMenuOpacity.rawValue,
-    TextMenu.annotationMenuThickness.rawValue,
-]
-
 extension DocViewerViewController: PDFViewControllerDelegate, AnnotationStateManagerDelegate {
     // swiftlint:disable function_parameter_count
     public func pdfViewController(
@@ -208,50 +203,22 @@ extension DocViewerViewController: PDFViewControllerDelegate, AnnotationStateMan
         in annotationRect: CGRect,
         on pageView: PDFPageView
     ) -> [MenuItem] {
-        guard isAnnotatable, metadata?.annotations?.enabled == true else {
-            return []
+        let commentTapHandler: DocViewerAnnotationContextMenuModel.CommentTapHandler = { [weak self] annotation, document, metadata in
+            let comments = self?.annotationProvider?.getReplies(to: annotation) ?? []
+            let view = CommentListViewController.create(comments: comments, inReplyTo: annotation, document: document, metadata: metadata)
+            self?.env.router.show(view, from: pdfController, options: .modal(embedInNav: true))
         }
-        // Only the teacher app should show the context menu when long tapped on an empty area
-        if (annotations == nil || annotations?.isEmpty == true) && env.app != .teacher {
-            return []
+        let deleteTapHandler: DocViewerAnnotationContextMenuModel.DeleteTapHandler = { annotation, document in
+            document.remove(annotations: [annotation], options: nil)
         }
-
-        annotations?.forEach {
-            (pageView.annotationView(for: $0) as? FreeTextAnnotationView)?.resizableView?.allowRotating = false
-        }
-        if annotations?.count == 1, let annotation = annotations?.first, let document = pdfController.document, let metadata = metadata?.annotations {
-            var realMenuItems = [MenuItem]()
-            realMenuItems.append(MenuItem(title: NSLocalizedString("Comments", bundle: .core, comment: "")) { [weak self] in
-                let comments = self?.annotationProvider?.getReplies(to: annotation) ?? []
-                let view = CommentListViewController.create(comments: comments, inReplyTo: annotation, document: document, metadata: metadata)
-                self?.env.router.show(view, from: pdfController, options: .modal(embedInNav: true))
-            })
-
-            realMenuItems.append(contentsOf: menuItems.filter {
-                guard let identifier = $0.identifier else { return true }
-                if identifier == TextMenu.annotationMenuInspector.rawValue {
-                    $0.title = NSLocalizedString("Style", bundle: .core, comment: "")
-                }
-                return (
-                    identifier != TextMenu.annotationMenuRemove.rawValue &&
-                    identifier != TextMenu.annotationMenuCopy.rawValue &&
-                    identifier != TextMenu.annotationMenuNote.rawValue &&
-                    !disabledMenuItems.contains(identifier)
-                )
-            })
-
-            if annotation.isEditable || metadata.permissions == .readwritemanage {
-                realMenuItems.append(MenuItem(title: NSLocalizedString("Remove", bundle: .core, comment: ""), image: .trashLine, block: {
-                    pdfController.document?.remove(annotations: [annotation], options: nil)
-                }, identifier: TextMenu.annotationMenuRemove.rawValue))
-            }
-            return realMenuItems
-        }
-
-        return menuItems.filter {
-            guard let identifier = $0.identifier else { return true }
-            return !disabledMenuItems.contains(identifier)
-        }
+        let model = DocViewerAnnotationContextMenuModel(env: env,
+                                                        isAnnotationEnabled: isAnnotatable,
+                                                        metadata: metadata,
+                                                        pageView: pageView,
+                                                        pdfController: pdfController,
+                                                        commentTapHandler: commentTapHandler,
+                                                        deleteTapHandler: deleteTapHandler)
+        return model.shouldShow(menuItems, for: annotations ?? [])
     }
 
     public func pdfViewController(_ pdfController: PDFViewController, shouldShow controller: UIViewController, options: [String: Any]? = nil, animated: Bool) -> Bool {

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -208,8 +208,12 @@ extension DocViewerViewController: PDFViewControllerDelegate, AnnotationStateMan
         in annotationRect: CGRect,
         on pageView: PDFPageView
     ) -> [MenuItem] {
-        guard env.app == .teacher || annotations?.isEmpty == false else {
-            return [] // no items for adding new annotations in Student
+        guard isAnnotatable, metadata?.annotations?.enabled == true else {
+            return []
+        }
+        // Only the teacher app should show the context menu when long tapped on an empty area
+        if (annotations == nil || annotations?.isEmpty == true) && env.app != .teacher {
+            return []
         }
 
         annotations?.forEach {

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -108,7 +108,8 @@ public class DocViewerViewController: UIViewController {
                                                            metadata: metadata,
                                                            annotations: annotations,
                                                            api: self.session.api,
-                                                           sessionID: sessionID)
+                                                           sessionID: sessionID,
+                                                           isAnnotationEditingDisabled: !self.isAnnotatable || metadata.annotations?.enabled == false)
                 provider.docViewerDelegate = self
                 documentProvider.annotationManager.annotationProviders = [provider]
                 self.annotationProvider = provider

--- a/Core/Core/DocViewer/PSPDFAnnotationExtension.swift
+++ b/Core/Core/DocViewer/PSPDFAnnotationExtension.swift
@@ -26,6 +26,21 @@ private var annotationHasRepliesKey: UInt8 = 0
 private var fontSizeTransform: CGFloat = 0.85
 
 extension Annotation {
+    private static let isFileAnnotationKey = "isFileAnnotationKey"
+
+    /** Returns true if the annotation is loaded from file and not created by a Canvas user. Must be set from code upon loading the annotation. This property is stored in the `customData` dictionary. */
+    var isFileAnnotation: Bool {
+        get {
+            guard let isFileAnnotation = customData?[Self.isFileAnnotationKey] as? Bool else { return false }
+            return isFileAnnotation
+        }
+        set {
+            var oldCustomData = customData ?? ([:] as [String: Any])
+            oldCustomData[Self.isFileAnnotationKey] = newValue
+            customData = oldCustomData
+        }
+    }
+
     var userName: String? {
         get { return objc_getAssociatedObject(self, &annotationUserNameKey) as? String }
         set { objc_setAssociatedObject(self, &annotationUserNameKey, newValue, .OBJC_ASSOCIATION_COPY) }

--- a/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
@@ -253,6 +253,14 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
 
         XCTAssertTrue(annotation.flags.contains(.readOnly))
     }
+
+    func testAnnotationFromPDFIsFlagged() {
+        let provider = getProvider(annotations: [], isAnnotationEditingDisabled: true, useMockFileAnnotationProvider: true)
+
+        guard let fileAnnotation = provider.annotationsForPage(at: 0)?.first else { XCTFail("No annotations to test"); return }
+
+        XCTAssertTrue(fileAnnotation.isFileAnnotation)
+    }
 }
 
 class MockPDFFileAnnotationProvider: PDFFileAnnotationProvider {

--- a/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
@@ -215,7 +215,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         XCTAssertEqual(results[1].title, "test2")
     }
 
-    func testAnnotationContextMenuForMultipleAnnotationsWhenAnootationDisabled() {
+    func testAnnotationContextMenuForMultipleAnnotationsWhenAnnotationDisabled() {
         let menuItems: [MenuItem] = [
             MenuItem(title: "test1", block: {}),
             MenuItem(title: "test2", block: {}),
@@ -237,7 +237,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
-    func testAnnotationContextMenuForSingleAnnotationWithoutCommentsWhenAnootationDisabled() {
+    func testAnnotationContextMenuForSingleAnnotationWithoutCommentsWhenAnnotationDisabled() {
         let menuItems: [MenuItem] = [
             MenuItem(title: "test1", block: {}),
             MenuItem(title: "test2", block: {}),
@@ -259,7 +259,7 @@ class DocViewerViewControllerTests: CoreTestCase {
         XCTAssertTrue(results.isEmpty)
     }
 
-    func testAnnotationContextMenuForSingleAnnotationWithCommentWhenAnootationDisabled() {
+    func testAnnotationContextMenuForSingleAnnotationWithCommentWhenAnnotationDisabled() {
         let menuItems: [MenuItem] = [
             MenuItem(title: "test1", block: {}),
             MenuItem(title: "test2", block: {}),

--- a/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
+++ b/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
@@ -190,4 +190,23 @@ class PSPDFAnnotationExtensionTests: XCTestCase {
             APIDocViewerInkPoint(x: 100, y: 0, width: nil, opacity: nil),
         ])
     }
+
+    func testIsFileAnnotation() {
+        let testee = try! Annotation(dictionary: nil)
+        XCTAssertFalse(testee.isFileAnnotation)
+
+        testee.isFileAnnotation = true
+        XCTAssertTrue(testee.isFileAnnotation)
+
+        testee.isFileAnnotation = false
+        XCTAssertFalse(testee.isFileAnnotation)
+
+        testee.isFileAnnotation = true
+        testee.customData = nil
+        XCTAssertFalse(testee.isFileAnnotation)
+
+        testee.isFileAnnotation = true
+        testee.customData = [:]
+        XCTAssertFalse(testee.isFileAnnotation)
+    }
 }


### PR DESCRIPTION
refs: MBL-15685
affects: Student, Teacher
release note: Fixed annotations being editable on a read-only document.

test plan: 
- As a student, create a file submission with a pdf file that has 3rd party annotations (use Preview app on macOS to create such).
- As a teacher start annotating the document. 3rd party annotations shouldn't be editable (move, style, delete, comment). Add some annotations. Add a comment to one of your annotations.
- As a student go to Submission & Rubric and load your uploaded file.
- Teacher and 3rd party annotations should be visible.
- Neither teacher's nor 3rd party annotations should be editable (move, style, delete).
- Comment menu should display on the annotation where the teacher left a comment.