### PR TITLE
Fix crash on the modules screen

### DIFF
--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -19,12 +19,6 @@
 import Foundation
 import SafariServices
 
-private var collapsedIDs: [String: [String]] = AppEnvironment.shared.userDefaults?.collapsedModules ?? [:] {
-    didSet {
-        AppEnvironment.shared.userDefaults?.collapsedModules = collapsedIDs
-    }
-}
-
 public class ModuleListViewController: UIViewController, ColoredNavViewProtocol, ErrorViewController {
     let refreshControl = CircleRefreshControl()
     @IBOutlet weak var emptyMessageLabel: UILabel!
@@ -55,6 +49,11 @@ public class ModuleListViewController: UIViewController, ColoredNavViewProtocol,
 
     var isPageDisabled: Bool {
         tabs.first { $0.id == "modules" } == nil && courses.first?.defaultView != .modules
+    }
+    private var collapsedIDs: [String: [String]] = AppEnvironment.shared.userDefaults?.collapsedModules ?? [:] {
+        didSet {
+            AppEnvironment.shared.userDefaults?.collapsedModules = collapsedIDs
+        }
     }
 
     public static func create(courseID: String, moduleID: String? = nil) -> ModuleListViewController {


### PR DESCRIPTION
Move global variable to instance one to prevent tableview state synchronization issues on modules screen.

refs: MBL-15898
affects: Student
release note: Fixed a crash on the modules screen.

test plan:
- Setup a course with multiple modules and the module page as the course home.
- On a split view capable device enter the course, modules list load on the detail view.
- Enter modules page as well on the course navigation panel.
- Collapse the first module on the left list.
- Collapse the second module on the right list.
- App shouldn't crash.