### PR TITLE
Removed favorite button for past courses.

### DIFF
--- a/Core/Core/Courses/CourseList/View/CourseListCellView.swift
+++ b/Core/Core/Courses/CourseList/View/CourseListCellView.swift
@@ -20,6 +20,7 @@ import SwiftUI
 
 struct CourseListCell: View {
     @ObservedObject var course: Course
+    let isFavoriteButtonHidden: Bool
 
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
@@ -37,6 +38,7 @@ struct CourseListCell: View {
                 .buttonStyle(PlainButtonStyle())
                 .accessibility(label: pending ? Text("Updating", bundle: .core) : Text("favorite", bundle: .core))
                 .accessibility(addTraits: (course.isFavorite && !pending) ? .isSelected : [])
+                .hidden(isFavoriteButtonHidden)
 
             Button(action: {
                 env.router.route(to: "/courses/\(course.id)", from: controller)

--- a/Core/Core/Courses/CourseList/View/CourseListView.swift
+++ b/Core/Core/Courses/CourseList/View/CourseListView.swift
@@ -89,9 +89,9 @@ public struct CourseListView: View {
             )
                 .frame(minHeight: height - Self.searchBarHeight)
         } else {
-            CourseListSection(header: Text("Current Enrollments", bundle: .core), courses: current)
-            CourseListSection(header: Text("Past Enrollments", bundle: .core), courses: past)
-            CourseListSection(header: Text("Future Enrollments", bundle: .core), courses: future)
+            CourseListSection(header: Text("Current Enrollments", bundle: .core), courses: current, hideFavoriteButton: false)
+            CourseListSection(header: Text("Past Enrollments", bundle: .core), courses: past, hideFavoriteButton: true)
+            CourseListSection(header: Text("Future Enrollments", bundle: .core), courses: future, hideFavoriteButton: false)
             Divider()
         }
     }
@@ -99,13 +99,14 @@ public struct CourseListView: View {
     struct CourseListSection: View {
         let header: Text
         let courses: [Course]
+        let hideFavoriteButton: Bool
 
         var body: some View {
             if !courses.isEmpty {
                 Section(header: ListSectionHeader { header }) {
                     ForEach(courses, id: \.id) { course in
                         if course.id != courses.first?.id { Divider() }
-                        CourseListCell(course: course)
+                        CourseListCell(course: course, isFavoriteButtonHidden: hideFavoriteButton)
                     }
                 }
             }


### PR DESCRIPTION
refs: MBL-16024
affects: Student, Teacher
release note: none

test plan:
- Enroll a teacher and a student to a past course.
- Go to Dashboard > Edit Dashboard
- Star icon shouldn't be displayed for past courses.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/168087634-7aa0cc11-c7d6-4c04-8d1a-69bafdc0e717.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/168087675-104b1a2c-0100-4168-a3b6-37b90119853c.png"></td>
</tr>
</table>