### PR TITLE
Add account announcements to homeroom view

### DIFF
--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomView.swift
@@ -35,6 +35,7 @@ public struct K5HomeroomView: View {
             VStack(alignment: .leading, spacing: 0) {
                 conferences
                 invitations
+                accountAnnouncements
 
                 Text(viewModel.welcomeText)
                     .foregroundColor(.licorice)
@@ -64,6 +65,13 @@ public struct K5HomeroomView: View {
     private var invitations: some View {
         ForEach(viewModel.invitationsViewModel.invitations, id: \.id) { (id, course, enrollment) in
             CourseInvitationCard(course: course, enrollment: enrollment, id: id)
+                .padding(.top, 16)
+        }
+    }
+
+    private var accountAnnouncements: some View {
+        ForEach(viewModel.accountAnnouncements, id: \.id) { announcement in
+            NotificationCard(notification: announcement)
                 .padding(.top, 16)
         }
     }

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -56,7 +56,7 @@ public class K5HomeroomViewModel: ObservableObject {
             self?.objectWillChange.send()
         }
 
-        cards.exhaust()
+        cards.refresh()
         profile.refresh()
         accountAnnouncementsStore.exhaust()
         conferencesViewModel.refresh()
@@ -198,7 +198,7 @@ extension K5HomeroomViewModel: Refreshable {
         announcementsStore = nil
         missingSubmissions = nil
         dueItems = nil
-        cards.exhaust(force: true)
+        cards.refresh(force: true)
         profile.refresh(force: true)
         accountAnnouncementsStore.exhaust(force: true)
         conferencesViewModel.refresh(force: true)

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -26,6 +26,7 @@ public class K5HomeroomViewModel: ObservableObject {
     @Published public private(set) var subjectCards: [K5HomeroomSubjectCardViewModel] = []
     @Published public private(set) var conferencesViewModel = DashboardConferencesViewModel()
     @Published public private(set) var invitationsViewModel = DashboardInvitationsViewModel()
+    @Published public private(set) var accountAnnouncements: [AccountNotification] = []
 
     // MARK: - Private Variables -
     private let env = AppEnvironment.shared
@@ -36,6 +37,9 @@ public class K5HomeroomViewModel: ObservableObject {
     }
     private lazy var profile = env.subscribe(GetUserProfile(userID: "self")) { [weak self] in
         self?.profileUpdated()
+    }
+    private lazy var accountAnnouncementsStore = env.subscribe(GetAccountNotifications()) { [weak self] in
+        self?.accountAnnouncementsUpdated()
     }
     private var announcementsStore: Store<GetLatestAnnouncements>?
     private var dueItems: Store<GetK5HomeroomDueItemCount>?
@@ -52,8 +56,9 @@ public class K5HomeroomViewModel: ObservableObject {
             self?.objectWillChange.send()
         }
 
-        cards.refresh()
+        cards.exhaust()
         profile.refresh()
+        accountAnnouncementsStore.exhaust()
         conferencesViewModel.refresh()
         invitationsViewModel.refresh()
     }
@@ -78,6 +83,11 @@ public class K5HomeroomViewModel: ObservableObject {
         guard cards.requested, !cards.pending else { return }
         requestAnnouncements()
         requestItemsDueToday()
+    }
+
+    private func accountAnnouncementsUpdated() {
+        guard accountAnnouncementsStore.requested, !accountAnnouncementsStore.pending else { return }
+        accountAnnouncements = accountAnnouncementsStore.all
     }
 
     // MARK: Subject Cards
@@ -188,8 +198,9 @@ extension K5HomeroomViewModel: Refreshable {
         announcementsStore = nil
         missingSubmissions = nil
         dueItems = nil
-        cards.refresh(force: true)
+        cards.exhaust(force: true)
         profile.refresh(force: true)
+        accountAnnouncementsStore.exhaust(force: true)
         conferencesViewModel.refresh(force: true)
         invitationsViewModel.refresh(force: true)
     }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
@@ -82,6 +82,17 @@ class K5HomeroomViewModelTests: CoreTestCase {
         XCTAssertEqual(announcement.htmlContent, "message 2")
     }
 
+    // MARK: - Account Announcement Tests
+
+    func testLoadsAccountAnnouncements() {
+        api.mock(GetAccountNotificationsRequest(), value: [.make()])
+
+        let testee = K5HomeroomViewModel()
+
+        XCTAssertEqual(testee.accountAnnouncements.count, 1)
+        XCTAssertEqual(testee.accountAnnouncements.first?.message, "The financial aid office is closed on Tuesdays.")
+    }
+
     // MARK: - Subject Card Tests
 
     func testLoadsNonHomeroomCourses() {


### PR DESCRIPTION
refs: MBL-15694
affects: Student
release note: Added account announcements to homeroom view.

test plan:
- Create an account announcement.
- Log in with a K5 user to the student app.
- Announcement should be visible on the homeroom screen.
- Check if opening, collapsing and dismissing works.

<img src="https://user-images.githubusercontent.com/72396990/144053966-e744f4a7-2f59-47ca-8028-6d8a6e894880.png" width=50% height=50%>