### PR TITLE
Force refresh dashboard each time it appears.

### DIFF
--- a/Parent/Parent/Courses/CourseListViewController.swift
+++ b/Parent/Parent/Courses/CourseListViewController.swift
@@ -56,15 +56,16 @@ class CourseListViewController: UIViewController {
         refreshControl.color = nil
         tableView.refreshControl = refreshControl
         tableView.separatorColor = .borderMedium
-
-        courses.exhaust()
     }
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         if let selected = tableView.indexPathForSelectedRow {
             tableView.deselectRow(at: selected, animated: true)
         }
+
+        courses.exhaust()
     }
 
     func update() {

--- a/Parent/ParentUnitTests/Courses/CourseListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Courses/CourseListViewControllerTests.swift
@@ -108,6 +108,7 @@ class CourseListViewControllerTests: ParentTestCase {
 
     func testLayout() {
         controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 6)
 


### PR DESCRIPTION
refs: MBL-15775
affects: Parent
release note: Fixed courses not being displayed on dashboard after visiting the calendar filter screen.

test plan:
- Start the parent app and log in with a parent observing a student with an active course
- Go to Calendar Tab
- Tap Calendars button
- Tap Done
- Go to courses tab
- Observed student's courses should be displayed

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/143855328-7c1e3186-e668-4784-b98d-f23cc4d0c72c.jpeg"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/143855341-0425644b-0b0e-4cad-b130-eb1e1dcf68f6.png"></td>
</tr>
</table>