### PR TITLE
Add support for locked parent alerts

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19206" systemVersion="20G95" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="20G95" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -609,6 +609,7 @@
         <attribute name="courseID" optional="YES" attributeType="String"/>
         <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="observerID" attributeType="String"/>
         <attribute name="thresholdID" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
@@ -986,7 +987,7 @@
         <element name="ModuleItemSequence" positionX="-540" positionY="-18" width="128" height="133"/>
         <element name="ModuleItemSequenceNode" positionX="-540" positionY="-18" width="128" height="118"/>
         <element name="NotificationCategory" positionX="-522" positionY="0" width="128" height="103"/>
-        <element name="ObserverAlert" positionX="-540" positionY="-18" width="128" height="208"/>
+        <element name="ObserverAlert" positionX="-540" positionY="-18" width="128" height="209"/>
         <element name="Page" positionX="-549" positionY="-27" width="128" height="193"/>
         <element name="Permissions" positionX="-369" positionY="-18" width="128" height="1080"/>
         <element name="Plannable" positionX="-540" positionY="-18" width="128" height="193"/>

--- a/Core/Core/ObserverAlerts/APIObserverAlert.swift
+++ b/Core/Core/ObserverAlerts/APIObserverAlert.swift
@@ -31,6 +31,7 @@ public struct APIObserverAlert: Codable {
     let title: String
     let user_id: ID
     let workflow_state: ObserverAlertWorkflowState
+    let locked_for_user: Bool?
 }
 
 #if DEBUG
@@ -46,7 +47,8 @@ extension APIObserverAlert {
         observer_alert_threshold_id: String = "1",
         title: String = "Announcement",
         user_id: String = "2",
-        workflow_state: ObserverAlertWorkflowState = .unread
+        workflow_state: ObserverAlertWorkflowState = .unread,
+        locked_for_user: Bool? = false
     ) -> APIObserverAlert {
         return APIObserverAlert(
             action_date: action_date,
@@ -59,7 +61,8 @@ extension APIObserverAlert {
             observer_alert_threshold_id: ID(observer_alert_threshold_id),
             title: title,
             user_id: ID(user_id),
-            workflow_state: workflow_state
+            workflow_state: workflow_state,
+            locked_for_user: locked_for_user
         )
     }
 }

--- a/Core/Core/ObserverAlerts/ObserverAlert.swift
+++ b/Core/Core/ObserverAlerts/ObserverAlert.swift
@@ -35,6 +35,7 @@ public final class ObserverAlert: NSManagedObject {
     @NSManaged public var title: String
     @NSManaged public var userID: String
     @NSManaged public var workflowStateRaw: String
+    @NSManaged public var lockedForUser: Bool
 
     public var alertType: AlertThresholdType {
         get { AlertThresholdType(rawValue: alertTypeRaw) ?? .institutionAnnouncement }
@@ -62,6 +63,7 @@ extension ObserverAlert: WriteableModel {
         model.title = item.title
         model.userID = item.user_id.value
         model.workflowState = item.workflow_state
+        model.lockedForUser = (item.locked_for_user == true)
         return model
     }
 }

--- a/Core/CoreTests/ObserverAlerts/ObserverAlertTests.swift
+++ b/Core/CoreTests/ObserverAlerts/ObserverAlertTests.swift
@@ -33,4 +33,23 @@ class ObserverAlertTests: CoreTestCase {
         alert.workflowState = .dismissed
         XCTAssertEqual(alert.workflowState, .dismissed)
     }
+
+    func testLockedForUserDefaultValue() {
+        let alert: ObserverAlert = databaseClient.insert()
+        XCTAssertEqual(alert.lockedForUser, false)
+    }
+
+    func testLockedForUserAPIMapping() {
+        let alert: ObserverAlert = databaseClient.insert()
+        alert.id = "testId"
+
+        ObserverAlert.save(.make(id: "testId", locked_for_user: nil), in: databaseClient)
+        XCTAssertEqual(alert.lockedForUser, false)
+
+        ObserverAlert.save(.make(id: "testId", locked_for_user: false), in: databaseClient)
+        XCTAssertEqual(alert.lockedForUser, false)
+
+        ObserverAlert.save(.make(id: "testId", locked_for_user: true), in: databaseClient)
+        XCTAssertEqual(alert.lockedForUser, true)
+    }
 }

--- a/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
+++ b/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
@@ -91,6 +91,16 @@ class ObserverAlertListViewController: UIViewController {
         }
         thresholds.exhaust()
     }
+
+    private func showItemLockedMessage() {
+        let alert = UIAlertController(
+            title: NSLocalizedString("Locked", bundle: .core, comment: ""),
+            message: NSLocalizedString("The linked item is no longer available.", bundle: .core, comment: ""),
+            preferredStyle: .alert
+        )
+        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel))
+        env.router.show(alert, from: self, options: .modal())
+    }
 }
 
 extension ObserverAlertListViewController: UITableViewDataSource, UITableViewDelegate {
@@ -109,6 +119,12 @@ extension ObserverAlertListViewController: UITableViewDataSource, UITableViewDel
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let alert = alerts[indexPath.row] else { return }
+        guard alert.lockedForUser == false else {
+            showItemLockedMessage()
+            tableView.deselectRow(at: indexPath, animated: true)
+            return
+        }
+
         MarkObserverAlertRead(alertID: alert.id).fetch()
         if [ .courseGradeLow, .courseGradeHigh ].contains(alert.alertType) {
             env.router.route(to: "/courses/\(alert.courseID ?? alert.contextID ?? "")/grades", from: self, options: .detail)
@@ -159,5 +175,23 @@ class ObserverAlertListCell: UITableViewCell {
             iconView.tintColor = .textDark
             iconView.image = .infoLine
         }
+
+        if alert?.lockedForUser == true {
+            updateTitleToLockedState()
+            iconView.image = .lockLine
+        }
+    }
+
+    private func updateTitleToLockedState() {
+        var newTypeText = typeLabel.text ?? ""
+        let lockedText = NSLocalizedString("Locked", bundle: .core, comment: "")
+
+        if newTypeText.isEmpty {
+            newTypeText = lockedText
+        } else {
+            newTypeText.append(String(format: " • %@", lockedText))
+        }
+
+        typeLabel.text = newTypeText
     }
 }

--- a/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
+++ b/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
@@ -119,13 +119,15 @@ extension ObserverAlertListViewController: UITableViewDataSource, UITableViewDel
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let alert = alerts[indexPath.row] else { return }
+
+        MarkObserverAlertRead(alertID: alert.id).fetch()
+
         guard alert.lockedForUser == false else {
             showItemLockedMessage()
             tableView.deselectRow(at: indexPath, animated: true)
             return
         }
 
-        MarkObserverAlertRead(alertID: alert.id).fetch()
         if [ .courseGradeLow, .courseGradeHigh ].contains(alert.alertType) {
             env.router.route(to: "/courses/\(alert.courseID ?? alert.contextID ?? "")/grades", from: self, options: .detail)
         } else if let url = alert.htmlURL {

--- a/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
@@ -56,6 +56,16 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
                 workflow_state: .read
             ),
             .make(id: "17", workflow_state: .dismissed),
+            .make(
+                action_date: DateComponents(calendar: .current, year: 2020, month: 6, day: 5).date,
+                alert_type: .courseGradeHigh,
+                context_id: "1", html_url: URL(string: "/courses/1"),
+                id: "11", observer_alert_threshold_id: "1",
+                title: "Course grade: 95% in C1",
+                user_id: "1",
+                workflow_state: .unread,
+                locked_for_user: true
+            ),
         ])
         api.mock(controller.thresholds, value: [
             .make(id: "1", user_id: "1", alert_type: .courseGradeHigh, threshold: 90),
@@ -70,7 +80,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
         controller.viewWillAppear(false)
         XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color)
 
-        XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 3)
+        XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 4)
 
         var index = IndexPath(row: 0, section: 0)
         var cell = controller.tableView.cellForRow(at: index) as? ObserverAlertListCell
@@ -105,6 +115,19 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
         XCTAssertEqual(cell?.iconView.image, .warningLine)
         XCTAssertEqual(cell?.iconView.tintColor, .textDanger)
 
+        index.row = 3
+        cell = controller.tableView.cellForRow(at: index) as? ObserverAlertListCell
+        XCTAssertEqual(cell?.unreadView.isHidden, false)
+        XCTAssertEqual(cell?.typeLabel.text, "Course Grade Above 90 • Locked")
+        XCTAssertEqual(cell?.titleLabel.text, "Course grade: 95% in C1")
+        XCTAssertEqual(cell?.dateLabel.text, "Jun 5, 2020 at 12:00 AM")
+        XCTAssertEqual(cell?.iconView.image, .lockLine)
+        XCTAssertEqual(cell?.iconView.tintColor, .textInfo)
+
+        controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: index)
+        XCTAssert(router.last is UIAlertController)
+
+        index.row = 2
         controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: index)
         XCTAssert(router.lastRoutedTo("/courses/1/assignments/1"))
 


### PR DESCRIPTION
refs: MBL-15735
affects: Parent
release note: Fixed handling of missing assignment alerts where the course is no longer available.

test plan: See ticket and its comments. There's a new API field which indicates if the alert is from a no longer available course. This field only works if the course is deleted but doesn't if the course is concluded. If the API team fixes this we'll need no client side modifications.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/144847259-e5441e06-5840-4246-9932-30a1dfe44f6b.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/144847248-e3eb6b5d-7f9e-43d9-872e-780faf219ee1.png"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/144847346-6ae603b2-d2fe-4d41-97c9-7649c81e7eb2.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/144847341-2b29f7ed-e0a2-48e4-bc46-6596abbb1e1b.png"></td>
</tr>
</table>