### PR TITLE
Move webview reload call to main thread.

### DIFF
--- a/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
+++ b/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
@@ -30,6 +30,7 @@ public class K5SubjectViewModel: ObservableObject {
     public var reloadWebView: AnyPublisher<Void, Never> {
         NotificationCenter.default.publisher(for: .moduleItemRequirementCompleted, object: nil)
             .map { _ in () } // map received notification to Void
+            .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()
     }
     /** The webview configuration to be used. In case of masquerading we can't use the default configuration because it will contain cookies with the original user's permissions. */


### PR DESCRIPTION
refs: MBL-15863
affects: Student
release note: Fixed a crash upon assignment submission in homeroom view.

test plan:
- Log in to a K5 account which has a course with a file upload assignment in a module.
- Go to subject page, modules tab.
- Tap on the assignment and submit a file to it.
- App shouldn't crash.