### PR TITLE
Fixed calendar's course filter reseting upon leaving calendar tab

### DIFF
--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -43,7 +43,6 @@ final public class Course: NSManagedObject, WriteableModel {
     @NSManaged public var isPastEnrollment: Bool
     @NSManaged public var isPublished: Bool
     @NSManaged public var name: String?
-    @NSManaged var planner: Planner?
     @NSManaged public var sections: Set<CourseSection>
     @NSManaged public var syllabusBody: String?
     @NSManaged public var termName: String?

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -721,6 +721,7 @@
     <entity name="Planner" representedClassName="Core.Planner" syncable="YES">
         <attribute name="availableCourseIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
         <attribute name="hiddenCourseIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="studentID" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Quiz" representedClassName="Core.Quiz" syncable="YES">
         <attribute name="accessCode" optional="YES" attributeType="String"/>
@@ -1002,7 +1003,7 @@
         <element name="Page" positionX="-549" positionY="-27" width="128" height="193"/>
         <element name="Permissions" positionX="-369" positionY="-18" width="128" height="1079"/>
         <element name="Plannable" positionX="-540" positionY="-18" width="128" height="193"/>
-        <element name="Planner" positionX="-540" positionY="-18" width="128" height="59"/>
+        <element name="Planner" positionX="-540" positionY="-18" width="128" height="74"/>
         <element name="Quiz" positionX="-26.7890625" positionY="226.0703125" width="128" height="508"/>
         <element name="QuizSubmission" positionX="-540" positionY="-27" width="128" height="240"/>
         <element name="Rubric" positionX="-540" positionY="-27" width="128" height="178"/>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="19574" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21E258" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -235,8 +235,6 @@
         <relationship name="enrollments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Enrollment" inverseName="course" inverseEntity="Enrollment"/>
         <relationship name="gradingPeriods" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GradingPeriod" inverseName="course" inverseEntity="GradingPeriod"/>
         <relationship name="groups" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Group" inverseName="course" inverseEntity="Group"/>
-        <relationship name="planner" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Planner" inverseName="courses" inverseEntity="Planner"/>
-        <relationship name="plannerHidden" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Planner" inverseName="hiddenCourses" inverseEntity="Planner"/>
         <relationship name="sections" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CourseSection" inverseName="course" inverseEntity="CourseSection"/>
         <relationship name="todos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Todo" inverseName="course" inverseEntity="Todo"/>
     </entity>
@@ -721,9 +719,8 @@
         <attribute name="userID" optional="YES" attributeType="String"/>
     </entity>
     <entity name="Planner" representedClassName="Core.Planner" syncable="YES">
-        <attribute name="studentID" optional="YES" attributeType="String"/>
-        <relationship name="courses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Course" inverseName="planner" inverseEntity="Course"/>
-        <relationship name="hiddenCourses" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Course" inverseName="plannerHidden" inverseEntity="Course"/>
+        <attribute name="availableCourseIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
+        <attribute name="hiddenCourseIDs" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]"/>
     </entity>
     <entity name="Quiz" representedClassName="Core.Quiz" syncable="YES">
         <attribute name="accessCode" optional="YES" attributeType="String"/>
@@ -969,7 +966,7 @@
         <element name="Conversation" positionX="-540" positionY="-18" width="128" height="238"/>
         <element name="ConversationMessage" positionX="-522" positionY="0" width="128" height="208"/>
         <element name="ConversationParticipant" positionX="-531" positionY="-9" width="128" height="133"/>
-        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="464"/>
+        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="434"/>
         <element name="CourseSection" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="CourseSettings" positionX="-540" positionY="-18" width="128" height="88"/>
         <element name="DashboardCard" positionX="-540" positionY="-18" width="128" height="254"/>
@@ -1005,7 +1002,7 @@
         <element name="Page" positionX="-549" positionY="-27" width="128" height="193"/>
         <element name="Permissions" positionX="-369" positionY="-18" width="128" height="1079"/>
         <element name="Plannable" positionX="-540" positionY="-18" width="128" height="193"/>
-        <element name="Planner" positionX="-540" positionY="-18" width="128" height="88"/>
+        <element name="Planner" positionX="-540" positionY="-18" width="128" height="59"/>
         <element name="Quiz" positionX="-26.7890625" positionY="226.0703125" width="128" height="508"/>
         <element name="QuizSubmission" positionX="-540" positionY="-27" width="128" height="240"/>
         <element name="Rubric" positionX="-540" positionY="-27" width="128" height="178"/>

--- a/Core/Core/Extensions/NSManagedObjectContextExtensions.swift
+++ b/Core/Core/Extensions/NSManagedObjectContextExtensions.swift
@@ -33,6 +33,10 @@ extension NSManagedObjectContext {
         return all(where: key, equals: value).first
     }
 
+    public func first<T>(scope: Scope) -> T? {
+        fetch(scope: scope).first
+    }
+
     public func all<T>(where key: String, equals value: CVarArg?) -> [T] {
         let predicate = NSPredicate(key: key, equals: value)
         return fetch(predicate)

--- a/Core/Core/Planner/GetPlannerCourses.swift
+++ b/Core/Core/Planner/GetPlannerCourses.swift
@@ -65,13 +65,6 @@ class GetPlannerCourses: APIUseCase {
         guard let courses = response else { return }
         let planner: Planner = client.first(scope: .all) ?? client.insert()
 
-        // These properties aren't optional in CoreData so we have to setup an initial
-        // value after the object's creation otherwise CoreData will throw an error
-        if planner.isInserted {
-            planner.hiddenCourseIDs = []
-            planner.availableCourseIDs = []
-        }
-
         for apiCourse in courses {
             let course = Course.save(apiCourse, in: client)
             planner.availableCourseIDs.append(course.id)

--- a/Core/Core/Planner/Planner.swift
+++ b/Core/Core/Planner/Planner.swift
@@ -19,21 +19,23 @@
 import Foundation
 import CoreData
 
+/**
+ This object stores the courses to be shown/hidden in the calendar's course filter menu. This is a single object in the DB.
+ */
 class Planner: NSManagedObject {
-    @NSManaged var studentID: String?
-    @NSManaged var courses: Set<Course>
-    @NSManaged var hiddenCourses: Set<Course>
+    @NSManaged var availableCourseIDs: [String]
+    @NSManaged var hiddenCourseIDs: [String]
 
-    var selectedCourses: Set<Course> {
+    var selectedCourses: Set<String> {
         get {
-            courses.subtracting(hiddenCourses)
+            Set(availableCourseIDs).subtracting(hiddenCourseIDs)
         }
         set {
-            hiddenCourses = courses.subtracting(newValue)
+            hiddenCourseIDs = Array(Set(availableCourseIDs).subtracting(newValue))
         }
     }
 
     var allSelected: Bool {
-        courses.allSatisfy { selectedCourses.contains($0) }
+        availableCourseIDs.allSatisfy { selectedCourses.contains($0) }
     }
 }

--- a/Core/Core/Planner/Planner.swift
+++ b/Core/Core/Planner/Planner.swift
@@ -23,6 +23,7 @@ import CoreData
  This object stores the courses to be shown/hidden in the calendar's course filter menu. This is a single object in the DB.
  */
 class Planner: NSManagedObject {
+    @NSManaged var studentID: String?
     @NSManaged var availableCourseIDs: [String]
     @NSManaged var hiddenCourseIDs: [String]
 

--- a/Core/Core/Planner/Planner.swift
+++ b/Core/Core/Planner/Planner.swift
@@ -38,4 +38,13 @@ class Planner: NSManagedObject {
     var allSelected: Bool {
         availableCourseIDs.allSatisfy { selectedCourses.contains($0) }
     }
+
+    override func awakeFromInsert() {
+        super.awakeFromInsert()
+
+        // These properties aren't optional in CoreData so we have to setup an initial
+        // value after the object's creation otherwise CoreData will throw an error
+        hiddenCourseIDs = []
+        availableCourseIDs = []
+    }
 }

--- a/Core/Core/Planner/PlannerFilterViewController.swift
+++ b/Core/Core/Planner/PlannerFilterViewController.swift
@@ -31,13 +31,17 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
     let env = AppEnvironment.shared
     var studentID: String?
 
-    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .all) { [weak self] in
+    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .where(#keyPath(Planner.studentID), equals: studentID)) { [weak self] in
         self?.update()
     }
     var planner: Planner? { planners.first }
 
     lazy var courses = env.subscribe(GetPlannerCourses(studentID: studentID)) { [weak self] in
         self?.update()
+    }
+    private var filteredCourses: [Course] {
+        let courseIDs = planner?.availableCourseIDs ?? []
+        return courses.all.filter { courseIDs.contains($0.id) }
     }
 
     public static func create(studentID: String?) -> PlannerFilterViewController {
@@ -71,7 +75,7 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
         guard courses.requested, courses.pending == false else { return }
         tableView.refreshControl?.endRefreshing()
         spinnerView.isHidden = true
-        emptyStateView.isHidden = courses.error != nil || !courses.isEmpty
+        emptyStateView.isHidden = courses.error != nil || !filteredCourses.isEmpty
         errorView.isHidden = courses.error == nil
         tableView.reloadData()
     }
@@ -96,7 +100,7 @@ extension PlannerFilterViewController: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        var count = courses.count
+        var count = filteredCourses.count
         if courses.hasNextPage {
             count += 1
         }
@@ -104,16 +108,16 @@ extension PlannerFilterViewController: UITableViewDataSource {
     }
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if courses.hasNextPage && indexPath.row == courses.count {
+        if courses.hasNextPage && indexPath.row == filteredCourses.count {
             courses.getNextPage()
             return LoadingCell(style: .default, reuseIdentifier: nil)
         }
         let cell = tableView.dequeue(for: indexPath) as PlannerFilterCell
-        let course = courses[indexPath]
+        let course = filteredCourses[indexPath.row]
         cell.accessibilityIdentifier = "PlannerFilter.section.\(indexPath.section).row.\(indexPath.row)"
-        cell.accessibilityLabel = course?.name
-        cell.courseNameLabel.text = course?.name
-        cell.isSelected = course.flatMap { planner?.selectedCourses.contains($0.id) } == true
+        cell.accessibilityLabel = course.name
+        cell.courseNameLabel.text = course.name
+        cell.isSelected = planner?.selectedCourses.contains(course.id) == true
         return cell
     }
 
@@ -128,7 +132,7 @@ extension PlannerFilterViewController: UITableViewDataSource {
 extension PlannerFilterViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         tableView.deselectRow(at: indexPath, animated: true)
-        guard let course = courses[indexPath] else { return }
+        let course = filteredCourses[indexPath.row]
         do {
             try toggleCourse(course)
         } catch {

--- a/Core/Core/Planner/PlannerFilterViewController.swift
+++ b/Core/Core/Planner/PlannerFilterViewController.swift
@@ -31,7 +31,7 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
     let env = AppEnvironment.shared
     var studentID: String?
 
-    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .where(#keyPath(Planner.studentID), equals: studentID)) { [weak self] in
+    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .all) { [weak self] in
         self?.update()
     }
     var planner: Planner? { planners.first }
@@ -81,10 +81,10 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
     }
 
     func toggleCourse(_ course: Course) throws {
-        if planner?.selectedCourses.contains(course) == true {
-            planner?.selectedCourses.remove(course)
+        if planner?.selectedCourses.contains(course.id) == true {
+            planner?.selectedCourses.remove(course.id)
         } else {
-            planner?.selectedCourses.insert(course)
+            planner?.selectedCourses.insert(course.id)
         }
         try env.database.viewContext.save()
     }
@@ -113,7 +113,7 @@ extension PlannerFilterViewController: UITableViewDataSource {
         cell.accessibilityIdentifier = "PlannerFilter.section.\(indexPath.section).row.\(indexPath.row)"
         cell.accessibilityLabel = course?.name
         cell.courseNameLabel.text = course?.name
-        cell.isSelected = course.flatMap { planner?.selectedCourses.contains($0) } == true
+        cell.isSelected = course.flatMap { planner?.selectedCourses.contains($0.id) } == true
         return cell
     }
 

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -34,7 +34,7 @@ public class PlannerViewController: UIViewController {
     public var selectedDate: Date = Clock.now
     var studentID: String?
 
-    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .all) { [weak self] in
+    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .where(#keyPath(Planner.studentID), equals: studentID)) { [weak self] in
         self?.plannerListWillRefresh()
     }
     var planner: Planner? { planners.first }

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -34,7 +34,7 @@ public class PlannerViewController: UIViewController {
     public var selectedDate: Date = Clock.now
     var studentID: String?
 
-    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .where(#keyPath(Planner.studentID), equals: studentID)) { [weak self] in
+    lazy var planners: Store<LocalUseCase<Planner>> = env.subscribe(scope: .all) { [weak self] in
         self?.plannerListWillRefresh()
     }
     var planner: Planner? { planners.first }
@@ -117,7 +117,7 @@ public class PlannerViewController: UIViewController {
         var contextCodes: [String]?
         if let planner = planner, !planner.allSelected {
             contextCodes = planner.selectedCourses.map {
-                Context(.course, id: $0.id).canvasContextID
+                Context(.course, id: $0).canvasContextID
             }
             if let studentID = studentID ?? env.currentSession?.userID {
                 contextCodes?.append(Context(.user, id: studentID).canvasContextID)

--- a/Core/Core/Store/Scope.swift
+++ b/Core/Core/Store/Scope.swift
@@ -58,10 +58,12 @@ public struct Scope: Equatable {
         return Scope(predicate: predicate, order: sortDescriptors)
     }
 
-    public static func all(orderBy order: String, ascending: Bool = true, naturally: Bool = false) -> Scope {
+    public static func all(orderBy order: String = "objectID", ascending: Bool = true, naturally: Bool = false) -> Scope {
         let sort = NSSortDescriptor(key: order, ascending: ascending, naturally: naturally)
         return Scope(predicate: .all, order: [sort])
     }
+
+    public static var all: Scope { all() }
 }
 
 extension NSSortDescriptor {

--- a/Core/CoreTests/Extensions/NSManagedObjectContextExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/NSManagedObjectContextExtensionsTests.swift
@@ -43,6 +43,18 @@ class NSManagedObjectContextExtensionsTests: CoreTestCase {
         XCTAssertFalse(result == no)
     }
 
+    func testFirstByScope() {
+        let firstCourse = Course.make(from: .make(id: "1"))
+        Course.make(from: .make(id: "2"))
+
+        guard let result: Course = databaseClient.first(scope: .all) else {
+            XCTFail()
+            return
+        }
+
+        XCTAssertEqual(result, firstCourse)
+    }
+
     func testIsObjectDeleted() throws {
         let object = Course.make()
         databaseClient.delete(object)


### PR DESCRIPTION
refs: MBL-16016
affects: Student
release note: none

test plan:
- Go to Calendar tab, tap Calendars
- De-select a course, tap Done
- Switch tabs, do pull to refreshes, restart the app
- Calendar's course filter shouldn't change
- Calendar should only show course events based on the saved selection
--
- Also test if this change caused any regression issues in the parent app
- Add two students to a parent
- Add each student to a different course with some upcoming assignments
- Start the parent app, login with the parent account
- Go to calendar
- Check if switching students correctly updates the calendar filter, only the active student's course should be visible
- Switch tabs, restart the app
- Per student calendar filter state should remain unchanged 

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/168279742-fb326933-5810-4dc2-9ba4-56f0bbb643e6.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/168279774-e6f54a58-08b8-4197-b6d7-0793e8d0696b.png"></td>
</tr>
</table>