### PR TITLE
Use the non-deprecated initializer on UIDocumentPickerViewController.

### DIFF
--- a/Core/Core/Files/FilePicker/FilePicker.swift
+++ b/Core/Core/Files/FilePicker/FilePicker.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import UIKit
+import UniformTypeIdentifiers
 
 public protocol FilePickerDelegate: ErrorViewController {
     func filePicker(didPick url: URL)
@@ -56,7 +57,14 @@ public class FilePicker: NSObject {
         }
 
         sheet.addAction(image: .paperclipLine, title: NSLocalizedString("Upload File", bundle: .core, comment: "")) { [weak self] in
-            let controller = UIDocumentPickerViewController(documentTypes: [UTI.any.rawValue], in: .import)
+            let controller: UIDocumentPickerViewController
+
+            if #available(iOS 14, *) {
+                controller = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
+            } else {
+                controller = UIDocumentPickerViewController(documentTypes: [UTI.any.rawValue], in: .import)
+            }
+
             controller.delegate = self
             self?.env.router.show(controller, from: from, options: .modal())
         }

--- a/Core/Core/Files/FilePicker/FilePickerViewController.swift
+++ b/Core/Core/Files/FilePicker/FilePickerViewController.swift
@@ -274,8 +274,16 @@ extension FilePickerViewController: UITabBarDelegate {
             libraryController.mediaTypes = mediaTypes
             env.router.show(libraryController, from: self, options: .modal())
         case .files:
-            let documentTypes = utis.map { $0.rawValue }
-            let documentPicker = UIDocumentPickerViewController(documentTypes: documentTypes, in: .import)
+            let documentPicker: UIDocumentPickerViewController
+
+            if #available(iOS 14, *) {
+                let documentTypes = utis.compactMap { $0.uttype }
+                documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: documentTypes, asCopy: true)
+            } else {
+                let documentTypes = utis.map { $0.rawValue }
+                documentPicker = UIDocumentPickerViewController(documentTypes: documentTypes, in: .import)
+            }
+
             documentPicker.delegate = self
             env.router.show(documentPicker, from: self, options: .modal())
         case .audio:

--- a/Core/Core/Files/UTI.swift
+++ b/Core/Core/Files/UTI.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import MobileCoreServices
+import UniformTypeIdentifiers
 
 public struct UTI: Equatable, Hashable {
     static let pagesBundleIdentifier = "com.apple.iwork.pages.pages"
@@ -52,6 +53,9 @@ public struct UTI: Equatable, Hashable {
 
         self.rawValue = value
     }
+
+    @available(iOSApplicationExtension 14.0, *)
+    public var uttype: UTType? { UTType(rawValue) }
 
     private init(rawValue: String) {
         self.rawValue = rawValue

--- a/Core/CoreTests/Files/UTITests.swift
+++ b/Core/CoreTests/Files/UTITests.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 @testable import Core
+import UniformTypeIdentifiers
 import XCTest
 
 class UTITests: XCTestCase {
@@ -80,5 +81,24 @@ class UTITests: XCTestCase {
         XCTAssert(result.contains(.keynoteSingleFile))
         XCTAssert(result.contains(.numbersBundle))
         XCTAssert(result.contains(.numbersSingleFile))
+    }
+
+    @available(iOS 14.0, *)
+    func testUTTypeConversion() {
+        XCTAssertEqual(UTI.any.uttype, UTType.item)
+        XCTAssertEqual(UTI.video.uttype, UTType.movie)
+        XCTAssertEqual(UTI.audio.uttype, UTType.audio)
+        XCTAssertEqual(UTI.image.uttype, UTType.image)
+        XCTAssertEqual(UTI.text.uttype, UTType.text)
+        XCTAssertEqual(UTI.url.uttype, UTType.url)
+        XCTAssertEqual(UTI.fileURL.uttype, UTType.fileURL)
+        XCTAssertEqual(UTI.folder.uttype, UTType.folder)
+
+        XCTAssertEqual(UTI.pagesBundle.uttype?.identifier, UTI.pagesBundleIdentifier)
+        XCTAssertEqual(UTI.pagesSingleFile.uttype?.identifier, UTI.pagesSingleFileIdentifier)
+        XCTAssertEqual(UTI.keynoteBundle.uttype?.identifier, UTI.keynoteBundleIdentifier)
+        XCTAssertEqual(UTI.keynoteSingleFile.uttype?.identifier, UTI.keynoteSingleFileIdentifier)
+        XCTAssertEqual(UTI.numbersBundle.uttype?.identifier, UTI.numbersBundleIdentifier)
+        XCTAssertEqual(UTI.numbersSingleFile.uttype?.identifier, UTI.numbersSingleFileIdentifier)
     }
 }


### PR DESCRIPTION
refs: MBL-15893
affects: Student, Teacher
release note: none

test plan:
- Sanity test if file picker works for file submissions and for submission comments.