### PR TITLE
Fix a11y issues.

### DIFF
--- a/Core/Core/ActAsUser/ActAsUserWindow.swift
+++ b/Core/Core/ActAsUser/ActAsUserWindow.swift
@@ -137,10 +137,6 @@ class ActAsUserOverlay: UIView {
         } else {
             buttonContainer.frame = frame
         }
-        // Make the button go last in order, but still activate correctly
-        button.accessibilityActivationPoint = CGPoint(x: frame.midX, y: frame.midY)
-        frame.origin.y = UIScreen.main.bounds.maxY - frame.height
-        button.accessibilityFrame = frame
     }
 
     @objc func stopActing() {

--- a/Core/Core/SwiftUIViews/Pandas/InteractivePanda.swift
+++ b/Core/Core/SwiftUIViews/Pandas/InteractivePanda.swift
@@ -60,6 +60,7 @@ public struct InteractivePanda: View {
                     .padding(.horizontal, 16)
             }
         }
+        .accessibilityElement(children: .combine)
     }
 }
 


### PR DESCRIPTION
refs: MBL-16010
affects: Student, Teacher
release note: none

test plan:
- Check if empty panda is focusable via VoiceOver.
- Check VoiceOver focus rectangle on stop masquerade button.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/162755152-5931ddc7-765a-4e5c-b9c1-1bdeebbe2223.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/162755202-1984a7e6-0299-46ca-b943-ea0c8a635610.PNG"></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/162755291-3f554db4-6a6a-4910-ae8d-9d497228de5a.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/162755351-ac14b6c4-3563-4146-89b5-b41a44e2263d.PNG"></td>
</tr>
</table>