### PR TITLE
Global announcements cannot be expanded

### DIFF
--- a/Core/Core/Dashboard/View/NotificationCard.swift
+++ b/Core/Core/Dashboard/View/NotificationCard.swift
@@ -58,17 +58,17 @@ struct NotificationCard: View {
                     button
                         .identifier("AccountNotification.\(notification.id).toggleButton")
                 }
-                WebView(html: notification.message)
-                    .onLink { url in
-                        env.router.route(to: url, from: controller, options: .detail)
-                        return true
-                    }
-                    .frameToFit()
-                    .accessibility(hidden: !isExpanded)
-                    .frame(maxHeight: isExpanded ? nil : 0, alignment: .top)
-                    .clipped()
-                    .padding(.trailing, 1)
                 if isExpanded {
+                    WebView(html: notification.message)
+                        .onLink { url in
+                            env.router.route(to: url, from: controller, options: .detail)
+                            return true
+                        }
+                        .frameToFit()
+                        .accessibility(hidden: !isExpanded)
+                        .frame(maxHeight: isExpanded ? nil : 0, alignment: .top)
+                        .clipped()
+                        .padding(.trailing, 1)
                     HStack {
                         Spacer()
                         Button(action: {
@@ -78,8 +78,8 @@ struct NotificationCard: View {
                                 .font(.semibold16).foregroundColor(Color(Brand.shared.linkColor))
                                 .padding(.horizontal, 16).padding(.bottom, 12)
                         })
-                            .accessibility(label: Text("Dismiss \(notification.subject)", bundle: .core))
-                            .identifier("AccountNotification.\(notification.id).dismissButton")
+                        .accessibility(label: Text("Dismiss \(notification.subject)", bundle: .core))
+                        .identifier("AccountNotification.\(notification.id).dismissButton")
                     }
                 }
             }

--- a/Core/Core/SwiftUIViews/WebView.swift
+++ b/Core/Core/SwiftUIViews/WebView.swift
@@ -129,8 +129,10 @@ extension WebView {
 
         var body: some View {
             view
-                .onChangeSize { height = $0 }
-                .frame(height: height)
+                .onChangeSize { height in
+                    withAnimation { self.height = height }
+                }
+                .frame(height: height, alignment: .top)
         }
     }
 


### PR DESCRIPTION
refs: MBL-15944
affects: Student, Teacher
release note: Fixed global announcements cannot be expanded on the dashboard.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/160798997-971cf6d3-1ff8-44f7-8199-86febd040c1b.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/160799006-79d4e38e-bd68-4810-a7f8-a25ac392152f.png"></td>
</tr>
</table>

