### PR TITLE
Fix letter grade display

### DIFF
--- a/Core/Core/Grades/GradeListViewController.swift
+++ b/Core/Core/Grades/GradeListViewController.swift
@@ -170,10 +170,10 @@ public class GradeListViewController: UIViewController, ColoredNavViewProtocol {
             var finalGrade: String?
             if gradingPeriodID != nil, gradeEnrollment?.currentScore(gradingPeriodID: gradingPeriodID) != nil {
                 totalGradeLabel.text = gradeEnrollment?.formattedCurrentScore(gradingPeriodID: gradingPeriodID)
-                finalGrade = gradeEnrollment?.computedFinalGrade
+                finalGrade = gradeEnrollment?.computedCurrentGrade
             } else {
                 totalGradeLabel.text = courseEnrollment?.formattedCurrentScore(gradingPeriodID: gradingPeriodID)
-                finalGrade = courseEnrollment?.computedFinalGrade
+                finalGrade = courseEnrollment?.computedCurrentGrade
             }
             if let gradeText = totalGradeLabel.text, let finalGrade = finalGrade {
                 totalGradeLabel.text = gradeText + " (\(finalGrade))"

--- a/Core/Core/Grades/GradeListViewController.swift
+++ b/Core/Core/Grades/GradeListViewController.swift
@@ -167,16 +167,16 @@ public class GradeListViewController: UIViewController, ColoredNavViewProtocol {
         if courses.first?.hideFinalGrades == true {
             totalGradeLabel.text = NSLocalizedString("N/A", bundle: .core, comment: "")
         } else {
-            var finalGrade: String?
+            var letterGrade: String?
             if gradingPeriodID != nil, gradeEnrollment?.currentScore(gradingPeriodID: gradingPeriodID) != nil {
                 totalGradeLabel.text = gradeEnrollment?.formattedCurrentScore(gradingPeriodID: gradingPeriodID)
-                finalGrade = gradeEnrollment?.computedCurrentGrade
+                letterGrade = gradeEnrollment?.computedCurrentGrade
             } else {
                 totalGradeLabel.text = courseEnrollment?.formattedCurrentScore(gradingPeriodID: gradingPeriodID)
-                finalGrade = courseEnrollment?.computedCurrentGrade
+                letterGrade = courseEnrollment?.computedCurrentGrade
             }
-            if let gradeText = totalGradeLabel.text, let finalGrade = finalGrade {
-                totalGradeLabel.text = gradeText + " (\(finalGrade))"
+            if let scoreText = totalGradeLabel.text, let finalGrade = letterGrade {
+                totalGradeLabel.text = scoreText + " (\(finalGrade))"
             }
         }
 

--- a/Core/CoreTests/Grades/GradeListViewControllerTests.swift
+++ b/Core/CoreTests/Grades/GradeListViewControllerTests.swift
@@ -210,7 +210,7 @@ class GradeListViewControllerTests: CoreTestCase {
         XCTAssertEqual(controller.totalGradeLabel.text, "N/A")
     }
 
-    func testShowFinalGradeLetter() {
+    func testShowGradeLetter() {
         api.mock(controller.courses, value: .make(enrollments: [ .make(
             id: nil,
             course_id: "1",
@@ -230,7 +230,7 @@ class GradeListViewControllerTests: CoreTestCase {
             enrollment_state: .active,
             type: "StudentEnrollment",
             user_id: self.currentSession.userID,
-            computed_final_grade: "C",
+            computed_current_grade: "C",
             current_period_computed_current_score: 42
         ), ])
         controller.view.layoutIfNeeded()


### PR DESCRIPTION
refs: MBL-15854
affects: Student
release note: Fixed grades page showing letter grade for the total score instead of the current one.

test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153601792-f255372b-9ec3-4113-ba12-b23defb234dc.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153601801-8914c900-9294-4047-bd9f-5669788bb289.png"></td>
</tr>
</table>