### PR TITLE
Fix announcement text alignment.

### DIFF
--- a/Core/Core/Dashboard/View/NotificationCard.swift
+++ b/Core/Core/Dashboard/View/NotificationCard.swift
@@ -40,7 +40,7 @@ struct NotificationCard: View {
                     VStack(alignment: .leading, spacing: 0) {
                         HStack { Spacer() }
                         Text(notification.subject)
-                            .font(.semibold16).foregroundColor(.textDarkest)
+                            .font(.semibold16).foregroundColor(.textDarkest).multilineTextAlignment(.leading)
                         if !isExpanded {
                             Text("Tap to view announcement", bundle: .core)
                                 .font(.regular14).foregroundColor(.textDark)


### PR DESCRIPTION
refs: MBL-15854
affects: Student
release note: none

test plan:
- Create an account announcement with a long title.
- Go to dashboard, check the invitation box's text alignment.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153604836-f72be6d3-b33a-4874-838e-5555b8792c52.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153604851-0d65cc68-2618-47d1-b311-97988253eaad.png"></td>
</tr>
</table>