### PR TITLE
Add conference banner to homeroom view

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -881,6 +881,8 @@
 		CF80135125B1A03700E5E744 /* GetSubmissionSummaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */; };
 		CF854B1A2721A49700AACDC8 /* iOS15ListRowSeparator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF854B192721A49700AACDC8 /* iOS15ListRowSeparator.swift */; };
 		CF86C2B4267CEDA5006FB6F5 /* UISplitViewControllerExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF86C2B3267CEDA5006FB6F5 /* UISplitViewControllerExtensionsTests.swift */; };
+		CF88FCDF2756171C004F2202 /* DashboardInvitationsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF88FCDE2756171C004F2202 /* DashboardInvitationsViewModel.swift */; };
+		CF88FCE127562DB1004F2202 /* DashboardInvitationsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF88FCE027562DB1004F2202 /* DashboardInvitationsViewModelTests.swift */; };
 		CF8ADC562563D96400F3DBA9 /* HelpItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8ADC552563D96400F3DBA9 /* HelpItemView.swift */; };
 		CF8CB51326CA7415008361E2 /* K5ScheduleWeekViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8CB51226CA7415008361E2 /* K5ScheduleWeekViewModelTests.swift */; };
 		CF8CB51E26CBB1D0008361E2 /* GetCourseNavigationToolsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8CB51D26CBB1D0008361E2 /* GetCourseNavigationToolsRequest.swift */; };
@@ -2120,6 +2122,8 @@
 		CF80135025B1A03700E5E744 /* GetSubmissionSummaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSubmissionSummaryTests.swift; sourceTree = "<group>"; };
 		CF854B192721A49700AACDC8 /* iOS15ListRowSeparator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOS15ListRowSeparator.swift; sourceTree = "<group>"; };
 		CF86C2B3267CEDA5006FB6F5 /* UISplitViewControllerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensionsTests.swift; sourceTree = "<group>"; };
+		CF88FCDE2756171C004F2202 /* DashboardInvitationsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInvitationsViewModel.swift; sourceTree = "<group>"; };
+		CF88FCE027562DB1004F2202 /* DashboardInvitationsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardInvitationsViewModelTests.swift; sourceTree = "<group>"; };
 		CF8ADC552563D96400F3DBA9 /* HelpItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpItemView.swift; sourceTree = "<group>"; };
 		CF8CB51226CA7415008361E2 /* K5ScheduleWeekViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleWeekViewModelTests.swift; sourceTree = "<group>"; };
 		CF8CB51D26CBB1D0008361E2 /* GetCourseNavigationToolsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCourseNavigationToolsRequest.swift; sourceTree = "<group>"; };
@@ -4468,6 +4472,7 @@
 			isa = PBXGroup;
 			children = (
 				CF748D1C274D43B9000EA34E /* DashboardConferencesViewModel.swift */,
+				CF88FCDE2756171C004F2202 /* DashboardInvitationsViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -4476,6 +4481,7 @@
 			isa = PBXGroup;
 			children = (
 				CF748D20274D52C6000EA34E /* DashboardConferencesViewModelTests.swift */,
+				CF88FCE027562DB1004F2202 /* DashboardInvitationsViewModelTests.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -5471,6 +5477,7 @@
 				3B35F073230F01F600674FF5 /* APIGraphQLRequestableTests.swift in Sources */,
 				B1A6BC8C218A9843000515E3 /* APILatePolicyTests.swift in Sources */,
 				977EAC452412AA26005E1290 /* CreateTodoViewControllerTests.swift in Sources */,
+				CF88FCE127562DB1004F2202 /* DashboardInvitationsViewModelTests.swift in Sources */,
 				7D70DEA4233EB07300F5C3D4 /* NotificationCategoryTests.swift in Sources */,
 				9FE84DE2215037A000B95A68 /* GetContextTabsTest.swift in Sources */,
 				9FE84DDC214FE5C500B95A68 /* GetGroupsTests.swift in Sources */,
@@ -5872,6 +5879,7 @@
 				B162469F2445001F00982C52 /* CompletionRequirement.swift in Sources */,
 				7DA25FFB23F7226E005D2121 /* DocViewerConstants.swift in Sources */,
 				7DA2600623F7227A005D2121 /* Int64Extensions.swift in Sources */,
+				CF88FCDF2756171C004F2202 /* DashboardInvitationsViewModel.swift in Sources */,
 				CF67B29226EBA12F00E51F13 /* HorizontalPagerProxy.swift in Sources */,
 				7DA25F9123F72128005D2121 /* GradeListViewController.swift in Sources */,
 				7DA260A123F7234C005D2121 /* MockMessage.swift in Sources */,

--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
@@ -34,6 +34,7 @@ public struct K5HomeroomView: View {
 
             VStack(alignment: .leading, spacing: 0) {
                 conferences
+                invitations
 
                 Text(viewModel.welcomeText)
                     .foregroundColor(.licorice)
@@ -56,6 +57,13 @@ public struct K5HomeroomView: View {
     private var conferences: some View {
         ForEach(viewModel.conferencesViewModel.conferences, id: \.entity.id) { conference in
             ConferenceCard(conference: conference.entity, contextName: conference.contextName)
+                .padding(.top, 16)
+        }
+    }
+
+    private var invitations: some View {
+        ForEach(viewModel.invitationsViewModel.invitations, id: \.id) { (id, course, enrollment) in
+            CourseInvitationCard(course: course, enrollment: enrollment, id: id)
                 .padding(.top, 16)
         }
     }

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -25,10 +25,11 @@ public class K5HomeroomViewModel: ObservableObject {
     @Published public private(set) var announcements: [K5HomeroomAnnouncementViewModel] = []
     @Published public private(set) var subjectCards: [K5HomeroomSubjectCardViewModel] = []
     @Published public private(set) var conferencesViewModel = DashboardConferencesViewModel()
+    @Published public private(set) var invitationsViewModel = DashboardInvitationsViewModel()
 
     // MARK: - Private Variables -
     private let env = AppEnvironment.shared
-    private var conferencesChangeListener: AnyCancellable?
+    private var childViewModelChangeListener: AnyCancellable?
     // MARK: Data Sources
     private lazy var cards = env.subscribe(GetDashboardCards()) { [weak self] in
         self?.dashboardCardsUpdated()
@@ -47,13 +48,14 @@ public class K5HomeroomViewModel: ObservableObject {
 
     public init() {
         // Propagate changes of the underlying view model to this observable class because there's no native support for nested ObservableObjects
-        conferencesChangeListener = conferencesViewModel.objectWillChange.sink { [weak self] _ in
+        childViewModelChangeListener = conferencesViewModel.objectWillChange.merge(with: invitationsViewModel.objectWillChange).sink { [weak self] _ in
             self?.objectWillChange.send()
         }
 
         cards.refresh()
         profile.refresh()
         conferencesViewModel.refresh()
+        invitationsViewModel.refresh()
     }
 
     // MARK: - Private Methods -
@@ -189,5 +191,6 @@ extension K5HomeroomViewModel: Refreshable {
         cards.refresh(force: true)
         profile.refresh(force: true)
         conferencesViewModel.refresh(force: true)
+        invitationsViewModel.refresh(force: true)
     }
 }

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -21,12 +21,11 @@ import SwiftUI
 public struct DashboardCardView: View {
     @ObservedObject var cards: Store<GetDashboardCards>
     @ObservedObject var colors: Store<GetCustomColors>
-    @ObservedObject var courses: Store<GetCourses>
     @ObservedObject var groups: Store<GetDashboardGroups>
-    @ObservedObject var invitations: Store<GetCourseInvitations>
     @ObservedObject var notifications: Store<GetAccountNotifications>
     @ObservedObject var settings: Store<GetUserSettings>
     @ObservedObject var conferencesViewModel = DashboardConferencesViewModel()
+    @ObservedObject var invitationsViewModel = DashboardInvitationsViewModel()
 
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
@@ -43,9 +42,7 @@ public struct DashboardCardView: View {
         let env = AppEnvironment.shared
         cards = env.subscribe(GetDashboardCards())
         colors = env.subscribe(GetCustomColors())
-        courses = env.subscribe(GetCourses(enrollmentState: nil))
         groups = env.subscribe(GetDashboardGroups())
-        invitations = env.subscribe(GetCourseInvitations())
         notifications = env.subscribe(GetAccountNotifications())
         settings = env.subscribe(GetUserSettings(userID: "self"))
     }
@@ -103,11 +100,9 @@ public struct DashboardCardView: View {
                 .padding(.top, 16)
         }
 
-        ForEach(invitations.all, id: \.id) { enrollment in
-            if let id = enrollment.id, let course = courses.first(where: { "course_\($0.id)" == enrollment.canvasContextID }) {
-                CourseInvitationCard(course: course, enrollment: enrollment, id: id)
-                    .padding(.top, 16)
-            }
+        ForEach(invitationsViewModel.invitations, id: \.id) { (id, course, enrollment) in
+            CourseInvitationCard(course: course, enrollment: enrollment, id: id)
+                .padding(.top, 16)
         }
 
         ForEach(notifications.all, id: \.id) { notification in
@@ -199,9 +194,8 @@ public struct DashboardCardView: View {
     func refresh(force: Bool, onComplete: (() -> Void)? = nil) {
         refreshCards(onComplete: onComplete)
         colors.refresh(force: force)
-        courses.exhaust(force: force)
         conferencesViewModel.refresh(force: force)
-        invitations.exhaust(force: force)
+        invitationsViewModel.refresh(force: force)
         groups.exhaust(force: force)
         notifications.exhaust(force: force)
         settings.refresh(force: force)

--- a/Core/Core/Dashboard/ViewModel/DashboardInvitationsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardInvitationsViewModel.swift
@@ -1,0 +1,61 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import SwiftUI
+
+public class DashboardInvitationsViewModel: ObservableObject {
+    // MARK: - Public Properties
+    /** `id` is the enrollment's id. */
+    @Published public private(set) var invitations: [(id: String, course: Course, enrollment: Enrollment)] = []
+
+    // MARK: - Private Properties
+    private lazy var invitationsStore = AppEnvironment.shared.subscribe(GetCourseInvitations()) { [weak self] in
+        self?.update()
+    }
+    private lazy var coursesStore = AppEnvironment.shared.subscribe(GetCourses(enrollmentState: nil)) { [weak self] in
+        self?.update()
+    }
+    private var isRefreshFinished: Bool {
+        invitationsStore.requested && !invitationsStore.pending &&
+        coursesStore.requested && !coursesStore.pending
+    }
+
+    // MARK: - Public Methods
+
+    public func refresh(force: Bool = false) {
+        coursesStore.exhaust(force: force)
+        invitationsStore.exhaust(force: force)
+    }
+
+    // MARK: - Private Methods
+
+    private func update() {
+        guard isRefreshFinished else { return }
+
+        var newInvitations: [(id: String, course: Course, enrollment: Enrollment)] = []
+
+        for enrollment in invitationsStore.all {
+            if let id = enrollment.id, let course = coursesStore.first(where: { "course_\($0.id)" == enrollment.canvasContextID }) {
+                newInvitations.append((id: id, course: course, enrollment: enrollment))
+            }
+        }
+
+        self.invitations = newInvitations
+    }
+}

--- a/Core/CoreTests/Dashboard/ViewModel/DashboardInvitationsViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/DashboardInvitationsViewModelTests.swift
@@ -1,0 +1,48 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+import TestsFoundation
+
+class DashboardInvitationsViewModelTests: CoreTestCase {
+
+    func testFetch() {
+        api.mock(GetCourses(enrollmentState: nil), value: [.make(id: "testCourseID", name: "testCourseName")])
+        api.mock(GetCourseInvitations(), value: [.make(id: "testEnrollmentID", course_id: "testCourseID")])
+
+        let testee = DashboardInvitationsViewModel()
+        let viewModelUpdatedExpectation = expectation(description: "view model updated")
+        let updateSubscription = testee.objectWillChange.sink {
+            viewModelUpdatedExpectation.fulfill()
+        }
+        testee.refresh()
+
+        wait(for: [viewModelUpdatedExpectation], timeout: 1)
+        XCTAssertEqual(testee.invitations.count, 1)
+        guard let invitation = testee.invitations.first else { return }
+
+        XCTAssertEqual(invitation.id, "testEnrollmentID")
+        XCTAssertEqual(invitation.enrollment.id, "testEnrollmentID")
+        XCTAssertEqual(invitation.course.id, "testCourseID")
+        XCTAssertEqual(invitation.course.name, "testCourseName")
+
+        updateSubscription.cancel()
+
+    }
+}


### PR DESCRIPTION
refs: MBL-15694
affects: Student
release note: Added course invitations to homeroom view.

test plan:
- Invite a K5 student to a course but don't accept it yet.
- Log in with the K5 user to the student app.
- Invitation banner should be visible in homeroom, accepting, declining and dismissing the message should work just as in non K5 mode.
- Repeat the above with a non-K5 user and check if no regression was introduced.

<img src="https://user-images.githubusercontent.com/72396990/144029842-22efe281-50b3-44d4-b37b-02ec496a556d.png" width=50% height=50%>