### PR TITLE
Add extended late policy status.

### DIFF
--- a/Core/Core/Assignments/LatePolicyStatus.swift
+++ b/Core/Core/Assignments/LatePolicyStatus.swift
@@ -19,5 +19,5 @@
 import Foundation
 
 public enum LatePolicyStatus: String, Codable {
-    case late, missing, none
+    case late, missing, none, extended
 }

--- a/Core/CoreTests/Assignments/LatePolicyStatusTests.swift
+++ b/Core/CoreTests/Assignments/LatePolicyStatusTests.swift
@@ -25,4 +25,8 @@ class LatePolicyStatusTests: XCTestCase {
         XCTAssertEqual(LatePolicyStatus(rawValue: "late"), .late)
         XCTAssertEqual(LatePolicyStatus.late.rawValue, "late")
     }
+
+    func testRecognizesExtendedCase() {
+        XCTAssertNotNil(LatePolicyStatus(rawValue: "extended"))
+    }
 }


### PR DESCRIPTION
refs: MBL-16064
affects: Student, Teacher, Parent
release note: none

test plan: This change adds the extended enumeration option to LatePolicyStatus to make sure that when this is available on the API the app won't fail parsing it. Since we don't use this field in the app there's no way to manually test it.