### PR TITLE
Fix table view section spacing.

### DIFF
--- a/Student/GradesWidget/GradesWidgetViewController.swift
+++ b/Student/GradesWidget/GradesWidgetViewController.swift
@@ -182,9 +182,10 @@ extension GradesWidgetViewController: UITableViewDataSource {
         view.backgroundColor = .clear
 
         let sectionFont = UIFont.scaledNamedFont(.bold20)
-        let title = UILabel(frame: CGRect(x: 16, y: 16, width: tableView.frame.size.width, height: sectionFont.lineHeight))
+        let title = UILabel(frame: CGRect(x: 16, y: 16, width: tableView.frame.size.width - 32, height: sectionFont.lineHeight))
         title.font = sectionFont
         title.textColor = UIColor.textDarkest
+        title.allowsDefaultTighteningForTruncation = true
         title.text = section == 0
             ? NSLocalizedString("Recently Graded Assignments", comment: "")
             : NSLocalizedString("Course Grades", comment: "")

--- a/Student/GradesWidget/GradesWidgetViewController.swift
+++ b/Student/GradesWidget/GradesWidgetViewController.swift
@@ -98,12 +98,8 @@ class GradesWidgetViewController: UIViewController {
     }
     var submissions: [Submission] { submissionList.first?.submissions ?? [] }
 
-    override func didReceiveMemoryWarning() {
-        super.didReceiveMemoryWarning()
-        print("Grades WIDGET MEMORY WARNING")
-    }
-
     override func viewDidLoad() {
+        UITableView.setupDefaultSectionHeaderTopPadding()
         view.backgroundColor = UIColor.clear
         extensionContext?.widgetLargestAvailableDisplayMode = .expanded
 


### PR DESCRIPTION
refs: MBL-15885
affects: Student
release note: none

test plan:
- Add the old grades widget to the home screen.
- Expand its layout with the arrow at the top right corner.
- Course grades should be visible.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/154084858-ce02287f-30bd-4900-bfff-579d934b2195.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/154084878-e25b5503-317f-414d-a3eb-7cc36a2e38aa.PNG"></td>
</tr>
</table>