### PR TITLE
Fix people page not showing missing submissions

### DIFF
--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
@@ -38,6 +38,7 @@ struct ContextCardSubmissionRow: View {
                     Text(assignment.name)
                         .font(.semibold16).foregroundColor(.textDarkest)
                         .lineLimit(2)
+                        .multilineTextAlignment(.leading)
                     Text(submission.status.text)
                         .font(.regular14).foregroundColor(Color(submission.status.color))
                     if submission.needsGrading {

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -171,7 +171,6 @@ public class GetSubmissionsForStudent: CollectionUseCase {
         scope = Scope(
             predicate: NSCompoundPredicate(andPredicateWithSubpredicates: [
                 NSPredicate(key: #keyPath(Submission.userID), equals: studentID),
-                NSPredicate(format: "%K != %@", #keyPath(Submission.workflowStateRaw), SubmissionWorkflowState.unsubmitted.rawValue),
                 NSPredicate(key: #keyPath(Submission.isLatest), equals: true),
             ]),
             order: [


### PR DESCRIPTION
affects: Student, Teacher
release note: Fixed people page not showing missing submissions.

test plan:
- Create an assignment with due date in the past.
- Login with a student assigned to that assignment.
- Check Grades → Assignment is shown as “Missing”.
- Check People page → No missing label.
- Do the same in the teacher app with a teacher account in the same course.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/153844929-d4bea451-2cb0-4664-9fbc-ea54f9df6a3f.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/153844942-31599778-c18e-4cce-9480-a9a376fad65d.png"></td>
</tr>
</table>