### PR TITLE
Add conference banner to homeroom view

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -865,6 +865,8 @@
 		CF6C7FC826F8DC15002937E5 /* CoursePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6C7FC726F8DC15002937E5 /* CoursePickerView.swift */; };
 		CF6C7FCB26F8DED2002937E5 /* SubmitAssignmentExtensionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6C7FCA26F8DED2002937E5 /* SubmitAssignmentExtensionViewModel.swift */; };
 		CF6C7FCD26F9CBAF002937E5 /* CoursePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF6C7FCC26F9CBAF002937E5 /* CoursePickerViewModel.swift */; };
+		CF748D1D274D43B9000EA34E /* DashboardConferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF748D1C274D43B9000EA34E /* DashboardConferencesViewModel.swift */; };
+		CF748D21274D52C6000EA34E /* DashboardConferencesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF748D20274D52C6000EA34E /* DashboardConferencesViewModelTests.swift */; };
 		CF7C36742677B0D200ACAC79 /* UIBarButtonItemExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF7C36732677B0D200ACAC79 /* UIBarButtonItemExtensions.swift */; };
 		CF7C368B2678AF1300ACAC79 /* balsamiq_regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF7C36832678AE7000ACAC79 /* balsamiq_regular.ttf */; };
 		CF7C368C2678AF1300ACAC79 /* balsamiq_bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = CF7C36842678AE7000ACAC79 /* balsamiq_bold.ttf */; };
@@ -2102,6 +2104,8 @@
 		CF6C7FC726F8DC15002937E5 /* CoursePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePickerView.swift; sourceTree = "<group>"; };
 		CF6C7FCA26F8DED2002937E5 /* SubmitAssignmentExtensionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmitAssignmentExtensionViewModel.swift; sourceTree = "<group>"; };
 		CF6C7FCC26F9CBAF002937E5 /* CoursePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePickerViewModel.swift; sourceTree = "<group>"; };
+		CF748D1C274D43B9000EA34E /* DashboardConferencesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardConferencesViewModel.swift; sourceTree = "<group>"; };
+		CF748D20274D52C6000EA34E /* DashboardConferencesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardConferencesViewModelTests.swift; sourceTree = "<group>"; };
 		CF7C36732677B0D200ACAC79 /* UIBarButtonItemExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensions.swift; sourceTree = "<group>"; };
 		CF7C36832678AE7000ACAC79 /* balsamiq_regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = balsamiq_regular.ttf; sourceTree = "<group>"; };
 		CF7C36842678AE7000ACAC79 /* balsamiq_bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = balsamiq_bold.ttf; sourceTree = "<group>"; };
@@ -2767,6 +2771,7 @@
 				CF4BDB582645393A00A91952 /* K5 */,
 				CF4BDB53264530A000A91952 /* Model */,
 				CF4BDB54264530DC00A91952 /* View */,
+				CF748D1E274D5283000EA34E /* ViewModel */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -2777,6 +2782,7 @@
 				CF575E46266792B600F8515F /* K5 */,
 				CF4BDB552645314A00A91952 /* Model */,
 				CF4BDB562645315700A91952 /* View */,
+				CF748D1F274D52AA000EA34E /* ViewModel */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -4458,6 +4464,22 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		CF748D1E274D5283000EA34E /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CF748D1C274D43B9000EA34E /* DashboardConferencesViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		CF748D1F274D52AA000EA34E /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CF748D20274D52C6000EA34E /* DashboardConferencesViewModelTests.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		CF7C368E2678AFA300ACAC79 /* Fonts */ = {
 			isa = PBXGroup;
 			children = (
@@ -5576,6 +5598,7 @@
 				9FAE410321B6C88000FE7F58 /* APIExternalToolTests.swift in Sources */,
 				E87A5E4424D4BF930065B2AA /* PreviewStoreTests.swift in Sources */,
 				CF8CB51326CA7415008361E2 /* K5ScheduleWeekViewModelTests.swift in Sources */,
+				CF748D21274D52C6000EA34E /* DashboardConferencesViewModelTests.swift in Sources */,
 				B1CA33462339434A0015CBB4 /* GetContextUsersTests.swift in Sources */,
 				7D26B84D23A8267600262380 /* ConversationParticipantTests.swift in Sources */,
 				7D016B6123E89B7F00C6E0CA /* CircleProgressViewTests.swift in Sources */,
@@ -5769,6 +5792,7 @@
 				7DBD150625477CEB00750F52 /* Badge.swift in Sources */,
 				7D7086932569607D00647D37 /* NotificationCard.swift in Sources */,
 				7DA2605623F722D9005D2121 /* ModuleItemType.swift in Sources */,
+				CF748D1D274D43B9000EA34E /* DashboardConferencesViewModel.swift in Sources */,
 				CF60CC5F26496EDE00C1C173 /* K5GradesViewModel.swift in Sources */,
 				E8D20399250A723E009B2ABE /* InboxView.swift in Sources */,
 				D94FA2AE26CBE787007B9CA4 /* K5GradeProgressBar.swift in Sources */,

--- a/Core/Core/Conferences/Conference.swift
+++ b/Core/Core/Conferences/Conference.swift
@@ -19,7 +19,7 @@
 import Foundation
 import CoreData
 
-final class Conference: NSManagedObject {
+public final class Conference: NSManagedObject {
     @NSManaged var canvasContextID: String
     @NSManaged var conferenceKey: String?
     @NSManaged var conferenceType: String

--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
@@ -33,6 +33,8 @@ public struct K5HomeroomView: View {
             }
 
             VStack(alignment: .leading, spacing: 0) {
+                conferences
+
                 Text(viewModel.welcomeText)
                     .foregroundColor(.licorice)
                     .font(.bold34)
@@ -48,6 +50,13 @@ public struct K5HomeroomView: View {
                     .padding(.top, 23)
             }
             .padding(.horizontal, horizontalPadding)
+        }
+    }
+
+    private var conferences: some View {
+        ForEach(viewModel.conferencesViewModel.conferences, id: \.entity.id) { conference in
+            ConferenceCard(conference: conference.entity, contextName: conference.contextName)
+                .padding(.top, 16)
         }
     }
 }

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import Combine
 import SwiftUI
 
 public class K5HomeroomViewModel: ObservableObject {
@@ -23,9 +24,11 @@ public class K5HomeroomViewModel: ObservableObject {
     @Published public private(set) var welcomeText = ""
     @Published public private(set) var announcements: [K5HomeroomAnnouncementViewModel] = []
     @Published public private(set) var subjectCards: [K5HomeroomSubjectCardViewModel] = []
+    @Published public private(set) var conferencesViewModel = DashboardConferencesViewModel()
 
     // MARK: - Private Variables -
     private let env = AppEnvironment.shared
+    private var conferencesChangeListener: AnyCancellable?
     // MARK: Data Sources
     private lazy var cards = env.subscribe(GetDashboardCards()) { [weak self] in
         self?.dashboardCardsUpdated()
@@ -43,8 +46,14 @@ public class K5HomeroomViewModel: ObservableObject {
     // MARK: - Public Interface -
 
     public init() {
+        // Propagate changes of the underlying view model to this observable class because there's no native support for nested ObservableObjects
+        conferencesChangeListener = conferencesViewModel.objectWillChange.sink { [weak self] _ in
+            self?.objectWillChange.send()
+        }
+
         cards.refresh()
         profile.refresh()
+        conferencesViewModel.refresh()
     }
 
     // MARK: - Private Methods -
@@ -179,5 +188,6 @@ extension K5HomeroomViewModel: Refreshable {
         dueItems = nil
         cards.refresh(force: true)
         profile.refresh(force: true)
+        conferencesViewModel.refresh(force: true)
     }
 }

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -21,12 +21,12 @@ import SwiftUI
 public struct DashboardCardView: View {
     @ObservedObject var cards: Store<GetDashboardCards>
     @ObservedObject var colors: Store<GetCustomColors>
-    @ObservedObject var conferences: Store<GetLiveConferences>
     @ObservedObject var courses: Store<GetCourses>
     @ObservedObject var groups: Store<GetDashboardGroups>
     @ObservedObject var invitations: Store<GetCourseInvitations>
     @ObservedObject var notifications: Store<GetAccountNotifications>
     @ObservedObject var settings: Store<GetUserSettings>
+    @ObservedObject var conferencesViewModel = DashboardConferencesViewModel()
 
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
@@ -43,7 +43,6 @@ public struct DashboardCardView: View {
         let env = AppEnvironment.shared
         cards = env.subscribe(GetDashboardCards())
         colors = env.subscribe(GetCustomColors())
-        conferences = env.subscribe(GetLiveConferences())
         courses = env.subscribe(GetCourses(enrollmentState: nil))
         groups = env.subscribe(GetDashboardGroups())
         invitations = env.subscribe(GetCourseInvitations())
@@ -99,13 +98,9 @@ public struct DashboardCardView: View {
     }
 
     @ViewBuilder func list(_ size: CGSize) -> some View {
-        ForEach(conferences.all, id: \.id) { conference in
-            if let contextName = conference.context.contextType == .group ?
-                groups.first(where: { $0.id == conference.context.id })?.name :
-                courses.first(where: { $0.id == conference.context.id })?.name {
-                ConferenceCard(conference: conference, contextName: contextName)
-                    .padding(.top, 16)
-            }
+        ForEach(conferencesViewModel.conferences, id: \.entity.id) { conference in
+            ConferenceCard(conference: conference.entity, contextName: conference.contextName)
+                .padding(.top, 16)
         }
 
         ForEach(invitations.all, id: \.id) { enrollment in
@@ -205,7 +200,7 @@ public struct DashboardCardView: View {
         refreshCards(onComplete: onComplete)
         colors.refresh(force: force)
         courses.exhaust(force: force)
-        conferences.refresh(force: force)
+        conferencesViewModel.refresh(force: force)
         invitations.exhaust(force: force)
         groups.exhaust(force: force)
         notifications.exhaust(force: force)

--- a/Core/Core/Dashboard/ViewModel/DashboardConferencesViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardConferencesViewModel.swift
@@ -42,8 +42,8 @@ public class DashboardConferencesViewModel: ObservableObject {
 
     public func refresh(force: Bool = false) {
         conferencesStore.refresh(force: force)
-        coursesStore.refresh(force: force)
-        groupsStore.refresh(force: force)
+        coursesStore.exhaust(force: force)
+        groupsStore.exhaust(force: force)
     }
 
     // MARK: - Private Methods

--- a/Core/Core/Dashboard/ViewModel/DashboardConferencesViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardConferencesViewModel.swift
@@ -1,0 +1,71 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public class DashboardConferencesViewModel: ObservableObject {
+    // MARK: - Public Properties
+    @Published public private(set) var conferences: [(entity: Conference, contextName: String)] = []
+
+    // MARK: - Private Properties
+    private lazy var conferencesStore: Store<GetLiveConferences> = AppEnvironment.shared.subscribe(GetLiveConferences()) { [weak self] in
+        self?.update()
+    }
+    private lazy var coursesStore = AppEnvironment.shared.subscribe(GetCourses(enrollmentState: nil)) { [weak self] in
+        self?.update()
+    }
+    private lazy var groupsStore = AppEnvironment.shared.subscribe(GetDashboardGroups()) { [weak self] in
+        self?.update()
+    }
+    private var isRefreshFinished: Bool {
+        conferencesStore.requested && !conferencesStore.pending &&
+        coursesStore.requested && !coursesStore.pending &&
+        groupsStore.requested && !groupsStore.pending
+    }
+
+    // MARK: - Public Methods
+
+    public func refresh(force: Bool = false) {
+        conferencesStore.refresh(force: force)
+        coursesStore.refresh(force: force)
+        groupsStore.refresh(force: force)
+    }
+
+    // MARK: - Private Methods
+
+    private func update() {
+        guard isRefreshFinished else { return }
+
+        var newConferences: [(Conference, String)] = []
+
+        for conference in conferencesStore.all {
+            guard let contextName = contextName(for: conference) else { continue }
+            newConferences.append((conference, contextName))
+        }
+
+        self.conferences = newConferences
+    }
+
+    private func contextName(for conference: Conference) -> String? {
+        if conference.context.contextType == .group {
+            return groupsStore.first { $0.id == conference.context.id }?.name
+        } else {
+            return coursesStore.first { $0.id == conference.context.id }?.name
+        }
+    }
+}

--- a/Core/CoreTests/Dashboard/ViewModel/DashboardConferencesViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/DashboardConferencesViewModelTests.swift
@@ -1,0 +1,64 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+import TestsFoundation
+
+class DashboardConferencesViewModelTests: CoreTestCase {
+
+    func testCourseConference() {
+        api.mock(GetCourses(enrollmentState: nil), value: [.make(id: "testCourseID", name: "testCourseName")])
+        api.mock(GetLiveConferences(), value: .init(conferences: [.make(context_id: ID("testCourseID"), context_type: "course", started_at: Clock.now.addMinutes(-60), title: "testConferenceName")]))
+
+        let testee = DashboardConferencesViewModel()
+        let viewModelUpdatedExpectation = expectation(description: "view model updated")
+        let updateSubscription = testee.objectWillChange.sink {
+            viewModelUpdatedExpectation.fulfill()
+        }
+        testee.refresh()
+
+        wait(for: [viewModelUpdatedExpectation], timeout: 1)
+        XCTAssertEqual(testee.conferences.count, 1)
+        guard let conference = testee.conferences.first else { return }
+        XCTAssertEqual(conference.contextName, "testCourseName")
+        XCTAssertEqual(conference.entity.title, "testConferenceName")
+
+        updateSubscription.cancel()
+    }
+
+    func testGroupConference() {
+        api.mock(GetDashboardGroups(), value: [.make(id: "testGroupID", name: "testGroupName")])
+        api.mock(GetLiveConferences(), value: .init(conferences: [.make(context_id: ID("testGroupID"), context_type: "group", started_at: Clock.now.addMinutes(-60), title: "testConferenceName")]))
+
+        let testee = DashboardConferencesViewModel()
+        let viewModelUpdatedExpectation = expectation(description: "view model updated")
+        let updateSubscription = testee.objectWillChange.sink {
+            viewModelUpdatedExpectation.fulfill()
+        }
+        testee.refresh()
+
+        wait(for: [viewModelUpdatedExpectation], timeout: 1)
+        XCTAssertEqual(testee.conferences.count, 1)
+        guard let conference = testee.conferences.first else { return }
+        XCTAssertEqual(conference.contextName, "testGroupName")
+        XCTAssertEqual(conference.entity.title, "testConferenceName")
+
+        updateSubscription.cancel()
+    }
+}


### PR DESCRIPTION
refs: MBL-15694
affects: Student
release note: Added conference banner to homeroom view.

test plan:
- Create conferences both for a K5 and a non-K5 account and start them.
- Log in with the K5 user.
- Conference banner should be visible, tapping on it should launch it in a browser, tapping on X should hide it.
- Log in with the non-K5 user and check the same.

<img src="https://user-images.githubusercontent.com/72396990/143276358-aabb3084-4f9b-497a-943c-c8b1e36c0382.png" width=50% height=50%>

