### PR TITLE
Update routes from K5 homeroom card.

### DIFF
--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
@@ -52,7 +52,7 @@ extension K5HomeroomSubjectCardViewModel {
 
         public static func make(from announcement: LatestAnnouncement?, courseId: String) -> InfoLine? {
             guard let announcement = announcement else { return nil }
-            return InfoLine(icon: .announcementLine, route: "/courses/\(courseId)/announcements", text: announcement.title)
+            return InfoLine(icon: .announcementLine, route: "/courses/\(courseId)", text: announcement.title)
         }
 
         public static func make(dueToday: Int, missing: Int, courseId: String) -> InfoLine {
@@ -73,7 +73,7 @@ extension K5HomeroomSubjectCardViewModel {
                 text += " | "
             }
 
-            return InfoLine(icon: .k5dueToday, route: "/courses/\(courseId)/assignments", text: text, highlightedText: highlightedText)
+            return InfoLine(icon: .k5dueToday, route: "/courses/\(courseId)#schedule", text: text, highlightedText: highlightedText)
         }
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModelTests.swift
@@ -49,7 +49,7 @@ class K5HomeroomSubjectCardViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee?.icon, .announcementLine)
         XCTAssertEqual(testee?.text, "Test announcement title.")
-        XCTAssertEqual(testee?.route, "/courses/test/announcements")
+        XCTAssertEqual(testee?.route, "/courses/test")
     }
 
     func testInfoLineFromNoAnnouncements() {
@@ -64,7 +64,7 @@ class K5HomeroomSubjectCardViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.icon, .k5dueToday)
         XCTAssertEqual(testee.text, "Nothing Due Today")
         XCTAssertEqual(testee.highlightedText, "")
-        XCTAssertEqual(testee.route, "/courses/test/assignments")
+        XCTAssertEqual(testee.route, "/courses/test#schedule")
     }
 
     func testInfoLineFromDueAssignments() {
@@ -73,7 +73,7 @@ class K5HomeroomSubjectCardViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.icon, .k5dueToday)
         XCTAssertEqual(testee.text, "3 due today")
         XCTAssertEqual(testee.highlightedText, "")
-        XCTAssertEqual(testee.route, "/courses/test/assignments")
+        XCTAssertEqual(testee.route, "/courses/test#schedule")
     }
 
     func testInfoLineFromMissingAssignments() {
@@ -82,7 +82,7 @@ class K5HomeroomSubjectCardViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.icon, .k5dueToday)
         XCTAssertEqual(testee.text, "")
         XCTAssertEqual(testee.highlightedText, "3 missing")
-        XCTAssertEqual(testee.route, "/courses/test/assignments")
+        XCTAssertEqual(testee.route, "/courses/test#schedule")
     }
 
     func testInfoLineFromDueAndMissingAssignments() {
@@ -91,6 +91,6 @@ class K5HomeroomSubjectCardViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.icon, .k5dueToday)
         XCTAssertEqual(testee.text, "3 due today | ")
         XCTAssertEqual(testee.highlightedText, "1 missing")
-        XCTAssertEqual(testee.route, "/courses/test/assignments")
+        XCTAssertEqual(testee.route, "/courses/test#schedule")
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
@@ -100,8 +100,8 @@ class K5HomeroomViewModelTests: CoreTestCase {
         XCTAssertEqual(card.color, Color(hexString: "#DEAD00"))
 
         guard card.infoLines.count == 2 else { XCTFail("Info line count mismatch"); return }
-        XCTAssertEqual(card.infoLines[0], K5HomeroomSubjectCardViewModel.InfoLine(icon: .k5dueToday, route: "/courses/1/assignments", text: "1 due today | ", highlightedText: "2 missing"))
-        XCTAssertEqual(card.infoLines[1], K5HomeroomSubjectCardViewModel.InfoLine(icon: .announcementLine, route: "/courses/1/announcements", text: "Non homeroom announcement"))
+        XCTAssertEqual(card.infoLines[0], K5HomeroomSubjectCardViewModel.InfoLine(icon: .k5dueToday, route: "/courses/1#schedule", text: "1 due today | ", highlightedText: "2 missing"))
+        XCTAssertEqual(card.infoLines[1], K5HomeroomSubjectCardViewModel.InfoLine(icon: .announcementLine, route: "/courses/1", text: "Non homeroom announcement"))
     }
 
     // MARK: - Private Helpers


### PR DESCRIPTION
refs: MBL-15653
affects: Student
release note: none

test plan:
- Create a course announcement and an overdue assignment on an elementary account.
- Log in to the student app.
- Elementary dashboard card for the above course should display that 1 item is missing and the course announcement title.
- Tap on the announcement.
- App should route to the subject home where the announcement is fully displayed.
- Go back.
- Tap on the missing item text.
- App should route to the subject schedule page.