### PR TITLE
Add edit courses button on empty dashboard

### DIFF
--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -33,7 +33,10 @@ public struct DashboardCardView: View {
 
     @State var showGrade = AppEnvironment.shared.userDefaults?.showGradesOnDashboard == true
 
+    private var activeGroups: [Group] { groups.all.filter { $0.isActive } }
+    private var isGroupSectionActive: Bool { !activeGroups.isEmpty && shouldShowGroupList }
     private let shouldShowGroupList: Bool
+    private let verticalSpacing: CGFloat = 16
 
     public init(shouldShowGroupList: Bool, showOnlyTeacherEnrollment: Bool) {
         self.cards = DashboardCardsViewModel(showOnlyTeacherEnrollment: showOnlyTeacherEnrollment)
@@ -54,7 +57,7 @@ public struct DashboardCardView: View {
                     }
                     list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                 }
-                .padding(.horizontal, 16)
+                .padding(.horizontal, verticalSpacing)
             }
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
@@ -93,17 +96,17 @@ public struct DashboardCardView: View {
     @ViewBuilder func list(_ size: CGSize) -> some View {
         ForEach(conferencesViewModel.conferences, id: \.entity.id) { conference in
             ConferenceCard(conference: conference.entity, contextName: conference.contextName)
-                .padding(.top, 16)
+                .padding(.top, verticalSpacing)
         }
 
         ForEach(invitationsViewModel.invitations, id: \.id) { (id, course, enrollment) in
             CourseInvitationCard(course: course, enrollment: enrollment, id: id)
-                .padding(.top, 16)
+                .padding(.top, verticalSpacing)
         }
 
         ForEach(notifications.all, id: \.id) { notification in
             NotificationCard(notification: notification)
-                .padding(.top, 16)
+                .padding(.top, verticalSpacing)
         }
 
         courseCards(size)
@@ -117,19 +120,7 @@ public struct DashboardCardView: View {
             ZStack { CircleProgress() }
                 .frame(minWidth: size.width, minHeight: size.height)
         case .data(let cards):
-            HStack(alignment: .lastTextBaseline) {
-                Text("Courses", bundle: .core)
-                    .font(.heavy24).foregroundColor(.textDarkest)
-                    .accessibility(identifier: "dashboard.courses.heading-lbl")
-                    .accessibility(addTraits: .isHeader)
-                Spacer()
-                Button(action: showAllCourses) {
-                    Text("Edit Dashboard", bundle: .core)
-                        .font(.semibold16).foregroundColor(Color(Brand.shared.linkColor))
-                }.identifier("Dashboard.editButton")
-            }
-            .frame(width: size.width) // If we rotate from single view to split view then this HStack won't fill its parent, this fixes it.
-            .padding(.top, 16).padding(.bottom, 8)
+            coursesHeader(width: size.width)
 
             let hideColorOverlay = settings.first?.hideDashcardColorOverlays == true
             let layoutInfo = layoutViewModel.layoutInfo(for: size.width)
@@ -143,24 +134,38 @@ public struct DashboardCardView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.bottom, 2)
         case .empty:
-            EmptyPanda(.Teacher,
-                title: Text("No Courses", bundle: .core),
-                message: Text("It looks like there aren’t any courses associated with this account. Visit the web to create a course today.", bundle: .core)
-            )
-                .frame(minWidth: size.width, minHeight: size.height)
+            coursesHeader(width: size.width)
+            InteractivePanda(scene: GradesPanda(), title: Text("No Courses", bundle: .core), subtitle: Text("It looks like you aren't enrolled in any courses.", bundle: .core))
+                .padding(.top, 50)
+                .padding(.bottom, 50 - verticalSpacing) // group header already has a top padding
         case .error(let message):
             ZStack {
                 Text(message)
                     .font(.regular16).foregroundColor(.textDanger)
                     .multilineTextAlignment(.center)
             }
-                .frame(minWidth: size.width, minHeight: size.height)
+            .frame(minWidth: size.width, minHeight: size.height)
         }
     }
 
+    private func coursesHeader(width: CGFloat) -> some View {
+        HStack(alignment: .lastTextBaseline) {
+            Text("Courses", bundle: .core)
+                .font(.heavy24).foregroundColor(.textDarkest)
+                .accessibility(identifier: "dashboard.courses.heading-lbl")
+                .accessibility(addTraits: .isHeader)
+            Spacer()
+            Button(action: showAllCourses) {
+                Text("Edit Dashboard", bundle: .core)
+                    .font(.semibold16).foregroundColor(Color(Brand.shared.linkColor))
+            }.identifier("Dashboard.editButton")
+        }
+        .frame(width: width) // If we rotate from single view to split view then this HStack won't fill its parent, this fixes it.
+        .padding(.top, verticalSpacing).padding(.bottom, verticalSpacing / 2)
+    }
+
     @ViewBuilder var groupCards: some View {
-        let filteredGroups = groups.all.filter { $0.isActive }
-        if !filteredGroups.isEmpty && shouldShowGroupList {
+        if isGroupSectionActive {
             Section(
                 header: HStack(alignment: .lastTextBaseline) {
                     Text("Groups", bundle: .core)
@@ -168,12 +173,13 @@ public struct DashboardCardView: View {
                         .accessibility(addTraits: .isHeader)
                     Spacer()
                 }
-                    .padding(.top, 16).padding(.bottom, 8)) {
+                .padding(.top, verticalSpacing).padding(.bottom, verticalSpacing / 2)) {
+                let filteredGroups = activeGroups
                 ForEach(filteredGroups, id: \.id) { group in
                     GroupCard(group: group, course: group.course)
                         // outside the GroupCard, because that isn't observing colors
                         .accentColor(Color(group.color.ensureContrast(against: .white)))
-                        .padding(.bottom, 16)
+                        .padding(.bottom, verticalSpacing)
                 }
             }
         }

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -54,34 +54,40 @@ public struct DashboardCardView: View {
                     }
                     list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                 }
-                    .padding(.horizontal, 16)
+                .padding(.horizontal, 16)
             }
         }
-            .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
+        .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
+        .navigationBarGlobal()
+        .navigationBarItems(leading: menuButton, trailing: layoutToggleButton)
+        .onAppear { refresh(force: false) }
+        .onReceive(NotificationCenter.default.publisher(for: .showGradesOnDashboardDidChange).receive(on: DispatchQueue.main)) { _ in
+            showGrade = env.userDefaults?.showGradesOnDashboard == true
+        }
+    }
 
-            .navigationBarGlobal()
-            .navigationBarItems(
-                leading: Button(action: {
-                    env.router.route(to: "/profile", from: controller, options: .modal())
-                }, label: {
-                    Image.hamburgerSolid
-                        .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
-                })
-                    .frame(width: 44, height: 44).padding(.leading, -6)
-                    .identifier("Dashboard.profileButton")
-                    .accessibility(label: Text("Profile Menu", bundle: .core)),
-                trailing: Button(action: layoutViewModel.toggle) {
-                    layoutViewModel.buttonImage
-                        .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
-                        .accessibility(label: Text(layoutViewModel.buttonA11yLabel))
-                }
-                    .frame(width: 44, height: 44).padding(.trailing, -6)
-            )
+    private var menuButton: some View {
+        Button(action: {
+            env.router.route(to: "/profile", from: controller, options: .modal())
+        }) {
+            Image.hamburgerSolid
+                .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
+        }
+        .frame(width: 44, height: 44).padding(.leading, -6)
+        .identifier("Dashboard.profileButton")
+        .accessibility(label: Text("Profile Menu", bundle: .core))
+    }
 
-            .onAppear { refresh(force: false) }
-            .onReceive(NotificationCenter.default.publisher(for: .showGradesOnDashboardDidChange).receive(on: DispatchQueue.main)) { _ in
-                showGrade = env.userDefaults?.showGradesOnDashboard == true
+    @ViewBuilder
+    private var layoutToggleButton: some View {
+        if cards.shouldShowLayoutToggleButton {
+            Button(action: layoutViewModel.toggle) {
+                layoutViewModel.buttonImage
+                    .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
+                    .accessibility(label: Text(layoutViewModel.buttonA11yLabel))
             }
+            .frame(width: 44, height: 44).padding(.trailing, -6)
+        }
     }
 
     @ViewBuilder func list(_ size: CGSize) -> some View {

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -135,7 +135,7 @@ public struct DashboardCardView: View {
             .padding(.bottom, 2)
         case .empty:
             coursesHeader(width: size.width)
-            InteractivePanda(scene: GradesPanda(), title: Text("No Courses", bundle: .core), subtitle: Text("It looks like you aren't enrolled in any courses.", bundle: .core))
+            InteractivePanda(scene: ConferencesPanda(), title: Text("No Courses", bundle: .core), subtitle: Text("It looks like you aren't enrolled in any courses.", bundle: .core))
                 .padding(.top, 50)
                 .padding(.bottom, 50 - verticalSpacing) // group header already has a top padding
         case .error(let message):

--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -28,6 +28,7 @@ class DashboardCardsViewModel: ObservableObject {
     }
 
     @Published public private(set) var state = ViewModelState<[DashboardCard]>.loading
+    @Published public private(set) var shouldShowLayoutToggleButton = false
     private let env = AppEnvironment.shared
     private lazy var cards: Store<GetDashboardCards> = env.subscribe(GetDashboardCards()) { [weak self] in
         self?.update()
@@ -84,6 +85,7 @@ class DashboardCardsViewModel: ObservableObject {
 
         let cards = filteredCards()
         state = cards.isEmpty ? .empty : .data(cards)
+        shouldShowLayoutToggleButton = !cards.isEmpty
     }
 
     private func filteredCards() -> [DashboardCard] {

--- a/Core/Core/SwiftUIViews/Pandas/InteractivePanda.swift
+++ b/Core/Core/SwiftUIViews/Pandas/InteractivePanda.swift
@@ -20,10 +20,10 @@ import SwiftUI
 
 public struct InteractivePanda: View {
     private let scene: PandaScene
-    private let title: String?
-    private let subtitle: String?
+    private let title: Text?
+    private let subtitle: Text?
 
-    public init(scene: PandaScene, title: String? = nil, subtitle: String? = nil) {
+    public init(scene: PandaScene, title: Text? = nil, subtitle: Text? = nil) {
         self.scene = scene
         self.title = title
         self.subtitle = subtitle
@@ -46,14 +46,14 @@ public struct InteractivePanda: View {
             .zIndex(1)
 
             if let title = title {
-                Text(title)
+                title
                     .font(.bold24)
                     .foregroundColor(.licorice)
                     .padding(.bottom, 8)
             }
 
             if let subtitle = subtitle {
-                Text(subtitle)
+                subtitle
                     .font(.regular16)
                     .foregroundColor(.licorice)
                     .multilineTextAlignment(.center)

--- a/Core/Core/SwiftUIViews/Pandas/PandaGallery.swift
+++ b/Core/Core/SwiftUIViews/Pandas/PandaGallery.swift
@@ -75,7 +75,7 @@ public struct PandaGallery: View {
             scene = PagesPanda()
         }
 
-        return InteractivePanda(scene: scene, title: "Title Text", subtitle: "Optional subtitle text here")
+        return InteractivePanda(scene: scene, title: Text(verbatim: "Title Text"), subtitle: Text(verbatim: "Optional subtitle text here"))
     }
 }
 

--- a/Core/CoreTests/Dashboard/ViewModel/DashboardCardsViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/DashboardCardsViewModelTests.swift
@@ -51,4 +51,31 @@ class DashboardCardsViewModelTests: CoreTestCase {
 
         subscription.cancel()
     }
+
+    func testLayoutSelectionFlagOnEmptyCourses() {
+        let testee = DashboardCardsViewModel(showOnlyTeacherEnrollment: false)
+        XCTAssertFalse(testee.shouldShowLayoutToggleButton)
+
+        testee.refresh()
+        drainMainQueue()
+
+        guard case .empty = testee.state else { XCTFail("View model should be empty"); return }
+
+        XCTAssertFalse(testee.shouldShowLayoutToggleButton)
+    }
+
+    func testLayoutSelectionFlagWhenCoursesAvailable() {
+        Course.make(from: .make(id: 1))
+        api.mock(GetDashboardCards(), value: [.make(id: 1, shortName: "card 1")])
+
+        let testee = DashboardCardsViewModel(showOnlyTeacherEnrollment: false)
+        XCTAssertFalse(testee.shouldShowLayoutToggleButton)
+
+        testee.refresh()
+        drainMainQueue()
+
+        guard case .data = testee.state else { XCTFail("No data in view model"); return }
+
+        XCTAssertTrue(testee.shouldShowLayoutToggleButton)
+    }
 }

--- a/Core/CoreTests/Dashboard/ViewModel/DashboardCardsViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/DashboardCardsViewModelTests.swift
@@ -23,8 +23,10 @@ import TestsFoundation
 class DashboardCardsViewModelTests: CoreTestCase {
 
     func testFetchesDashboardCards() {
-        Course.make(from: .make(id: 1))
-        Course.make(from: .make(id: 2))
+        api.mock(GetCourses(enrollmentState: nil), value: [
+            .make(id: 1),
+            .make(id: 2),
+        ])
         api.mock(GetDashboardCards(), value: [
             .make(id: 1, shortName: "card 1"),
             .make(id: 2, shortName: "card 2"),
@@ -65,7 +67,7 @@ class DashboardCardsViewModelTests: CoreTestCase {
     }
 
     func testLayoutSelectionFlagWhenCoursesAvailable() {
-        Course.make(from: .make(id: 1))
+        api.mock(GetCourses(enrollmentState: nil), value: [.make(id: 1)])
         api.mock(GetDashboardCards(), value: [.make(id: 1, shortName: "card 1")])
 
         let testee = DashboardCardsViewModel(showOnlyTeacherEnrollment: false)

--- a/Core/CoreTests/Dashboard/ViewModel/DashboardInvitationsViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/DashboardInvitationsViewModelTests.swift
@@ -23,7 +23,7 @@ import TestsFoundation
 class DashboardInvitationsViewModelTests: CoreTestCase {
 
     func testFetch() {
-        api.mock(GetCourses(enrollmentState: nil), value: [.make(id: "testCourseID", name: "testCourseName")])
+        Course.save(.make(id: "testCourseID", name: "testCourseName"), in: databaseClient)
         api.mock(GetCourseInvitations(), value: [.make(id: "testEnrollmentID", course_id: "testCourseID")])
 
         let testee = DashboardInvitationsViewModel()
@@ -43,6 +43,5 @@ class DashboardInvitationsViewModelTests: CoreTestCase {
         XCTAssertEqual(invitation.course.name, "testCourseName")
 
         updateSubscription.cancel()
-
     }
 }


### PR DESCRIPTION
refs: MBL-15962
affects: Student
release note: Fixed missing edit dashboard button in case there were no active courses on the dashboard.

test plan: 
- Edit dashboard button should be visible even if there are no courses.
- Layout selector button should be hidden in case there are no course cards.
- Interactive empty panda!
- User's groups should be visible even if there are no active courses.
- Empty panda shouldn't be visible for a second upon first login before course cards are displayed.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/161516409-c086f0ed-4ca1-499e-8890-939da9aca2a8.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/161516427-d192e73e-59af-4ee9-ab11-296e12f14814.png"></td>
</tr>
</table>