### PR TITLE
Fix edit due dates screen nav bar

### DIFF
--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -133,7 +133,7 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
 
     return (
       <Screen
-        navBarColor={this.props.courseColor}
+        title={i18n('Edit Due Dates')}
         navBarStyle='context'
         rightBarButtons={[
           {

--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -133,7 +133,7 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
 
     return (
       <Screen
-        title={i18n('Edit Due Dates')}
+        title={i18n('Due Dates')}
         navBarStyle='context'
         rightBarButtons={[
           {

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
@@ -12,6 +12,7 @@ exports[`renders 1`] = `
       },
     ]
   }
+  title="Edit Due Dates"
 >
   <View
     style={
@@ -47,6 +48,7 @@ exports[`renders with overrides 1`] = `
       },
     ]
   }
+  title="Edit Due Dates"
 >
   <View
     style={

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
@@ -12,7 +12,7 @@ exports[`renders 1`] = `
       },
     ]
   }
-  title="Edit Due Dates"
+  title="Due Dates"
 >
   <View
     style={
@@ -48,7 +48,7 @@ exports[`renders with overrides 1`] = `
       },
     ]
   }
-  title="Edit Due Dates"
+  title="Due Dates"
 >
   <View
     style={


### PR DESCRIPTION
Remove nav bar color setting to keep the previous screen's context color. Set page title to change long back button text to a one word back.

refs: MBL-16080
affects: Teacher
release note: none

test plan:
- Navigate to Course > Assignments > Assignment Details.
- Tap on Due section.
- Nav bar color should retain the context color.
- Back button should read as back instead of the previous screen's title.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/175496667-aa16a9e3-06c7-4f84-9ff1-6ec8ffd32ecb.png"></td>
<td><img src="https://user-images.githubusercontent.com/72396990/175497599-adbc8b1e-686d-4f85-8bbe-57baa568faf9.png"></td>
</tr>
</table>