### PR TITLE
New Analytics Online Attendance gives 401 error

### DIFF
--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -115,7 +115,7 @@ public class LTITools: NSObject {
                     completionHandler(true)
                 }
             } else if self.openInSafari {
-                    self.env.loginDelegate?.openExternalURL(url)
+                    self.env.loginDelegate?.openExternalURLinSafari(url)
                     completionHandler(true)
             } else {
                 let safari = SFSafariViewController(url: url)

--- a/Core/Core/Login/LoginDelegate.swift
+++ b/Core/Core/Login/LoginDelegate.swift
@@ -25,6 +25,7 @@ public protocol LoginDelegate: AnyObject {
     var findSchoolButtonTitle: String { get }
 
     func openExternalURL(_ url: URL)
+    func openExternalURLinSafari(_ url: URL)
     func openSupportTicket()
     func userDidLogin(session: LoginSession)
     func userDidStartActing(as session: LoginSession)
@@ -42,6 +43,7 @@ public extension LoginDelegate {
 
     func openSupportTicket() {}
     func changeUser() {}
+    func openExternalURLinSafari(_ url: URL) {}
 
     func userDidStartActing(as session: LoginSession) {
         userDidLogin(session: session)

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -180,6 +180,10 @@ extension ParentAppDelegate: LoginDelegate {
         }
     }
 
+    func openExternalURLinSafari(_ url: URL) {
+        UIApplication.shared.open(url)
+    }
+
     func launchLimitedWebView(url: URL, from sourceViewController: UIViewController) {
         let controller = CoreWebViewController(invertColorsInDarkMode: true)
         controller.isInteractionLimited = true

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -351,7 +351,11 @@ extension StudentAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
     }
 
     func openExternalURL(_ url: URL) {
-        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+        openExternalURLinSafari(url)
+    }
+
+    func openExternalURLinSafari(_ url: URL) {
+        UIApplication.shared.open(url)
     }
 
     func userDidLogin(session: LoginSession) {

--- a/TestsFoundation/TestsFoundation/Login/TestLoginDelegate.swift
+++ b/TestsFoundation/TestsFoundation/Login/TestLoginDelegate.swift
@@ -27,6 +27,10 @@ public class TestLoginDelegate: LoginDelegate {
         externalURL = url
     }
 
+    public func openExternalURLinSafari(_ url: URL) {
+        externalURL = url
+    }
+
     public var session: LoginSession?
     public func userDidLogin(session: LoginSession) {
         self.session = session

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -252,6 +252,10 @@ extension TeacherAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
         environment.router.show(safari, from: from, options: .modal())
     }
 
+    func openExternalURLinSafari(_ url: URL) {
+        UIApplication.shared.open(url)
+    }
+
     func userDidLogin(session: LoginSession) {
         LoginSession.add(session)
         setup(session: session)


### PR DESCRIPTION
refs: MBL-16109
affects: Teacher, Student
release note: Fixed open external tools in Safari settings.
test plan: See ticket. 
- In the Canvas app settings toggle the 'Open external tools in Safari' and see if Canvas opens the New Analytics in Safari. 
- In Safari settings set the 'Prevent Cross-Site Tracking' off to see the tool in iframe load on the Online Attendance tab.