### PR TITLE
Disable pop gesture on root navigation controllers

### DIFF
--- a/Core/Core/UIViews/HelmNavigationController.swift
+++ b/Core/Core/UIViews/HelmNavigationController.swift
@@ -59,6 +59,14 @@ public class HelmNavigationController: UINavigationController {
 
 extension HelmNavigationController: UIGestureRecognizerDelegate {
 
+    /**
+     We only want the pop navigation gesture to work when there are multiple view controllers in the stack.
+     Enabling it on the root view when it also have a swipe gesture setup causes a weird screen freeze issue.
+     */
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        viewControllers.count != 1
+    }
+
     public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         return true
     }


### PR DESCRIPTION
refs: MBL-16123
affects: Parent, Student, Teacher
release note: none

test plan:
- See ticket.
- Check if pop gesture still works correctly if there are multiple view controllers in the stack (except on Homeroom tab where this gesture is disabled)