### PR TITLE
Fix dashboard rendering crash

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2845,7 +2845,6 @@
 			children = (
 				CF575E46266792B600F8515F /* K5 */,
 				CF4BDB552645314A00A91952 /* Model */,
-				CF4BDB562645315700A91952 /* View */,
 				CF748D1F274D52AA000EA34E /* ViewModel */,
 			);
 			path = Dashboard;
@@ -4282,17 +4281,10 @@
 			children = (
 				E86CFBD723A2F7CD00EAE487 /* APIDashboardTests.swift */,
 				7D80AC1A212B6A7700C40ECE /* APIFavoriteTests.swift */,
+				7D288B0E25758F630013FF65 /* DashboardCardTests.swift */,
 				CFFE285F27AAD4DB0029A408 /* CourseSectionStatusTests.swift */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		CF4BDB562645315700A91952 /* View */ = {
-			isa = PBXGroup;
-			children = (
-				7D288B0E25758F630013FF65 /* DashboardCardTests.swift */,
-			);
-			path = View;
 			sourceTree = "<group>";
 		};
 		CF4BDB582645393A00A91952 /* K5 */ = {

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -129,6 +129,10 @@ final public class Course: NSManagedObject, WriteableModel {
             model.sections = Set(sections.map { CourseSection.save($0, courseID: model.id, in: context) })
         }
 
+        if let dashboardCard: DashboardCard = context.fetch(scope: .where(#keyPath(DashboardCard.id), equals: model.id)).first {
+            dashboardCard.course = model
+        }
+
         return model
     }
 }

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -133,6 +133,10 @@ final public class Course: NSManagedObject, WriteableModel {
             dashboardCard.course = model
         }
 
+        if let group: Group = context.fetch(scope: .where(#keyPath(Group.courseID), equals: model.id)).first {
+            group.course = model
+        }
+
         return model
     }
 }

--- a/Core/Core/Dashboard/Model/DashboardCard.swift
+++ b/Core/Core/Dashboard/Model/DashboardCard.swift
@@ -21,6 +21,7 @@ import CoreData
 final class DashboardCard: NSManagedObject {
     typealias JSON = APIDashboardCard
 
+    @NSManaged var course: Course?
     @NSManaged var contextColor: ContextColor?
     @NSManaged var courseCode: String
     @NSManaged var enrollmentType: String
@@ -43,8 +44,6 @@ final class DashboardCard: NSManagedObject {
         let teacherRoles = ["teacher", "ta"]
         return teacherRoles.contains(where: enrollmentType.lowercased().contains)
     }
-
-    var course: Course? { managedObjectContext?.first(where: #keyPath(Course.id), equals: id) }
 
     var shouldShow: Bool {
         guard let enrollments = course?.enrollments else { return false }
@@ -72,6 +71,10 @@ final class DashboardCard: NSManagedObject {
 
         if let contextColor: ContextColor = context.fetch(scope: .where(#keyPath(ContextColor.canvasContextID), equals: "course_\(model.id)")).first {
             model.contextColor = contextColor
+        }
+
+        if let course: Course = context.fetch(scope: .where(#keyPath(Course.id), equals: model.id)).first {
+            model.course = course
         }
 
         return model

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -166,7 +166,7 @@ public struct DashboardCardView: View {
                 }
                     .padding(.top, 16).padding(.bottom, 8)) {
                 ForEach(filteredGroups, id: \.id) { group in
-                    GroupCard(group: group, course: group.getCourse())
+                    GroupCard(group: group, course: group.course)
                         // outside the GroupCard, because that isn't observing colors
                         .accentColor(Color(group.color.ensureContrast(against: .white)))
                         .padding(.bottom, 16)

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19461" systemVersion="20G95" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="20G95" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -269,6 +269,7 @@
         <attribute name="subtitle" attributeType="String"/>
         <attribute name="term" optional="YES" attributeType="String"/>
         <relationship name="contextColor" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContextColor" inverseName="card" inverseEntity="ContextColor"/>
+        <relationship name="course" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course"/>
     </entity>
     <entity name="DiscussionEntry" representedClassName="Core.DiscussionEntry" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -961,11 +962,12 @@
         <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="463"/>
         <element name="CourseSection" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="CourseSettings" positionX="-540" positionY="-18" width="128" height="88"/>
-        <element name="DashboardCard" positionX="-540" positionY="-18" width="128" height="253"/>
+        <element name="DashboardCard" positionX="-540" positionY="-18" width="128" height="254"/>
         <element name="DiscussionEntry" positionX="-513.66796875" positionY="535.73828125" width="128" height="313"/>
         <element name="DiscussionParticipant" positionX="-540" positionY="-18" width="128" height="133"/>
         <element name="DiscussionTopic" positionX="-540" positionY="-27" width="128" height="613"/>
         <element name="Enrollment" positionX="-578.41796875" positionY="2.78125" width="128" height="404"/>
+        <element name="Entity" positionX="-549" positionY="-18" width="128" height="29"/>
         <element name="ExternalTool" positionX="-540" positionY="-27" width="128" height="90"/>
         <element name="ExternalToolLaunchPlacement" positionX="-513" positionY="0" width="128" height="120"/>
         <element name="FeatureFlag" positionX="-540" positionY="-27" width="128" height="90"/>
@@ -1013,6 +1015,5 @@
         <element name="User" positionX="-540" positionY="-27" width="128" height="209"/>
         <element name="UserProfile" positionX="-540" positionY="-18" width="128" height="28"/>
         <element name="UserSettings" positionX="-540" positionY="-27" width="128" height="90"/>
-        <element name="Entity" positionX="-549" positionY="-18" width="128" height="29"/>
     </elements>
 </model>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -231,6 +231,7 @@
         <attribute name="syllabusBody" optional="YES" attributeType="String"/>
         <attribute name="termName" optional="YES" attributeType="String"/>
         <relationship name="contextColor" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContextColor" inverseName="course" inverseEntity="ContextColor"/>
+        <relationship name="dashboardCards" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="DashboardCard" inverseName="course" inverseEntity="DashboardCard"/>
         <relationship name="enrollments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Enrollment" inverseName="course" inverseEntity="Enrollment"/>
         <relationship name="gradingPeriods" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GradingPeriod" inverseName="course" inverseEntity="GradingPeriod"/>
         <relationship name="groups" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Group" inverseName="course" inverseEntity="Group"/>
@@ -269,7 +270,7 @@
         <attribute name="subtitle" attributeType="String"/>
         <attribute name="term" optional="YES" attributeType="String"/>
         <relationship name="contextColor" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ContextColor" inverseName="card" inverseEntity="ContextColor"/>
-        <relationship name="course" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course"/>
+        <relationship name="course" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Course" inverseName="dashboardCards" inverseEntity="Course"/>
     </entity>
     <entity name="DiscussionEntry" representedClassName="Core.DiscussionEntry" syncable="YES">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -959,7 +960,7 @@
         <element name="Conversation" positionX="-540" positionY="-18" width="128" height="238"/>
         <element name="ConversationMessage" positionX="-522" positionY="0" width="128" height="208"/>
         <element name="ConversationParticipant" positionX="-531" positionY="-9" width="128" height="133"/>
-        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="463"/>
+        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="464"/>
         <element name="CourseSection" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="CourseSettings" positionX="-540" positionY="-18" width="128" height="88"/>
         <element name="DashboardCard" positionX="-540" positionY="-18" width="128" height="254"/>
@@ -976,7 +977,7 @@
         <element name="FolderItem" positionX="-540" positionY="-18" width="128" height="118"/>
         <element name="Grade" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="GradingPeriod" positionX="-540" positionY="-27" width="128" height="148"/>
-        <element name="Group" positionX="-366.25" positionY="-174.85546875" width="128" height="223"/>
+        <element name="Group" positionX="-366.25" positionY="-174.85546875" width="128" height="224"/>
         <element name="HelpLink" positionX="-540" positionY="-27" width="128" height="135"/>
         <element name="K5HomeroomDueItemCount" positionX="-540" positionY="-18" width="128" height="73"/>
         <element name="K5HomeroomMissingSubmissionsCount" positionX="-531" positionY="-9" width="128" height="73"/>

--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -46,15 +46,8 @@ public final class Group: NSManagedObject, WriteableModel {
 
     public var color: UIColor { contextColor?.color ?? .ash }
 
-    public func getCourse() -> Course? {
-        if let id = courseID, course == nil, let fetchedCourse: Course = managedObjectContext?.first(where: #keyPath(Course.id), equals: id) {
-            course = fetchedCourse
-        }
-        return course
-    }
-
     public var isActive: Bool {
-        courseID == nil || getCourse()?.enrollments?.contains(where: {$0.state == .active}) == true
+        courseID == nil || course?.enrollments?.contains(where: {$0.state == .active}) == true
     }
 
     @discardableResult
@@ -78,6 +71,10 @@ public final class Group: NSManagedObject, WriteableModel {
         if let permissions = item.permissions {
             model.canCreateAnnouncement = permissions.create_announcement
             model.canCreateDiscussionTopic = permissions.create_discussion_topic
+        }
+
+        if let id = model.courseID, let course: Course = context.first(where: #keyPath(Course.id), equals: id) {
+            model.course = course
         }
 
         return model

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -180,4 +180,11 @@ class CourseTests: CoreTestCase {
         let course = Course.save(.make(), in: databaseClient)
         XCTAssertEqual(card.course, course)
     }
+
+    func testUpdatesRelatedGroupRelationship() {
+        let group = Group.save(.make(course_id: "course_1"), in: databaseClient)
+        XCTAssertNil(group.course)
+        let course = Course.save(.make(id: "course_1"), in: databaseClient)
+        XCTAssertEqual(group.course, course)
+    }
 }

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -173,4 +173,11 @@ class CourseTests: CoreTestCase {
         XCTAssertFalse(Course.make(from: .make(enrollments: [.make(type: "StudentEnrollment")])).hasTeacherEnrollment)
         XCTAssertTrue(Course.make(from: .make(enrollments: [.make(type: "StudentEnrollment"), .make(type: "TeacherEnrollment")])).hasTeacherEnrollment)
     }
+
+    func testUpdatesRelatedDashboardCardRelationship() {
+        let card = DashboardCard.save(.make(), position: 0, in: databaseClient)
+        XCTAssertNil(card.course)
+        let course = Course.save(.make(), in: databaseClient)
+        XCTAssertEqual(card.course, course)
+    }
 }

--- a/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
+++ b/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
@@ -55,4 +55,10 @@ class DashboardCardTests: CoreTestCase {
         XCTAssertTrue(teacherCard?.isTeacherEnrollment == true)
         XCTAssertTrue(taCard?.isTeacherEnrollment == true)
     }
+
+    func testUpdatesCourseRelationship() {
+        let course = Course.save(.make(), in: databaseClient)
+        let card = DashboardCard.save(.make(), position: 0, in: databaseClient)
+        XCTAssertEqual(card.course, course)
+    }
 }

--- a/Core/CoreTests/Groups/GroupTests.swift
+++ b/Core/CoreTests/Groups/GroupTests.swift
@@ -48,7 +48,13 @@ class GroupTests: CoreTestCase {
         XCTAssertTrue(group.isActive)
 
         Course.make()
-        group = Group.make(from: .make(course_id: "1"))
+        group = Group.save(.make(course_id: "1"), in: databaseClient)
         XCTAssertTrue(group.isActive)
+    }
+
+    func testCourseRelationship() {
+        let course = Course.save(.make(id: "course_1"), in: databaseClient)
+        let testee = Group.save(.make(course_id: "course_1"), in: databaseClient)
+        XCTAssertEqual(testee.course, course)
     }
 }


### PR DESCRIPTION
Change course property on DashboardCard from a dynamic lookup to a stored property to avoid managed object context access during SwiftUI rendering.

refs: MBL-15888
affects: Student, Teacher
release note: Fixed a crash on dashboard.

test plan: All dashboard functions should work without crashing.