### PR TITLE
Add event name to the accessibility label of checkboxes in K5 Schedule

### DIFF
--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
@@ -153,7 +153,7 @@ public struct K5ScheduleEntryView: View {
                 background.overlay(icon)
             }
         })
-        .accessibility(label: Text("Mark item as done", bundle: .core))
+        .accessibility(label: Text(viewModel.title) + Text(",") + Text("Mark item as done", bundle: .core))
 
         if isChecked {
             button = button.accessibility(addTraits: .isSelected)

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleEntryView.swift
@@ -153,7 +153,7 @@ public struct K5ScheduleEntryView: View {
                 background.overlay(icon)
             }
         })
-        .accessibility(label: Text(viewModel.title) + Text(",") + Text("Mark item as done", bundle: .core))
+        .accessibility(label: Text(viewModel.title) + Text(verbatim: ",") + Text("Mark item as done", bundle: .core))
 
         if isChecked {
             button = button.accessibility(addTraits: .isSelected)


### PR DESCRIPTION
refs: MBL-15968
affects: Student
release note: none
test plan: see ticket