### PR TITLE
Filter out invited courses from calendar filter

### DIFF
--- a/Core/Core/Planner/GetPlannerCourses.swift
+++ b/Core/Core/Planner/GetPlannerCourses.swift
@@ -30,13 +30,18 @@ class GetPlannerCourses: APIUseCase {
     }
 
     var scope: Scope {
-        .where(
-            #keyPath(Course.planner.studentID),
-            equals: studentID,
-            orderBy: #keyPath(Course.name),
-            ascending: true,
-            naturally: true
-        )
+        let studentIdPredicate: NSPredicate
+
+        if let studentID = studentID {
+            studentIdPredicate = NSPredicate(format: "%K == %@", #keyPath(Course.planner.studentID), studentID)
+        } else {
+            studentIdPredicate = NSPredicate(format: "%K == NIL", #keyPath(Course.planner.studentID))
+        }
+        let enrollmentPredicate = NSPredicate(format: "ANY %K == %@", #keyPath(Course.enrollments.stateRaw), EnrollmentState.active.rawValue)
+        return Scope(predicate: NSCompoundPredicate(andPredicateWithSubpredicates: [studentIdPredicate, enrollmentPredicate]),
+                     orderBy: #keyPath(Course.name),
+                     ascending: true,
+                     naturally: true)
     }
 
     init(studentID: String?) {


### PR DESCRIPTION
refs: MBL-15842
affects: Student
release note: none

test plan:
- Have a student invited to a course.
- Log in to the Student app as the student
- Tap on Calendar on the bottom tab bar.
- Tap on Calendars in the top right corner.
- The invited course shouldn’t show up.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153613241-6087bb7b-ef25-4da6-bd2d-b7a9ff24c418.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153613259-259cd5b2-4d56-443b-bf94-59ec7431a848.png"></td>
</tr>
</table>