### PR TITLE
Fix discussion loading

### DIFF
--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -190,7 +190,6 @@ extension Assignment {
         if let topic = item.discussion_topic {
             discussionTopic = DiscussionTopic.save(topic, in: client)
         } else if let topic = discussionTopic {
-            client.delete(topic)
             self.discussionTopic = nil
         }
 

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -189,7 +189,7 @@ extension Assignment {
 
         if let topic = item.discussion_topic {
             discussionTopic = DiscussionTopic.save(topic, in: client)
-        } else if let topic = discussionTopic {
+        } else if discussionTopic != nil {
             self.discussionTopic = nil
         }
 

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -338,7 +338,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
         entries.refresh()
         group.refresh()
         permissions.refresh()
-        self.topic.refresh()
+        self.topic.refresh(force: true)
         return false
     }
 


### PR DESCRIPTION
Force refresh discussion details to make sure discussion entry is available. Don't delete discussion assigned to an assignment, only clear the relation.

refs: MBL-16075
affects: Student, Teacher
release note: none

test plan:
- Test on iPad, see ticket.
- Also test if doing a pull to refresh on the detail view doesn't remove any entries from the discussions list.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/171836082-9e0d4571-928b-4a04-9711-607a322d394b.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/171836095-048c9cec-7ce9-41e3-adb1-6715586b1d2a.png"></td>
</tr>
</table>