### PR TITLE
Set the default section header top padding to 0.

### DIFF
--- a/Core/Core/Extensions/UITableViewExtensions.swift
+++ b/Core/Core/Extensions/UITableViewExtensions.swift
@@ -19,6 +19,13 @@
 import UIKit
 
 extension UITableView {
+
+    public static func setupDefaultSectionHeaderTopPadding() {
+        if #available(iOS 15.0, *) {
+            UITableView.appearance().sectionHeaderTopPadding = 0.0
+        }
+    }
+
     /// Returns a reusable table-view cell object of the specified type and adds it to the table.
     /// This can assume that the reuse identifier matches the type name.
     public func dequeue<T: UITableViewCell>(_ type: T.Type = T.self, withID identifier: String = String(describing: T.self), for indexPath: IndexPath) -> T {

--- a/Core/CoreTests/Extensions/UITableViewExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UITableViewExtensionsTests.swift
@@ -49,5 +49,11 @@ class UITableViewExtensionsTests: XCTestCase {
         XCTAssertNotNil(header)
     }
 
+    @available(iOS 15.0, *)
+    func testSetupDefaultSectionHeaderTopPadding() {
+        UITableView.setupDefaultSectionHeaderTopPadding()
+        XCTAssertEqual(UITableView.appearance().sectionHeaderTopPadding, 0)
+    }
+
     class MockHeaderView: UITableViewHeaderFooterView {}
 }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -48,6 +48,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         Analytics.shared.handler = self
         NotificationManager.shared.notificationCenter.delegate = self
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        UITableView.setupDefaultSectionHeaderTopPadding()
 
         if let session = LoginSession.mostRecent {
             window?.rootViewController = LoadingViewController.create()

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -55,6 +55,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
         TabBarBadgeCounts.application = UIApplication.shared
         NotificationManager.shared.notificationCenter.delegate = self
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        UITableView.setupDefaultSectionHeaderTopPadding()
 
         if launchOptions?[.sourceApplication] as? String == Bundle.teacherBundleID,
            let url = launchOptions?[.url] as? URL,

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -54,6 +54,7 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
         prepareReactNative()
         NotificationManager.shared.notificationCenter.delegate = self
         try? AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+        UITableView.setupDefaultSectionHeaderTopPadding()
 
         TabBarBadgeCounts.application = UIApplication.shared
 


### PR DESCRIPTION
refs: MBL-15827
affects: Student, Teacher, Parent
release note: none

test plan: Check screens where a native tableview is used.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/150993480-54d262bd-a97e-446d-a29a-e9793b46bd21.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/150993490-517407a2-7456-4008-b5bd-2a0c611d4474.png"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/150993616-51c14865-3f2a-48fa-a4d0-02c822a3306f.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/150993670-eee77d67-fb84-4f99-bd0e-aa316c9ff23a.png"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/150993725-a7699bcf-cb07-46c2-ba71-2204560ad0aa.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/150993777-f0577f7f-ed2b-4702-9682-a037c727191c.png"></td>
</tr>
</table>