### PR TITLE
Remove JS injection to keep html based video player instead of the native one.

### DIFF
--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -253,17 +253,6 @@ open class CoreWebView: WKWebView {
                     }
                     if (/\\/(courses|accounts)\\/[^\\/]+\\/external_tools\\/retrieve/.test(iframe.src)) {
                         replace(iframe)
-                    } else if (/\\/media_objects_iframe\\/m-\\w+/.test(iframe.src)) {
-                        const match = iframe.src.match(/\\/media_objects_iframe\\/(m-\\w+)/)
-                        if (match.length == 2) {
-                            const mediaID = match[1]
-                            const video = document.createElement('video')
-                            video.src = '/users/self/media_download?entryId='+mediaID+'&media_type=video&redirect=1'
-                            video.setAttribute('poster', '/media_objects/'+mediaID+'/thumbnail?width=550&height=448')
-                            video.setAttribute('controls', '')
-                            video.setAttribute('preload', 'none')
-                            iframe.replaceWith(video)
-                        }
                     } else {
                         iframe.addEventListener('error', event => replace(event.target))
                     }


### PR DESCRIPTION
refs: MBL-15717
affects: Student, Teacher
release note: Fixed videos embedded in pages content not displaying captions on iPads.

test plan: See ticket. Note that this only fixes iPads, iPhones will be fixed in another ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/142831579-1e28ff86-aff1-4142-b459-265ab9e6f7a5.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/142831630-a8f99b89-4b22-475a-8a93-687528928b97.png"></td>
</tr>
</table>