### PR TITLE
fix crash on homescreen

### DIFF
--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomSubjectCardView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomSubjectCardView.swift
@@ -80,7 +80,7 @@ public struct K5HomeroomSubjectCardView: View {
     private var infoLines: some View {
         VStack(alignment: .leading, spacing: 5) {
             let infoLines = viewModel.infoLines
-            ForEach(0..<infoLines.count) { index in
+            ForEach(0..<infoLines.count, id: \.self) { index in
                 infoLine(from: infoLines[index])
 
                 if index != infoLines.count - 1 {


### PR DESCRIPTION
refs: none
affects: Student
release note: none
test plan: pull to refresh on K5 homeroom like there's no tomorrow, try after opening an announcement previously