### PR TITLE
Add default value to K5 flag.

### DIFF
--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -32,7 +32,13 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case hybridDiscussionDetails = "hybrid_discussion_details"
 
     public var isEnabled: Bool {
-        get { UserDefaults.standard.bool(forKey: userDefaultsKey) }
+        get {
+            // If there are no saved values for K5 mode we return true by default. Debug builds without Firebase feature flag fetch will have this enabled.
+            if self == .K5Dashboard, UserDefaults.standard.object(forKey: userDefaultsKey) == nil {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: userDefaultsKey)
+        }
         nonmutating set { UserDefaults.standard.set(newValue, forKey: userDefaultsKey) }
     }
 

--- a/Core/CoreTests/AppEnvironment/ExperimentalFeatureTests.swift
+++ b/Core/CoreTests/AppEnvironment/ExperimentalFeatureTests.swift
@@ -41,4 +41,19 @@ class ExperimentalFeatureTests: CoreTestCase {
         testFeature.isEnabled = true
         XCTAssertTrue(UserDefaults.standard.bool(forKey: testFeature.userDefaultsKey))
     }
+
+    func testK5FlagDefaultValue() {
+        UserDefaults.standard.removeObject(forKey: ExperimentalFeature.K5Dashboard.userDefaultsKey)
+        XCTAssertTrue(ExperimentalFeature.K5Dashboard.isEnabled)
+    }
+
+    func testSavedDisabledK5FlagValue() {
+        UserDefaults.standard.set(false, forKey: ExperimentalFeature.K5Dashboard.userDefaultsKey)
+        XCTAssertFalse(ExperimentalFeature.K5Dashboard.isEnabled)
+    }
+
+    func testSavedEnabledK5FlagValue() {
+        UserDefaults.standard.set(true, forKey: ExperimentalFeature.K5Dashboard.userDefaultsKey)
+        XCTAssertTrue(ExperimentalFeature.K5Dashboard.isEnabled)
+    }
 }


### PR DESCRIPTION
refs: MBL-16113
affects: Student
release note: none

test plan: K5 feature flag in debug builds should be enabled after a clean app install.