### PR TITLE
Make url parsing in course navigation response more tolerant.

### DIFF
--- a/Core/Core/API/SafeURL.swift
+++ b/Core/Core/API/SafeURL.swift
@@ -19,6 +19,7 @@
 /**
  The purpose of this property wrapper is to allow decoding of URLs from Strings with non url safe characters.
  The non-safe characters are percent encoded before decoding.
+ This wrapper also threats empty string literal as nil instead of throwing an exception during parsing.
  */
 @propertyWrapper
 public struct SafeURL: Equatable {

--- a/Core/Core/Courses/GetCourseNavigationToolsRequest.swift
+++ b/Core/Core/Courses/GetCourseNavigationToolsRequest.swift
@@ -34,7 +34,7 @@ public struct CourseNavigationTool: Codable {
         let text: String?
         let url: URL?
         let label: String?
-        let icon_url: URL?
+        @SafeURL private(set) var icon_url: URL?
     }
 
     public let id: String?
@@ -42,5 +42,5 @@ public struct CourseNavigationTool: Codable {
     public let context_id: String?
     public let course_navigation: CourseNavigation?
     public let name: String?
-    public let url: URL?
+    @SafeURL public private(set) var url: URL?
 }

--- a/Core/CoreTests/API/SafeURLTests.swift
+++ b/Core/CoreTests/API/SafeURLTests.swift
@@ -42,6 +42,16 @@ class SafeURLTests: XCTestCase {
         XCTAssertNil(decoded?.url)
     }
 
+    func testDecodesEmptyStringValue() {
+        let decoded = decode("""
+        {
+            "url": ""
+        }
+        """)
+        XCTAssertNotNil(decoded)
+        XCTAssertNil(decoded?.url)
+    }
+
     func testDecodesValidURL() {
         let decoded = decode("""
         {


### PR DESCRIPTION
refs: MBL-16043
affects: Teacher
release note: Fixed attendance tool opening in a web view.

test plan: See ticket. Attendance tool should open natively.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/165733076-244f203c-d8c5-4160-9c0f-d0441be742c6.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/165733126-a601fc12-32d0-4625-bfb2-2d2faa3b2835.PNG"></td>
</tr>
</table>