### PR TITLE
Set multi line text alignment to leading.

### DIFF
--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
@@ -101,6 +101,7 @@ public struct K5ScheduleEntryView: View {
         Text(viewModel.title)
             .foregroundColor(.textDarkest)
             .font(.regular17)
+            .multilineTextAlignment(.leading)
     }
 
     private var disclosureIndicator: some View {
@@ -176,6 +177,7 @@ public struct K5ScheduleEntryView: View {
             .foregroundColor(model.color)
             .font(model.font)
             .padding(.top, 4)
+            .multilineTextAlignment(.leading)
     }
 }
 

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleSubjectView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleSubjectView.swift
@@ -111,7 +111,7 @@ public struct K5ScheduleSubjectView: View {
 
     @ViewBuilder
     private var subjectName: some View {
-        let text = Text(viewModel.subject.name).foregroundColor(viewModel.subject.color)
+        let text = Text(viewModel.subject.name).foregroundColor(viewModel.subject.color).multilineTextAlignment(.leading)
 
         if #available(iOS 14, *) {
             text.textCase(.uppercase)

--- a/Core/Core/Profile/Help/View/HelpItemView.swift
+++ b/Core/Core/Profile/Help/View/HelpItemView.swift
@@ -29,12 +29,14 @@ struct HelpItemView: View {
                     .foregroundColor(.textDarkest)
                     .testID()
                     .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
+                    .multilineTextAlignment(.leading)
                 if let subtext = model.subtext {
                     Text(subtext)
                         .font(.regular16)
                         .foregroundColor(.textDark)
                         .testID()
                         .fixedSize(horizontal: false, vertical: true) // iOS 13.0 multi line support
+                        .multilineTextAlignment(.leading)
                 }
             }.frame(maxWidth: .infinity, alignment: .leading)
         })


### PR DESCRIPTION
refs: none
affects: Student, Parent, Teacher
release note: none

test plan:
- Open help menu where long item names are present.
- Go to homeroom schedule page with long subject and assignment names.
- Text alignment should be leading and not centered.