### PR TITLE
Disable using customData dictionary on annotations.

### DIFF
--- a/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
+++ b/Core/Core/DocViewer/DocViewerAnnotationProvider.swift
@@ -100,7 +100,8 @@ class DocViewerAnnotationProvider: PDFContainerAnnotationProvider {
         // Editing of annotations stored in the pdf file are always disabled
         fileAnnotations.forEach {
             $0.flags.update(with: .readOnly)
-            $0.isFileAnnotation = true
+//            This is commented out to work around a PSPDFKit bug
+//            $0.isFileAnnotation = true
         }
         // Then ask `super` to retrieve the custom annotations from cache.
         let docViewerAnnotations = super.annotationsForPage(at: pageIndex) ?? []

--- a/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
@@ -259,7 +259,9 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
 
         guard let fileAnnotation = provider.annotationsForPage(at: 0)?.first else { XCTFail("No annotations to test"); return }
 
-        XCTAssertTrue(fileAnnotation.isFileAnnotation)
+        XCTExpectFailure("Will work when pspdfkit releases an update.") {
+            XCTAssertTrue(fileAnnotation.isFileAnnotation)
+        }
     }
 }
 


### PR DESCRIPTION
refs: MBL-15825
affects: Student, Teacher
release note: Fixed annotations made in iOS not appearing on submissions.

test plan:
- Create an assignment with a pdf file attached.
- As a student, download the pdf file to iOS Files.
- Open the pdf in iOS Files and add annotations.
- Submit the annotated file to the assignment.
- As a student check your submission in Submission & Rubric.
- As a teacher go to SpeedGrader and check the file.
- Annotations added in Files app should appear.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/149745368-58b97042-60da-4008-a7a6-f1ccbdbffabe.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/149745454-e944e398-81e0-4c20-8d4e-4c23cc9186f7.png"></td>
</tr>
</table>