### PR TITLE
Change date picker mode to datetime in quiz edit screen.

### DIFF
--- a/rn/Teacher/src/modules/assignment-details/components/AssignmentDatesEditor.js
+++ b/rn/Teacher/src/modules/assignment-details/components/AssignmentDatesEditor.js
@@ -478,7 +478,7 @@ export default class AssignmentDatesEditor extends Component<Props, any> {
   renderDatePicker = (date: StagedAssignmentDate, type: ModifyDateType) => {
     if (type === 'none') return <View />
     return <View style={styles.dateEditorContainer}>
-      <DateTimePicker value={date[type] ? new Date(date[type]) : new Date()} onChange={(event, updated) => this.updateDate(date, type, updated)}/>
+      <DateTimePicker value={date[type] ? new Date(date[type]) : new Date()} onChange={(event, updated) => this.updateDate(date, type, updated)} mode='datetime'/>
     </View>
   }
 

--- a/rn/Teacher/src/modules/quizzes/edit/QuizEdit.js
+++ b/rn/Teacher/src/modules/quizzes/edit/QuizEdit.js
@@ -360,6 +360,7 @@ export class QuizEdit extends Component<Props, any> {
                         value={extractDateFromString(quiz.show_correct_answers_at) || defaultDate}
                         onChange={(e, d) => this._setQuiz({ show_correct_answers_at: d.toISOString() }, true)}
                         testID='quizzes.edit.show-correct-answers-at-date-picker'
+                        mode='datetime'
                       />
                     }
                     <View style={{ flexDirection: 'row' }}>
@@ -385,6 +386,7 @@ export class QuizEdit extends Component<Props, any> {
                         value={extractDateFromString(quiz.hide_correct_answers_at) || defaultDate}
                         onChange={(e, d) => this._setQuiz({ hide_correct_answers_at: d.toISOString() }, true)}
                         testID='quizzes.edit.hide-correct-answers-at-date-picker'
+                        mode='datetime'
                       />
                     }
                   </View>

--- a/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
+++ b/rn/Teacher/src/modules/quizzes/edit/__tests__/__snapshots__/QuizEdit.test.js.snap
@@ -36995,6 +36995,7 @@ exports[`QuizEdit toggles "hide correct answers" date picker 1`] = `
             </View>
           </View>
           <DateTimePicker
+            mode="datetime"
             onChange={[Function]}
             testID="quizzes.edit.hide-correct-answers-at-date-picker"
             value={1970-01-01T00:00:00.000Z}
@@ -48123,6 +48124,7 @@ exports[`QuizEdit toggles "show correct answers" date picker 1`] = `
             </View>
           </View>
           <DateTimePicker
+            mode="datetime"
             onChange={[Function]}
             testID="quizzes.edit.show-correct-answers-at-date-picker"
             value={1970-01-01T00:00:00.000Z}
@@ -64797,6 +64799,7 @@ exports[`QuizEdit updates "hide correct answers at" date from picker 1`] = `
             </View>
           </View>
           <DateTimePicker
+            mode="datetime"
             onChange={[Function]}
             testID="quizzes.edit.hide-correct-answers-at-date-picker"
             value={1970-01-01T00:00:01.000Z}
@@ -66726,6 +66729,7 @@ exports[`QuizEdit updates "show correct answers at" date from picker 1`] = `
             </View>
           </View>
           <DateTimePicker
+            mode="datetime"
             onChange={[Function]}
             testID="quizzes.edit.show-correct-answers-at-date-picker"
             value={1970-01-01T00:00:01.000Z}


### PR DESCRIPTION
refs: MBL-15714
affects: Teacher
release note: Added time picker for date related rows in edit quiz details screen.

test plan:
- As a teacher go to Quizzes and select a quiz.
- Tap edit in the top right corner.
- Check "Show correct answers at", "Hide correct answers at", "Available From" and "Available Until" fields if they allow time selection in their date picker. 
- Add time to those fields. Save changes.
- Check quiz details on web if they have time set.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/142615048-7510eb25-e59e-4cca-ba88-ba9cfba5ded4.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/142615234-a5f2310f-74eb-41b9-897e-c275f76dfb66.png"></td>
</tr>
</table>

