### PR TITLE
Map hidden property from API entity to CoreData.

### DIFF
--- a/Core/Core/Contexts/Tab.swift
+++ b/Core/Core/Contexts/Tab.swift
@@ -65,5 +65,6 @@ public class Tab: NSManagedObject {
         self.context = context
         type = item.type
         visibility = TabVisibility(rawValue: item.visibility) ?? .none
+        hidden = item.hidden
     }
 }

--- a/Core/CoreTests/Contexts/TabTests.swift
+++ b/Core/CoreTests/Contexts/TabTests.swift
@@ -44,4 +44,18 @@ class TabTests: CoreTestCase {
         tab.visibilityRaw = "bogus"
         XCTAssertEqual(tab.visibility, .none)
     }
+
+    func testSavesIsHiddenProperty() {
+        let context = Context(.group, id: "1")
+        let tab = Tab.make()
+
+        tab.save(.make(hidden: nil), in: databaseClient, context: context)
+        XCTAssertNil(tab.hidden)
+
+        tab.save(.make(hidden: false), in: databaseClient, context: context)
+        XCTAssertEqual(tab.hidden, false)
+
+        tab.save(.make(hidden: true), in: databaseClient, context: context)
+        XCTAssertEqual(tab.hidden, true)
+    }
 }


### PR DESCRIPTION
refs: MBL-16068
affects: Student, Teacher
release note: none

test plan:
- Hide a LTI tool in a course.
- Go to the app and check course details.
- Hidden LTI tool shouldn't be visible.