### PR TITLE
Disable tap action in homeroom schedule screen in case the to-do item is from a homeroom course.

### DIFF
--- a/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
+++ b/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
@@ -84,7 +84,7 @@ public extension APIPlannable {
         return labels
     }
 
-    func k5ScheduleSubject(courseInfoByCourseIDs: [String: (color: Color, image: URL?)]) -> K5ScheduleSubject {
+    func k5ScheduleSubject(courseInfoByCourseIDs: [String: (color: Color, image: URL?, isHomeroom: Bool)]) -> K5ScheduleSubject {
         let name: String = {
             if plannableType == .calendar_event {
                 return NSLocalizedString("To Do", comment: "")
@@ -100,7 +100,14 @@ public extension APIPlannable {
             }
         }()
         let route: URL? = {
-            guard let context = context, context.contextType != .user else { return nil }
+            let isHomeroom: Bool = {
+                guard let courseID = course_id?.value else {
+                    return false
+                }
+                return courseInfoByCourseIDs[courseID]?.isHomeroom ?? false
+            }()
+
+            guard let context = context, context.contextType != .user, !isHomeroom  else { return nil }
             return URL(string: context.pathComponent)
         }()
         let image: URL? = {

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
@@ -34,7 +34,7 @@ public class K5ScheduleWeekViewModel: ObservableObject {
 
     private var plannables: [APIPlannable] = []
     private var missingSubmissions: [APIAssignment] = []
-    private var courseInfoByCourseIDs: [String: (color: Color, image: URL?)] = [:]
+    private var courseInfoByCourseIDs: [String: (color: Color, image: URL?, isHomeroom: Bool)] = [:]
 
     public init(weekRange: Range<Date>, isTodayButtonAvailable: Bool, days: [K5ScheduleDayViewModel]) {
         self.weekRange = weekRange
@@ -125,7 +125,7 @@ public class K5ScheduleWeekViewModel: ObservableObject {
 
     private func setupCourseColors(_ courses: [Course]) {
         let coursesByIDs = Dictionary(grouping: courses) { $0.id }
-        let courseInfoByCourseIDs = coursesByIDs.mapValues { (Color($0[0].color), $0[0].imageDownloadURL) }
+        let courseInfoByCourseIDs = coursesByIDs.mapValues { (Color($0[0].color), $0[0].imageDownloadURL, isHomeroom: $0[0].isHomeroomCourse) }
         self.courseInfoByCourseIDs = courseInfoByCourseIDs
     }
 

--- a/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
+++ b/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
@@ -41,6 +41,10 @@ class K5ScheduleItemInfoTests: CoreTestCase {
         XCTAssertEqual(APIPlannable.make(course_id: ID("testId"), context_type: "Course").k5ScheduleSubject(courseInfoByCourseIDs: [:]).route, URL(string: "courses/testId")!)
     }
 
+    func testHomeroomSubjectRoute() {
+        XCTAssertNil(APIPlannable.make(course_id: ID("testId"), context_type: "Course").k5ScheduleSubject(courseInfoByCourseIDs: ["testId": (color: .green, image: nil, isHomeroom: true)]).route)
+    }
+
     func testScheduleSubjectColor() {
         Brand.shared = Brand(buttonPrimaryBackground: nil,
                              buttonPrimaryText: nil,
@@ -58,9 +62,9 @@ class K5ScheduleItemInfoTests: CoreTestCase {
                              navTextColor: nil,
                              navTextColorActive: nil,
                              primary: .red)
-        XCTAssertEqual(APIPlannable.make(course_id: ID("testID")).k5ScheduleSubject(courseInfoByCourseIDs: ["testID": (color: .green, image: nil)]).color, .green)
+        XCTAssertEqual(APIPlannable.make(course_id: ID("testID")).k5ScheduleSubject(courseInfoByCourseIDs: ["testID": (color: .green, image: nil, isHomeroom: false)]).color, .green)
         XCTAssertEqual(APIPlannable.make(course_id: ID("testID")).k5ScheduleSubject(courseInfoByCourseIDs: [:]).color, Color(.red))
-        XCTAssertEqual(APIPlannable.make(course_id: ID("testID_2")).k5ScheduleSubject(courseInfoByCourseIDs: ["testID": (color: .green, image: nil)]).color, Color(.red))
+        XCTAssertEqual(APIPlannable.make(course_id: ID("testID_2")).k5ScheduleSubject(courseInfoByCourseIDs: ["testID": (color: .green, image: nil, isHomeroom: false)]).color, Color(.red))
     }
 
     func testDueText() {


### PR DESCRIPTION
refs: none
affects: Student
release note: none

test plan:
- Create an announcement in a homeroom course
- Log in as a student and go to schedule page
- Find the announcement item
- Homeroom name shouldn't be tappable, only the announcement