### PR TITLE
Update all groups when saving a course that has group assignments.

### DIFF
--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -132,7 +132,7 @@ final public class Course: NSManagedObject, WriteableModel {
             dashboardCard.course = model
         }
 
-        if let group: Group = context.fetch(scope: .where(#keyPath(Group.courseID), equals: model.id)).first {
+        for group: Group in context.fetch(scope: .where(#keyPath(Group.courseID), equals: model.id)) {
             group.course = model
         }
 

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -182,9 +182,12 @@ class CourseTests: CoreTestCase {
     }
 
     func testUpdatesRelatedGroupRelationship() {
-        let group = Group.save(.make(course_id: "course_1"), in: databaseClient)
-        XCTAssertNil(group.course)
+        let group1 = Group.save(.make(id: "1", course_id: "course_1"), in: databaseClient)
+        let group2 = Group.save(.make(id: "2", course_id: "course_1"), in: databaseClient)
+        XCTAssertNil(group1.course)
+        XCTAssertNil(group2.course)
         let course = Course.save(.make(id: "course_1"), in: databaseClient)
-        XCTAssertEqual(group.course, course)
+        XCTAssertEqual(group1.course, course)
+        XCTAssertEqual(group2.course, course)
     }
 }


### PR DESCRIPTION
refs: MBL-16074
affects: Student
release note: Fixed a dashboard issue that caused only one group from a course appearing at a time.

test plan:
- Create two groups in the same active course.
- Add a user to both groups.
- Start the app, login with the user, dashboard should display both groups.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/171428387-7fda50f0-efcf-4e86-841d-85b09767dad6.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/171428321-3bd0e017-2254-4fdd-9470-2125029b02b2.png"></td>
</tr>
</table>