### PR TITLE
Grades page ordering by due date descending

### DIFF
--- a/Core/Core/Grades/GetAssignmentsByGroup.swift
+++ b/Core/Core/Grades/GetAssignmentsByGroup.swift
@@ -60,6 +60,7 @@ public class GetAssignmentsByGroup: APIUseCase {
         order: [
             NSSortDescriptor(key: #keyPath(Assignment.assignmentGroup.position), ascending: true),
             NSSortDescriptor(key: #keyPath(Assignment.assignmentGroup.name), ascending: true, naturally: true),
+            NSSortDescriptor(key: #keyPath(Assignment.dueAtSortNilsAtBottom), ascending: true),
             NSSortDescriptor(key: #keyPath(Assignment.position), ascending: true),
             NSSortDescriptor(key: #keyPath(Assignment.name), ascending: true, naturally: true),
         ],


### PR DESCRIPTION
refs: MBL-15730
affects: Student
release note: Fixed assignments not being ordered by due date on the grades page.
test plan: see ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/145426273-6f38d6f3-d1da-4a15-ac70-4948cfcfaae1.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/145426265-e29b0bcd-1949-4b3e-8f06-deea5af4b71a.png"></td>
</tr>
</table>

