### PR TITLE
Allow announcement list to select the first announcement after a force refresh.

### DIFF
--- a/Core/Core/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Discussions/AnnouncementListViewController.swift
@@ -91,6 +91,7 @@ public class AnnouncementListViewController: UIViewController, ColoredNavViewPro
     }
 
     @objc func refresh() {
+        selectedFirstTopic = false
         colors.refresh(force: true)
         course?.refresh(force: true)
         group?.refresh(force: true)


### PR DESCRIPTION
refs: MBL-15794
affects: Student, Teacher
release note: none

test plan: See ticket and its comment for details.