### PR TITLE
Fix announcement order when paging is active

### DIFF
--- a/Core/Core/Discussions/GetDiscussions.swift
+++ b/Core/Core/Discussions/GetDiscussions.swift
@@ -40,8 +40,20 @@ class GetAnnouncements: CollectionUseCase {
     ) }
 
     func write(response: [APIDiscussionTopic]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        let pageOffset: Int = {
+            guard
+                let url = urlResponse?.url,
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: true),
+                let pageSize = components.pageSize
+            else {
+                return 0
+            }
+
+            return (components.page - 1) * pageSize
+        }()
+
         response?.enumerated().forEach {
-            Model.save($0.element, apiPosition: $0.offset, in: client)
+            Model.save($0.element, apiPosition: pageOffset + $0.offset, in: client)
         }
     }
 }

--- a/Core/Core/Extensions/URLComponentsExtensions.swift
+++ b/Core/Core/Extensions/URLComponentsExtensions.swift
@@ -103,6 +103,26 @@ public extension URLComponents {
     var skipModuleItemSequence: Bool {
         queryItems?.contains(URLQueryItem(name: "skipModuleItemSequence", value: "true")) == true
     }
+
+    var page: Int {
+        guard let pageIndexQueryValue = queryValue(for: "page"), let pageIndex = Int(pageIndexQueryValue) else {
+            return 1
+        }
+
+        return pageIndex
+    }
+
+    var pageSize: Int? {
+        guard let pageSizeQueryValue = queryValue(for: "per_page") else {
+            return nil
+        }
+
+        return Int(pageSizeQueryValue)
+    }
+
+    func queryValue(for queryName: String) -> String? {
+        queryItems?.first(where: { $0.name == queryName })?.value
+    }
 }
 
 public extension CharacterSet {

--- a/Core/CoreTests/Discussions/GetDiscussionsTests.swift
+++ b/Core/CoreTests/Discussions/GetDiscussionsTests.swift
@@ -161,4 +161,15 @@ class GetDiscussionsTests: CoreTestCase {
         useCase.write(response: nil, urlResponse: emptyResponse, to: databaseClient)
         XCTAssertEqual(entry.isRemoved, true)
     }
+
+    func testPageIndexSaveOnGetAnnouncements() {
+        let testee = GetAnnouncements(context: .course("1"))
+        let requestedURL = URL(string: "/courses/1/announcements?page=2&per_page=100")!
+        let urlResponse = URLResponse(url: requestedURL, mimeType: nil, expectedContentLength: 0, textEncodingName: nil)
+        let announcement = DiscussionTopic.make()
+
+        XCTAssertEqual(announcement.position, Int.max)
+        testee.write(response: [.make()], urlResponse: urlResponse, to: databaseClient)
+        XCTAssertEqual(announcement.position, 100)
+    }
 }

--- a/Core/CoreTests/Extensions/URLComponentsExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLComponentsExtensionsTests.swift
@@ -89,6 +89,21 @@ class URLComponentsExtensionsTests: XCTestCase {
 
         url = URLComponents.parse("/courses/165/assignments/900?origin=calendar&origin=module_item_details")
         XCTAssertTrue(url.originIsModuleItemDetails)
+    }
 
+    func testPageQueryValue() {
+        var testee = URLComponents.parse("/courses/165/assignments/900?page=3")
+        XCTAssertEqual(testee.page, 3)
+
+        testee = URLComponents.parse("/courses/165/assignments/900")
+        XCTAssertEqual(testee.page, 1)
+    }
+
+    func testPageSizeQueryValue() {
+        var testee = URLComponents.parse("/courses/165/assignments/900?per_page=100")
+        XCTAssertEqual(testee.pageSize, 100)
+
+        testee = URLComponents.parse("/courses/165/assignments/900")
+        XCTAssertNil(testee.pageSize)
     }
 }


### PR DESCRIPTION
refs: MBL-15732
affects: Student, Teacher
release note: Fixed announcements getting out of order if there were more than 100.

test plan: See ticket.