### PR TITLE
Update already existing DashboardCard objects instead of delete and re-create.

### DIFF
--- a/Core/Core/Dashboard/Model/DashboardCard.swift
+++ b/Core/Core/Dashboard/Model/DashboardCard.swift
@@ -93,7 +93,16 @@ public class GetDashboardCards: CollectionUseCase {
     public init() {
     }
 
+    public func reset(context: NSManagedObjectContext) {
+        // We don't want the default implementation to delete everything, we'll delete what's no longer needed in the write method
+    }
+
     public func write(response: [APIDashboardCard]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        let idsToKeep = (response ?? []).map { $0.id.value }
+        let objectsManagedByUseCase: [Model] = client.fetch(scope: scope)
+        let objectsToDelete = objectsManagedByUseCase.filter { !idsToKeep.contains($0.id) }
+        client.delete(objectsToDelete)
+
         response?.enumerated().forEach {
             Model.save($0.element, position: $0.offset, in: client)
         }

--- a/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
+++ b/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
@@ -63,4 +63,24 @@ class DashboardCardTests: CoreTestCase {
         let card = DashboardCard.save(.make(), position: 0, in: databaseClient)
         XCTAssertEqual(card.course, course)
     }
+
+    func testUseCaseDoesntDeleteUpdatedObjects() {
+        let card1 = DashboardCard.save(.make(id: "1", longName: "original name"), position: 0, in: databaseClient)
+        let card2 = DashboardCard.save(.make(id: "2"), position: 0, in: databaseClient)
+        try! databaseClient.save()
+        let useCase = GetDashboardCards()
+        api.mock(useCase, value: [
+            .make(id: "1", longName: "updated name"),
+        ])
+
+        XCTAssertFalse(card1.isFault)
+        XCTAssertEqual(card1.longName, "original name")
+        XCTAssertFalse(card2.isFault)
+
+        useCase.fetch()
+
+        XCTAssertFalse(card1.isFault)
+        XCTAssertEqual(card1.longName, "updated name")
+        XCTAssertTrue(card2.isFault)
+    }
 }


### PR DESCRIPTION
refs: MBL-16046
affects: Student, Teacher
release note: none

test plan:
- Do a pull to refresh on the dashboard.
- Card colors shouldn't reset back to gray before getting their final color.