### PR TITLE
Can’t view documents embedded by students in a discussion

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -496,7 +496,7 @@ extension DiscussionDetailsViewController: CoreWebViewLinkDelegate {
             url.host == env.currentSession?.baseURL.host,
             url.path.hasPrefix("/\(context.pathComponent)/discussion_topics/\(topicID)/")
         else {
-            if url.pathComponents.count > 1, url.pathComponents[1] == "files" {
+            if url.pathComponents.contains("files") {
                 env.router.route(to: url, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             } else {
                 env.router.route(to: url, from: self)

--- a/Core/Core/Files/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/FileDetails/FileDetailsViewController.swift
@@ -127,7 +127,7 @@ public class FileDetailsViewController: UIViewController, CoreWebViewLinkDelegat
         guard let file = files.first else {
             if let error = files.error {
                 // If file download failed because of unauthorization error and we have a verifier token, then we modify the url and try to open the file in a webview.
-                if var url = originURL, url.containsVerifier, case .unauthorized = (error as? APIError) {
+                if var url = originURL, url.containsVerifier {
                     if !url.path.hasSuffix("download") {
                         url.path.append("/download")
                         url.queryItems?.append(URLQueryItem(name: "download_frd", value: "1"))


### PR DESCRIPTION
refs: MBL-16152
affects: Student, Teacher
release note: Fixed can’t view documents embedded by students in a discussion.
test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/179235671-d272ead5-4ab1-4a78-b176-817e407017e9.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/179235653-822c1d6b-af93-44d4-87ae-489f6077b400.png"></td>
</tr>
</table>