### PR TITLE
Remove script reference pointing to the old grades widget plist file.

### DIFF
--- a/scripts/build_automation/automateVersioning.sh
+++ b/scripts/build_automation/automateVersioning.sh
@@ -49,10 +49,6 @@ checkoutReleaseBranch() {
 }
 
 checkInReleaseBranchAndTag() {
-	#	Add the following to the scrip outside this file
-#	git add Canvas/Canvas/Info.plist
-#	git add Canvas/GradesWidget/Info.plist
-
 	git commit -m "Release $BITRISE_APP_TITLE $APP_RELEASE_VERSION"
 
 	TAG="$APP_NAME-$APP_RELEASE_VERSION"

--- a/scripts/build_automation/bitrise_workflows/common.yml
+++ b/scripts/build_automation/bitrise_workflows/common.yml
@@ -297,7 +297,7 @@ workflows:
             envman add --key BITRISE_SCHEME --value Student
             envman add --key RELEASE_BRANCH --value release/student
             envman add --key APP_NAME --value Student
-            envman add --key INFO_PLISTS --value "Student/Student/Info.plist Student/GradesWidget/Info.plist Student/SubmitAssignment/Info.plist Student/Widgets/Resources/Info.plist"
+            envman add --key INFO_PLISTS --value "Student/Student/Info.plist Student/SubmitAssignment/Info.plist Student/Widgets/Resources/Info.plist"
 
             envman add --key BITRISE_EXPORT_METHOD --value app-store
 

--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -15,7 +15,6 @@
     "\/SwiftUIViews\/",
     "\/ViewModifiers\/",
     "Student\/Canvas\/",
-    "Student\/GradesWidget\/",
     "UITestHelpers\/",
     "\/Teacher\/SpeedGrader\/",
     "SubmissionButtonPresenter.swift",


### PR DESCRIPTION
refs: MBL-15704
affects: Student
release note: none

test plan: Release script shouldn't try to update the non-existing plist file.