### PR TITLE
Fix module progress not updating

### DIFF
--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -34,6 +34,7 @@ public struct K5SubjectView: View {
                     K5SubjectHeaderView(title: viewModel.courseTitle, imageUrl: viewModel.courseImageUrl, backgroundColor: Color(viewModel.courseColor ?? .clear)).padding(padding)
                 }
                 WebView(url: viewModel.pageUrl(for: topBarViewModel.selectedItemId), customUserAgentName: nil, disableZoom: true)
+                    .reload(on: viewModel.reloadWebView)
                 Divider()
             }
         }

--- a/Core/Core/SwiftUIViews/WebView.swift
+++ b/Core/Core/SwiftUIViews/WebView.swift
@@ -16,23 +16,22 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import Combine
 import SwiftUI
 
 public struct WebView: UIViewRepresentable {
-    enum Source: Equatable {
-        case html(String)
-        case url(URL)
-    }
+    private var handleLink: ((URL) -> Bool)?
+    private var handleSize: ((CGFloat) -> Void)?
+    private var handleNavigationFinished: (() -> Void)?
+    private let source: Source?
+    private var customUserAgentName: String?
+    private var disableZoom: Bool = false
+    private var reloadTrigger: AnyPublisher<Void, Never>?
 
-    var handleLink: ((URL) -> Bool)?
-    var handleSize: ((CGFloat) -> Void)?
-    var handleNavigationFinished: (() -> Void)?
-    let source: Source?
-    var customUserAgentName: String?
-    var disableZoom: Bool = false
+    @Environment(\.appEnvironment) private var env
+    @Environment(\.viewController) private var controller
 
-    @Environment(\.appEnvironment) var env
-    @Environment(\.viewController) var controller
+    // MARK: - Initializers
 
     public init(url: URL?) {
         source = url.map { .url($0) }
@@ -47,6 +46,8 @@ public struct WebView: UIViewRepresentable {
     public init(html: String?) {
         source = html.map { .html($0) }
     }
+
+    // MARK: - View Modifiers
 
     public func onLink(_ handleLink: @escaping (URL) -> Bool) -> Self {
         var modified = self
@@ -70,17 +71,18 @@ public struct WebView: UIViewRepresentable {
         FrameToFit(view: self)
     }
 
-    struct FrameToFit: View {
-        let view: WebView
+    // MARK: - Event Listening
 
-        @State var height: CGFloat = 0
-
-        var body: some View {
-            view
-                .onChangeSize { height = $0 }
-                .frame(height: height)
-        }
+    /**
+     This modifier makes the underlying CoreWebView to call its reload() method when the given publisher is signaled.
+     */
+    public func reload(on trigger: AnyPublisher<Void, Never>) -> Self {
+        var modified = self
+        modified.reloadTrigger = trigger
+        return modified
     }
+
+    // MARK: - UIViewRepresentable Protocol
 
     public func makeUIView(context: Self.Context) -> CoreWebView {
         CoreWebView(customUserAgentName: customUserAgentName, disableZoom: disableZoom)
@@ -89,6 +91,8 @@ public struct WebView: UIViewRepresentable {
     public func updateUIView(_ uiView: CoreWebView, context: Self.Context) {
         uiView.linkDelegate = context.coordinator
         uiView.sizeDelegate = context.coordinator
+        context.coordinator.reload(webView: uiView, on: reloadTrigger)
+
         if context.coordinator.loaded != source {
             context.coordinator.loaded = source
             switch source {
@@ -102,9 +106,35 @@ public struct WebView: UIViewRepresentable {
         }
     }
 
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(view: self)
+    }
+}
+
+// MARK: - Inner Types
+
+extension WebView {
+    enum Source: Equatable {
+        case html(String)
+        case url(URL)
+    }
+
+    private struct FrameToFit: View {
+        let view: WebView
+
+        @State var height: CGFloat = 0
+
+        var body: some View {
+            view
+                .onChangeSize { height = $0 }
+                .frame(height: height)
+        }
+    }
+
     public class Coordinator: CoreWebViewLinkDelegate, CoreWebViewSizeDelegate {
         var loaded: Source?
-        let view: WebView
+        private let view: WebView
+        private var reloadObserver: AnyCancellable?
 
         init(view: WebView) {
             self.view = view
@@ -127,9 +157,12 @@ public struct WebView: UIViewRepresentable {
         public func finishedNavigation() {
             view.handleNavigationFinished?()
         }
-    }
 
-    public func makeCoordinator() -> Coordinator {
-        Coordinator(view: self)
+        public func reload(webView: CoreWebView, on trigger: AnyPublisher<Void, Never>?) {
+            reloadObserver?.cancel()
+            reloadObserver = trigger?.sink {
+                webView.reload()
+            }
+        }
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/K5SubjectViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/K5SubjectViewModelTests.swift
@@ -55,4 +55,18 @@ class K5SubjectViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee.topBarViewModel?.selectedItemIndex, 1)
     }
+
+    func testReloadsOnModuleRequirementCompletedNotification() {
+        let testee = K5SubjectViewModel(context: context, selectedTabId: "grades")
+        let expectation = self.expectation(description: "WebView reload trigger received")
+        expectation.expectedFulfillmentCount = 1
+
+        let reloadListener = testee.reloadWebView.sink {
+            expectation.fulfill()
+        }
+        NotificationCenter.default.post(name: .moduleItemRequirementCompleted, object: nil)
+
+        wait(for: [expectation], timeout: 0.1)
+        reloadListener.cancel()
+    }
 }


### PR DESCRIPTION
Make K5 subject page reload upon module item completion. Add support for SwiftUI webview to perform a reload.

refs: MBL-15798
affects: Student
release note: Fixed module item progress not being updated on homeroom module page.

test plan:
- Create a module with a few items (page view for convenience) and enable sequential requirement order on a K5 account.
- Log in to the student app.
- Go to subject home and enter Modules tab.
- Complete the first module item then close the page.
- Subject home page should be updated and the module item should be marked as completed.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/148403162-b731baf6-4e61-49f0-b674-efdaa778ae66.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/148403171-57b98810-62b3-4bc0-a092-539050105746.PNG"></td>
</tr>
</table>