### PR TITLE
Fixed only the last section of a course taken into account when deciding if it's active or not

### DIFF
--- a/Core/CoreTests/Dashboard/Model/CourseSectionStatusTests.swift
+++ b/Core/CoreTests/Dashboard/Model/CourseSectionStatusTests.swift
@@ -56,4 +56,54 @@ class CourseSectionStatusTests: CoreTestCase {
         XCTAssertTrue(testee.isSectionExpired(in: course))
         XCTAssertTrue(testee.isSectionExpired(for: dashboardCard, in: [course]))
     }
+
+    func testExpiredSectionAndActiveSectionWithoutEndDate() {
+        // Enrollments mock
+        let enrollments: [APIEnrollment] = [
+            .make(id: "1", course_id: "course_1", course_section_id: "activeSection"),
+            .make(id: "2", course_id: "course_1", course_section_id: "expiredSection"),
+        ]
+        let request = GetEnrollmentsRequest(context: .currentUser, types: [Role.student.rawValue], states: [.active])
+        api.mock(request, value: enrollments)
+
+        // Course mock
+        let activeSection = APICourse.SectionRef(end_at: nil, enrollment_role: "", id: "activeSection", name: "", start_at: nil)
+        let expiredSection = APICourse.SectionRef(end_at: .distantPast, enrollment_role: "", id: "expiredSection", name: "", start_at: nil)
+        let course = Course.make(from: .make(id: "course_1", sections: [activeSection, expiredSection]))
+
+        // DashboardCard mock
+        let dashboardCard = DashboardCard.save(.make(id: "course_1"), position: 0, in: databaseClient)
+
+        let testee = CourseSectionStatus()
+        testee.refresh { }
+        drainMainQueue()
+
+        XCTAssertFalse(testee.isSectionExpired(in: course))
+        XCTAssertFalse(testee.isSectionExpired(for: dashboardCard, in: [course]))
+    }
+
+    func testExpiredSectionAndActiveSectionWithNonPastEndDate() {
+        // Enrollments mock
+        let enrollments: [APIEnrollment] = [
+            .make(id: "1", course_id: "course_1", course_section_id: "activeSection"),
+            .make(id: "2", course_id: "course_1", course_section_id: "expiredSection"),
+        ]
+        let request = GetEnrollmentsRequest(context: .currentUser, types: [Role.student.rawValue], states: [.active])
+        api.mock(request, value: enrollments)
+
+        // Course mock
+        let activeSection = APICourse.SectionRef(end_at: Clock.now.addDays(1), enrollment_role: "", id: "activeSection", name: "", start_at: nil)
+        let expiredSection = APICourse.SectionRef(end_at: .distantPast, enrollment_role: "", id: "expiredSection", name: "", start_at: nil)
+        let course = Course.make(from: .make(id: "course_1", sections: [activeSection, expiredSection]))
+
+        // DashboardCard mock
+        let dashboardCard = DashboardCard.save(.make(id: "course_1"), position: 0, in: databaseClient)
+
+        let testee = CourseSectionStatus()
+        testee.refresh { }
+        drainMainQueue()
+
+        XCTAssertFalse(testee.isSectionExpired(in: course))
+        XCTAssertFalse(testee.isSectionExpired(for: dashboardCard, in: [course]))
+    }
 }


### PR DESCRIPTION
refs: MBL-16035
affects: Student
release note: Fixed courses with mixed active and expired sections listed as past enrollments.

test plan:
- Add a user to two sections in a course.
- Add a past end date to one section making in expired.
- Leave the other section intact to keep it active.
- Log in to the app, tap Edit Dashboard.
- The course should be listed in the Current Enrollments section.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/167637522-c22ea446-c64d-4578-bf15-d7e5dd7a456e.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/167637541-909a2de7-9d10-4acd-8b89-ca901d5eb675.PNG"></td>
</tr>
</table>