### PR TITLE
Fix conditional mastery path selection UI issue

### DIFF
--- a/Core/Core/Modules/APIModule.swift
+++ b/Core/Core/Modules/APIModule.swift
@@ -164,7 +164,7 @@ public struct APIMasteryPath: Codable, Equatable {
     public struct AssignmentSet: Codable, Equatable {
         public let id: ID
         public let position: Int?
-        public let assignments: [Assignment]?
+        public let assignment_set_associations: [Assignment]?
     }
 
     public struct Assignment: Codable, Equatable {
@@ -287,7 +287,7 @@ extension APIMasteryPath.AssignmentSet {
         position: Int = 0,
         assignments: [APIMasteryPath.Assignment] = [.make()]
     ) -> Self {
-        return .init(id: id, position: position, assignments: assignments)
+        return .init(id: id, position: position, assignment_set_associations: assignments)
     }
 }
 

--- a/Core/Core/Modules/MasteryPath.swift
+++ b/Core/Core/Modules/MasteryPath.swift
@@ -46,7 +46,7 @@ public class MasteryPathAssignmentSet: NSManagedObject {
     public static func save(_ item: APIMasteryPath.AssignmentSet, in context: NSManagedObjectContext) -> MasteryPathAssignmentSet {
         let model = context.insert() as MasteryPathAssignmentSet
         model.id = item.id.value
-        model.assignments = Set(item.assignments?.map { .save($0, in: context) } ?? [])
+        model.assignments = Set(item.assignment_set_associations?.map { .save($0, in: context) } ?? [])
         model.position = item.position ?? 0
         return model
     }


### PR DESCRIPTION
refs: MBL-15750
affects: Student
release note: Fixed the assignment titles not appearing with conditional mastery path selection
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/143442414-add140ee-f9f0-4d76-befd-600e1eaeedf8.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/143442487-37698d24-8d47-469c-a4e0-ca6910870993.png"></td>
</tr>
</table>


