### PR TITLE
Fix content shape of course and group cards.

### DIFF
--- a/Core/Core/Dashboard/View/CourseCard.swift
+++ b/Core/Core/Dashboard/View/CourseCard.swift
@@ -60,6 +60,7 @@ struct CourseCard: View {
                     }
                     .padding(.horizontal, 10).padding(.top, 8)
                 }
+                .contentShape(Rectangle())
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.gray, lineWidth: 1 / UIScreen.main.scale))
                 .cornerRadius(4)
             })

--- a/Core/Core/Dashboard/View/GroupCard.swift
+++ b/Core/Core/Dashboard/View/GroupCard.swift
@@ -45,6 +45,7 @@ struct GroupCard: View {
                 }
                 .padding(8)
             }
+            .contentShape(Rectangle())
             .background(RoundedRectangle(cornerRadius: 4).stroke(Color.gray, lineWidth: 1 / UIScreen.main.scale))
             .cornerRadius(4)
         })

--- a/Core/Core/Fonts/FontPreview.swift
+++ b/Core/Core/Fonts/FontPreview.swift
@@ -24,7 +24,7 @@ private func fontPreview() -> some View {
     VStack(alignment: .leading) {
         ForEach(UIFont.Name.allCases, id: \.rawValue) {
             Text($0.rawValue)
-            Text("ABC Gg 123 Ű lM")
+            Text(verbatim: "ABC Gg 123 Ű lM")
                 .font(Font(UIFont.scaledNamedFont($0)))
                 .padding(.bottom, 10)
         }


### PR DESCRIPTION
refs: MBL-16106
affects: Student, Teacher
release note: none

test plan:
- Tap on the empty area of the course and group cards.
- App should navigate to course and group details.