### PR TITLE
Guard next page fetch on courses update.

### DIFF
--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -73,7 +73,7 @@ class DashboardCardsViewModel: ObservableObject {
     }
 
     private func update() {
-        guard cards.requested, !cards.pending, !courseSectionStatus.isUpdatePending, courses.requested, !courses.pending else { return }
+        guard cards.requested, !cards.pending, !courseSectionStatus.isUpdatePending, courses.requested, !courses.pending, !courses.hasNextPage else { return }
 
         guard cards.state != .error else {
             state = .error(NSLocalizedString("Something went wrong", comment: ""))


### PR DESCRIPTION
refs: MBL-16165
affects: Teacher
release note: Fixed large number of enrollments causes 'No Courses' message on the dashboard.
test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/181784188-eb761491-ae7c-4ef9-8051-6020d1ab5fda.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/181784180-9f0e7b35-5560-465b-b349-a0d8e385ef97.png"></td>
</tr>
</table>