### PR TITLE
Fix crash on people list screen

### DIFF
--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -228,7 +228,6 @@ extension PeopleListViewController: UITableViewDataSource, UITableViewDelegate {
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if users.hasNextPage && indexPath.row == users.count {
-            users.getNextPage()
             return LoadingCell(style: .default, reuseIdentifier: nil)
         }
         let cell = tableView.dequeue(PeopleListCell.self, for: indexPath)
@@ -239,6 +238,16 @@ extension PeopleListViewController: UITableViewDataSource, UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let user = users[indexPath.row] else { return }
         env.router.route(to: "/\(context.pathComponent)/users/\(user.id)", from: self, options: .detail)
+    }
+
+    public func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
+        if users.hasNextPage && indexPath.row == users.count {
+            // In case of a fast network the table view blinks once with the scroll indicator jumping and it's not clear what happened,
+            // so we delay the next page load thus the loading indicator can appear and users know what's happening.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.users.getNextPage()
+            }
+        }
     }
 }
 

--- a/Core/CoreTests/People/PeopleListViewControllerTests.swift
+++ b/Core/CoreTests/People/PeopleListViewControllerTests.swift
@@ -134,6 +134,10 @@ class PeopleListViewControllerTests: CoreTestCase {
         let loading = tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 1, section: 0)) as? LoadingCell
         XCTAssertNotNil(loading)
         XCTAssertEqual(tableView.dataSource?.tableView(tableView, numberOfRowsInSection: 0), 2)
+        // simulate cell appearance
+        tableView.delegate?.tableView?(tableView, willDisplay: loading!, forRowAt: IndexPath(row: 1, section: 0))
+        // wait until loading indicator appears and refresh finishes
+        RunLoop.main.run(until: Date() + 1)
         let cell = tableView.dataSource?.tableView(tableView, cellForRowAt: IndexPath(row: 1, section: 0)) as! PeopleListCell
         XCTAssertEqual(cell.nameLabel.text, "Bob")
     }


### PR DESCRIPTION
Add time for the table view to display the loading cell before triggering next page load.

refs: MBL-15808
affects: Student, Teacher
release note: Fixed a crash on people list screen.

test plan: See ticket.