### PR TITLE
Fixed undefined return statement causing Inbox to fail to load.

### DIFF
--- a/rn/Teacher/src/modules/inbox/Inbox.js
+++ b/rn/Teacher/src/modules/inbox/Inbox.js
@@ -206,7 +206,7 @@ export function mapStateToProps ({ inbox, entities }: AppState) {
       const course = entities.courses[id].course
 
       if (course == null || course.name == null) {
-        return
+        return acc
       }
 
       acc.push(course)


### PR DESCRIPTION
refs: MBL-15927
affects: Student
release note: Fixed inbox not loading in case there are locked courses.

test plan: See ticket.