### PR TITLE
Update grades routing in K5 homeroom.

### DIFF
--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -41,8 +41,8 @@ public struct K5SubjectView: View {
         .navigationTitle(self.viewModel.courseTitle ?? "", subtitle: nil)
     }
 
-    public init(context: Context) {
-        self.viewModel = K5SubjectViewModel(context: context)
+    public init(context: Context, selectedTabId: String? = nil) {
+        self.viewModel = K5SubjectViewModel(context: context, selectedTabId: selectedTabId)
         self.controller.value.navigationController?.navigationBar.tintColor = self.viewModel.courseColor
     }
 }

--- a/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
+++ b/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
@@ -30,6 +30,7 @@ public class K5SubjectViewModel: ObservableObject {
     @Published private(set) var courseImageUrl: URL?
 
     private let context: Context
+    private let selectedTabId: String?
 
     private lazy var tabs = env.subscribe(GetContextTabs(context: context)) { [weak self] in
         self?.tabsUpdated()
@@ -41,8 +42,13 @@ public class K5SubjectViewModel: ObservableObject {
 
     private var topBarChangeListener: AnyCancellable?
 
-    init(context: Context) {
+    /**
+     - parameters:
+        - selectedTabId: The identifier of the subject tab that should be selected when the page appears.
+     */
+    init(context: Context, selectedTabId: String? = nil) {
         self.context = context
+        self.selectedTabId = selectedTabId
         course.refresh()
         tabs.refresh()
     }
@@ -62,6 +68,10 @@ public class K5SubjectViewModel: ObservableObject {
         // Propagate changes of the underlying view model to this observable class because there's no native support for nested ObservableObjects
         topBarChangeListener = topBarViewModel?.objectWillChange.sink { [weak self] _ in
             self?.objectWillChange.send()
+        }
+
+        if let selectedTabId = selectedTabId, let selectedTabIndex = tabItems.firstIndex(where: { $0.id == selectedTabId }) {
+            topBarViewModel?.selectedItemIndex = selectedTabIndex
         }
     }
 

--- a/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModel.swift
@@ -49,7 +49,7 @@ public struct K5GradeCellViewModel {
     }
 
     public var route: String {
-        "/courses/\(courseID)/grades/"
+        "/courses/\(courseID)?selectedTabId=grades"
     }
 }
 

--- a/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModel.swift
@@ -49,7 +49,7 @@ public struct K5GradeCellViewModel {
     }
 
     public var route: String {
-        "/courses/\(courseID)?selectedTabId=grades"
+        "/courses/\(courseID)#grades"
     }
 }
 

--- a/Core/Core/SwiftUIViews/TopBar/View/TopBarView.swift
+++ b/Core/Core/SwiftUIViews/TopBar/View/TopBarView.swift
@@ -42,6 +42,11 @@ public struct TopBarView: View {
                     selectionIndicator(selectedItemBounds: boundsForSelectedItem(in: geometry, using: boundsPreferences))
                 }
             }
+            .onReceive(viewModel.$selectedItemIndex) { selectedItemIndex in
+                withAnimation {
+                    scrollViewProxy.scrollTo(selectedItemIndex, anchor: nil)
+                }
+            }
         }
     }
 
@@ -50,9 +55,6 @@ public struct TopBarView: View {
         let isLastItem = (index == viewModel.items.count - 1)
         let item = TopBarItemView(viewModel: viewModel.items[index]) {
             viewModel.selectedItemIndex = index
-            withAnimation {
-                scrollViewProxy.scrollTo(index, anchor: nil)
-            }
         }
         .anchorPreference(key: ViewBoundsPreferenceKey.self, value: .bounds, transform: { [ViewBoundsPreferenceData(viewId: index, bounds: $0)] })
         .padding(.leading, isFirstItem ? horizontalInset : (itemSpacing / 2))

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModelTests.swift
@@ -44,6 +44,6 @@ class K5GradeCellViewModelTests: CoreTestCase {
 
     func testRoute() {
         let testee = K5GradeCellViewModel(title: "ART", imageURL: nil, grade: "A", score: 99.9, color: nil, courseID: "66")
-        XCTAssertEqual(testee.route, "/courses/66/grades/")
+        XCTAssertEqual(testee.route, "/courses/66?selectedTabId=grades")
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Grades/K5GradeCellViewModelTests.swift
@@ -44,6 +44,6 @@ class K5GradeCellViewModelTests: CoreTestCase {
 
     func testRoute() {
         let testee = K5GradeCellViewModel(title: "ART", imageURL: nil, grade: "A", score: 99.9, color: nil, courseID: "66")
-        XCTAssertEqual(testee.route, "/courses/66?selectedTabId=grades")
+        XCTAssertEqual(testee.route, "/courses/66#grades")
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/K5SubjectViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/K5SubjectViewModelTests.swift
@@ -46,4 +46,13 @@ class K5SubjectViewModelTests: CoreTestCase {
         XCTAssertEqual(url?.query, "embed=true")
         XCTAssertEqual(url?.fragment, "\(pageId)")
     }
+
+    func testInitiallySelectedTab() {
+        Tab.make(from: .make(id: "home", type: .internal, position: 0), context: context)
+        Tab.make(from: .make(id: "grades", type: .internal, position: 1), context: context)
+
+        let testee = K5SubjectViewModel(context: context, selectedTabId: "grades")
+
+        XCTAssertEqual(testee.topBarViewModel?.selectedItemIndex, 1)
+    }
 }

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -60,7 +60,8 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 
     "/courses/:courseID": { url, params, _ in
         if AppEnvironment.shared.k5.isK5Enabled == true, let context = Context(path: url.path) {
-            return CoreHostingController(K5SubjectView(context: context))
+            let selectedTabId = url.queryItems?.first(where: { $0.name == "selectedTabId" })?.value
+            return CoreHostingController(K5SubjectView(context: context, selectedTabId: selectedTabId))
         } else {
             return HelmViewController(moduleName: "/courses/:courseID", url: url, params: params, userInfo: nil)
         }

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -60,8 +60,7 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 
     "/courses/:courseID": { url, params, _ in
         if AppEnvironment.shared.k5.isK5Enabled == true, let context = Context(path: url.path) {
-            let selectedTabId = url.queryItems?.first(where: { $0.name == "selectedTabId" })?.value
-            return CoreHostingController(K5SubjectView(context: context, selectedTabId: selectedTabId))
+            return CoreHostingController(K5SubjectView(context: context, selectedTabId: url.fragment))
         } else {
             return HelmViewController(moduleName: "/courses/:courseID", url: url, params: params, userInfo: nil)
         }


### PR DESCRIPTION
refs: MBL-15756
affects: Student
release note: none

test plan:
- Login to a K5 account as student
- On the K5 homeroom, go to grades tab
- Tap on a subject
- Elementary subject page should load with the grades tab selected