### PR TITLE
Move http upload body creation from memory to file

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,8 @@
 		CEF0D1462837D571005867EF /* ContextCellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */; };
 		CEF0D1472837D571005867EF /* ContextCellBackgroundView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */; };
 		CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */; };
+		CF0075DA28746E3B00588E40 /* APIFormData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075D928746E3B00588E40 /* APIFormData.swift */; };
+		CF0075DC2874765300588E40 /* APIFormDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DB2874765300588E40 /* APIFormDataTests.swift */; };
 		CF0075DE2875C51E00588E40 /* InputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */; };
 		CF0075E02875C56500588E40 /* InputStreamExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */; };
 		CF0075E22875E4AF00588E40 /* OutputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */; };
@@ -2211,6 +2213,8 @@
 		CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCellBackgroundView.swift; sourceTree = "<group>"; };
 		CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContextCellBackgroundView.xib; sourceTree = "<group>"; };
 		CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
+		CF0075D928746E3B00588E40 /* APIFormData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIFormData.swift; sourceTree = "<group>"; };
+		CF0075DB2874765300588E40 /* APIFormDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIFormDataTests.swift; sourceTree = "<group>"; };
 		CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensions.swift; sourceTree = "<group>"; };
 		CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensionsTests.swift; sourceTree = "<group>"; };
 		CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStreamExtensions.swift; sourceTree = "<group>"; };
@@ -3796,6 +3800,7 @@
 				7D7F71DB241FD90600D6F9CB /* APIDateTests.swift */,
 				7D819FF8228C898100C61EDD /* APIErrorTests.swift */,
 				3B35F072230F01F600674FF5 /* APIGraphQLRequestableTests.swift */,
+				CF0075DB2874765300588E40 /* APIFormDataTests.swift */,
 				7D5A2BC322CD0D8C0029B6AC /* APIListTests.swift */,
 				7D80AC55212CF41900C40ECE /* APIRequestableTests.swift */,
 				7D80AC1E212B738500C40ECE /* APITests.swift */,
@@ -3868,6 +3873,7 @@
 				7D80AC11212B4F8E00C40ECE /* API.swift */,
 				7D7F71D9241C41BC00D6F9CB /* APIDate.swift */,
 				7D819FF6228C7C7E00C61EDD /* APIError.swift */,
+				CF0075D928746E3B00588E40 /* APIFormData.swift */,
 				3B35F06A230EEAA800674FF5 /* APIGraphQLRequestable.swift */,
 				7D5A2BC122CD062E0029B6AC /* APIList.swift */,
 				7D5400B2252BD3D7003691F4 /* APIMock.swift */,
@@ -6554,6 +6560,7 @@
 				7D2DC2FD219A001E008FE29A /* UIViewExtensionsTests.swift in Sources */,
 				9F6878B722397E8F00E559CE /* MediaCommentTests.swift in Sources */,
 				7D288B0F25758F630013FF65 /* DashboardCardTests.swift in Sources */,
+				CF0075DC2874765300588E40 /* APIFormDataTests.swift in Sources */,
 				7D82DB382374A82800C699B8 /* FileDetailsViewControllerTests.swift in Sources */,
 				E8E070ED24E1843600B37176 /* AvoidKeyboardAreaTests.swift in Sources */,
 				B150C63C2298DE590096D58C /* WKWebViewExtensionsTests.swift in Sources */,
@@ -6934,6 +6941,7 @@
 				7D5400B3252BD3D7003691F4 /* APIMock.swift in Sources */,
 				E8AC2D3224AE3A160053AA8A /* APIAlertThreshold.swift in Sources */,
 				7DA25F9023F72123005D2121 /* SyllabusViewController.swift in Sources */,
+				CF0075DA28746E3B00588E40 /* APIFormData.swift in Sources */,
 				B1A7848B2441136C001A2B50 /* GetModules.swift in Sources */,
 				EB7A8FF1285C946400940F3D /* UIApplicationDelegateExtensions.swift in Sources */,
 				7DA260E423F72359005D2121 /* LoadingViewController.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,8 @@
 		CEF0D1462837D571005867EF /* ContextCellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */; };
 		CEF0D1472837D571005867EF /* ContextCellBackgroundView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */; };
 		CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */; };
+		CF0075DE2875C51E00588E40 /* InputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */; };
+		CF0075E02875C56500588E40 /* InputStreamExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */; };
 		CF0894FB26FA218C0051A1BA /* AssignmentPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */; };
 		CF0894FD26FA2CD30051A1BA /* AssignmentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */; };
 		CF09E6A32840FB13000C72D0 /* UTIFromNSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */; };
@@ -2208,6 +2210,8 @@
 		CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCellBackgroundView.swift; sourceTree = "<group>"; };
 		CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContextCellBackgroundView.xib; sourceTree = "<group>"; };
 		CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
+		CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensions.swift; sourceTree = "<group>"; };
+		CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensionsTests.swift; sourceTree = "<group>"; };
 		CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerViewModel.swift; sourceTree = "<group>"; };
 		CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerView.swift; sourceTree = "<group>"; };
 		CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFromNSItemProvider.swift; sourceTree = "<group>"; };
@@ -3736,6 +3740,7 @@
 				CF9DFB5F2584F3EE004E27A5 /* ColorExtensions.swift */,
 				B1EA5AF5212E67CE00DABC5F /* DateExtensions.swift */,
 				B1A464BA225669140052F8DF /* DispatchExtensions.swift */,
+				CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */,
 				7DF2F5FA2347DAE900C1802C /* InstColorExtensions.swift */,
 				7DA20E8E21680DBF00F5FD19 /* InstIconExtensions.swift */,
 				3B69253F21A12E020023ED75 /* Int64Extensions.swift */,
@@ -3807,6 +3812,7 @@
 				7DD694802194CE8C00BA4984 /* DateExtensionsTests.swift */,
 				B1A464BC225669B50052F8DF /* DispatchExtensionsTests.swift */,
 				CF941B0E267B3F1000700DE9 /* FontExtensionTests.swift */,
+				CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */,
 				7D7BA23E24DC776000B1A68B /* InstColorExtensionsTests.swift */,
 				7DA20E922168128400F5FD19 /* InstIconExtensionsTests.swift */,
 				7DC4A558222EFC9900FA03DC /* Int64ExtensionsTests.swift */,
@@ -6532,6 +6538,7 @@
 				E887275F24E1F85B00798DCA /* SequenceExtensionsTests.swift in Sources */,
 				3B1988B524256CE7004ADCC6 /* PairWithObserverViewControllerTests.swift in Sources */,
 				3B3FCA3323802D680011F11A /* GetActivitiesTests.swift in Sources */,
+				CF0075E02875C56500588E40 /* InputStreamExtensionsTests.swift in Sources */,
 				D9FD8EF8254187D600C6842B /* SyllabusTabViewControllerTests.swift in Sources */,
 				7D8B78F8215EC74A005E08F1 /* UIImageExtensionsTests.swift in Sources */,
 				7D016B5F23E8984B00C6E0CA /* BottomSheetPickerViewControllerTests.swift in Sources */,
@@ -7215,6 +7222,7 @@
 				7DA25FEF23F721DE005D2121 /* GetSearchRecipients.swift in Sources */,
 				7DA25FBF23F72136005D2121 /* APIModule.swift in Sources */,
 				EB2A9BD22632E43600A19A5A /* SideMenuToggleItem.swift in Sources */,
+				CF0075DE2875C51E00588E40 /* InputStreamExtensions.swift in Sources */,
 				7D70869925699AAA00647D37 /* CourseInvitationCard.swift in Sources */,
 				CF5F602E25DBD7D800E7E0ED /* EnvironmentValues.swift in Sources */,
 				7DF4AAD8248833A400B07BB8 /* AppStoreReview.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */; };
 		CF0075DE2875C51E00588E40 /* InputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */; };
 		CF0075E02875C56500588E40 /* InputStreamExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */; };
+		CF0075E22875E4AF00588E40 /* OutputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */; };
 		CF0894FB26FA218C0051A1BA /* AssignmentPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */; };
 		CF0894FD26FA2CD30051A1BA /* AssignmentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */; };
 		CF09E6A32840FB13000C72D0 /* UTIFromNSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */; };
@@ -2212,6 +2213,7 @@
 		CF00481625E6457500321C8B /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
 		CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensions.swift; sourceTree = "<group>"; };
 		CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensionsTests.swift; sourceTree = "<group>"; };
+		CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStreamExtensions.swift; sourceTree = "<group>"; };
 		CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerViewModel.swift; sourceTree = "<group>"; };
 		CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerView.swift; sourceTree = "<group>"; };
 		CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFromNSItemProvider.swift; sourceTree = "<group>"; };
@@ -3751,6 +3753,7 @@
 				7DF4FFE421714952007E5F81 /* NSNumberExtensions.swift */,
 				B1C783F02241EB5E00DD89A9 /* NSPersistentContainerExtensions.swift */,
 				B195DC48213215A300797FE4 /* NSPredicateExtensions.swift */,
+				CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */,
 				B1911CF021C851AD00F42F91 /* ProcessInfoExtensions.swift */,
 				E888382924DDD20D00DDF691 /* SequenceExtensions.swift */,
 				3B158C8C22E12DC50039A568 /* StringExtensions.swift */,
@@ -6881,6 +6884,7 @@
 				7DA2600A23F7227A005D2121 /* NSManagedObjectContextExtensions.swift in Sources */,
 				7DA260CD23F72359005D2121 /* BottomSheetTransitioning.swift in Sources */,
 				7DA260C223F72352005D2121 /* UploadFileComment.swift in Sources */,
+				CF0075E22875E4AF00588E40 /* OutputStreamExtensions.swift in Sources */,
 				D97020C52581013C002B7B73 /* ContextCardHeaderView.swift in Sources */,
 				CFAD0D15281839FC0017D07B /* DocViewerAnnotationUploader.swift in Sources */,
 				CF53F73F266FBB8E00FA58D7 /* K5HomeroomMissingSubmissionsCount.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -818,6 +818,8 @@
 		CF0075DE2875C51E00588E40 /* InputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */; };
 		CF0075E02875C56500588E40 /* InputStreamExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */; };
 		CF0075E22875E4AF00588E40 /* OutputStreamExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */; };
+		CF0075E428772E9E00588E40 /* URLRequestExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075E328772E9E00588E40 /* URLRequestExtensions.swift */; };
+		CF0075E628772ECA00588E40 /* URLRequestExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0075E528772ECA00588E40 /* URLRequestExtensionsTests.swift */; };
 		CF0894FB26FA218C0051A1BA /* AssignmentPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */; };
 		CF0894FD26FA2CD30051A1BA /* AssignmentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */; };
 		CF09E6A32840FB13000C72D0 /* UTIFromNSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */; };
@@ -2218,6 +2220,8 @@
 		CF0075DD2875C51E00588E40 /* InputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensions.swift; sourceTree = "<group>"; };
 		CF0075DF2875C56500588E40 /* InputStreamExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputStreamExtensionsTests.swift; sourceTree = "<group>"; };
 		CF0075E12875E4AF00588E40 /* OutputStreamExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputStreamExtensions.swift; sourceTree = "<group>"; };
+		CF0075E328772E9E00588E40 /* URLRequestExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestExtensions.swift; sourceTree = "<group>"; };
+		CF0075E528772ECA00588E40 /* URLRequestExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLRequestExtensionsTests.swift; sourceTree = "<group>"; };
 		CF0894FA26FA218C0051A1BA /* AssignmentPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerViewModel.swift; sourceTree = "<group>"; };
 		CF0894FC26FA2CD30051A1BA /* AssignmentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentPickerView.swift; sourceTree = "<group>"; };
 		CF09E6A22840FB13000C72D0 /* UTIFromNSItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTIFromNSItemProvider.swift; sourceTree = "<group>"; };
@@ -3787,6 +3791,7 @@
 				EB9BF7D4282E907B0025F6D0 /* UIWindowExtensions.swift */,
 				7D7110C92139A57A0085C2E5 /* URLComponentsExtensions.swift */,
 				3B5369E1219CDD3500D3F62E /* URLExtensions.swift */,
+				CF0075E328772E9E00588E40 /* URLRequestExtensions.swift */,
 				7D80AC57212DAE4C00C40ECE /* URLResponseExtensions.swift */,
 				B150C6392298DAB90096D58C /* WKWebViewExtensions.swift */,
 			);
@@ -3852,6 +3857,7 @@
 				EB24231028521EF00058A100 /* UIWindowExtensionsTests.swift */,
 				7D7110CB2139AB310085C2E5 /* URLComponentsExtensionsTests.swift */,
 				3B5369E3219D0FD000D3F62E /* URLExtensionsTests.swift */,
+				CF0075E528772ECA00588E40 /* URLRequestExtensionsTests.swift */,
 				7D80AC5A212DB0B500C40ECE /* URLResponseExtensionsTests.swift */,
 				B150C63B2298DE590096D58C /* WKWebViewExtensionsTests.swift */,
 			);
@@ -6586,6 +6592,7 @@
 				3BEA6CCB24588D1400BE4589 /* AttachmentCardsViewControllerTests.swift in Sources */,
 				7D7F71DC241FD90600D6F9CB /* APIDateTests.swift in Sources */,
 				B11AAC3B237A1EB4002BC41F /* APIURLTests.swift in Sources */,
+				CF0075E628772ECA00588E40 /* URLRequestExtensionsTests.swift in Sources */,
 				7D016B5D23E883AC00C6E0CA /* FilePickerTests.swift in Sources */,
 				CF00481725E6457500321C8B /* GroupContextCardViewModelTests.swift in Sources */,
 				B1A464BD225669B50052F8DF /* DispatchExtensionsTests.swift in Sources */,
@@ -7246,6 +7253,7 @@
 				CF911BA627A29B1800E1EECB /* iOS15Refreshable.swift in Sources */,
 				7DA25FC223F72136005D2121 /* APIPage.swift in Sources */,
 				7DA260C123F72352005D2121 /* GetGradingPeriods.swift in Sources */,
+				CF0075E428772E9E00588E40 /* URLRequestExtensions.swift in Sources */,
 				7DA2604323F722D9005D2121 /* DiscussionEntry.swift in Sources */,
 				D9D7EBE227BC0A1D00544339 /* CourseSettingsView.swift in Sources */,
 				7D1E85622566E80100D093C5 /* CustomizeCourseView.swift in Sources */,

--- a/Core/Core/API/API.swift
+++ b/Core/Core/API/API.swift
@@ -116,7 +116,11 @@ public class API {
     @discardableResult
     public func uploadTask<Request: APIRequestable>(_ requestable: Request) throws -> APITask {
         let boundary = UUID.string
-        let request = try requestable.urlRequest(relativeTo: baseURL, accessToken: loginSession?.accessToken, actAsUserID: loginSession?.actAsUserID, skipBodyCreation: requestable.isFormRequest, boundary: boundary)
+        let request = try requestable.urlRequest(relativeTo: baseURL,
+                                                 accessToken: loginSession?.accessToken,
+                                                 actAsUserID: loginSession?.actAsUserID,
+                                                 skipBodyCreation: requestable.isFormRequest,
+                                                 boundary: boundary)
 
         #if DEBUG
         if API.shouldMock(request) {

--- a/Core/Core/API/APIFormData.swift
+++ b/Core/Core/API/APIFormData.swift
@@ -35,6 +35,10 @@ public typealias APIFormData = [(key: String, value: APIFormDatum)]
 
 extension APIFormData {
 
+    /**
+     Encodes the form data into a file.
+     - returns: The URL of the file where form data was written to.
+     */
     public func encode(using boundary: String) throws -> URL {
         let tempFileURL = URL.temporaryDirectory.appendingPathComponent(UUID.string)
         guard FileManager.default.createFile(atPath: tempFileURL.path, contents: nil),

--- a/Core/Core/API/APIFormData.swift
+++ b/Core/Core/API/APIFormData.swift
@@ -75,12 +75,17 @@ extension APIFormData {
                 outputStream += contents
             case .file(let filename, let type, let url):
                 outputStream += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n"
-                guard let inputStream = InputStream(fileAtPath: url.path) else {
-                    throw NSError.instructureError("Failed to open file for reading.")
+
+                if url.isFileURL {
+                    guard let inputStream = InputStream(fileAtPath: url.path) else {
+                        throw NSError.instructureError("Failed to open file for reading.")
+                    }
+                    inputStream.open()
+                    defer { inputStream.close() }
+                    try inputStream.copy(to: outputStream)
+                } else {
+                    outputStream += try Data(contentsOf: url)
                 }
-                inputStream.open()
-                defer { inputStream.close() }
-                try inputStream.copy(to: outputStream)
             }
             outputStream += "\r\n"
         }

--- a/Core/Core/API/APIFormData.swift
+++ b/Core/Core/API/APIFormData.swift
@@ -1,0 +1,86 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public enum APIFormDatum: Equatable {
+    case string(String)
+    case data(filename: String, type: String, data: Data)
+    case file(filename: String, type: String, at: URL)
+
+    public static func bool(_ value: Bool) -> APIFormDatum {
+        .string(value ? "1" : "0")
+    }
+    public static func date(_ value: Date?) -> APIFormDatum {
+        .string(value?.isoString() ?? "")
+    }
+}
+
+public typealias APIFormData = [(key: String, value: APIFormDatum)]
+
+extension APIFormData {
+
+    public func encode(using boundary: String) throws -> URL {
+        let tempFileURL = URL.temporaryDirectory.appendingPathComponent(UUID.string)
+        guard FileManager.default.createFile(atPath: tempFileURL.path, contents: nil),
+              var outputStream = OutputStream(toFileAtPath: tempFileURL.path, append: false)
+        else {
+            throw NSError.instructureError("Failed to create temp file.")
+        }
+
+        outputStream.open()
+        defer { outputStream.close() }
+        try encode(to: &outputStream, boundary: boundary)
+        return tempFileURL
+    }
+
+    public func encode(using boundary: String) throws -> Data {
+        var outputStream = OutputStream(toMemory: ())
+        outputStream.open()
+        defer { outputStream.close() }
+        try encode(to: &outputStream, boundary: boundary)
+        return outputStream.property(forKey: .dataWrittenToMemoryStreamKey) as? Data ?? Data()
+    }
+
+    private func encode(to outputStream: inout OutputStream, boundary: String) throws {
+        let delimiter = "--\(boundary)\r\n"
+
+        for (key, value) in self {
+            outputStream += delimiter
+            outputStream += "Content-Disposition: form-data; name=\"\(key)\""
+            switch value {
+            case .string(let string):
+                outputStream += "\r\n\r\n\(string)"
+            case .data(let filename, let type, let contents):
+                outputStream += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n"
+                outputStream += contents
+            case .file(let filename, let type, let url):
+                outputStream += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n"
+                guard let inputStream = InputStream(fileAtPath: url.path) else {
+                    throw NSError.instructureError("Failed to open file for reading.")
+                }
+                inputStream.open()
+                defer { inputStream.close() }
+                try inputStream.copy(to: outputStream)
+            }
+            outputStream += "\r\n"
+        }
+
+        outputStream += "--\(boundary)--\r\n"
+    }
+}

--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -131,8 +131,9 @@ public protocol APIRequestable {
     /**
      - parameters:
         - skipBodyCreation: If this parameter is true, then the returned request's `httpBody` parameter won't be set and it will be the caller's responsibility to create one either by assigning a value to `httpBody` or write it to an external file. Useful if the body would be so big that it wouldn't fit into memory.
+        - boundary: The boundary string that separates form fields in the body. Only used if there's a `form` parameter set.
      */
-    func urlRequest(relativeTo: URL, accessToken: String?, actAsUserID: String?, skipBodyCreation: Bool) throws -> URLRequest
+    func urlRequest(relativeTo: URL, accessToken: String?, actAsUserID: String?, skipBodyCreation: Bool, boundary: String) throws -> URLRequest
     func decode(_ data: Data) throws -> Response
     func encode(_ body: Body) throws -> Data
     func encode(response: Response) throws -> Data
@@ -164,7 +165,7 @@ extension APIRequestable {
         return true
     }
 
-    public func urlRequest(relativeTo baseURL: URL, accessToken: String?, actAsUserID: String?, skipBodyCreation: Bool = false) throws -> URLRequest {
+    public func urlRequest(relativeTo baseURL: URL, accessToken: String?, actAsUserID: String?, skipBodyCreation: Bool = false, boundary: String = UUID.string) throws -> URLRequest {
         guard var components = URLComponents(string: path) else { throw APIRequestableError.invalidPath(path) }
 
         if !path.hasPrefix("/") && components.host == nil {
@@ -186,8 +187,6 @@ extension APIRequestable {
         request.httpMethod = method.rawValue.uppercased()
 
         if let form = self.form {
-            let boundary = UUID.string
-
             if !skipBodyCreation {
                 request.httpBody = try encodeFormData(boundary: boundary, form: form)
             }

--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -108,6 +108,7 @@ public protocol APIRequestable {
     var query: [APIQueryItem] { get }
     /** If `form` property is set, then the `body` property is ignored. */
     var form: APIFormData? { get }
+    var isFormRequest: Bool { get }
     /** Only used if `form` property is `nil`. */
     var body: Body? { get }
     var cachePolicy: URLRequest.CachePolicy { get }
@@ -140,6 +141,7 @@ extension APIRequestable {
     public var form: APIFormData? {
         return nil
     }
+    public var isFormRequest: Bool { form != nil }
     public var body: Body? {
         return nil
     }

--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -90,21 +90,6 @@ public class APIJSONEncoder: JSONEncoder {
     }
 }
 
-public typealias APIFormData = [(key: String, value: APIFormDatum)]
-
-public enum APIFormDatum: Equatable {
-    case string(String)
-    case data(filename: String, type: String, data: Data)
-    case file(filename: String, type: String, at: URL)
-
-    public static func bool(_ value: Bool) -> APIFormDatum {
-        return .string(value ? "1" : "0")
-    }
-    public static func date(_ value: Date?) -> APIFormDatum {
-        return .string(value?.isoString() ?? "")
-    }
-}
-
 // These errors are all definitely mistakes in our app code
 enum APIRequestableError: Error, Equatable {
     case invalidPath(String) // our request path string can't be parsed by URLComponents
@@ -188,7 +173,7 @@ extension APIRequestable {
 
         if let form = self.form {
             if !skipBodyCreation {
-                request.httpBody = try encodeFormData(boundary: boundary, form: form)
+                request.httpBody = try form.encode(using: boundary)
             }
 
             request.setValue("multipart/form-data; charset=utf-8; boundary=\"\(boundary)\"", forHTTPHeaderField: HttpHeader.contentType)
@@ -231,30 +216,6 @@ extension APIRequestable {
 
     public func encode(response: Response) throws -> Data {
         try APIJSONEncoder().encode(response)
-    }
-
-    public func encodeFormData(boundary: String, form: APIFormData) throws -> Data {
-        var data = Data()
-        let delimiter = "--\(boundary)\r\n".data(using: .utf8)!
-
-        for (key, value) in form {
-            data += delimiter
-            data += "Content-Disposition: form-data; name=\"\(key)\"".data(using: .utf8)!
-            switch value {
-            case .string(let string):
-                data += "\r\n\r\n\(string)".data(using: .utf8)!
-            case .data(filename: let filename, type: let type, data: let contents):
-                data += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n".data(using: .utf8)!
-                data += contents
-            case .file(filename: let filename, type: let type, at: let url):
-                data += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n".data(using: .utf8)!
-                data += try Data(contentsOf: url)
-            }
-            data += "\r\n".data(using: .utf8)!
-        }
-
-        data += "--\(boundary)--\r\n".data(using: .utf8)!
-        return data
     }
 }
 

--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -116,7 +116,9 @@ public protocol APIRequestable {
 
     /**
      - parameters:
-        - skipBodyCreation: If this parameter is true, then the returned request's `httpBody` parameter won't be set and it will be the caller's responsibility to create one either by assigning a value to `httpBody` or write it to an external file. Useful if the body would be so big that it wouldn't fit into memory.
+        - skipBodyCreation: If this parameter is true, then the returned request's `httpBody` parameter won't be set and it will be the caller's responsibility
+                            to create one either by assigning a value to `httpBody` or write it to an external file.
+                            Useful if the body would be so big that it wouldn't fit into memory.
         - boundary: The boundary string that separates form fields in the body. Only used if there's a `form` parameter set.
      */
     func urlRequest(relativeTo: URL, accessToken: String?, actAsUserID: String?, skipBodyCreation: Bool, boundary: String) throws -> URLRequest

--- a/Core/Core/Extensions/InputStreamExtensions.swift
+++ b/Core/Core/Extensions/InputStreamExtensions.swift
@@ -45,7 +45,7 @@ extension InputStream {
         let errorOccurred = readResult < 0
 
         if errorOccurred {
-            throw streamError ?? NSError.instructureError("Error while copying contents of InputStream to FileHandle.")
+            throw streamError ?? NSError.instructureError("Error while copying contents of InputStream to OutputStream.")
         }
     }
 }

--- a/Core/Core/Extensions/InputStreamExtensions.swift
+++ b/Core/Core/Extensions/InputStreamExtensions.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension InputStream {
+
+    /**
+     Reads this stream until it is exhausted and writes its contents to the given `FileHandle`. The `FileHandle` must be created for writing.
+     - parameters:
+        - fileHandle: The file handle where the stream's content will be written. It must be created for writing and be opened.
+        - bufferSize: The size of the buffer used during copiyng. The buffer is filled from this `InputStream` then written to the `FileHandle` until the stream has any content available. The default size of the buffer is 1 MB.
+     */
+    public func copy(to fileHandle: FileHandle, bufferSize: Int = 1_048_576) throws {
+        var readResult: Int = 0
+        var buffer: [UInt8] = Array(repeating: 0, count: bufferSize)
+        let dataAvailable = { readResult > 0 }
+
+        repeat {
+            readResult = read(&buffer, maxLength: bufferSize)
+
+            if dataAvailable() {
+                let readDataSize = readResult
+                let bufferContent = Data(bytes: buffer, count: readDataSize)
+                try fileHandle.write(contentsOf: bufferContent)
+            }
+        } while dataAvailable()
+
+        let errorOccurred = readResult < 0
+
+        if errorOccurred {
+            throw streamError ?? NSError.instructureError("Error while copying contents of InputStream to FileHandle.")
+        }
+    }
+}

--- a/Core/Core/Extensions/InputStreamExtensions.swift
+++ b/Core/Core/Extensions/InputStreamExtensions.swift
@@ -21,12 +21,12 @@ import Foundation
 extension InputStream {
 
     /**
-     Reads this stream until it is exhausted and writes its contents to the given `FileHandle`. The `FileHandle` must be created for writing.
+     Reads this stream until it is exhausted and writes its contents to the given `OutputStream`.
      - parameters:
-        - fileHandle: The file handle where the stream's content will be written. It must be created for writing and be opened.
-        - bufferSize: The size of the buffer used during copiyng. The buffer is filled from this `InputStream` then written to the `FileHandle` until the stream has any content available. The default size of the buffer is 1 MB.
+        - outputStream: The output stream to where this stream's content will be written. It must be  be opened.
+        - bufferSize: The size of the buffer used during copiyng. The buffer is filled from this `InputStream` then written to the `OutputStream` until the stream has any content available. The default size of the buffer is 1 MB.
      */
-    public func copy(to fileHandle: FileHandle, bufferSize: Int = 1_048_576) throws {
+    public func copy(to outputStream: OutputStream, bufferSize: Int = 1_048_576) throws {
         var readResult: Int = 0
         var buffer: [UInt8] = Array(repeating: 0, count: bufferSize)
         let dataAvailable = { readResult > 0 }
@@ -37,7 +37,8 @@ extension InputStream {
             if dataAvailable() {
                 let readDataSize = readResult
                 let bufferContent = Data(bytes: buffer, count: readDataSize)
-                try fileHandle.write(contentsOf: bufferContent)
+                let bufferBytes: [UInt8] = Array(bufferContent)
+                outputStream.write(bufferBytes, maxLength: bufferBytes.count)
             }
         } while dataAvailable()
 

--- a/Core/Core/Extensions/OutputStreamExtensions.swift
+++ b/Core/Core/Extensions/OutputStreamExtensions.swift
@@ -1,0 +1,30 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+extension OutputStream {
+
+    static func +=(outputStream: inout OutputStream, string: String) {
+        guard let data = string.data(using: .utf8) else { return }
+        outputStream += data
+    }
+
+    static func +=(outputStream: inout OutputStream, data: Data) {
+        let dataBuffer: [UInt8] = Array(data)
+        outputStream.write(dataBuffer, maxLength: dataBuffer.count)
+    }
+}

--- a/Core/Core/Extensions/OutputStreamExtensions.swift
+++ b/Core/Core/Extensions/OutputStreamExtensions.swift
@@ -18,12 +18,12 @@
 
 extension OutputStream {
 
-    static func +=(outputStream: inout OutputStream, string: String) {
+    static func += (outputStream: inout OutputStream, string: String) {
         guard let data = string.data(using: .utf8) else { return }
         outputStream += data
     }
 
-    static func +=(outputStream: inout OutputStream, data: Data) {
+    static func += (outputStream: inout OutputStream, data: Data) {
         let dataBuffer: [UInt8] = Array(data)
         outputStream.write(dataBuffer, maxLength: dataBuffer.count)
     }

--- a/Core/Core/Extensions/URLRequestExtensions.swift
+++ b/Core/Core/Extensions/URLRequestExtensions.swift
@@ -1,0 +1,33 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension URLRequest {
+
+    /** Returns the form boundary property from the `Content-Type` http header field. */
+    public var boundary: String? {
+        guard let contentType = value(forHTTPHeaderField: HttpHeader.contentType),
+              let boundaryKeyRange = contentType.range(of: "boundary=\"")
+        else { return nil }
+
+        let boundaryValueStart = contentType[boundaryKeyRange.upperBound...]
+        guard let boundaryCloseQuoteIndex =  boundaryValueStart.firstIndex(of: "\"") else { return nil }
+        return String(boundaryValueStart[..<boundaryCloseQuoteIndex])
+    }
+}

--- a/Core/Core/Files/APIFile.swift
+++ b/Core/Core/Files/APIFile.swift
@@ -437,6 +437,7 @@ public struct PostFileUploadRequest: APIRequestable {
         )))
         return form
     }
+    public var isBodyFromURL: Bool { true }
 }
 
 // https://canvas.instructure.com/doc/api/files.html#method.folders.resolve_path

--- a/Core/CoreTests/API/APIFormDataTests.swift
+++ b/Core/CoreTests/API/APIFormDataTests.swift
@@ -1,0 +1,66 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import XCTest
+
+class APIFormDataTests: XCTestCase {
+
+    func testDataEncodeInMemory() {
+        let expectedDataEncoding =
+        """
+        --boundary\r
+        Content-Disposition: form-data; name=\"submission\"; filename=\"filename.txt\"\r
+        Content-Type: text/plain\r
+        \r
+        aaa\r
+        --boundary--\r
+
+        """
+
+        let data = "aaa".data(using: .utf8)!
+        let testee: APIFormData = [(key: "submission", value: .data(filename: "filename.txt", type: "text/plain", data: data))]
+        let result = String(data: try! testee.encode(using: "boundary"), encoding: .utf8)
+        XCTAssertEqual(result, expectedDataEncoding)
+    }
+
+    func testDataEncodeToDisk() throws {
+        let expectedDataEncoding =
+        """
+        --boundary\r
+        Content-Disposition: form-data; name=\"submission\"; filename=\"filename.txt\"\r
+        Content-Type: text/plain\r
+        \r
+        aaa\r
+        --boundary--\r
+
+        """
+
+        let data = "aaa".data(using: .utf8)!
+        let testee: APIFormData = [(key: "submission", value: .data(filename: "filename.txt", type: "text/plain", data: data))]
+        let resultURL: URL = try testee.encode(using: "boundary")
+
+        guard let resultData = try? Data(contentsOf: resultURL) else {
+            XCTFail("Failed to read result file.")
+            return
+        }
+
+        let resultString = String(data: resultData, encoding: .utf8)
+        XCTAssertEqual(resultString, expectedDataEncoding)
+    }
+}

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -175,12 +175,26 @@ class APIRequestableTests: XCTestCase {
         XCTAssertEqual(request.httpBody, expected)
     }
 
+    func testSkipHttpBody() throws {
+        let requestable = UploadBody(body: "hello")
+        let request = try requestable.urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil, skipBodyCreation: true)
+        XCTAssertNil(request.httpBody)
+    }
+
     func testFormData() throws {
         UUID.mock("xxzzxx")
         let requestable = PostForm()
         let expected = try requestable.encodeFormData(boundary: UUID.string, form: requestable.form!)
         let request = try requestable.urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil)
         XCTAssertEqual(request.httpBody, expected)
+        XCTAssertEqual(request.allHTTPHeaderFields?[HttpHeader.contentType], "multipart/form-data; charset=utf-8; boundary=\"xxzzxx\"")
+    }
+
+    func testFormDataWithSkippedHttpBody() throws {
+        UUID.mock("xxzzxx")
+        let requestable = PostForm()
+        let request = try requestable.urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil, skipBodyCreation: true)
+        XCTAssertNil(request.httpBody)
         XCTAssertEqual(request.allHTTPHeaderFields?[HttpHeader.contentType], "multipart/form-data; charset=utf-8; boundary=\"xxzzxx\"")
     }
 

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -184,7 +184,7 @@ class APIRequestableTests: XCTestCase {
     func testFormData() throws {
         UUID.mock("xxzzxx")
         let requestable = PostForm()
-        let expected = try requestable.encodeFormData(boundary: UUID.string, form: requestable.form!)
+        let expected: Data = try requestable.form!.encode(using: UUID.string)
         let request = try requestable.urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil)
         XCTAssertEqual(request.httpBody, expected)
         XCTAssertEqual(request.allHTTPHeaderFields?[HttpHeader.contentType], "multipart/form-data; charset=utf-8; boundary=\"xxzzxx\"")

--- a/Core/CoreTests/Extensions/InputStreamExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/InputStreamExtensionsTests.swift
@@ -1,0 +1,64 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import XCTest
+
+class InputStreamExtensionsTests: XCTestCase {
+
+    func testCopyWithContentSmallerThanBuffer() {
+        copyStreamToFile(streamSize: 10, bufferSize: 15)
+    }
+
+    func testCopyWithContentSizeEqualBuffer() {
+        copyStreamToFile(streamSize: 10, bufferSize: 10)
+    }
+
+    func testCopyWithContentBiggerThanBuffer() {
+        copyStreamToFile(streamSize: 13, bufferSize: 10)
+    }
+
+    private func copyStreamToFile(streamSize: Int, bufferSize: Int) {
+        // Create temp file to where stream content will be written
+        let targetFilePath = URL.temporaryDirectory.appendingPathComponent(UUID.string)
+        guard FileManager.default.createFile(atPath: targetFilePath.path, contents: nil) else {
+            XCTFail("Failed to create temp file.")
+            return
+        }
+        defer { try? FileManager.default.removeItem(at: targetFilePath) }
+        let handle = try! FileHandle(forWritingTo: targetFilePath)
+        defer { handle.closeFile() }
+
+        // Create test data and setup a stream to read it
+        let testData = Data(repeating: 6, count: streamSize)
+        let testDataStream = InputStream(data: testData)
+        testDataStream.open()
+        defer { testDataStream.close() }
+
+        // Copy stream content to file
+        try! testDataStream.copy(to: handle, bufferSize: bufferSize)
+
+        // Read back written data to be compared with original data
+        guard let resultData = try? Data(contentsOf: targetFilePath) else {
+            XCTFail("Failed to read temp file.")
+            return
+        }
+
+        XCTAssertEqual(resultData, testData)
+    }
+}

--- a/Core/CoreTests/Extensions/InputStreamExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/InputStreamExtensionsTests.swift
@@ -41,8 +41,12 @@ class InputStreamExtensionsTests: XCTestCase {
             return
         }
         defer { try? FileManager.default.removeItem(at: targetFilePath) }
-        let handle = try! FileHandle(forWritingTo: targetFilePath)
-        defer { handle.closeFile() }
+        guard let outputStream = OutputStream(toFileAtPath: targetFilePath.path, append: false) else {
+            XCTFail("Failed to open stream to temp file.")
+            return
+        }
+        outputStream.open()
+        defer { outputStream.close() }
 
         // Create test data and setup a stream to read it
         let testData = Data(repeating: 6, count: streamSize)
@@ -51,7 +55,7 @@ class InputStreamExtensionsTests: XCTestCase {
         defer { testDataStream.close() }
 
         // Copy stream content to file
-        try! testDataStream.copy(to: handle, bufferSize: bufferSize)
+        try! testDataStream.copy(to: outputStream, bufferSize: bufferSize)
 
         // Read back written data to be compared with original data
         guard let resultData = try? Data(contentsOf: targetFilePath) else {

--- a/Core/CoreTests/Extensions/URLRequestExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLRequestExtensionsTests.swift
@@ -1,0 +1,29 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import Core
+
+class URLRequestExtensionsTests: XCTestCase {
+
+    func testBoundary() {
+        var testee = URLRequest(url: URL(string: "/")!)
+        testee.setValue("multipart/form-data; charset=utf-8; boundary=\"testBoundary\"", forHTTPHeaderField: HttpHeader.contentType)
+        XCTAssertEqual(testee.boundary, "testBoundary")
+    }
+}


### PR DESCRIPTION
refs: MBL-16104
affects: Student
release note: Fixed a crash on submitting big files.

test plan:
- Try to submit a big file with the share extension. (On an iPhone SE2 a 105 MB pdf was enough. The app also crashes but it requires a larger file.)
- Submission should go through without the share extension crashing.
- Check if file upload works from the application.

<table>
<tr><td/><th>Application memory usage while uploading a 105 MB pdf file</th></tr>
<tr>
<th>Before</th>
<td><img src="https://user-images.githubusercontent.com/72396990/177749296-4ec3d7d6-8405-46cd-8ffe-413eac9e0f0d.png"></td>
</tr>
<tr>
<th>After</th>
<td><img src="https://user-images.githubusercontent.com/72396990/177749336-52c066d5-478a-41bc-b558-f167dacb6f9b.png"></td>
</tr>
</table>