### PR TITLE
Assign to everyone else still shows up when it does not apply to an assignment

### DIFF
--- a/Core/Core/Assignments/APIAssignment.swift
+++ b/Core/Core/Assignments/APIAssignment.swift
@@ -46,6 +46,7 @@ public struct APIAssignment: Codable, Equatable {
     let moderated_grading: Bool?
     let name: String
     let needs_grading_count: Int?
+    let only_visible_to_overrides: Bool?
     let overrides: [APIAssignmentOverride]?
     let planner_override: APIPlannerOverride?
     let points_possible: Double?
@@ -129,6 +130,7 @@ extension APIAssignment {
         moderated_grading: Bool? = nil,
         name: String = "some assignment",
         needs_grading_count: Int = 1,
+        only_visible_to_overrides: Bool? = false,
         overrides: [APIAssignmentOverride]? = nil,
         planner_override: APIPlannerOverride? = nil,
         points_possible: Double? = 10,
@@ -181,6 +183,7 @@ extension APIAssignment {
             moderated_grading: moderated_grading,
             name: name,
             needs_grading_count: needs_grading_count,
+            only_visible_to_overrides: only_visible_to_overrides,
             overrides: overrides,
             planner_override: planner_override,
             points_possible: points_possible,
@@ -311,6 +314,7 @@ struct APIAssignmentParameters: Codable, Equatable {
     let grading_type: GradingType?
     let lock_at: Date?
     let name: String?
+    let only_visible_to_overrides: Bool?
     let points_possible: Double?
     let published: Bool?
     // let submission_types: [SubmissionType]?
@@ -324,6 +328,7 @@ struct APIAssignmentParameters: Codable, Equatable {
         try container.encodeIfPresent(grading_type, forKey: .grading_type)
         try container.encode(lock_at, forKey: .lock_at) // encode null to unset
         try container.encodeIfPresent(name, forKey: .name)
+        try container.encodeIfPresent(only_visible_to_overrides, forKey: .only_visible_to_overrides)
         try container.encode(points_possible, forKey: .points_possible)
         try container.encodeIfPresent(published, forKey: .published)
         try container.encode(unlock_at, forKey: .unlock_at) // encode null to unset

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -57,6 +57,7 @@ public class Assignment: NSManagedObject {
     @NSManaged public var moderatedGrading: Bool
     @NSManaged public var name: String
     @NSManaged public var needsGradingCount: Int
+    @NSManaged public var onlyVisibleToOverrides: Bool
     @NSManaged public var overrides: Set<AssignmentOverride>
     @NSManaged public var pointsPossibleRaw: NSNumber?
     @NSManaged public var position: Int
@@ -174,6 +175,7 @@ extension Assignment {
         moderatedGrading = item.moderated_grading == true
         name = item.name
         needsGradingCount = item.needs_grading_count ?? 0
+        onlyVisibleToOverrides = item.only_visible_to_overrides ?? false
         pointsPossible = item.points_possible
         position = item.position ?? Int.max
         published = item.published != false

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -217,6 +217,7 @@ public struct AssignmentEditorView: View {
             gradingType: gradingType,
             lockAt: lockAt,
             name: name,
+            onlyVisibleToOverrides: !overrides.contains { $0.isEveryone },
             overrides: originalOverrides == overrides ? nil : apiOverrides,
             pointsPossible: pointsPossible,
             published: published,

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
@@ -28,17 +28,14 @@ struct AssignmentOverridesEditor: View {
     @Environment(\.viewController) var controller
 
     var body: some View {
-        let everyonesCount = overrides.filter { $0.isEveryone } .count
         ForEach(overrides) { override in
             EditorSection(label: HStack {
                 Text("Assign", bundle: .core)
                 Spacer()
-                if !override.isEveryone || everyonesCount != 1 {
-                    Button(action: { toRemove = override }, label: {
-                        Text("Remove", bundle: .core)
-                            .foregroundColor(Color(Brand.shared.linkColor))
-                    })
-                }
+                Button(action: { toRemove = override }, label: {
+                    Text("Remove", bundle: .core)
+                        .foregroundColor(Color(Brand.shared.linkColor))
+                })
             }) {
                 ButtonRow(action: { pickAssignee(for: override) }, content: {
                     Text("Assign to", bundle: .core)
@@ -147,17 +144,18 @@ struct AssignmentOverridesEditor: View {
             )
         } .sorted { $0.id < $1.id }
         // Everyone
-        let base = assignment.allDates.first { $0.base }
-        overrides.append(Override(
-            dueAt: base?.dueAt,
-            id: "base",
-            groupID: nil,
-            lockAt: base?.lockAt,
-            sectionID: nil,
-            studentIDs: nil,
-            title: nil,
-            unlockAt: base?.unlockAt
-        ))
+        if assignment.onlyVisibleToOverrides == false, let base = assignment.allDates.first(where: { $0.base }) {
+            overrides.append(Override(
+                dueAt: base.dueAt,
+                id: "base",
+                groupID: nil,
+                lockAt: base.lockAt,
+                sectionID: nil,
+                studentIDs: nil,
+                title: nil,
+                unlockAt: base.unlockAt
+            ))
+        }
         return overrides
     }
 

--- a/Core/Core/Assignments/GetAssignments.swift
+++ b/Core/Core/Assignments/GetAssignments.swift
@@ -162,6 +162,7 @@ class UpdateAssignment: APIUseCase {
         gradingType: GradingType?,
         lockAt: Date?,
         name: String? = nil,
+        onlyVisibleToOverrides: Bool? = false,
         overrides: [APIAssignmentOverride]?,
         pointsPossible: Double?,
         published: Bool? = nil,
@@ -177,6 +178,7 @@ class UpdateAssignment: APIUseCase {
                 grading_type: gradingType,
                 lock_at: lockAt,
                 name: name,
+                only_visible_to_overrides: onlyVisibleToOverrides,
                 points_possible: pointsPossible,
                 published: published,
                 unlock_at: unlockAt

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -59,6 +59,7 @@
         <attribute name="moderatedGrading" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="needsGradingCount" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="onlyVisibleToOverrides" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="pointsPossibleRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="position" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="published" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>

--- a/Core/CoreTests/Assignments/APIAssignmentTests.swift
+++ b/Core/CoreTests/Assignments/APIAssignmentTests.swift
@@ -63,6 +63,7 @@ class APIAssignmentRequestableTests: XCTestCase {
             grading_type: .percent,
             lock_at: nil,
             name: nil,
+            only_visible_to_overrides: nil,
             points_possible: 10,
             published: nil,
             unlock_at: nil


### PR DESCRIPTION
refs: MBL-16189
affects: Teacher
release note: Fixed assign to everyone else still shows up when it does not apply to an assignment.
test plan: See ticket.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/186427225-0d11662b-8aef-4fba-801c-5abde66760a3.png"></td>
<td><img src="https://user-images.githubusercontent.com/79920680/186427234-18acae30-2b99-4091-a847-94ea0141de6f.png"></td>
</tr>
</table>

