### PR TITLE
Fix concluded section enrollment courses listed as active.

### DIFF
--- a/Core/Core/Courses/CourseList/ViewModel/CourseListViewModel.swift
+++ b/Core/Core/Courses/CourseList/ViewModel/CourseListViewModel.swift
@@ -102,7 +102,7 @@ public class CourseListViewModel: ObservableObject {
             guard !course.accessRestrictedByDate, matches else { continue }
             if course.isFutureEnrollment {
                 future.append(course)
-            } else if course.isPastEnrollment || courseSectionStatus.isSectionExpired(in: course) {
+            } else if course.isPastEnrollment || courseSectionStatus.isAllSectionsExpired(in: course) || courseSectionStatus.isNoActiveEnrollments(in: course) {
                 past.append(course)
             } else {
                 current.append(course)

--- a/Core/Core/Dashboard/Model/CourseSectionStatus.swift
+++ b/Core/Core/Dashboard/Model/CourseSectionStatus.swift
@@ -18,26 +18,27 @@
 
 /**
  This class fetches the current user's enrollments and based on the extracted section info can return if the current user's
- section is expired or not in a given course. If the network request fails or the lookup fails because some data is missing
- this class will report that the section is active.
+ sections are expired or not in a given course.
  */
 class CourseSectionStatus {
     public var isUpdatePending: Bool { initialUpdatePending || enrollmentsRequest != nil }
 
     private var enrollmentsRequest: APITask?
-    /** This dictionary contains the user's section IDs within courses referenced by their IDs. */
+    /** This dictionary contains the user's section IDs which have an active enrollment, grouped by course IDs. */
     private var sectionIDsByCourseIDs: [String: [String]] = [:]
+    /** Contains course ids for which we've found an active enrollment. */
+    private var activeEnrollmentCourseIDs = Set<String>()
     private var initialUpdatePending = true
 
-    public func isSectionExpired(for card: DashboardCard, in courses: [Course]) -> Bool {
+    public func isAllSectionsExpired(for card: DashboardCard, in courses: [Course]) -> Bool {
         guard let course = courses.first(where: { $0.id == card.id }) else { return false }
-        return isSectionExpired(in: course)
+        return isAllSectionsExpired(in: course)
     }
 
     /**
      - returns: False if there's a section whose end date is nil or not nil but doesn't elapsed. True if all sections the user is assigned to in this course having a non-nil end date are expired.
      */
-    public func isSectionExpired(in course: Course) -> Bool {
+    public func isAllSectionsExpired(in course: Course) -> Bool {
         guard let sectionIds = sectionIDsByCourseIDs[course.id] else { return false }
 
         let sections = course.sections.filter({ sectionIds.contains($0.id) })
@@ -52,14 +53,22 @@ class CourseSectionStatus {
         return validsectionEndDates.allSatisfy { Clock.now > $0 }
     }
 
+    /**
+     - returns: True if there are no enrollments for the given course with `active`  `enrollment_state`.
+     */
+    public func isNoActiveEnrollments(in course: Course) -> Bool {
+        !activeEnrollmentCourseIDs.contains(course.id)
+    }
+
     public func refresh(completion: @escaping () -> Void) {
         guard enrollmentsRequest == nil else { return }
 
-        let request = GetEnrollmentsRequest(context: .currentUser, types: [Role.student.rawValue], states: [.active])
+        let request = GetEnrollmentsRequest(context: .currentUser, states: [.active])
         enrollmentsRequest = AppEnvironment.shared.api.makeRequest(request) { [weak self] enrollments, _, _ in
             DispatchQueue.main.async {
                 self?.enrollmentsRequest = nil
                 self?.extractSectionInfo(from: enrollments ?? [])
+                self?.saveActiveEnrollmentIDs(from: enrollments ?? [])
                 self?.initialUpdatePending = false
                 completion()
             }
@@ -76,5 +85,11 @@ class CourseSectionStatus {
             sectionIDs.append(sectionId)
             dictionary[courseId] = sectionIDs
         }
+    }
+
+    private func saveActiveEnrollmentIDs(from enrollments: [APIEnrollment]) {
+        activeEnrollmentCourseIDs.removeAll()
+        let enrollmentIDs = enrollments.compactMap { $0.course_id?.value }
+        activeEnrollmentCourseIDs.formUnion(enrollmentIDs)
     }
 }

--- a/Core/Core/Dashboard/Model/CourseSectionStatus.swift
+++ b/Core/Core/Dashboard/Model/CourseSectionStatus.swift
@@ -89,7 +89,7 @@ class CourseSectionStatus {
 
     private func saveActiveEnrollmentIDs(from enrollments: [APIEnrollment]) {
         activeEnrollmentCourseIDs.removeAll()
-        let enrollmentIDs = enrollments.compactMap { $0.course_id?.value }
-        activeEnrollmentCourseIDs.formUnion(enrollmentIDs)
+        let courseIDs = enrollments.compactMap { $0.course_id?.value }
+        activeEnrollmentCourseIDs.formUnion(courseIDs)
     }
 }

--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -86,7 +86,7 @@ class DashboardCardsViewModel: ObservableObject {
     }
 
     private func filteredCards() -> [DashboardCard] {
-        var filteredCards = cards.all.filter { $0.shouldShow && !courseSectionStatus.isSectionExpired(for: $0, in: courses.all) }
+        var filteredCards = cards.all.filter { $0.shouldShow && !courseSectionStatus.isAllSectionsExpired(for: $0, in: courses.all) }
 
         if showOnlyTeacherEnrollment {
             filteredCards = filteredCards.filter { $0.isTeacherEnrollment }

--- a/Core/CoreTests/Courses/CourseList/ViewModel/CourseListViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseList/ViewModel/CourseListViewModelTests.swift
@@ -69,9 +69,10 @@ class CourseListViewModelTests: CoreTestCase {
 
     private func setupMocks() {
         let currentCourses: [APICourse] = [
-            .make(id: "1", name: "Fall 2020", workflow_state: .available, term: .make(name: "Fall 2020"), is_favorite: true),
-            .make(id: "2", workflow_state: .available),
+            .make(id: "1", name: "Fall 2020", workflow_state: .available, enrollments: [.make(course_id: "1")], term: .make(name: "Fall 2020"), is_favorite: true),
+            .make(id: "2", workflow_state: .available, enrollments: [.make(course_id: "2")]),
         ]
+
         let pastCourse: APICourse = .make(
             id: "3",
             workflow_state: .completed,
@@ -86,7 +87,15 @@ class CourseListViewModelTests: CoreTestCase {
                 role: "TeacherEnrollment"
             ), ]
         )
-        let futureCourse: APICourse = .make(id: "4", workflow_state: .available, start_at: .distantFuture, end_at: .distantFuture)
+        let futureCourse: APICourse = .make(id: "4", workflow_state: .available, start_at: .distantFuture, end_at: .distantFuture, enrollments: [.make(course_id: "4")])
         api.mock(GetAllCourses(), value: [futureCourse, pastCourse] + currentCourses)
+
+        // Enrollments mock
+        let enrollments: [APIEnrollment] = [
+            currentCourses[0].enrollments![0],
+            currentCourses[1].enrollments![0],
+        ]
+        let request = GetEnrollmentsRequest(context: .currentUser, states: [.active])
+        api.mock(request, value: enrollments)
     }
 }


### PR DESCRIPTION
refs: MBL-16035
affects: Student, Teacher
release note: Fixed concluded section courses listed as active.

test plan:
- Enroll a student/teacher to a course's section.
- Go to the user's profile and conclude this section's enrollment.
- Go to the app and check the contents of the Edit Dashboard menu.
- All courses should list this course amongst past enrollments.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/167857830-cbef2214-076e-40c3-a204-ad9722512fd3.PNG"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/167857845-0c7dad83-b328-4f8e-b02b-db4be938c0ce.PNG"></td>
</tr>
</table>