### PR TITLE
Added DataSeeding support for discussions

### DIFF
--- a/Student/Student.xcodeproj/project.pbxproj
+++ b/Student/Student.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		B1DC259E23DF81CF0005809D /* SubmitAssignment.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = B1BB7A8222BAC820006CA068 /* SubmitAssignment.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		B1FF02D02404353E004B7B1C /* KeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1FF02CF2404353E004B7B1C /* KeychainTests.swift */; };
 		B5E212D31D88856B009D8C07 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = B5E212D51D88856B009D8C07 /* Localizable.strings */; };
+		C9299FE528102A62003A47C2 /* DSAnnouncementsE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FE428102A62003A47C2 /* DSAnnouncementsE2ETests.swift */; };
+		C9299FEC2817CCF2003A47C2 /* DSDiscussionsE2ETest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FEB2817CCF2003A47C2 /* DSDiscussionsE2ETest.swift */; };
 		C935D41E26DD1BDE00C940F7 /* NewQuizzesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D41D26DD1BDE00C940F7 /* NewQuizzesE2ETests.swift */; };
 		C935D43026E0EAE700C940F7 /* K5ScheduleE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D42F26E0EAE700C940F7 /* K5ScheduleE2ETests.swift */; };
 		C935D43D26E5F5AF00C940F7 /* K5GradesE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D43C26E5F5AF00C940F7 /* K5GradesE2ETests.swift */; };
@@ -730,6 +732,8 @@
 		B5F122D01D8C4E050045063A /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		B75B05C5859701C8F14179C5 /* Pods-defaults-CanvasTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-CanvasTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-CanvasTests/Pods-defaults-CanvasTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BEDDBB798D4D4EA95C1F9796 /* Pods-defaults-StudentUnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-defaults-StudentUnitTests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-defaults-StudentUnitTests/Pods-defaults-StudentUnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C9299FE428102A62003A47C2 /* DSAnnouncementsE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSAnnouncementsE2ETests.swift; sourceTree = "<group>"; };
+		C9299FEB2817CCF2003A47C2 /* DSDiscussionsE2ETest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSDiscussionsE2ETest.swift; sourceTree = "<group>"; };
 		C935D41D26DD1BDE00C940F7 /* NewQuizzesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewQuizzesE2ETests.swift; sourceTree = "<group>"; };
 		C935D42F26E0EAE700C940F7 /* K5ScheduleE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleE2ETests.swift; sourceTree = "<group>"; };
 		C935D43C26E5F5AF00C940F7 /* K5GradesE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesE2ETests.swift; sourceTree = "<group>"; };
@@ -1830,6 +1834,7 @@
 			children = (
 				E809364D24C21CB600D15E9A /* DiscussionListE2ETests.swift */,
 				E809364E24C21CB600D15E9A /* DiscussionDetailsE2ETests.swift */,
+				C9299FEB2817CCF2003A47C2 /* DSDiscussionsE2ETest.swift */,
 			);
 			path = Discussions;
 			sourceTree = "<group>";
@@ -1838,6 +1843,7 @@
 			isa = PBXGroup;
 			children = (
 				E809365024C21CB600D15E9A /* AnnouncementE2ETests.swift */,
+				C9299FE428102A62003A47C2 /* DSAnnouncementsE2ETests.swift */,
 			);
 			path = Announcements;
 			sourceTree = "<group>";
@@ -2931,6 +2937,8 @@
 				5859544C501D5668C211D44C /* ConferencesE2ETests.swift in Sources */,
 				C935D43026E0EAE700C940F7 /* K5ScheduleE2ETests.swift in Sources */,
 				E80936E824C24CDD00D15E9A /* InboxE2ETests.swift in Sources */,
+				C9299FEC2817CCF2003A47C2 /* DSDiscussionsE2ETest.swift in Sources */,
+				C9299FE528102A62003A47C2 /* DSAnnouncementsE2ETests.swift in Sources */,
 				E80936EB24C24CDD00D15E9A /* ProfileE2ETests.swift in Sources */,
 				E80936E324C24CDD00D15E9A /* CourseFileE2ETests.swift in Sources */,
 				E80936F024C2514600D15E9A /* DiscussionListE2ETests.swift in Sources */,

--- a/Student/StudentE2ETests/Announcements/DSAnnouncementsE2ETests.swift
+++ b/Student/StudentE2ETests/Announcements/DSAnnouncementsE2ETests.swift
@@ -1,0 +1,44 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import TestsFoundation
+
+class DSAnnouncementsE2ETests: E2ETestCase {
+    func testAnnouncementsE2E() {
+        let student = seeder.createUser()
+        let teacher = seeder.createUser()
+        let course = seeder.createCourse()
+        seeder.enrollTeacher(teacher, in: course)
+        seeder.enrollStudent(student, in: course)
+
+        let announcementTitle = "Announcement Title"
+        let announcementMessage = "This is an announcement"
+        seeder.createDiscussion(courseId: course.id, requestBody: .init(title: announcementTitle, message: announcementMessage, is_announcement: true, published: true))
+
+        logInDSUser(student)
+        Dashboard.courseCard(id: course.id).waitToExist()
+        Dashboard.courseCard(id: course.id).tap()
+        pullToRefresh()
+        CourseNavigation.announcements.waitToExist()
+        CourseNavigation.announcements.tap()
+        XCTAssert(AnnouncementList.cell(index: 0).label().contains(announcementTitle))
+        AnnouncementList.cell(index: 0).tap()
+        XCTAssertEqual(DiscussionDetails.title.label(), announcementTitle)
+        XCTAssertTrue(app.find(label: announcementMessage).exists())
+    }
+}

--- a/Student/StudentE2ETests/Discussions/DSDiscussionsE2ETest.swift
+++ b/Student/StudentE2ETests/Discussions/DSDiscussionsE2ETest.swift
@@ -1,0 +1,41 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import TestsFoundation
+
+class DSDiscussionsE2ETests: E2ETestCase {
+    func testDiscussionsE2E() {
+        let student = seeder.createUser()
+        let teacher = seeder.createUser()
+        let course = seeder.createCourse()
+        seeder.enrollTeacher(teacher, in: course)
+        seeder.enrollStudent(student, in: course)
+
+        let discussionTitle = "Discussion Title"
+        let discussionMessage = "This is a discussion"
+        let discussion = seeder.createDiscussion(courseId: course.id, requestBody: .init(title: discussionTitle, message: discussionMessage, is_announcement: false, published: true))
+
+        logInDSUser(student)
+        Dashboard.courseCard(id: course.id).waitToExist()
+        Dashboard.courseCard(id: course.id).tap()
+        pullToRefresh()
+        CourseNavigation.discussions.waitToExist()
+        CourseNavigation.discussions.tap()
+        DiscussionListCell.cell(id: discussion.id).waitToExist()
+    }
+}

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -79,6 +79,11 @@
 		C909F7CF27C37CE500CB89DE /* DSSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7CE27C37CE500CB89DE /* DSSubmission.swift */; };
 		C909F7D127C37DA200CB89DE /* CreateDSSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7D027C37DA200CB89DE /* CreateDSSubmissionRequest.swift */; };
 		C909F7D327C3831F00CB89DE /* DataSeeder+DSSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7D227C3831F00CB89DE /* DataSeeder+DSSubmission.swift */; };
+		C9299FDF281020BC003A47C2 /* DSDiscussionTopic.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FDE281020BC003A47C2 /* DSDiscussionTopic.swift */; };
+		C9299FE128102238003A47C2 /* CreateDSDiscussionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FE028102238003A47C2 /* CreateDSDiscussionRequest.swift */; };
+		C9299FE32810249D003A47C2 /* DataSeeder+Discussion.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FE22810249D003A47C2 /* DataSeeder+Discussion.swift */; };
+		C9299FE828166A51003A47C2 /* CreateDSTabsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FE728166A51003A47C2 /* CreateDSTabsRequest.swift */; };
+		C9299FEA2816B515003A47C2 /* DataSeeder+Tabs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9299FE92816B515003A47C2 /* DataSeeder+Tabs.swift */; };
 		C935D43726E0EB9700C940F7 /* K5Schedule.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D43626E0EB9700C940F7 /* K5Schedule.swift */; };
 		C935D43A26E5F59700C940F7 /* K5Grades.swift in Sources */ = {isa = PBXBuildFile; fileRef = C935D43926E5F59700C940F7 /* K5Grades.swift */; };
 		C95E966D27C3DB4E00DAAB4A /* SubmissionsListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C95E966C27C3DB4E00DAAB4A /* SubmissionsListPage.swift */; };
@@ -233,6 +238,11 @@
 		C909F7CE27C37CE500CB89DE /* DSSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSSubmission.swift; sourceTree = "<group>"; };
 		C909F7D027C37DA200CB89DE /* CreateDSSubmissionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDSSubmissionRequest.swift; sourceTree = "<group>"; };
 		C909F7D227C3831F00CB89DE /* DataSeeder+DSSubmission.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataSeeder+DSSubmission.swift"; sourceTree = "<group>"; };
+		C9299FDE281020BC003A47C2 /* DSDiscussionTopic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSDiscussionTopic.swift; sourceTree = "<group>"; };
+		C9299FE028102238003A47C2 /* CreateDSDiscussionRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDSDiscussionRequest.swift; sourceTree = "<group>"; };
+		C9299FE22810249D003A47C2 /* DataSeeder+Discussion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataSeeder+Discussion.swift"; sourceTree = "<group>"; };
+		C9299FE728166A51003A47C2 /* CreateDSTabsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDSTabsRequest.swift; sourceTree = "<group>"; };
+		C9299FE92816B515003A47C2 /* DataSeeder+Tabs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataSeeder+Tabs.swift"; sourceTree = "<group>"; };
 		C935D43626E0EB9700C940F7 /* K5Schedule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5Schedule.swift; sourceTree = "<group>"; };
 		C935D43926E5F59700C940F7 /* K5Grades.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5Grades.swift; sourceTree = "<group>"; };
 		C95E966C27C3DB4E00DAAB4A /* SubmissionsListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionsListPage.swift; sourceTree = "<group>"; };
@@ -573,6 +583,25 @@
 			path = Submissions;
 			sourceTree = "<group>";
 		};
+		C9299FDD281020A9003A47C2 /* Discussions */ = {
+			isa = PBXGroup;
+			children = (
+				C9299FDE281020BC003A47C2 /* DSDiscussionTopic.swift */,
+				C9299FE028102238003A47C2 /* CreateDSDiscussionRequest.swift */,
+				C9299FE22810249D003A47C2 /* DataSeeder+Discussion.swift */,
+			);
+			path = Discussions;
+			sourceTree = "<group>";
+		};
+		C9299FE628166A2F003A47C2 /* Tabs */ = {
+			isa = PBXGroup;
+			children = (
+				C9299FE728166A51003A47C2 /* CreateDSTabsRequest.swift */,
+				C9299FE92816B515003A47C2 /* DataSeeder+Tabs.swift */,
+			);
+			path = Tabs;
+			sourceTree = "<group>";
+		};
 		C95E967227C630CD00DAAB4A /* EmptyPanda */ = {
 			isa = PBXGroup;
 			children = (
@@ -621,6 +650,7 @@
 		CFA078B327981B790078B27B /* DataSeeding */ = {
 			isa = PBXGroup;
 			children = (
+				C9299FDD281020A9003A47C2 /* Discussions */,
 				C909F7CD27C37C2A00CB89DE /* Submissions */,
 				C909F7C627BA7E8600CB89DE /* Pages */,
 				C9A23D1A27A294C900A1EE3B /* Assignment */,
@@ -645,6 +675,7 @@
 		CFA078BD2799A7740078B27B /* Course */ = {
 			isa = PBXGroup;
 			children = (
+				C9299FE628166A2F003A47C2 /* Tabs */,
 				CFA078C02799A8280078B27B /* CreateDSCourseRequest.swift */,
 				CFA078BE2799A7800078B27B /* DSCourse.swift */,
 				CFA078C22799A9310078B27B /* DataSeeder+DSCourse.swift */,
@@ -1071,6 +1102,7 @@
 				3B519EFF2332D74D00C8DEB8 /* GradingPeriodFixture.swift in Sources */,
 				7D903C0A22BC1329009D9E9E /* LoginStart.swift in Sources */,
 				E871978624E5963600D9B062 /* TestTreeExtensions.swift in Sources */,
+				C9299FE828166A51003A47C2 /* CreateDSTabsRequest.swift in Sources */,
 				3B6043AA232AB93900757B93 /* AssignmentGroupsFixture.swift in Sources */,
 				C9A23D1C27A2950D00A1EE3B /* DSAssignment.swift in Sources */,
 				E81B575B23E243CA002A0C38 /* ConversationList.swift in Sources */,
@@ -1089,6 +1121,7 @@
 				7DBED034233409D900392F3C /* TestLoginDelegate.swift in Sources */,
 				7DAC288022B1A3F900C0B692 /* XCUIElementExtensions.swift in Sources */,
 				E8104C492406F5EC0077D207 /* MiniCanvasServer.swift in Sources */,
+				C9299FEA2816B515003A47C2 /* DataSeeder+Tabs.swift in Sources */,
 				E80936CD24C2480B00D15E9A /* ExternalURL.swift in Sources */,
 				E80936D024C2480B00D15E9A /* FileEditor.swift in Sources */,
 				C909F7CA27BA7F8D00CB89DE /* CreateDSPageRequest.swift in Sources */,
@@ -1118,6 +1151,7 @@
 				CFA078BC279868160078B27B /* DataSeeder+DSUser.swift in Sources */,
 				E8BE4F5C233E73E100DC399A /* XCUIElementQueryExtensions.swift in Sources */,
 				B15CA280221DFED00014FB02 /* ModuleFixture.swift in Sources */,
+				C9299FE32810249D003A47C2 /* DataSeeder+Discussion.swift in Sources */,
 				C95E966D27C3DB4E00DAAB4A /* SubmissionsListPage.swift in Sources */,
 				3B3FCA2F238027470011F11A /* ActivityFixture.swift in Sources */,
 				3B19D25D2265391F003A0565 /* RubricFixture.swift in Sources */,
@@ -1159,6 +1193,7 @@
 				C935D43726E0EB9700C940F7 /* K5Schedule.swift in Sources */,
 				E80936DF24C2480B00D15E9A /* SubmissionComments.swift in Sources */,
 				585951A0E753164D3759B783 /* MiniAssignment.swift in Sources */,
+				C9299FE128102238003A47C2 /* CreateDSDiscussionRequest.swift in Sources */,
 				E80936D224C2480B00D15E9A /* ItemPickerItem.swift in Sources */,
 				CFA078BF2799A7800078B27B /* DSCourse.swift in Sources */,
 				C909F7D327C3831F00CB89DE /* DataSeeder+DSSubmission.swift in Sources */,
@@ -1171,6 +1206,7 @@
 				E80936C924C2480B00D15E9A /* DiscussionEditor.swift in Sources */,
 				E80936C824C2480B00D15E9A /* DiscussionDetails.swift in Sources */,
 				58595E26C62900CF858B2B08 /* MiniCanvasUITestCase.swift in Sources */,
+				C9299FDF281020BC003A47C2 /* DSDiscussionTopic.swift in Sources */,
 				58595E42B4831A7E2BE0102B /* MiniQuiz.swift in Sources */,
 				58595A570E0930B6EE1E451A /* MiniSubmission.swift in Sources */,
 			);

--- a/TestsFoundation/TestsFoundation/DataSeeding/Course/Tabs/CreateDSTabsRequest.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/Course/Tabs/CreateDSTabsRequest.swift
@@ -1,0 +1,49 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+
+//https://canvas.instructure.com/doc/api/tabs.html#method.tabs.update
+public struct CreateDSTabsRequest: APIRequestable {
+    public typealias Response = APINoContent
+
+    public let method = APIMethod.put
+    public let path: String
+    public let body: Body?
+
+    public init(courseID: String, tabId: String, body: Body) {
+        self.path = "courses/\(courseID)/tabs/\(tabId)"
+        self.body = body
+    }
+}
+
+extension CreateDSTabsRequest {
+    public struct RequestedTabs: Encodable {
+        let tab_id: String
+        let body: String
+
+        public init(tabId: String, body: String) {
+            self.tab_id = tabId
+            self.body = body
+        }
+    }
+
+    public struct Body: Encodable {
+        let requestedTab: RequestedTabs
+    }
+}

--- a/TestsFoundation/TestsFoundation/DataSeeding/Course/Tabs/DataSeeder+Tabs.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/Course/Tabs/DataSeeder+Tabs.swift
@@ -1,0 +1,26 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+extension DataSeeder {
+
+    public func changeCourseTabs(courseId: String, tabId: String, tabsBody: CreateDSTabsRequest.RequestedTabs) {
+        let requestBody = CreateDSTabsRequest.Body(requestedTab: tabsBody)
+        let request = CreateDSTabsRequest(courseID: courseId, tabId: tabId, body: requestBody)
+        try! makeRequest(request)
+    }
+}

--- a/TestsFoundation/TestsFoundation/DataSeeding/Discussions/CreateDSDiscussionRequest.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/Discussions/CreateDSDiscussionRequest.swift
@@ -1,0 +1,49 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+
+//https://canvas.instructure.com/doc/api/discussion_topics.html#method.discussion_topics.create
+public struct CreateDSDiscussionRequest: APIRequestable {
+    public typealias Response = DSDiscussionTopic
+
+    public let method = APIMethod.post
+    public let path: String
+    public let body: RequestDSDiscussion?
+
+    public init(courseID: String, body: RequestDSDiscussion) {
+        self.path = "courses/\(courseID)/discussion_topics"
+        self.body = body
+    }
+}
+
+extension CreateDSDiscussionRequest {
+    public struct RequestDSDiscussion: Encodable {
+        let title: String
+        let message: String
+        let is_announcement: Bool
+        let published: Bool
+
+        public init(title: String, message: String, is_announcement: Bool = false, published: Bool = true) {
+            self.title = title
+            self.message = message
+            self.is_announcement = is_announcement
+            self.published = published
+        }
+    }
+}

--- a/TestsFoundation/TestsFoundation/DataSeeding/Discussions/DSDiscussionTopic.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/Discussions/DSDiscussionTopic.swift
@@ -1,0 +1,24 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public struct DSDiscussionTopic: Codable {
+    public let id: String
+    public let title: String
+    public let message: String
+    public let published: Bool
+}

--- a/TestsFoundation/TestsFoundation/DataSeeding/Discussions/DataSeeder+Discussion.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/Discussions/DataSeeder+Discussion.swift
@@ -1,0 +1,26 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+extension DataSeeder {
+
+    @discardableResult
+    public func createDiscussion(courseId: String, requestBody: CreateDSDiscussionRequest.RequestDSDiscussion) -> DSDiscussionTopic {
+        let request = CreateDSDiscussionRequest(courseID: courseId, body: requestBody)
+        return try! makeRequest(request)
+    }
+}


### PR DESCRIPTION
refs: MBL-15981
affects: Teacher, Student
release note: none

test plan: Course tabs update was added aswell, but it is unused at the moment. Tests are basic to validate DS methods, will expand them once we are done with the hybrid integration, so no old tests were disabled