### PR TITLE
Courses show as past enrollments when logged in through trust URL

### DIFF
--- a/Core/Core/Dashboard/Model/CourseSectionStatus.swift
+++ b/Core/Core/Dashboard/Model/CourseSectionStatus.swift
@@ -45,7 +45,7 @@ class CourseSectionStatus {
         let sectionEndDates = sections.map { $0.endAt }
 
         // Check if there's an active section
-        if sectionEndDates.contains(where: { $0 == nil || ($0 != nil && Clock.now < $0!) }) {
+        if sections.count == 0 || sectionEndDates.contains(where: { $0 == nil || ($0 != nil && Clock.now < $0!) }) {
             return false
         }
 

--- a/Core/CoreTests/Dashboard/Model/CourseSectionStatusTests.swift
+++ b/Core/CoreTests/Dashboard/Model/CourseSectionStatusTests.swift
@@ -55,6 +55,9 @@ class CourseSectionStatusTests: CoreTestCase {
 
         XCTAssertTrue(testee.isAllSectionsExpired(in: course))
         XCTAssertTrue(testee.isAllSectionsExpired(for: dashboardCard, in: [course]))
+
+        let noSectionCourse = Course.make(from: .make(id: "course_2", sections: nil))
+        XCTAssertFalse(testee.isAllSectionsExpired(in: noSectionCourse))
     }
 
     func testExpiredSectionAndActiveSectionWithoutEndDate() {


### PR DESCRIPTION
refs: MBL-16157
affects: Student
release note: Fixed courses show as past enrollments when logged in through trust URL
test plan: See ticket. Check if [MBL-16035](https://github.com/instructure/canvas-ios/pull/2160) and [MBL-16035_2](https://github.com/instructure/canvas-ios/pull/2161) are still working properly.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/178981483-680e09df-143b-493c-9d40-8643de406c3c.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/178981243-4a93a28b-cfea-48a3-972d-204f0a878079.png"></td>
</tr>
</table>