### PR TITLE
Filter missing items to current grading period in homeroom

### DIFF
--- a/Core/Core/Dashboard/K5/Model/MissingSubmissions/GetMissingSubmissionsRequest.swift
+++ b/Core/Core/Dashboard/K5/Model/MissingSubmissions/GetMissingSubmissionsRequest.swift
@@ -28,6 +28,7 @@ public struct GetMissingSubmissionsRequest: APIRequestable {
     public var query: [APIQueryItem] {[
         .array("course_ids", courseIds),
         .array("include", includes.map { $0.rawValue }),
+        .array("filter", ["current_grading_period"]),
     ]}
 
     private let userId: String


### PR DESCRIPTION
refs: MBL-15814
affects: Student
release note: Fixed homeroom view showing missing items from closed grading periods.

test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/148797150-a5fd33f7-c773-435c-adab-039adaacc438.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/148797196-d9d5e90d-eb2a-49aa-a908-f3e3c12a49fc.png"></td>
</tr>
</table>