### PR TITLE
Check if course is concluded when checking whether a course's group is active

### DIFF
--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -47,7 +47,12 @@ public final class Group: NSManagedObject, WriteableModel {
     public var color: UIColor { contextColor?.color ?? .ash }
 
     public var isActive: Bool {
-        courseID == nil || course?.enrollments?.contains(where: {$0.state == .active}) == true
+        if courseID == nil { return true }
+        guard let course = course, let enrollments = course.enrollments else {
+            return false
+        }
+
+        return enrollments.contains(where: {$0.state == .active}) && !course.isPastEnrollment
     }
 
     @discardableResult

--- a/Core/CoreTests/Groups/GroupTests.swift
+++ b/Core/CoreTests/Groups/GroupTests.swift
@@ -50,6 +50,10 @@ class GroupTests: CoreTestCase {
         Course.make()
         group = Group.save(.make(course_id: "1"), in: databaseClient)
         XCTAssertTrue(group.isActive)
+
+        Course.make(from: .make(end_at: Date.distantPast), in: databaseClient)
+        group = Group.save(.make(course_id: "1"), in: databaseClient)
+        XCTAssertFalse(group.isActive)
     }
 
     func testCourseRelationship() {


### PR DESCRIPTION
refs: MBL-15839
affects: Student
release note: Fixed groups for concluded courses showing up on dashboard.

test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/157059974-1283eac1-7c94-4d9c-82c7-565021a64448.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/157059991-64d93bb3-84d4-45ed-a2a3-22d5f9233337.png"></td>
</tr>
</table>