### PR TITLE
Share extension fixes

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -817,6 +817,8 @@
 		CF11565226FB5C4C00DE25B6 /* AttachmentSubmissionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF11565126FB5C4C00DE25B6 /* AttachmentSubmissionService.swift */; };
 		CF12DFC026CE9BE7000BE452 /* K5ScheduleMissingItemsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12DFBF26CE9BE7000BE452 /* K5ScheduleMissingItemsView.swift */; };
 		CF12DFC826D63937000BE452 /* CompatibleNavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */; };
+		CF2091A6275A5B37003E8EA6 /* AssignmentPickerListRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2091A5275A5B37003E8EA6 /* AssignmentPickerListRequest.swift */; };
+		CF2091A8275A5B4E003E8EA6 /* AssignmentPickerListResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2091A7275A5B4E003E8EA6 /* AssignmentPickerListResponse.swift */; };
 		CF22C94325F2874A00C2E012 /* UIAccessibilityAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */; };
 		CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */; };
 		CF29DF91272BD9F10046C04D /* DynamicHeightTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */; };
@@ -2058,6 +2060,8 @@
 		CF11565126FB5C4C00DE25B6 /* AttachmentSubmissionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentSubmissionService.swift; sourceTree = "<group>"; };
 		CF12DFBF26CE9BE7000BE452 /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		CF12DFC726D63937000BE452 /* CompatibleNavBarItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompatibleNavBarItems.swift; sourceTree = "<group>"; };
+		CF2091A5275A5B37003E8EA6 /* AssignmentPickerListRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerListRequest.swift; sourceTree = "<group>"; };
+		CF2091A7275A5B4E003E8EA6 /* AssignmentPickerListResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerListResponse.swift; sourceTree = "<group>"; };
 		CF22C94225F2874A00C2E012 /* UIAccessibilityAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncement.swift; sourceTree = "<group>"; };
 		CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncementTests.swift; sourceTree = "<group>"; };
 		CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightTextEditor.swift; sourceTree = "<group>"; };
@@ -4153,11 +4157,21 @@
 		CF11564E26FB566D00DE25B6 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				CF2091A4275A5B25003E8EA6 /* API */,
 				CF11564F26FB56E900DE25B6 /* AttachmentCopyService.swift */,
 				CF11565126FB5C4C00DE25B6 /* AttachmentSubmissionService.swift */,
 				CFC2C2752733C9DA006CA3E0 /* IdentifiableName.swift */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		CF2091A4275A5B25003E8EA6 /* API */ = {
+			isa = PBXGroup;
+			children = (
+				CF2091A5275A5B37003E8EA6 /* AssignmentPickerListRequest.swift */,
+				CF2091A7275A5B4E003E8EA6 /* AssignmentPickerListResponse.swift */,
+			);
+			path = API;
 			sourceTree = "<group>";
 		};
 		CF22C94125F286E000C2E012 /* Accessibility */ = {
@@ -5950,6 +5964,7 @@
 				E890AF3024CF5C28000401FB /* CourseListView.swift in Sources */,
 				E880B4FF24AE352800A382F4 /* APIObserverAlert.swift in Sources */,
 				7DA25FC423F72136005D2121 /* APIPandata.swift in Sources */,
+				CF2091A6275A5B37003E8EA6 /* AssignmentPickerListRequest.swift in Sources */,
 				7DA4DA2C2440C94D009CA964 /* GetPage.swift in Sources */,
 				7DA260D323F72359005D2121 /* DividerView.swift in Sources */,
 				7DA260AC23F72352005D2121 /* GetContextPermissions.swift in Sources */,
@@ -6243,6 +6258,7 @@
 				7D531D3B2549CF0500CBFCA6 /* AssignmentOverridesEditor.swift in Sources */,
 				7DA260EA23F72359005D2121 /* TitleSubtitleView.swift in Sources */,
 				7DA25FF823F7226E005D2121 /* DocViewerAnnotationToolbar.swift in Sources */,
+				CF2091A8275A5B4E003E8EA6 /* AssignmentPickerListResponse.swift in Sources */,
 				7DA260E723F72359005D2121 /* SectionHeaderView.swift in Sources */,
 				7DA260CC23F72359005D2121 /* BottomSheetPickerViewController.swift in Sources */,
 				E8D6949824D46B1E0080D883 /* CoreHostingController.swift in Sources */,

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListRequest.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListRequest.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public struct AssignmentPickerListRequest: APIGraphQLRequestable {
+    public typealias Response = AssignmentPickerListResponse
+
+    static let operationName = "AssignmentPickerList"
+    /**`gradingPeriodId: null` is to return all assignments irrespective of their grading period in the course. */
+    static let query = """
+        query \(operationName)($courseID: ID!) {
+          course(id: $courseID) {
+            assignmentsConnection(filter: { gradingPeriodId: null }) {
+              nodes {
+                name
+                _id
+                submissionTypes
+                lockInfo {
+                  isLocked
+                }
+              }
+            }
+          }
+        }
+        """
+
+    public struct Variables: Codable, Equatable {
+        public let courseID: String
+    }
+
+    public let variables: Variables
+
+    public init(courseID: String) {
+        variables = Variables(courseID: courseID)
+    }
+}

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListResponse.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListResponse.swift
@@ -1,0 +1,46 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2021-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public struct AssignmentPickerListResponse: Codable, Equatable {
+    public struct Assignment: Codable, Equatable {
+        struct LockInfo: Codable, Equatable {
+            let isLocked: Bool
+        }
+
+        let name: String
+        let _id: String
+        let submissionTypes: [SubmissionType]
+        let lockInfo: LockInfo
+
+        public var isLocked: Bool { lockInfo.isLocked }
+    }
+
+    struct Data: Codable, Equatable {
+        struct Course: Codable, Equatable {
+            struct AssignmentsConnection: Codable, Equatable {
+                let nodes: [Assignment]
+            }
+            let assignmentsConnection: AssignmentsConnection
+        }
+        let course: Course
+    }
+
+    public var assignments: [Assignment] { data.course.assignmentsConnection.nodes.map { $0 } }
+
+    let data: Self.Data
+}

--- a/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
@@ -68,6 +68,7 @@ public struct AssignmentPickerView: View {
                                 .font(.regular16)
                                 .foregroundColor(.textDarkest)
                                 .frame(height: 50)
+                                .multilineTextAlignment(.leading)
                             Spacer()
 
                             if viewModel.selectedAssignment == assignment {

--- a/Core/Core/SubmitAssignmentExtension/View/AttachmentPreviewView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AttachmentPreviewView.swift
@@ -23,6 +23,7 @@ public struct AttachmentPreviewView: View {
     private let url: URL
     private let size: CGFloat = 200
     private let videoLengthFormatter = DateComponentsFormatter()
+    private var isPDFDocument: Bool { url.pathExtension.lowercased().hasSuffix("pdf") }
 
     public init(url: URL) {
         self.url = url
@@ -31,7 +32,9 @@ public struct AttachmentPreviewView: View {
     }
 
     public var body: some View {
-        if let image = self.image {
+        if isPDFDocument {
+            pdfPreview(fileName: url.lastPathComponent)
+        } else if let image = self.image {
             imagePreview(image)
         } else if let movieData = self.movieData {
             moviePreview(movieData.frame, movieLength: movieData.movieLength)
@@ -78,7 +81,23 @@ public struct AttachmentPreviewView: View {
         }
         .frame(width: size, height: size)
         .background(Color.backgroundLight)
+    }
 
+    public func pdfPreview(fileName: String) -> some View {
+        ZStack(alignment: .bottom) {
+            Image.pdfLine
+                .resizable()
+                .foregroundColor(.textDark)
+                .opacity(0.8)
+                .padding(30)
+            Text(fileName)
+                .lineLimit(1)
+                .padding(.horizontal, 10)
+                .padding(.bottom, 10)
+                .font(.regular16)
+                .foregroundColor(.textDarkest)
+        }
+        .frame(width: size, height: size)
     }
 
     private var image: UIImage? {
@@ -111,6 +130,13 @@ struct AttachmentPreviewView_Previews: PreviewProvider {
         view.imagePreview(image).previewLayout(.sizeThatFits)
         view.moviePreview(image, movieLength: 186).previewLayout(.sizeThatFits)
         view.noPreview.previewLayout(.sizeThatFits)
+        view.noPreview
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
+        view.pdfPreview(fileName: "verylongfilenamejusttoseeifitfits.pdf").previewLayout(.sizeThatFits)
+        view.pdfPreview(fileName: "test.pdf")
+            .previewLayout(.sizeThatFits)
+            .preferredColorScheme(.dark)
     }
 }
 

--- a/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
@@ -64,6 +64,7 @@ public struct CoursePickerView: View {
                                 .font(.regular16)
                                 .foregroundColor(.textDarkest)
                                 .frame(height: 50)
+                                .multilineTextAlignment(.leading)
                             Spacer()
 
                             if viewModel.selectedCourse == course {

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -125,6 +125,7 @@ public struct SubmitAssignmentExtensionView: View {
                 viewModel.selectCourseButtonTitle
                     .foregroundColor(viewModel.coursePickerViewModel.selectedCourse == nil ? .textDark : .textDarkest)
                     .font(.regular16)
+                    .multilineTextAlignment(.leading)
                 Spacer()
                 disclosureIndicator
             }
@@ -146,6 +147,7 @@ public struct SubmitAssignmentExtensionView: View {
                         viewModel.selectAssignmentButtonTitle
                             .foregroundColor(viewModel.assignmentPickerViewModel.selectedAssignment == nil ? .textDark : .textDarkest)
                             .font(.regular16)
+                            .multilineTextAlignment(.leading)
                         Spacer()
                         disclosureIndicator
                     }

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModel.swift
@@ -98,6 +98,5 @@ public class AssignmentPickerViewModel: ObservableObject {
         else { return }
 
         selectedAssignment = defaultAssignment
-        AppEnvironment.shared.userDefaults?.submitAssignmentID = nil
     }
 }

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModel.swift
@@ -59,9 +59,9 @@ public class AssignmentPickerViewModel: ObservableObject {
 
     private func fetchAssignments(for courseID: String) {
         requestedCourseID = courseID
-        let request = GetAssignmentsRequest(courseID: courseID, perPage: 100)
+        let request = AssignmentPickerListRequest(courseID: courseID)
 
-        AppEnvironment.shared.api.exhaust(request) { assignments, _, error in
+        AppEnvironment.shared.api.makeRequest(request) { response, _, error in
             // If the finished request was for an older fetch we ignore its results
             if self.requestedCourseID != courseID {
                 return
@@ -69,8 +69,8 @@ public class AssignmentPickerViewModel: ObservableObject {
 
             let newState: ViewModelState<[Assignment]>
 
-            if let assignments = assignments {
-                newState = .data(Self.filterAssignments(assignments))
+            if let response = response {
+                newState = .data(Self.filterAssignments(response.assignments))
             } else {
                 let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
                 newState = .error(errorMessage)
@@ -83,10 +83,10 @@ public class AssignmentPickerViewModel: ObservableObject {
         }
     }
 
-    private static func filterAssignments(_ assignments: [APIAssignment]) -> [Assignment] {
+    private static func filterAssignments(_ assignments: [AssignmentPickerListResponse.Assignment]) -> [Assignment] {
         assignments.compactMap {
-            guard $0.isLockedForUser == false, $0.submission_types.contains(.online_upload) else { return nil }
-            return Assignment(id: $0.id.value, name: $0.name)
+            guard $0.isLocked == false, $0.submissionTypes.contains(.online_upload) else { return nil }
+            return Assignment(id: $0._id, name: $0.name)
         }
     }
 

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
@@ -67,6 +67,5 @@ public class CoursePickerViewModel: ObservableObject {
         else { return }
 
         selectedCourse = defaultCourse
-        AppEnvironment.shared.userDefaults?.submitAssignmentCourseID = nil
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
@@ -25,6 +25,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     override func setUp() {
         super.setUp()
         testee = AssignmentPickerViewModel()
+        environment.userDefaults?.reset()
     }
 
     func testUnknownAPIError() {
@@ -34,19 +35,19 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     }
 
     func testAPIError() {
-        api.mock(GetAssignmentsRequest(courseID: "failingID", perPage: 100), data: nil, response: nil, error: NSError.instructureError("Custom error"))
+        api.mock(AssignmentPickerListRequest(courseID: "failingID"), data: nil, response: nil, error: NSError.instructureError("Custom error"))
         testee.courseID = "failingID"
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .error("Custom error"))
     }
 
     func testAssignmentFetchSuccessful() {
-        api.mock(GetAssignmentsRequest(courseID: "successID", perPage: 100), value: [
-            APIAssignment.make(id: "A1", name: "unknown submission type"),
-            APIAssignment.make(id: "A2", name: "online upload", submission_types: [.online_upload]),
-            APIAssignment.make(id: "A3", locked_for_user: true, name: "online upload, locked", submission_types: [.online_upload]),
-            APIAssignment.make(id: "A4", name: "external tool", submission_types: [.external_tool]),
-        ])
+        api.mock(AssignmentPickerListRequest(courseID: "successID"), value: mockAssignments([
+            mockAssignment(id: "A1", name: "unknown submission type"),
+            mockAssignment(id: "A2", name: "online upload", submission_types: [.online_upload]),
+            mockAssignment(id: "A3", isLocked: true, name: "online upload, locked", submission_types: [.online_upload]),
+            mockAssignment(id: "A4", name: "external tool", submission_types: [.external_tool]),
+        ]))
         testee.courseID = "successID"
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .data([
@@ -55,16 +56,16 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     }
 
     func testSameCourseIdDoesntTriggerRefresh() {
-        api.mock(GetAssignmentsRequest(courseID: "successID", perPage: 100), value: [
-            APIAssignment.make(id: "A1", name: "online upload", submission_types: [.online_upload]),
-        ])
+        api.mock(AssignmentPickerListRequest(courseID: "successID"), value: mockAssignments([
+            mockAssignment(id: "A1", name: "online upload", submission_types: [.online_upload]),
+        ]))
         testee.courseID = "successID"
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .data([
             .init(id: "A1", name: "online upload"),
         ]))
 
-        api.mock(GetAssignmentsRequest(courseID: "failingID", perPage: 100), data: nil, response: nil, error: NSError.instructureError("Custom error"))
+        api.mock(AssignmentPickerListRequest(courseID: "failingID"), data: nil, response: nil, error: NSError.instructureError("Custom error"))
         testee.courseID = "successID"
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .data([
@@ -74,9 +75,9 @@ class AssignmentPickerViewModelTests: CoreTestCase {
 
     func testDefaultAssignmentSelection() {
         environment.userDefaults?.submitAssignmentID = "A2"
-        api.mock(GetAssignmentsRequest(courseID: "successID", perPage: 100), value: [
-            APIAssignment.make(id: "A2", name: "online upload", submission_types: [.online_upload]),
-        ])
+        api.mock(AssignmentPickerListRequest(courseID: "successID"), value: mockAssignments([
+            mockAssignment(id: "A2", name: "online upload", submission_types: [.online_upload]),
+        ]))
         testee.courseID = "successID"
         XCTAssertEqual(testee.selectedAssignment, .init(id: "A2", name: "online upload"))
         XCTAssertEqual(testee.state, .data([
@@ -86,18 +87,18 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     }
 
     func testCourseChangeRefreshesState() {
-        api.mock(GetAssignmentsRequest(courseID: "successID", perPage: 100), value: [
-            APIAssignment.make(id: "A1", name: "online upload", submission_types: [.online_upload]),
-        ])
+        api.mock(AssignmentPickerListRequest(courseID: "successID"), value: mockAssignments([
+            mockAssignment(id: "A1", name: "online upload", submission_types: [.online_upload]),
+        ]))
         testee.courseID = "successID"
         XCTAssertEqual(testee.state, .data([
             .init(id: "A1", name: "online upload"),
         ]))
 
         testee.selectedAssignment = .init(id: "A1", name: "online upload")
-        api.mock(GetAssignmentsRequest(courseID: "successID2", perPage: 100), value: [
-            APIAssignment.make(id: "A2", name: "online upload", submission_types: [.online_upload]),
-        ])
+        api.mock(AssignmentPickerListRequest(courseID: "successID2"), value: mockAssignments([
+            mockAssignment(id: "A2", name: "online upload", submission_types: [.online_upload]),
+        ]))
         testee.courseID = "successID2"
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .data([
@@ -109,5 +110,13 @@ class AssignmentPickerViewModelTests: CoreTestCase {
         let testee = AssignmentPickerViewModel(state: .loading)
         XCTAssertNil(testee.selectedAssignment)
         XCTAssertEqual(testee.state, .loading)
+    }
+
+    private func mockAssignments(_ assignments: [AssignmentPickerListResponse.Assignment]) -> AssignmentPickerListRequest.Response {
+        return AssignmentPickerListRequest.Response(data: .init(course: .init(assignmentsConnection: .init(nodes: assignments))))
+    }
+
+    private func mockAssignment(id: String, isLocked: Bool = false, name: String, submission_types: [SubmissionType] = []) -> AssignmentPickerListResponse.Assignment {
+        .init(name: name, _id: id, submissionTypes: submission_types, lockInfo: .init(isLocked: isLocked))
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
@@ -83,7 +83,8 @@ class AssignmentPickerViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.state, .data([
             .init(id: "A2", name: "online upload"),
         ]))
-        XCTAssertNil(environment.userDefaults?.submitAssignmentID)
+        // Keep the assignment ID so if the user submits another attempt without starting the app we'll pre-select
+        XCTAssertNotNil(environment.userDefaults?.submitAssignmentID)
     }
 
     func testCourseChangeRefreshesState() {

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/CoursePickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/CoursePickerViewModelTests.swift
@@ -60,7 +60,8 @@ class CoursePickerViewModelTests: CoreTestCase {
             .init(id: "testCourse1_ID", name: "testCourse1"),
             .init(id: "testCourse2_ID", name: "testCourse2"),
         ]))
-        XCTAssertNil(environment.userDefaults?.submitAssignmentCourseID)
+        // Keep the course ID so if the user submits another attempt without starting the app we'll pre-select
+        XCTAssertNotNil(environment.userDefaults?.submitAssignmentCourseID)
     }
 
     func testPreviewInitializer() {


### PR DESCRIPTION
refs: MBL-15784
affects: Student
release note: Fixed file share extension not showing all assignments in a course. Fixed file share extension pre-selecting course and assignment only on the first attempt.

test plan: See ticket, assignments above number 100 should also be displayed in the app. I added a preview icon for pdf files, fixed text alignments in case of long course and assignment names and I also modified the course and assignment pre-select logic not to work only for the first time. The REST API call was replaced with an equivalent GraphQL one to make assignment list load faster in case of courses with a lot of assignments.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/144637763-3d9b2dda-94fd-44fc-92c2-18dd52dce286.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/144637777-e5efaf19-9f8a-422a-b0f5-d3dddd07c246.PNG"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/144637796-df9dd593-304b-4bd9-b62c-f54e7a949344.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/144637808-61eb5c8b-2acb-4aba-8b12-8ee2da351f67.PNG"></td>
</tr>
</table>

