### PR TITLE
Fix front page header cell height.

### DIFF
--- a/Core/Core/Pages/PageList/PageListViewController.swift
+++ b/Core/Core/Pages/PageList/PageListViewController.swift
@@ -202,7 +202,9 @@ extension PageListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.row == pages.count {
+        if indexPath.section == 0 && !frontPage.isEmpty {
+            return UITableView.automaticDimension
+        } else if indexPath.row == pages.count {
             // Loading cell height
             return 73
         } else {

--- a/Core/CoreTests/Pages/PageList/PageListViewControllerTests.swift
+++ b/Core/CoreTests/Pages/PageList/PageListViewControllerTests.swift
@@ -137,6 +137,15 @@ class PageListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell.titleLabel.text, "z next page")
     }
 
+    func testFrontPageCellHeightWithFrontPageButNoOtherPages() {
+        api.mock(controller.pages, value: [])
+
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+
+        XCTAssertEqual(controller.tableView(controller.tableView, heightForRowAt: IndexPath(row: 0, section: 0)), UITableView.automaticDimension)
+    }
+
     func apiPageToDictionary(page: APIPage) -> [String: Any] {
         let encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .iso8601


### PR DESCRIPTION
refs: MBL-15906
affects: Student, Teacher
release note: none

test plan:
- Remove all pages from a course
- Add a new Page that is Published and is Front Page
- Go to course > pages in both apps
- Check the front page header cell if “Front Page” text and the title of the page is visible

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/154287633-5e3d21d6-216e-4abb-bb17-3ae112e3d9d6.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/154287667-70939bb5-4712-4a5f-89cc-33532fd20d96.png"></td>
</tr>
</table>