### PR TITLE
Side menu won't show unread Inbox capsule

### DIFF
--- a/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
@@ -64,7 +64,7 @@ struct SideMenuBottomSection: View {
                 Button {
                     showHelpMenu()
                 } label: {
-                    SideMenuItem(id: "help", image: .questionLine, title: Text("\(root.text ?? "")", bundle: .core), badgeValue: 0)
+                    SideMenuItem(id: "help", image: .questionLine, title: Text("\(root.text ?? "")", bundle: .core))
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             }
@@ -73,7 +73,7 @@ struct SideMenuBottomSection: View {
                 Button {
                     self.route(to: "/act-as-user", options: .modal(embedInNav: true))
                 } label: {
-                    SideMenuItem(id: "actAsUser", image: .userLine, title: Text("Act as User", bundle: .core), badgeValue: 0)
+                    SideMenuItem(id: "actAsUser", image: .userLine, title: Text("Act as User", bundle: .core))
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             }
@@ -85,7 +85,7 @@ struct SideMenuBottomSection: View {
                         delegate.changeUser()
                     }
                 } label: {
-                    SideMenuItem(id: "changeUser", image: .userLine, title: Text("Change User", bundle: .core), badgeValue: 0)
+                    SideMenuItem(id: "changeUser", image: .userLine, title: Text("Change User", bundle: .core))
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             }
@@ -98,14 +98,14 @@ struct SideMenuBottomSection: View {
                 Button {
                     stopActing()
                 } label: {
-                    SideMenuItem(id: "logOut", image: Image("logout", bundle: .core), title: logoutTitleText, badgeValue: 0)
+                    SideMenuItem(id: "logOut", image: Image("logout", bundle: .core), title: logoutTitleText)
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             } else {
                 Button {
                     handleLogout()
                 } label: {
-                    SideMenuItem(id: "logOut", image: Image("logout", bundle: .core), title: Text("Log Out", bundle: .core), badgeValue: 0)
+                    SideMenuItem(id: "logOut", image: Image("logout", bundle: .core), title: Text("Log Out", bundle: .core))
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             }

--- a/Core/Core/Profile/SideMenu/SideMenuItem.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuItem.swift
@@ -24,7 +24,21 @@ struct SideMenuItem: View {
     let image: Image
     let title: Text
 
-    @State var badgeValue: UInt = 0
+    @Binding var badgeValue: UInt
+
+    init(id: String, image: Image, title: Text, badgeValue: Binding<UInt>) {
+        self.id = id
+        self.image = image
+        self.title = title
+        _badgeValue = badgeValue
+    }
+
+    init(id: String, image: Image, title: Text) {
+        self.id = id
+        self.image = image
+        self.title = title
+        _badgeValue = .constant(0)
+    }
 
     var body: some View {
         HStack(spacing: 20) {
@@ -35,7 +49,7 @@ struct SideMenuItem: View {
             Spacer()
 
             if badgeValue > 0 {
-                Badge(value: badgeValue)
+                Badge(value: $badgeValue)
             }
         }
         .padding(20)
@@ -48,18 +62,20 @@ struct SideMenuItem: View {
 }
 
 private struct Badge: View {
-    @State var value: UInt
+    @Binding var value: UInt
 
     var body: some View {
-        ZStack {
-            Capsule().fill(Color.crimson).frame(maxWidth: CGFloat(digitCount()) * 12, maxHeight: 18)
-            Text("\(value)").font(.regular12).foregroundColor(.white)
-        }
+             clampedValueText()
+                .font(.semibold12)
+                .padding(EdgeInsets(top: 2.5, leading: 6.5, bottom: 3, trailing: 6.5))
+                .foregroundColor(.white)
+                .background(Color.crimson)
+                .clipShape(Capsule())
     }
 
-    func digitCount() -> Double {
-        let count = Double("\(value)".count)
-        return count == 1 ? 1.5 : count
+    func clampedValueText() -> Text {
+        guard value < 100 else { return Text("99+") }
+        return Text("\(value)")
     }
 }
 
@@ -67,7 +83,7 @@ private struct Badge: View {
 
 struct SideMenuItem_Previews: PreviewProvider {
     static var previews: some View {
-        SideMenuItem(id: "inbox", image: .emailLine, title: Text("Inbox", bundle: .core), badgeValue: 42).buttonStyle(ContextButton(contextColor: Brand.shared.primary))
+        SideMenuItem(id: "inbox", image: .emailLine, title: Text("Inbox", bundle: .core), badgeValue: .constant(123)).buttonStyle(ContextButton(contextColor: Brand.shared.primary))
     }
 }
 

--- a/Core/Core/Profile/SideMenu/SideMenuItem.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuItem.swift
@@ -56,6 +56,7 @@ struct SideMenuItem: View {
 
             if badgeValue > 0 {
                 Badge(value: $badgeValue)
+                    .accessibilityHidden(true)
             }
         }
         .padding(20)

--- a/Core/Core/Profile/SideMenu/SideMenuItem.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuItem.swift
@@ -20,11 +20,17 @@ import SwiftUI
 
 struct SideMenuItem: View {
     @Environment(\.colorScheme) var colorScheme
+    @Binding var badgeValue: UInt
+
     let id: String
     let image: Image
     let title: Text
-
-    @Binding var badgeValue: UInt
+    var accessibilityHint: Text {
+        guard badgeValue > 0 else { return Text("") }
+        return Text(String.localizedStringWithFormat(
+            NSLocalizedString("conversation_unread_messages", bundle: .core, comment: ""),
+            badgeValue))
+    }
 
     init(id: String, image: Image, title: Text, badgeValue: Binding<UInt>) {
         self.id = id
@@ -57,6 +63,7 @@ struct SideMenuItem: View {
         .contentShape(Rectangle())
         .accessibilityElement(children: .ignore)
         .accessibility(label: title)
+        .accessibilityHint(accessibilityHint)
         .identifier("Profile.\(id)Button")
     }
 }
@@ -65,12 +72,12 @@ private struct Badge: View {
     @Binding var value: UInt
 
     var body: some View {
-             clampedValueText()
-                .font(.semibold12)
-                .padding(EdgeInsets(top: 2.5, leading: 6.5, bottom: 3, trailing: 6.5))
-                .foregroundColor(.white)
-                .background(Color.crimson)
-                .clipShape(Capsule())
+        clampedValueText()
+            .font(.semibold12)
+            .padding(EdgeInsets(top: 2.5, leading: 6.5, bottom: 3, trailing: 6.5))
+            .foregroundColor(.white)
+            .background(Color.crimson)
+            .clipShape(Capsule())
     }
 
     func clampedValueText() -> Text {

--- a/Core/Core/Profile/SideMenu/SideMenuMainSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuMainSection.swift
@@ -53,7 +53,7 @@ struct SideMenuMainSection: View {
                 Button {
                     route(to: "/conversations")
                 } label: {
-                    SideMenuItem(id: "inbox", image: .emailLine, title: Text("Inbox", bundle: .core), badgeValue: unreadCount).onAppear {
+                    SideMenuItem(id: "inbox", image: .emailLine, title: Text("Inbox", bundle: .core), badgeValue: $unreadCount).onAppear {
                         env.api.makeRequest(GetConversationsUnreadCountRequest()) { (response, _, _) in
                             self.unreadCount = response?.unread_count ?? 0
                         }
@@ -91,7 +91,7 @@ struct SideMenuMainSection: View {
                     route(to: "/profile/settings", options: .modal(.formSheet, embedInNav: true, addDoneButton: true))
                 } label: {
                         SideMenuItem(id: "settings", image: .settingsLine,
-                                 title: Text("Settings", bundle: .core), badgeValue: 0)
+                                 title: Text("Settings", bundle: .core))
                 }
                 .buttonStyle(ContextButton(contextColor: Brand.shared.primary))
             }

--- a/Core/Core/Profile/SideMenu/SideMenuOptionsSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuOptionsSection.swift
@@ -39,7 +39,7 @@ struct SideMenuOptionsSection: View {
                     viewModel.colorOverlay.toggle()
                 }
             } else {
-                SideMenuToggleItem(id: "darkMode", image: .imageSolid, title: Text("Dark Mode", bundle: .core), isOn: $viewModel.darkMode).onTapGesture {
+                SideMenuToggleItem(id: "darkMode", image: .imageLine, title: Text("Dark Mode", bundle: .core), isOn: $viewModel.darkMode).onTapGesture {
                     viewModel.darkMode.toggle()
                 }
             }

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -136,17 +136,12 @@ class DashboardViewController: UIViewController, ErrorViewController {
 
     func updateBadgeCount() {
         profileButton.addBadge(number: badgeCount, color: currentColor)
+        profileButton.accessibilityLabel = NSLocalizedString("Settings", comment: "")
         if badgeCount > 0 {
-            let unreadMessages = String.localizedStringWithFormat(
+            profileButton.accessibilityHint = String.localizedStringWithFormat(
                 NSLocalizedString("conversation_unread_messages", bundle: .core, comment: ""),
                 badgeCount
             )
-            profileButton.accessibilityLabel = String.localizedStringWithFormat(
-                NSLocalizedString("Settings. %@", comment: ""),
-                unreadMessages
-            )
-        } else {
-            profileButton.accessibilityLabel = NSLocalizedString("Settings", comment: "")
         }
     }
 

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -55,7 +55,8 @@ class DashboardViewControllerTests: ParentTestCase {
         XCTAssert(vc.tabsController.viewControllers?[1] is PlannerViewController)
         XCTAssert(vc.tabsController.viewControllers?[2] is ObserverAlertListViewController)
 
-        XCTAssertEqual(vc.profileButton.accessibilityLabel, "Settings. 3 unread conversations")
+        XCTAssertEqual(vc.profileButton.accessibilityLabel, "Settings")
+        XCTAssertEqual(vc.profileButton.accessibilityHint, "3 unread conversations")
         vc.profileButton.sendActions(for: .primaryActionTriggered)
         XCTAssert(router.lastRoutedTo("/profile", withOptions: .modal()))
 


### PR DESCRIPTION
refs: MBL-16219
affects: Parent
release note: Fixed the count of unread Inbox messages won't show in the side menu.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/187470104-dc92eb97-39d4-4489-b0d9-2861f08fbf4e.png" height=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/187469875-a5b77b6e-c623-4d35-880c-fffbe1b52e73.png" height=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
