### PR TITLE
Support for course banner image

### DIFF
--- a/Core/Core/Courses/APICourse.swift
+++ b/Core/Core/Courses/APICourse.swift
@@ -70,6 +70,7 @@ public struct APICourse: Codable, Equatable {
     // let blueprint: Bool?
     // let blueprint_restrictions: ?
     // let blueprint_restrictions_by_object_type: ?
+    let banner_image_download_url: String?
     let image_download_url: String? // include[]=course_image, api sometimes returns an empty string instead of nil so don't use URL
     var is_favorite: Bool? // include[]=favorites
     let sections: [SectionRef]? // include[]=sections
@@ -151,6 +152,7 @@ extension APICourse {
         hide_final_grades: Bool? = false,
         homeroom_course: Bool? = false,
         access_restricted_by_date: Bool? = nil,
+        banner_image_download_url: String? = nil,
         image_download_url: String? = nil,
         is_favorite: Bool? = nil,
         sections: [SectionRef]? = nil
@@ -174,6 +176,7 @@ extension APICourse {
             hide_final_grades: hide_final_grades,
             homeroom_course: homeroom_course,
             access_restricted_by_date: access_restricted_by_date,
+            banner_image_download_url: banner_image_download_url,
             image_download_url: image_download_url,
             is_favorite: is_favorite,
             sections: sections
@@ -227,6 +230,7 @@ public struct GetCoursesRequest: APIRequestable {
     }
 
     private enum Include: String, CaseIterable {
+        case banner_image
         case course_image
         case current_grading_period_scores
         case favorites
@@ -285,6 +289,7 @@ public struct GetCourseRequest: APIRequestable {
 
     public enum Include: String, CaseIterable {
         case courseImage = "course_image"
+        case courseBannerImage = "banner_image"
         case currentGradingPeriodScores = "current_grading_period_scores"
         case favorites
         case permissions
@@ -297,6 +302,7 @@ public struct GetCourseRequest: APIRequestable {
 
     let courseID: String
     public static let defaultIncludes: [Include] = [
+        .courseBannerImage,
         .courseImage,
         .currentGradingPeriodScores,
         .favorites,

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -23,6 +23,7 @@ final public class Course: NSManagedObject, WriteableModel {
     public typealias JSON = APICourse
 
     @NSManaged public var accessRestrictedByDate: Bool
+    @NSManaged public var bannerImageDownloadURL: URL?
     @NSManaged public var canCreateAnnouncement: Bool
     @NSManaged public var canCreateDiscussionTopic: Bool
     @NSManaged var contextColor: ContextColor?
@@ -72,6 +73,7 @@ final public class Course: NSManagedObject, WriteableModel {
         model.isFavorite = item.is_favorite ?? false
         model.courseCode = item.course_code
         model.courseColor = item.course_color
+        model.bannerImageDownloadURL = URL(string: item.banner_image_download_url ?? "")
         model.imageDownloadURL = URL(string: item.image_download_url ?? "")
         model.syllabusBody = item.syllabus_body
         model.defaultViewRaw = item.default_view?.rawValue

--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -32,7 +32,9 @@ public struct K5SubjectView: View {
                 TopBarView(viewModel: topBarViewModel, horizontalInset: padding, itemSpacing: padding)
                 Divider()
                 if UIDevice.current.userInterfaceIdiom == .pad {
-                    K5SubjectHeaderView(title: viewModel.courseTitle, imageUrl: viewModel.courseImageUrl, backgroundColor: Color(viewModel.courseColor ?? .clear)).padding(padding)
+                    K5SubjectHeaderView(title: viewModel.courseTitle,
+                                        imageUrl: viewModel.courseBannerImageUrl ?? viewModel.courseImageUrl,
+                                        backgroundColor: Color(viewModel.courseColor ?? .clear)).padding(padding)
                 }
                 if let currentPageURL = viewModel.currentPageURL {
                     WebView(url: currentPageURL, customUserAgentName: nil, disableZoom: true, configuration: viewModel.config, invertColorsInDarkMode: true)

--- a/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
+++ b/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
@@ -26,6 +26,7 @@ public class K5SubjectViewModel: ObservableObject {
     @Published public private(set) var courseTitle: String?
     @Published public private(set) var courseColor: UIColor?
     @Published public private(set) var currentPageURL: URL?
+    @Published public private(set) var courseBannerImageUrl: URL?
     @Published public private(set) var courseImageUrl: URL?
     public var reloadWebView: AnyPublisher<Void, Never> {
         NotificationCenter.default.publisher(for: .moduleItemRequirementCompleted, object: nil)
@@ -99,6 +100,7 @@ public class K5SubjectViewModel: ObservableObject {
         guard let course = course.first else { return }
         courseTitle = course.name
         courseColor = course.color
+        courseBannerImageUrl = course.bannerImageDownloadURL
         courseImageUrl = course.imageDownloadURL
     }
 

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -214,6 +214,7 @@
         <attribute name="accessRestrictedByDate" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="arcEnabledRaw" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="arcID" optional="YES" attributeType="String"/>
+        <attribute name="bannerImageDownloadURL" optional="YES" attributeType="URI"/>
         <attribute name="canCreateAnnouncement" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="canCreateDiscussionTopic" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="courseCode" optional="YES" attributeType="String"/>
@@ -984,7 +985,7 @@
         <element name="Conversation" positionX="-540" positionY="-18" width="128" height="238"/>
         <element name="ConversationMessage" positionX="-522" positionY="0" width="128" height="208"/>
         <element name="ConversationParticipant" positionX="-531" positionY="-9" width="128" height="133"/>
-        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="434"/>
+        <element name="Course" positionX="-365.20703125" positionY="2.984375" width="128" height="449"/>
         <element name="CourseSection" positionX="-540" positionY="-18" width="128" height="163"/>
         <element name="CourseSettings" positionX="-540" positionY="-18" width="128" height="88"/>
         <element name="DashboardCard" positionX="-540" positionY="-18" width="128" height="254"/>

--- a/Core/CoreTests/Courses/APICourseTests.swift
+++ b/Core/CoreTests/Courses/APICourseTests.swift
@@ -23,6 +23,7 @@ class APICourseTests: XCTestCase {
     func testGetCoursesRequest() {
         XCTAssertEqual(GetCoursesRequest().path, "courses")
         XCTAssertEqual(GetCoursesRequest().queryItems, [
+            URLQueryItem(name: "include[]", value: "banner_image"),
             URLQueryItem(name: "include[]", value: "course_image"),
             URLQueryItem(name: "include[]", value: "current_grading_period_scores"),
             URLQueryItem(name: "include[]", value: "favorites"),
@@ -38,6 +39,7 @@ class APICourseTests: XCTestCase {
             URLQueryItem(name: "enrollment_state", value: "active"),
         ])
         XCTAssertEqual(GetCoursesRequest(enrollmentState: .completed, state: [.available, .completed, .unpublished], perPage: 20).queryItems, [
+            URLQueryItem(name: "include[]", value: "banner_image"),
             URLQueryItem(name: "include[]", value: "course_image"),
             URLQueryItem(name: "include[]", value: "current_grading_period_scores"),
             URLQueryItem(name: "include[]", value: "favorites"),
@@ -64,6 +66,7 @@ class APICourseTests: XCTestCase {
     func testGetCourseRequest() {
         XCTAssertEqual(GetCourseRequest(courseID: "2").path, "courses/2")
         XCTAssertEqual(GetCourseRequest(courseID: "2").queryItems, [
+            URLQueryItem(name: "include[]", value: "banner_image"),
             URLQueryItem(name: "include[]", value: "course_image"),
             URLQueryItem(name: "include[]", value: "current_grading_period_scores"),
             URLQueryItem(name: "include[]", value: "favorites"),


### PR DESCRIPTION
refs: MBL-16129
affects: Student
release note: Added banner image support for Canvas for elementary courses.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Course image overlay</th><th>Banner image overlay</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/188158687-a6118f2e-036f-43c1-9c44-bfc3688ede8d.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/188158695-7e313f41-d54a-432f-9704-ff7e051b6232.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
