### PR TITLE
Add property wrapper to decode urls with unsafe characters.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -824,6 +824,8 @@
 		CF22C94F25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */; };
 		CF29DF91272BD9F10046C04D /* DynamicHeightTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */; };
 		CF326B352563D4D3005ABAAA /* HelpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF326B342563D4D3005ABAAA /* HelpView.swift */; };
+		CF43DE7927B5611400015B6F /* SafeURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF43DE7827B5611400015B6F /* SafeURL.swift */; };
+		CF43DE7B27B5667100015B6F /* SafeURLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF43DE7A27B5667100015B6F /* SafeURLTests.swift */; };
 		CF4A5A5127A96AE000948E14 /* DashboardCardsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4A5A5027A96AE000948E14 /* DashboardCardsViewModel.swift */; };
 		CF4BDB5C26453A3000A91952 /* K5DashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4BDB5B26453A3000A91952 /* K5DashboardView.swift */; };
 		CF4BDB6026453BD900A91952 /* K5DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */; };
@@ -2095,6 +2097,8 @@
 		CF22C94E25F60FDC00C2E012 /* UIAccessibilityAnnouncementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIAccessibilityAnnouncementTests.swift; sourceTree = "<group>"; };
 		CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicHeightTextEditor.swift; sourceTree = "<group>"; };
 		CF326B342563D4D3005ABAAA /* HelpView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpView.swift; sourceTree = "<group>"; };
+		CF43DE7827B5611400015B6F /* SafeURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeURL.swift; sourceTree = "<group>"; };
+		CF43DE7A27B5667100015B6F /* SafeURLTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafeURLTests.swift; sourceTree = "<group>"; };
 		CF4A5A5027A96AE000948E14 /* DashboardCardsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardsViewModel.swift; sourceTree = "<group>"; };
 		CF4BDB5B26453A3000A91952 /* K5DashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5DashboardView.swift; sourceTree = "<group>"; };
 		CF4BDB5F26453BD900A91952 /* K5DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5DashboardViewModel.swift; sourceTree = "<group>"; };
@@ -3532,6 +3536,7 @@
 				B11AAC3A237A1EB4002BC41F /* APIURLTests.swift */,
 				3B3467D52135B99700F9BC2E /* IDTests.swift */,
 				CF7C3698267A3E3400ACAC79 /* TypeSafeCodableTests.swift */,
+				CF43DE7A27B5667100015B6F /* SafeURLTests.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -3601,6 +3606,7 @@
 				B11AAC3C237A2428002BC41F /* APIURL.swift */,
 				3B3467D32135B7B700F9BC2E /* ID.swift */,
 				CF7C3695267A3CEE00ACAC79 /* TypeSafeCodable.swift */,
+				CF43DE7827B5611400015B6F /* SafeURL.swift */,
 			);
 			path = API;
 			sourceTree = "<group>";
@@ -5770,6 +5776,7 @@
 				7D8B78F8215EC74A005E08F1 /* UIImageExtensionsTests.swift in Sources */,
 				7D016B5F23E8984B00C6E0CA /* BottomSheetPickerViewControllerTests.swift in Sources */,
 				7D148645230B491C003944A2 /* APIAccountNotificationTests.swift in Sources */,
+				CF43DE7B27B5667100015B6F /* SafeURLTests.swift in Sources */,
 				97F5520824062199005D80FC /* PlannerNoteDetailViewControllerTests.swift in Sources */,
 				B1AAFFFE226988440088BC20 /* UITableViewCellExtensionsTests.swift in Sources */,
 				B1F3780C22499037000B7CAA /* MockMDMManager.swift in Sources */,
@@ -6209,6 +6216,7 @@
 				7D1E85662567294A00D093C5 /* ScaleButtonStyle.swift in Sources */,
 				7DA260B923F72352005D2121 /* GetQuizSubmission.swift in Sources */,
 				7DA260F023F72391005D2121 /* FileUploadContext.swift in Sources */,
+				CF43DE7927B5611400015B6F /* SafeURL.swift in Sources */,
 				CFEC7F3B26B409D1008B9F77 /* K5ScheduleWeekView.swift in Sources */,
 				7D2E812925631BEC008C568F /* AssignmentDateSection.swift in Sources */,
 				EB66DB9526451CAE002D3325 /* CustomTextField.swift in Sources */,

--- a/Core/Core/API/SafeURL.swift
+++ b/Core/Core/API/SafeURL.swift
@@ -1,0 +1,63 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+/**
+ The purpose of this property wrapper is to allow decoding of URLs from Strings with non url safe characters.
+ The non-safe characters are percent encoded before decoding.
+ */
+@propertyWrapper
+public struct SafeURL: Equatable {
+    public var wrappedValue: URL?
+
+    public init(wrappedValue: URL?) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension SafeURL: Encodable {
+
+    public func encode(to encoder: Encoder) throws {
+        try wrappedValue.encode(to: encoder)
+    }
+}
+
+extension SafeURL: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let stringValue = try container.decode(String.self)
+
+        guard let safeURLString = stringValue.addingPercentEncoding(withAllowedCharacters: .urlSafe) else {
+            wrappedValue = nil
+            return
+        }
+
+        wrappedValue = URL(string: safeURLString)
+    }
+}
+
+extension KeyedDecodingContainer {
+
+    /**
+     This is required because the default decode implementation for property wrappers throws an error in case the JSON key is missing for an optional wrapped value.
+     We override the default implementation and handle the missing key manually.
+     */
+    func decode(_ type: SafeURL.Type, forKey key: Self.Key) throws -> SafeURL {
+        try decodeIfPresent(type, forKey: key) ?? SafeURL(wrappedValue: nil)
+    }
+}

--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -49,7 +49,7 @@ public struct APISubmission: Codable, Equatable {
     let submission_type: SubmissionType?
     let submitted_at: Date?
     let turnitin_data: APITurnItInData?
-    let url: URL?
+    @SafeURL private(set) var url: URL?
     var user: APIUser? // include[]=user
     let user_id: ID
     let workflow_state: SubmissionWorkflowState

--- a/Core/CoreTests/API/SafeURLTests.swift
+++ b/Core/CoreTests/API/SafeURLTests.swift
@@ -1,0 +1,116 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+class SafeURLTests: XCTestCase {
+    private struct MockEnity: Codable, Equatable {
+        @SafeURL public private(set) var url: URL?
+    }
+
+    // MARK: - Decoding
+
+    func testDecodesMissingKey() {
+        let decoded = decode("{}")
+        XCTAssertNotNil(decoded)
+        XCTAssertNil(decoded?.url)
+    }
+
+    func testDecodesMissingValue() {
+        let decoded = decode("""
+        {
+            "url": null
+        }
+        """)
+        XCTAssertNotNil(decoded)
+        XCTAssertNil(decoded?.url)
+    }
+
+    func testDecodesValidURL() {
+        let decoded = decode("""
+        {
+            "url": "https://instructure.com/courses/courseID?param=5"
+        }
+        """)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.url, URL(string: "https://instructure.com/courses/courseID?param=5")!)
+    }
+
+    func testDecodesInvalidURL() {
+        let decoded = decode("""
+        {
+            "url": "https://instructure.com/courses/courseID?param={}"
+        }
+        """)
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.url, URL(string: "https://instructure.com/courses/courseID?param=%7B%7D")!)
+    }
+
+    // MARK: - Encode
+
+    func testEncodesMissingURL() {
+        let mockEntity = MockEnity(url: nil)
+        let json = encode(mockEntity)
+        XCTAssertEqual(json, """
+        {
+          \"url\" : null
+        }
+        """)
+    }
+
+    func testEncodesValidURL() {
+        let mockEntity = MockEnity(url: URL(string: "https://instructure.com/courses/courseID?param=%7B%7D")!)
+        let json = encode(mockEntity)
+        XCTAssertEqual(json, """
+        {
+          \"url\" : \"https://instructure.com/courses/courseID?param=%7B%7D\"
+        }
+        """)
+    }
+
+    // MARK: - Helper Methods
+
+    private func decode(_ json: String) -> MockEnity? {
+        let jsonData = json.data(using: .utf8)!
+        var decoded: MockEnity?
+
+        do {
+            decoded = try JSONDecoder().decode(MockEnity.self, from: jsonData)
+        } catch(let error) {
+            XCTFail("Decoding failed: \(error)")
+        }
+
+        return decoded
+    }
+
+    private func encode(_ entity: MockEnity) -> String? {
+        var json: String?
+
+        do {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.withoutEscapingSlashes, .prettyPrinted]
+            let data = try encoder.encode(entity)
+            json = String(data: data, encoding: .utf8)
+        } catch(let error) {
+            XCTFail("Encoding failed: \(error)")
+        }
+
+        return json
+    }
+}


### PR DESCRIPTION
refs: MBL-15855
affects: Student, Teacher
release note: Fixed grades and assignments pages not loading in some cases.

test plan: See ticket. Test account in comments.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153458693-a3b7a566-6b75-473f-951e-213a20a56027.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153458712-53848104-41bb-48fc-8779-fb540a6fa077.PNG"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153458787-e94dd4cb-a629-405c-bbfb-239e179e5edd.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153458830-7d3d20cc-0627-48f9-b6c7-5b390fc5cf86.PNG"></td>
</tr>
</table>
