### PR TITLE
Course cards show grades as 0% when navigating from People page to Dashboard

### DIFF
--- a/Core/Core/Enrollments/Enrollment.swift
+++ b/Core/Core/Enrollments/Enrollment.swift
@@ -135,7 +135,7 @@ extension Enrollment {
 
         self.course = course
 
-        if let apiGrades = item.grades, let gradingPeriodID = gradingPeriodID {
+        if let apiGrades = item.grades, gradingPeriodID != nil || item.current_grading_period_id != nil {
             let grade = grades.first { $0.gradingPeriodID == gradingPeriodID } ?? client.insert()
             grade.currentGrade = apiGrades.current_grade
             grade.currentScore = apiGrades.current_score

--- a/Core/Core/Enrollments/Enrollment.swift
+++ b/Core/Core/Enrollments/Enrollment.swift
@@ -135,7 +135,7 @@ extension Enrollment {
 
         self.course = course
 
-        if let apiGrades = item.grades {
+        if let apiGrades = item.grades, let gradingPeriodID = gradingPeriodID {
             let grade = grades.first { $0.gradingPeriodID == gradingPeriodID } ?? client.insert()
             grade.currentGrade = apiGrades.current_grade
             grade.currentScore = apiGrades.current_score


### PR DESCRIPTION
refs: MBL-15961
affects: Student
release note: Fixed grade displaying 0% when navigation back from the People page.
test plan: see ticket

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/162984390-04aaab69-96bf-4b30-af12-444ff8e3e18a.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/162984393-521d19d7-f615-439e-9132-98be9ddaf62f.png"></td>
</tr>
</table>

