### PR TITLE
Exiting "Act As User" logs the admin out of their account as well

### DIFF
--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -367,7 +367,6 @@ extension StudentAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
         UIApplication.shared.applicationIconBadgeNumber = 0
         environment.userDidLogout(session: session)
         CoreWebView.stopCookieKeepAlive()
-        NativeLoginManager.shared().logout()
     }
 
     func userDidLogout(session: LoginSession) {


### PR DESCRIPTION
refs: MBL-16067
affects: Student
release note: Fixed admin is logged out leaving student view.
test plan: See ticket. **Use your own siteadmin login.**