### PR TITLE
Select Current Grading Period Button on the Grades tab in K5 does not read if it's expanded/collapsed

### DIFF
--- a/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
+++ b/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
@@ -58,6 +58,7 @@ struct K5GradesView: View {
                     .background(Color.white)
                     .foregroundColor(.ash)
                     .padding(.top, 15)
+                    .accessibility(hidden: true)
                 HStack(spacing: 7) {
                     Button(action: {
                         withAnimation {
@@ -68,6 +69,9 @@ struct K5GradesView: View {
                             .font(.bold24)
                             .foregroundColor(.licorice)
                     })
+                    .accessibility(label: Text("Select grading period", bundle: .core))
+                    .accessibility(hint: Text(gradeSelectorOpen ? "Open": "Closed", bundle: .core) +
+                                   Text(", \(viewModel.currentGradingPeriod.title ?? "")"))
 
                     Image.arrowOpenDownLine
                         .resizable()
@@ -75,6 +79,7 @@ struct K5GradesView: View {
                         .foregroundColor(.licorice)
                         .rotationEffect(.degrees(gradeSelectorOpen ? -180 : 0))
                         .animation(.easeOut)
+                        .accessibility(hidden: true)
                     Spacer()
                 }
                 .padding(.bottom, 13)

--- a/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
+++ b/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
@@ -70,8 +70,8 @@ struct K5GradesView: View {
                             .font(.bold24)
                             .foregroundColor(.licorice)
                     })
-                    .accessibility(label: Text("Select grading period, ", bundle: .core) + selectorStateText)
-                    .accessibility(hint: Text(", \(viewModel.currentGradingPeriod.title ?? ""), ") + Text("Selected", bundle: .core))
+                    .accessibility(label: Text("Select grading period", bundle: .core) + Text(verbatim: ", ") + selectorStateText)
+                    .accessibility(hint: Text(verbatim: ", \(viewModel.currentGradingPeriod.title ?? "") ,") + Text("Selected", bundle: .core))
 
                     Image.arrowOpenDownLine
                         .resizable()

--- a/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
+++ b/Core/Core/Dashboard/K5/View/Grades/K5GradesView.swift
@@ -60,6 +60,7 @@ struct K5GradesView: View {
                     .padding(.top, 15)
                     .accessibility(hidden: true)
                 HStack(spacing: 7) {
+                    let selectorStateText = gradeSelectorOpen ? Text("Open", bundle: .core) : Text("Closed", bundle: .core)
                     Button(action: {
                         withAnimation {
                             gradeSelectorOpen.toggle()
@@ -69,9 +70,8 @@ struct K5GradesView: View {
                             .font(.bold24)
                             .foregroundColor(.licorice)
                     })
-                    .accessibility(label: Text("Select grading period", bundle: .core))
-                    .accessibility(hint: Text(gradeSelectorOpen ? "Open": "Closed", bundle: .core) +
-                                   Text(", \(viewModel.currentGradingPeriod.title ?? "")"))
+                    .accessibility(label: Text("Select grading period, ", bundle: .core) + selectorStateText)
+                    .accessibility(hint: Text(", \(viewModel.currentGradingPeriod.title ?? ""), ") + Text("Selected", bundle: .core))
 
                     Image.arrowOpenDownLine
                         .resizable()


### PR DESCRIPTION
refs: MBL-15971
affects: Student
release note: Fixed grading period selector accessibility announcement.
test plan: see ticket