### PR TITLE
Transparent background is not retained when editing existing text annotations

### DIFF
--- a/Core/Core/DocViewer/PSPDFAnnotationExtension.swift
+++ b/Core/Core/DocViewer/PSPDFAnnotationExtension.swift
@@ -176,7 +176,7 @@ extension Annotation {
             deleted_by_id: deletedByID,
             type: type,
             color: color?.hexString,
-            bgColor: fillColor?.hexString,
+            bgColor: fillColor?.hexString ?? "transparent",
             icon: type == .text ? "Comment" : nil,
             contents: contents,
             inreplyto: inreplyto,

--- a/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
+++ b/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
@@ -42,7 +42,7 @@ class PSPDFAnnotationExtensionTests: XCTestCase {
         deleted_by: String? = "b",
         deleted_by_id: String? = "2",
         color: String? = "#ffff00",
-        bgColor: String? = nil,
+        bgColor: String? = "transparent",
         icon: String? = nil,
         contents: String? = nil,
         inreplyto: String? = nil,
@@ -104,12 +104,11 @@ class PSPDFAnnotationExtensionTests: XCTestCase {
         XCTAssertEqual(annotation?.fontSize, 38 * 0.85)
 
         let apiEmpty = model(type: .freetext, contents: nil, font: nil)
-        let empty = Annotation.from(apiEmpty, metadata: metadata)
-        XCTAssertEqual(empty?.contents, "")
-        XCTAssertEqual(empty?.fontName, "Helvetica")
-        XCTAssertEqual(empty?.fontSize, 14 * 0.85)
-        guard let fillColor = empty?.fillColor, let testColor = UIColor(hexString: "#ffffff") else { XCTFail(); return }
-        XCTAssertEqual(Double(fillColor.difference(to: testColor)), 0, accuracy: 0.000001)
+        guard let empty = Annotation.from(apiEmpty, metadata: metadata) else { return XCTFail() }
+        XCTAssertEqual(empty.contents, "")
+        XCTAssertEqual(empty.fontName, "Helvetica")
+        XCTAssertEqual(empty.fontSize, 14 * 0.85)
+        XCTAssertNil(empty.fillColor)
     }
 
     func testPoint() {


### PR DESCRIPTION
refs: MBL-16038
affects: Student, Teacher
release note: Fixed text annotation background color changing from transparent to white.
test plan: see ticket