### PR TITLE
Pull to refresh for webViews

### DIFF
--- a/CanvasCore/CanvasCore/ReactNativeModules/CoreWebViewWrapper.swift
+++ b/CanvasCore/CanvasCore/ReactNativeModules/CoreWebViewWrapper.swift
@@ -20,7 +20,7 @@ import WebKit
 import Core
 
 public class CoreWebViewWrapper: UIView, RCTAutoInsetsProtocol {
-    @objc public let webView = CoreWebView()
+    @objc public let webView = CoreWebView(isPullToRefreshEnabled: false)
 
     @objc public var onError: RCTDirectEventBlock?
     @objc public var onFinishedLoading: RCTDirectEventBlock?

--- a/CanvasCore/CanvasCore/ReactNativeModules/CoreWebViewWrapper.swift
+++ b/CanvasCore/CanvasCore/ReactNativeModules/CoreWebViewWrapper.swift
@@ -20,7 +20,7 @@ import WebKit
 import Core
 
 public class CoreWebViewWrapper: UIView, RCTAutoInsetsProtocol {
-    @objc public let webView = CoreWebView(isPullToRefreshEnabled: false)
+    @objc public let webView = CoreWebView(pullToRefresh: .disabled)
 
     @objc public var onError: RCTDirectEventBlock?
     @objc public var onFinishedLoading: RCTDirectEventBlock?

--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -35,8 +35,16 @@ public struct K5SubjectView: View {
                     K5SubjectHeaderView(title: viewModel.courseTitle, imageUrl: viewModel.courseImageUrl, backgroundColor: Color(viewModel.courseColor ?? .clear)).padding(padding)
                 }
                 if let currentPageURL = viewModel.currentPageURL {
-                    WebView(url: currentPageURL, customUserAgentName: nil, disableZoom: true, configuration: viewModel.config, invertColorsInDarkMode: true)
-                        .reload(on: viewModel.reloadWebView)
+                    WebView(
+                        url: currentPageURL,
+                        customUserAgentName: nil,
+                        disableZoom: true,
+                        isPullToRefreshEnabled: true,
+                        pullToRefreshColor: viewModel.courseColor,
+                        configuration: viewModel.config,
+                        invertColorsInDarkMode: true
+                    )
+                    .reload(on: viewModel.reloadWebView)
                 }
                 Divider()
             }

--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -39,8 +39,7 @@ public struct K5SubjectView: View {
                         url: currentPageURL,
                         customUserAgentName: nil,
                         disableZoom: true,
-                        isPullToRefreshEnabled: true,
-                        pullToRefreshColor: viewModel.courseColor,
+                        pullToRefresh: .enabled(color: viewModel.courseColor),
                         configuration: viewModel.config,
                         invertColorsInDarkMode: true
                     )

--- a/Core/Core/Dashboard/K5/Model/Schedule/PlannerOverrideUpdater.swift
+++ b/Core/Core/Dashboard/K5/Model/Schedule/PlannerOverrideUpdater.swift
@@ -23,7 +23,7 @@ public class PlannerOverrideUpdater {
     public var updateInProgress: Bool { completion != nil }
 
     private let api: API
-    private var completion:((_ succeeded: Bool) -> Void)?
+    private var completion: ((_ succeeded: Bool) -> Void)?
 
     public init(api: API, plannableId: ID, plannableType: String, overrideId: ID?) {
         self.api = api

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -37,7 +37,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
     public var titleSubtitleView = TitleSubtitleView.create()
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewPlaceholder: UIView!
-    var webView = CoreWebView()
+    var webView = CoreWebView(isPullToRefreshEnabled: false)
 
     public var color: UIColor?
     var context = Context.currentUser

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -37,7 +37,7 @@ public class DiscussionDetailsViewController: UIViewController, ColoredNavViewPr
     public var titleSubtitleView = TitleSubtitleView.create()
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewPlaceholder: UIView!
-    var webView = CoreWebView(isPullToRefreshEnabled: false)
+    var webView = CoreWebView(pullToRefresh: .disabled)
 
     public var color: UIColor?
     var context = Context.currentUser

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -29,7 +29,7 @@ public class DiscussionReplyViewController: UIViewController, ErrorViewControlle
     @IBOutlet weak var scrollView: UIScrollView!
     let titleSubtitleView = TitleSubtitleView.create()
     @IBOutlet weak var viewMoreButton: UIButton!
-    var webView = CoreWebView(isPullToRefreshEnabled: false)
+    var webView = CoreWebView(pullToRefresh: .disabled)
     @IBOutlet weak var webViewContainer: UIView!
     @IBOutlet var webViewHeight: NSLayoutConstraint!
 

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -29,7 +29,7 @@ public class DiscussionReplyViewController: UIViewController, ErrorViewControlle
     @IBOutlet weak var scrollView: UIScrollView!
     let titleSubtitleView = TitleSubtitleView.create()
     @IBOutlet weak var viewMoreButton: UIButton!
-    var webView = CoreWebView()
+    var webView = CoreWebView(isPullToRefreshEnabled: false)
     @IBOutlet weak var webViewContainer: UIView!
     @IBOutlet var webViewHeight: NSLayoutConstraint!
 

--- a/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
+++ b/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 public struct EmbeddedWebPageView<ViewModel: EmbeddedWebPageViewModel>: View {
     @ObservedObject private var viewModel: ViewModel
     private let isPullToRefreshEnabled: Bool
-    
+
     public init(
         viewModel: ViewModel,
         isPullToRefreshEnabled: Bool

--- a/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
+++ b/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
@@ -20,14 +20,25 @@ import SwiftUI
 
 public struct EmbeddedWebPageView<ViewModel: EmbeddedWebPageViewModel>: View {
     @ObservedObject private var viewModel: ViewModel
-
-    public init(viewModel: ViewModel) {
+    private let isPullToRefreshEnabled: Bool
+    
+    public init(
+        viewModel: ViewModel,
+        isPullToRefreshEnabled: Bool
+    ) {
         self.viewModel = viewModel
+        self.isPullToRefreshEnabled = isPullToRefreshEnabled
     }
 
     public var body: some View {
         WebSession(url: viewModel.url) { sessionURL in
-            WebView(url: sessionURL, customUserAgentName: nil, disableZoom: true)
+            WebView(
+                url: sessionURL,
+                customUserAgentName: nil,
+                disableZoom: true,
+                isPullToRefreshEnabled: isPullToRefreshEnabled,
+                pullToRefreshColor: viewModel.contextColor
+            )
         }
         .navigationTitle(viewModel.navTitle, subtitle: viewModel.subTitle)
         .navigationBarStyle(.color(viewModel.contextColor))

--- a/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
+++ b/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
@@ -36,8 +36,7 @@ public struct EmbeddedWebPageView<ViewModel: EmbeddedWebPageViewModel>: View {
                 url: sessionURL,
                 customUserAgentName: nil,
                 disableZoom: true,
-                isPullToRefreshEnabled: isPullToRefreshEnabled,
-                pullToRefreshColor: viewModel.contextColor
+                pullToRefresh: isPullToRefreshEnabled ? .enabled(color: viewModel.contextColor) : .disabled
             )
         }
         .navigationTitle(viewModel.navTitle, subtitle: viewModel.subTitle)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -181,7 +181,7 @@ public class FileDetailsViewController: UIViewController, CoreWebViewLinkDelegat
 
     func embedWebView(for url: URL, isLocalURL: Bool = true) {
         let webView = CoreWebView(
-            isPullToRefreshEnabled: false,
+            pullToRefresh: .disabled,
             invertColorsInDarkMode: true
         )
         contentView.addSubview(webView)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -180,7 +180,10 @@ public class FileDetailsViewController: UIViewController, CoreWebViewLinkDelegat
     }
 
     func embedWebView(for url: URL, isLocalURL: Bool = true) {
-        let webView = CoreWebView(invertColorsInDarkMode: true)
+        let webView = CoreWebView(
+            isPullToRefreshEnabled: false,
+            invertColorsInDarkMode: true
+        )
         contentView.addSubview(webView)
         webView.pin(inside: contentView)
         webView.linkDelegate = self

--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 public class PageDetailsViewController: UIViewController, ColoredNavViewProtocol, ErrorViewController {
     lazy var optionsButton = UIBarButtonItem(image: .moreLine, style: .plain, target: self, action: #selector(showOptions))
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
     public let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 public class PageDetailsViewController: UIViewController, ColoredNavViewProtocol, ErrorViewController {
     lazy var optionsButton = UIBarButtonItem(image: .moreLine, style: .plain, target: self, action: #selector(showOptions))
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
     public let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Core/Core/SwiftUIViews/WebView.swift
+++ b/Core/Core/SwiftUIViews/WebView.swift
@@ -27,8 +27,7 @@ public struct WebView: UIViewRepresentable {
     private let source: Source?
     private var customUserAgentName: String?
     private var disableZoom: Bool = false
-    private var isPullToRefreshEnabled: Bool
-    private var pullToRefreshColor: UIColor?
+    private var pullToRefresh: CoreWebView.PullToRefresh
     private var invertColorsInDarkMode: Bool = false
     private var reloadTrigger: AnyPublisher<Void, Never>?
     private var configuration: WKWebViewConfiguration?
@@ -40,43 +39,41 @@ public struct WebView: UIViewRepresentable {
 
     public init(
         url: URL?,
-        isPullToRefreshEnabled: Bool
+        pullToRefresh: CoreWebView.PullToRefresh
     ) {
         source = url.map { .request(URLRequest(url: $0)) }
-        self.isPullToRefreshEnabled = isPullToRefreshEnabled
+        self.pullToRefresh = pullToRefresh
     }
 
     public init(
         url: URL?,
         customUserAgentName: String?,
         disableZoom: Bool = false,
-        isPullToRefreshEnabled: Bool,
-        pullToRefreshColor: UIColor? = nil,
+        pullToRefresh: CoreWebView.PullToRefresh,
         configuration: WKWebViewConfiguration? = nil,
         invertColorsInDarkMode: Bool = false
     ) {
-        self.init(url: url, isPullToRefreshEnabled: isPullToRefreshEnabled)
+        self.init(url: url, pullToRefresh: pullToRefresh)
         self.customUserAgentName = customUserAgentName
         self.disableZoom = disableZoom
-        self.isPullToRefreshEnabled = isPullToRefreshEnabled
-        self.pullToRefreshColor = pullToRefreshColor
+        self.pullToRefresh = pullToRefresh
         self.invertColorsInDarkMode = invertColorsInDarkMode
         self.configuration = configuration
     }
 
     public init(html: String?) {
         source = html.map { .html($0) }
-        isPullToRefreshEnabled = false
+        pullToRefresh = .disabled
     }
 
     public init(
         request: URLRequest,
         disableZoom: Bool = false,
-        isPullToRefreshEnabled: Bool
+        pullToRefresh: CoreWebView.PullToRefresh
     ) {
         source = .request(request)
         self.disableZoom = disableZoom
-        self.isPullToRefreshEnabled = isPullToRefreshEnabled
+        self.pullToRefresh = pullToRefresh
     }
 
     // MARK: - View Modifiers
@@ -120,8 +117,7 @@ public struct WebView: UIViewRepresentable {
         CoreWebView(
             customUserAgentName: customUserAgentName,
             disableZoom: disableZoom,
-            isPullToRefreshEnabled: isPullToRefreshEnabled,
-            pullToRefreshColor: pullToRefreshColor,
+            pullToRefresh: pullToRefresh,
             configuration: configuration,
             invertColorsInDarkMode: invertColorsInDarkMode
         )

--- a/Core/Core/SwiftUIViews/WebView.swift
+++ b/Core/Core/SwiftUIViews/WebView.swift
@@ -28,7 +28,7 @@ public struct WebView: UIViewRepresentable {
     private var customUserAgentName: String?
     private var disableZoom: Bool = false
     private var isPullToRefreshEnabled: Bool
-    private var pullToRefreshColor: UIColor? = nil
+    private var pullToRefreshColor: UIColor?
     private var invertColorsInDarkMode: Bool = false
     private var reloadTrigger: AnyPublisher<Void, Never>?
     private var configuration: WKWebViewConfiguration?
@@ -73,9 +73,8 @@ public struct WebView: UIViewRepresentable {
         request: URLRequest,
         disableZoom: Bool = false,
         isPullToRefreshEnabled: Bool
-        
     ) {
-        self.source = .request(request)
+        source = .request(request)
         self.disableZoom = disableZoom
         self.isPullToRefreshEnabled = isPullToRefreshEnabled
     }

--- a/Core/Core/SwiftUIViews/WebView.swift
+++ b/Core/Core/SwiftUIViews/WebView.swift
@@ -27,6 +27,8 @@ public struct WebView: UIViewRepresentable {
     private let source: Source?
     private var customUserAgentName: String?
     private var disableZoom: Bool = false
+    private var isPullToRefreshEnabled: Bool
+    private var pullToRefreshColor: UIColor? = nil
     private var invertColorsInDarkMode: Bool = false
     private var reloadTrigger: AnyPublisher<Void, Never>?
     private var configuration: WKWebViewConfiguration?
@@ -36,25 +38,46 @@ public struct WebView: UIViewRepresentable {
 
     // MARK: - Initializers
 
-    public init(url: URL?) {
+    public init(
+        url: URL?,
+        isPullToRefreshEnabled: Bool
+    ) {
         source = url.map { .request(URLRequest(url: $0)) }
+        self.isPullToRefreshEnabled = isPullToRefreshEnabled
     }
 
-    public init(url: URL?, customUserAgentName: String?, disableZoom: Bool = false, configuration: WKWebViewConfiguration? = nil, invertColorsInDarkMode: Bool = false) {
-        self.init(url: url)
+    public init(
+        url: URL?,
+        customUserAgentName: String?,
+        disableZoom: Bool = false,
+        isPullToRefreshEnabled: Bool,
+        pullToRefreshColor: UIColor? = nil,
+        configuration: WKWebViewConfiguration? = nil,
+        invertColorsInDarkMode: Bool = false
+    ) {
+        self.init(url: url, isPullToRefreshEnabled: isPullToRefreshEnabled)
         self.customUserAgentName = customUserAgentName
         self.disableZoom = disableZoom
+        self.isPullToRefreshEnabled = isPullToRefreshEnabled
+        self.pullToRefreshColor = pullToRefreshColor
         self.invertColorsInDarkMode = invertColorsInDarkMode
         self.configuration = configuration
     }
 
     public init(html: String?) {
         source = html.map { .html($0) }
+        isPullToRefreshEnabled = false
     }
 
-    public init(request: URLRequest, disableZoom: Bool = false) {
+    public init(
+        request: URLRequest,
+        disableZoom: Bool = false,
+        isPullToRefreshEnabled: Bool
+        
+    ) {
         self.source = .request(request)
         self.disableZoom = disableZoom
+        self.isPullToRefreshEnabled = isPullToRefreshEnabled
     }
 
     // MARK: - View Modifiers
@@ -95,7 +118,14 @@ public struct WebView: UIViewRepresentable {
     // MARK: - UIViewRepresentable Protocol
 
     public func makeUIView(context: Self.Context) -> CoreWebView {
-        CoreWebView(customUserAgentName: customUserAgentName, disableZoom: disableZoom, configuration: configuration, invertColorsInDarkMode: invertColorsInDarkMode)
+        CoreWebView(
+            customUserAgentName: customUserAgentName,
+            disableZoom: disableZoom,
+            isPullToRefreshEnabled: isPullToRefreshEnabled,
+            pullToRefreshColor: pullToRefreshColor,
+            configuration: configuration,
+            invertColorsInDarkMode: invertColorsInDarkMode
+        )
     }
 
     public func updateUIView(_ uiView: CoreWebView, context: Self.Context) {

--- a/Core/Core/Syllabus/SyllabusViewController.swift
+++ b/Core/Core/Syllabus/SyllabusViewController.swift
@@ -22,7 +22,7 @@ open class SyllabusViewController: UIViewController, CoreWebViewLinkDelegate {
     public var courseID = ""
     public let env = AppEnvironment.shared
     public let refreshControl = CircleRefreshControl()
-    public var webView = CoreWebView(isPullToRefreshEnabled: false)
+    public var webView = CoreWebView(pullToRefresh: .disabled)
 
     public lazy var courses = env.subscribe(GetCourse(courseID: courseID)) { [weak self] in
         self?.update()

--- a/Core/Core/Syllabus/SyllabusViewController.swift
+++ b/Core/Core/Syllabus/SyllabusViewController.swift
@@ -22,7 +22,7 @@ open class SyllabusViewController: UIViewController, CoreWebViewLinkDelegate {
     public var courseID = ""
     public let env = AppEnvironment.shared
     public let refreshControl = CircleRefreshControl()
-    public var webView = CoreWebView()
+    public var webView = CoreWebView(isPullToRefreshEnabled: false)
 
     public lazy var courses = env.subscribe(GetCourse(courseID: courseID)) { [weak self] in
         self?.update()

--- a/Core/Core/TermsOfService/TermsOfServiceViewController.swift
+++ b/Core/Core/TermsOfService/TermsOfServiceViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 
 public class TermsOfServiceViewController: UIViewController {
     let env = AppEnvironment.shared
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
 
     public override func viewDidLoad() {
         title = NSLocalizedString("Terms of Use", bundle: .core, comment: "")

--- a/Core/Core/TermsOfService/TermsOfServiceViewController.swift
+++ b/Core/Core/TermsOfService/TermsOfServiceViewController.swift
@@ -20,7 +20,7 @@ import UIKit
 
 public class TermsOfServiceViewController: UIViewController {
     let env = AppEnvironment.shared
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
 
     public override func viewDidLoad() {
         title = NSLocalizedString("Terms of Use", bundle: .core, comment: "")

--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -50,22 +50,23 @@ private extension WKWebViewConfiguration {
 
 @IBDesignable
 open class CoreWebView: WKWebView {
-    
     public enum PullToRefresh {
         case disabled
         case enabled(color: UIColor?)
     }
-    
+
     public static var defaultConfiguration: WKWebViewConfiguration {
         let configuration = WKWebViewConfiguration()
         configuration.applyDefaultSettings()
         return configuration
     }
+
     private static var BalsamiqRegularCSSFontFace: String = {
         let url = Bundle.core.url(forResource: "font_balsamiq_regular", withExtension: "css")!
         // swiftlint:disable:next force_try
         return try! String(contentsOf: url)
     }()
+
     private static var LatoRegularCSSFontFace: String = {
         let url = Bundle.core.url(forResource: "font_lato_regular", withExtension: "css")!
         // swiftlint:disable:next force_try
@@ -80,7 +81,7 @@ open class CoreWebView: WKWebView {
         )
         return refreshControl
     }()
-    private let pullToRefresh: CoreWebView.PullToRefresh
+    private let pullToRefresh: PullToRefresh
     private var pullToRefreshNavigation: WKNavigation?
 
     @IBInspectable public var autoresizesHeight: Bool = false
@@ -91,7 +92,7 @@ open class CoreWebView: WKWebView {
 
     public static let processPool = WKProcessPool()
 
-    public init(pullToRefresh: CoreWebView.PullToRefresh) {
+    public init(pullToRefresh: PullToRefresh) {
         self.pullToRefresh = pullToRefresh
         super.init(frame: .zero)
     }
@@ -116,7 +117,7 @@ open class CoreWebView: WKWebView {
     public init(
         customUserAgentName: String? = nil,
         disableZoom: Bool = false,
-        pullToRefresh: CoreWebView.PullToRefresh,
+        pullToRefresh: PullToRefresh,
         pullToRefreshColor: UIColor? = nil,
         configuration: WKWebViewConfiguration? = nil,
         invertColorsInDarkMode: Bool = false
@@ -515,7 +516,7 @@ extension CoreWebView: WKNavigationDelegate {
         if let fragment = url?.fragment {
             scrollIntoView(fragment: fragment)
         }
-        
+
         if navigation == pullToRefreshNavigation {
             refreshControl.endRefreshing()
             pullToRefreshNavigation = nil

--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -88,7 +88,7 @@ open class CoreWebView: WKWebView {
         self.isPullToRefreshEnabled = isPullToRefreshEnabled
         super.init(frame: .zero)
     }
-    
+
     public required init?(coder: NSCoder) {
         isPullToRefreshEnabled = false
         super.init(coder: coder)
@@ -174,7 +174,7 @@ open class CoreWebView: WKWebView {
         scrollView.bounces = true
         refreshControl.color = color
     }
-    
+
     @objc func refreshWebView(_ sender: UIRefreshControl) {
         reload()
         sender.endRefreshing()

--- a/Core/Core/UIViews/CoreWebView.swift
+++ b/Core/Core/UIViews/CoreWebView.swift
@@ -95,7 +95,7 @@ open class CoreWebView: WKWebView {
         setup()
     }
 
-    public override init(frame: CGRect, configuration: WKWebViewConfiguration) {
+    override public init(frame: CGRect, configuration: WKWebViewConfiguration) {
         isPullToRefreshEnabled = false
         configuration.applyDefaultSettings()
         super.init(frame: frame, configuration: configuration)
@@ -115,7 +115,7 @@ open class CoreWebView: WKWebView {
         invertColorsInDarkMode: Bool = false
     ) {
         self.isPullToRefreshEnabled = isPullToRefreshEnabled
-        
+
         let config = configuration ?? Self.defaultConfiguration
         config.applyDefaultSettings()
 
@@ -136,7 +136,7 @@ open class CoreWebView: WKWebView {
         if isPullToRefreshEnabled {
             addRefreshControl(color: pullToRefreshColor)
         }
-        
+
         setup()
     }
 

--- a/Core/Core/UIViews/CoreWebViewController.swift
+++ b/Core/Core/UIViews/CoreWebViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 
 public class CoreWebViewController: UIViewController, CoreWebViewLinkDelegate {
-    public var webView = CoreWebView(isPullToRefreshEnabled: false)
+    public var webView = CoreWebView(pullToRefresh: .disabled)
 
     var limitedInteractionView: NotificationView?
 

--- a/Core/Core/UIViews/CoreWebViewController.swift
+++ b/Core/Core/UIViews/CoreWebViewController.swift
@@ -19,7 +19,7 @@
 import UIKit
 
 public class CoreWebViewController: UIViewController, CoreWebViewLinkDelegate {
-    public var webView = CoreWebView()
+    public var webView = CoreWebView(isPullToRefreshEnabled: false)
 
     var limitedInteractionView: NotificationView?
 

--- a/Core/Core/WebSitePreview/ViewModel/WebSitePreviewViewModel.swift
+++ b/Core/Core/WebSitePreview/ViewModel/WebSitePreviewViewModel.swift
@@ -70,6 +70,14 @@ class WebSitePreviewViewModel: ObservableObject {
             request.addValue(value, forHTTPHeaderField: key)
         }
 
-        AppEnvironment.shared.router.show(CoreHostingController(WebView(request: request).navigationTitle("WebSite Preview")), from: viewController)
+        AppEnvironment.shared.router.show(
+            CoreHostingController(
+                WebView(
+                    request: request,
+                    isPullToRefreshEnabled: false
+                )
+                .navigationTitle("WebSite Preview")
+            ), from: viewController
+        )
     }
 }

--- a/Core/Core/WebSitePreview/ViewModel/WebSitePreviewViewModel.swift
+++ b/Core/Core/WebSitePreview/ViewModel/WebSitePreviewViewModel.swift
@@ -74,7 +74,7 @@ class WebSitePreviewViewModel: ObservableObject {
             CoreHostingController(
                 WebView(
                     request: request,
-                    isPullToRefreshEnabled: false
+                    pullToRefresh: .disabled
                 )
                 .navigationTitle("WebSite Preview")
             ), from: viewController

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -29,7 +29,7 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
     let unread = "class=\"\(DiscussionHTML.Styles.unread)\""
 
     var baseURL: URL { environment.api.baseURL }
-    let webView = MockWebView()
+    let webView = MockWebView(pullToRefresh: .disabled)
     class MockWebView: CoreWebView {
         @objc var runningCount = 0
         override func evaluateJavaScript(_ javaScriptString: String, completionHandler: ((Any?, Error?) -> Void)? = nil) {

--- a/Core/CoreTests/Discussions/DiscussionReplyViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionReplyViewControllerTests.swift
@@ -27,7 +27,7 @@ class DiscussionReplyViewControllerTests: CoreTestCase {
     lazy var controller = DiscussionReplyViewController.create(context: context, topicID: "1")
 
     var baseURL: URL { environment.api.baseURL }
-    let webView = MockWebView()
+    let webView = MockWebView(pullToRefresh: .disabled)
     class MockWebView: CoreWebView {
         var html: String = ""
         open override func loadHTMLString(_ string: String, baseURL: URL? = AppEnvironment.shared.currentSession?.baseURL) -> WKNavigation? {
@@ -41,7 +41,7 @@ class DiscussionReplyViewControllerTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
-        controller.editor.webView = MockWebView()
+        controller.editor.webView = MockWebView(pullToRefresh: .disabled)
         controller.webView = webView
         api.mock(controller.course, value: .make())
         api.mock(GetDiscussionEntry(context: context, topicID: "1", entryID: "1"), value: .make(

--- a/Core/CoreTests/Syllabus/SyllabusViewControllerTests.swift
+++ b/Core/CoreTests/Syllabus/SyllabusViewControllerTests.swift
@@ -33,7 +33,7 @@ class SyllabusViewControllerTests: CoreTestCase {
 
     func testLayout() {
         let html = "<body>hello world</body>"
-        let webView = MockWebView()
+        let webView = MockWebView(pullToRefresh: .disabled)
         api.mock(controller.courses, value: .make(syllabus_body: html))
 
         controller.webView = webView

--- a/Core/CoreTests/UIViews/CoreWebViewTests.swift
+++ b/Core/CoreTests/UIViews/CoreWebViewTests.swift
@@ -41,7 +41,10 @@ class CoreWebViewTests: CoreTestCase {
 
     func testCustomUserAgentName() {
         let customeUserAgentName = "customUserAgent"
-        let view = CoreWebView(customUserAgentName: customeUserAgentName)
+        let view = CoreWebView(
+            customUserAgentName: customeUserAgentName,
+            pullToRefresh: .disabled
+        )
         XCTAssertEqual(view.configuration.applicationNameForUserAgent, customeUserAgentName)
     }
 

--- a/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
+++ b/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
@@ -24,7 +24,7 @@ class AccountNotificationDetailsViewController: UIViewController, CoreWebViewLin
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
 
     let env = AppEnvironment.shared

--- a/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
+++ b/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
@@ -24,7 +24,7 @@ class AccountNotificationDetailsViewController: UIViewController, CoreWebViewLin
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
 
     let env = AppEnvironment.shared

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -38,7 +38,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
 
     var assignmentID = ""

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -38,7 +38,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
 
     var assignmentID = ""

--- a/Parent/Parent/Discussions/DiscussionDetailsViewController.swift
+++ b/Parent/Parent/Discussions/DiscussionDetailsViewController.swift
@@ -24,7 +24,7 @@ class DiscussionDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
 
     var courseID = ""

--- a/Parent/Parent/Discussions/DiscussionDetailsViewController.swift
+++ b/Parent/Parent/Discussions/DiscussionDetailsViewController.swift
@@ -24,7 +24,7 @@ class DiscussionDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
 
     var courseID = ""

--- a/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
+++ b/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
@@ -38,7 +38,7 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
     let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
+++ b/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
@@ -38,7 +38,7 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
     let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Student/Student/Planner/CalendarEventDetailsViewController.swift
+++ b/Student/Student/Planner/CalendarEventDetailsViewController.swift
@@ -29,7 +29,7 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView()
+    let webView = CoreWebView(isPullToRefreshEnabled: false)
     let refreshControl = CircleRefreshControl()
     let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Student/Student/Planner/CalendarEventDetailsViewController.swift
+++ b/Student/Student/Planner/CalendarEventDetailsViewController.swift
@@ -29,7 +29,7 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
     @IBOutlet weak var scrollView: UIScrollView!
     @IBOutlet weak var titleLabel: UILabel!
     @IBOutlet weak var webViewContainer: UIView!
-    let webView = CoreWebView(isPullToRefreshEnabled: false)
+    let webView = CoreWebView(pullToRefresh: .disabled)
     let refreshControl = CircleRefreshControl()
     let titleSubtitleView = TitleSubtitleView.create()
 

--- a/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
@@ -27,7 +27,7 @@ class QuizDetailsViewController: UIViewController, ColoredNavViewProtocol, CoreW
     @IBOutlet weak var dueLabel: UILabel!
     @IBOutlet weak var instructionsHeadingLabel: UILabel!
     @IBOutlet weak var instructionsContainer: UIView!
-    let instructionsWebView = CoreWebView(isPullToRefreshEnabled: false)
+    let instructionsWebView = CoreWebView(pullToRefresh: .disabled)
     @IBOutlet weak var loadingView: CircleProgressView!
     @IBOutlet weak var pointsLabel: UILabel!
     @IBOutlet weak var questionsLabel: UILabel!

--- a/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
@@ -27,7 +27,7 @@ class QuizDetailsViewController: UIViewController, ColoredNavViewProtocol, CoreW
     @IBOutlet weak var dueLabel: UILabel!
     @IBOutlet weak var instructionsHeadingLabel: UILabel!
     @IBOutlet weak var instructionsContainer: UIView!
-    let instructionsWebView = CoreWebView()
+    let instructionsWebView = CoreWebView(isPullToRefreshEnabled: false)
     @IBOutlet weak var loadingView: CircleProgressView!
     @IBOutlet weak var pointsLabel: UILabel!
     @IBOutlet weak var questionsLabel: UILabel!

--- a/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
@@ -28,7 +28,7 @@ class QuizWebViewController: UIViewController {
     let webView = CoreWebView(
         customUserAgentName: nil,
         disableZoom: false,
-        isPullToRefreshEnabled: false,
+        pullToRefresh: .disabled,
         configuration: nil,
         invertColorsInDarkMode: true
     )

--- a/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
@@ -25,7 +25,13 @@ class QuizWebViewController: UIViewController {
     var quizID = ""
 
     let env = AppEnvironment.shared
-    let webView = CoreWebView(customUserAgentName: nil, disableZoom: false, configuration: nil, invertColorsInDarkMode: true)
+    let webView = CoreWebView(
+        customUserAgentName: nil,
+        disableZoom: false,
+        isPullToRefreshEnabled: false,
+        configuration: nil,
+        invertColorsInDarkMode: true
+    )
 
     static func create(courseID: String, quizID: String) -> QuizWebViewController {
         let controller = QuizWebViewController()

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -461,8 +461,7 @@ private func discussionViewController(url: URLComponents, params: [String: Strin
     }
 
     if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
-       DiscussionWebPageViewModel.isRedesignEnabled(in: context)
-    {
+       DiscussionWebPageViewModel.isRedesignEnabled(in: context) {
         let viewModel = DiscussionWebPageViewModel(
             context: context,
             topicID: discussionID

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -460,9 +460,19 @@ private func discussionViewController(url: URLComponents, params: [String: Strin
         )
     }
 
-    if ExperimentalFeature.hybridDiscussionDetails.isEnabled, DiscussionWebPageViewModel.isRedesignEnabled(in: context) {
-        let viewModel = DiscussionWebPageViewModel(context: context, topicID: discussionID)
-        return CoreHostingController(EmbeddedWebPageView(viewModel: viewModel))
+    if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
+       DiscussionWebPageViewModel.isRedesignEnabled(in: context)
+    {
+        let viewModel = DiscussionWebPageViewModel(
+            context: context,
+            topicID: discussionID
+        )
+        return CoreHostingController(
+            EmbeddedWebPageView(
+                viewModel: viewModel,
+                isPullToRefreshEnabled: true
+            )
+        )
     } else {
         return DiscussionDetailsViewController.create(context: context, topicID: discussionID)
     }

--- a/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
@@ -39,7 +39,7 @@ class RubricLongDescriptionViewController: UIViewController {
 
         self.addDoneButton()
 
-        let webView = CoreWebView(isPullToRefreshEnabled: false)
+        let webView = CoreWebView(pullToRefresh: .disabled)
         webView.linkDelegate = delegate
         webView.loadHTMLString(longDescription)
 

--- a/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
@@ -39,7 +39,7 @@ class RubricLongDescriptionViewController: UIViewController {
 
         self.addDoneButton()
 
-        let webView = CoreWebView()
+        let webView = CoreWebView(isPullToRefreshEnabled: false)
         webView.linkDelegate = delegate
         webView.loadHTMLString(longDescription)
 

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -323,9 +323,19 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 private func discussionDetails(url: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
     guard let context = Context(path: url.path), let topicID = params["discussionID"] else { return nil }
 
-    if ExperimentalFeature.hybridDiscussionDetails.isEnabled, DiscussionWebPageViewModel.isRedesignEnabled(in: context) {
-        let viewModel = DiscussionWebPageViewModel(context: context, topicID: topicID)
-        return CoreHostingController(EmbeddedWebPageView(viewModel: viewModel))
+    if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
+       DiscussionWebPageViewModel.isRedesignEnabled(in: context)
+    {
+        let viewModel = DiscussionWebPageViewModel(
+            context: context,
+            topicID: topicID
+        )
+        return CoreHostingController(
+            EmbeddedWebPageView(
+                viewModel: viewModel,
+                isPullToRefreshEnabled: true
+            )
+        )
     } else {
         return DiscussionDetailsViewController.create(context: context, topicID: topicID)
     }

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -324,8 +324,7 @@ private func discussionDetails(url: URLComponents, params: [String: String], use
     guard let context = Context(path: url.path), let topicID = params["discussionID"] else { return nil }
 
     if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
-       DiscussionWebPageViewModel.isRedesignEnabled(in: context)
-    {
+       DiscussionWebPageViewModel.isRedesignEnabled(in: context) {
         let viewModel = DiscussionWebPageViewModel(
             context: context,
             topicID: topicID

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
@@ -41,13 +41,24 @@ struct SubmissionViewer: View {
         switch submission.type {
         case .basic_lti_launch, .external_tool:
             WebSession(url: submission.previewUrl) { url in
-                WebView(url: url, customUserAgentName: UserAgent.safariLTI.description, invertColorsInDarkMode: true).onLink(openInSafari)
+                WebView(
+                    url: url,
+                    customUserAgentName: UserAgent.safariLTI.description,
+                    pullToRefresh: .disabled,
+                    invertColorsInDarkMode: true
+                )
+                .onLink(openInSafari)
             }
         case .discussion_topic:
             WebSession(url: submission.previewUrl) { url in
-                WebView(url: url, customUserAgentName: nil, invertColorsInDarkMode: true)
-                    .onLink(handleLink)
-                    .onNavigationFinished(handleRefresh)
+                WebView(
+                    url: url,
+                    customUserAgentName: nil,
+                    pullToRefresh: .disabled,
+                    invertColorsInDarkMode: true
+                )
+                .onLink(handleLink)
+                .onNavigationFinished(handleRefresh)
             }
         case .online_quiz:
             if assignment.anonymousSubmissions == true {
@@ -61,9 +72,14 @@ struct SubmissionViewer: View {
                 .multilineTextAlignment(.center)
             } else {
                 WebSession(url: submission.previewUrl) { url in
-                    WebView(url: url, customUserAgentName: nil, invertColorsInDarkMode: true)
-                        .onLink(handleLink)
-                        .onNavigationFinished(handleRefresh)
+                    WebView(
+                        url: url,
+                        customUserAgentName: nil,
+                        pullToRefresh: .disabled,
+                        invertColorsInDarkMode: true
+                    )
+                    .onLink(handleLink)
+                    .onNavigationFinished(handleRefresh)
                 }
             }
         case .media_recording:


### PR DESCRIPTION
Adds the option to pull to refresh `CoreWebView` and `WebView`. 

refs: MBL-16026
affects: Student, Teacher
release note: Added pull to refresh for webViews
test plan: See ticket

## Screenshots

<table>
<tr><th>K5SubjectView</th><th>Hybrid Discussion Details</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/110813321/187870346-e40570e4-7b36-4844-9418-513e4caf8157.png" height=500></td>
<td><img src="https://user-images.githubusercontent.com/110813321/187870358-cbf05101-2844-48af-8e00-b5a575cdceb0.png" height=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product or not needed
