### PR TITLE
Use generic network error message instead of non thread safe error property on Store.

### DIFF
--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -78,7 +78,7 @@ class DashboardCardsViewModel: ObservableObject {
         guard cards.requested, !cards.pending, !courseSectionStatus.isUpdatePending else { return }
 
         guard cards.state != .error else {
-            state = .error(cards.error?.localizedDescription ?? "")
+            state = .error(NSLocalizedString("Something went wrong", comment: ""))
             return
         }
 


### PR DESCRIPTION
refs: MBL-15931
affects: Student, Teacher
release note: Fixed an occasional crash on the dashboard in case of a network error.

test plan: See ticket.