### PR TITLE
CircularProgressView SwiftUI component

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -812,6 +812,7 @@
 		B4372B5B28AF9CB30030FFB9 /* FileUploadNotificationCardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4372B5A28AF9CB30030FFB9 /* FileUploadNotificationCardListViewModel.swift */; };
 		B451D3CB28AE83A1009A7AEE /* FileUploadNotificationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B451D3CA28AE83A1009A7AEE /* FileUploadNotificationCard.swift */; };
 		B453728828B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */; };
+		B4CD9DAF28C63CFC0084EB65 /* RefreshableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */; };
 		CEB57AE8286B32BB00F4BFC8 /* HelmNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB57AE7286B32BB00F4BFC8 /* HelmNavigationController.swift */; };
 		CEF0D1462837D571005867EF /* ContextCellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */; };
 		CEF0D1472837D571005867EF /* ContextCellBackgroundView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */; };
@@ -2267,6 +2268,7 @@
 		B4372B5A28AF9CB30030FFB9 /* FileUploadNotificationCardListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardListViewModel.swift; sourceTree = "<group>"; };
 		B451D3CA28AE83A1009A7AEE /* FileUploadNotificationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCard.swift; sourceTree = "<group>"; };
 		B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModel.swift; sourceTree = "<group>"; };
+		B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableView.swift; sourceTree = "<group>"; };
 		CEB57AE7286B32BB00F4BFC8 /* HelmNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmNavigationController.swift; sourceTree = "<group>"; };
 		CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCellBackgroundView.swift; sourceTree = "<group>"; };
 		CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContextCellBackgroundView.xib; sourceTree = "<group>"; };
@@ -6119,6 +6121,7 @@
 				E8A8FA8D24D328C3000B27DF /* SearchBar.swift */,
 				7DCA32112541DB8B00458651 /* WebSession.swift */,
 				7DCA31F72540835300458651 /* WebView.swift */,
+				B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";
@@ -7407,6 +7410,7 @@
 				7DA25FE123F72154005D2121 /* AudioRecorderViewController.swift in Sources */,
 				3B4D892D2450A8E9004ED120 /* ComposeRecipientsView.swift in Sources */,
 				7DA260CA23F72359005D2121 /* AvatarGroupView.swift in Sources */,
+				B4CD9DAF28C63CFC0084EB65 /* RefreshableView.swift in Sources */,
 				CFD5814626B2AFD3000B2A8A /* K5ScheduleSubjectViewModel.swift in Sources */,
 				7DA2604523F722D9005D2121 /* Enrollment.swift in Sources */,
 				7DA25FD923F72148005D2121 /* ExperimentalFeature.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -6107,6 +6107,7 @@
 				7D0A28D925194CE6004FB3B6 /* Avatar.swift */,
 				7D7BA23824DB57BD00B1A68B /* CircleProgress.swift */,
 				7D2FA37E255EEC3F00C9552F /* CircleRefresh.swift */,
+				B4D76D7128C75641005750AF /* CircularProgressView.swift */,
 				EB66DB9426451CAE002D3325 /* CustomTextField.swift */,
 				7D89A2C82509326B009D0FD2 /* DisclosureIndicator.swift */,
 				CF29DF90272BD9F10046C04D /* DynamicHeightTextEditor.swift */,
@@ -6118,13 +6119,12 @@
 				CFD9B44227EDB7CC0099F173 /* ListWithoutVerticalScrollIndicator.swift */,
 				CFD3EC39289422FB001E7D4E /* LottieView.swift */,
 				7DD6FB3525081CD900DB5286 /* OptionalDatePicker.swift */,
+				B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */,
 				7D0A28DC251952A2004FB3B6 /* RemoteImage.swift */,
 				CF575E1F265E9D5200F8515F /* ScrollViewWithReader.swift */,
 				E8A8FA8D24D328C3000B27DF /* SearchBar.swift */,
 				7DCA32112541DB8B00458651 /* WebSession.swift */,
 				7DCA31F72540835300458651 /* WebView.swift */,
-				B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */,
-				B4D76D7128C75641005750AF /* CircularProgressView.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		B451D3CB28AE83A1009A7AEE /* FileUploadNotificationCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = B451D3CA28AE83A1009A7AEE /* FileUploadNotificationCard.swift */; };
 		B453728828B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */; };
 		B4CD9DAF28C63CFC0084EB65 /* RefreshableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */; };
+		B4D76D7228C75641005750AF /* CircularProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D76D7128C75641005750AF /* CircularProgressView.swift */; };
 		CEB57AE8286B32BB00F4BFC8 /* HelmNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB57AE7286B32BB00F4BFC8 /* HelmNavigationController.swift */; };
 		CEF0D1462837D571005867EF /* ContextCellBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */; };
 		CEF0D1472837D571005867EF /* ContextCellBackgroundView.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */; };
@@ -2269,6 +2270,7 @@
 		B451D3CA28AE83A1009A7AEE /* FileUploadNotificationCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCard.swift; sourceTree = "<group>"; };
 		B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModel.swift; sourceTree = "<group>"; };
 		B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableView.swift; sourceTree = "<group>"; };
+		B4D76D7128C75641005750AF /* CircularProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CircularProgressView.swift; sourceTree = "<group>"; };
 		CEB57AE7286B32BB00F4BFC8 /* HelmNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelmNavigationController.swift; sourceTree = "<group>"; };
 		CEF0D1442837D571005867EF /* ContextCellBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCellBackgroundView.swift; sourceTree = "<group>"; };
 		CEF0D1452837D571005867EF /* ContextCellBackgroundView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ContextCellBackgroundView.xib; sourceTree = "<group>"; };
@@ -6122,6 +6124,7 @@
 				7DCA32112541DB8B00458651 /* WebSession.swift */,
 				7DCA31F72540835300458651 /* WebView.swift */,
 				B4CD9DAE28C63CFC0084EB65 /* RefreshableView.swift */,
+				B4D76D7128C75641005750AF /* CircularProgressView.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";
@@ -7815,6 +7818,7 @@
 				CFB06F9628BD0D0D00DAC40B /* FileSubmissionSubmitter.swift in Sources */,
 				7DA260CC23F72359005D2121 /* BottomSheetPickerViewController.swift in Sources */,
 				E8D6949824D46B1E0080D883 /* CoreHostingController.swift in Sources */,
+				B4D76D7228C75641005750AF /* CircularProgressView.swift in Sources */,
 				49C56C9D24BECA7400E96799 /* ClosedRangeExtensions.swift in Sources */,
 				D9436D1725A4BAD200DD3873 /* GetCourseSingleUser.swift in Sources */,
 				7D5F103D2429BA5D00803324 /* CardView.swift in Sources */,

--- a/Core/Core/Dashboard/K5/Model/Schedule/PlannerOverrideUpdater.swift
+++ b/Core/Core/Dashboard/K5/Model/Schedule/PlannerOverrideUpdater.swift
@@ -23,7 +23,7 @@ public class PlannerOverrideUpdater {
     public var updateInProgress: Bool { completion != nil }
 
     private let api: API
-    private var completion:((_ succeeded: Bool) -> Void)?
+    private var completion: ((_ succeeded: Bool) -> Void)?
 
     public init(api: API, plannableId: ID, plannableType: String, overrideId: ID?) {
         self.api = api

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -51,18 +51,16 @@ public struct DashboardCardView: View {
 
     public var body: some View {
         GeometryReader { geometry in
-            if #available(iOSApplicationExtension 15.0, *) {
-                ScrollView {
-                    RefreshableView {
-                        VStack(spacing: 0) {
-                            fileUploadNotificationCards()
-                            list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
-                        }
-                        .padding(.horizontal, verticalSpacing)
+            ScrollView {
+                RefreshableView {
+                    VStack(spacing: 0) {
+                        fileUploadNotificationCards()
+                        list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                     }
+                    .padding(.horizontal, verticalSpacing)
                 }
-                .refreshable {
-                    await forceRefresh()
+                    refreshAction: { onComplete in
+                    refresh(force: true, onComplete: onComplete)
                 }
             }
         }
@@ -81,14 +79,6 @@ public struct DashboardCardView: View {
             showGrade = env.userDefaults?.showGradesOnDashboard == true
         }
         .onReceive(invitationsViewModel.coursesChanged) { _ in refresh(force: true) }
-    }
-
-    private func forceRefresh() async {
-        await withCheckedContinuation { continuation in
-            refresh(force: true) {
-                continuation.resume()
-            }
-        }
     }
 
     private func setStyle(style: UIUserInterfaceStyle?) {

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -84,8 +84,6 @@ public struct DashboardCardView: View {
     }
 
     private func forceRefresh() async {
-        // swiftlint:disable:next force_try
-        try! await Task.sleep(nanoseconds: 1_000_000_000)
         await withCheckedContinuation { continuation in
             refresh(force: true) {
                 continuation.resume()

--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -52,16 +52,14 @@ public struct DashboardCardView: View {
     public var body: some View {
         GeometryReader { geometry in
             ScrollView {
-                RefreshableView {
-                    VStack(spacing: 0) {
-                        fileUploadNotificationCards()
-                        list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
+                VStack(spacing: 0) {
+                    CircleRefresh { endRefreshing in
+                        refresh(force: true, onComplete: endRefreshing)
                     }
-                    .padding(.horizontal, verticalSpacing)
+                    fileUploadNotificationCards()
+                    list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                 }
-                    refreshAction: { onComplete in
-                    refresh(force: true, onComplete: onComplete)
-                }
+                .padding(.horizontal, verticalSpacing)
             }
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))

--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -53,10 +53,7 @@ class DashboardCardsViewModel: ObservableObject {
         needsRefresh = false
         courses.exhaust(force: true)
         cards.refresh(force: true) { [weak self] _ in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
-                onComplete?()
-            }
-
+            onComplete?()
             guard let self = self else { return }
             if self.needsRefresh { self.refresh() }
         }

--- a/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
+++ b/Core/Core/Dashboard/ViewModel/DashboardCardsViewModel.swift
@@ -53,7 +53,9 @@ class DashboardCardsViewModel: ObservableObject {
         needsRefresh = false
         courses.exhaust(force: true)
         cards.refresh(force: true) { [weak self] _ in
-            onComplete?()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                onComplete?()
+            }
 
             guard let self = self else { return }
             if self.needsRefresh { self.refresh() }

--- a/Core/Core/Notifications/Activity.swift
+++ b/Core/Core/Notifications/Activity.swift
@@ -83,7 +83,7 @@ extension Activity {
         case .submission:       return .assignmentLine
         case .conference:       return .conferences
         case .collaboration:    return .collaborations
-        case .assessmentRequest:return .quizLine
+        case .assessmentRequest: return .quizLine
         }
     }
 }

--- a/Core/Core/SwiftUIViews/CircularProgressView.swift
+++ b/Core/Core/SwiftUIViews/CircularProgressView.swift
@@ -85,7 +85,7 @@ struct CircularProgressView_Previews: PreviewProvider {
         CircularProgressView(viewState: .constant(.animating))
             .preferredColorScheme(.dark)
             .previewLayout(.sizeThatFits)
-        
+
         CircularProgressView(viewState: .constant(.progress(0.25)))
             .preferredColorScheme(.light)
             .previewLayout(.sizeThatFits)

--- a/Core/Core/SwiftUIViews/CircularProgressView.swift
+++ b/Core/Core/SwiftUIViews/CircularProgressView.swift
@@ -1,0 +1,96 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public struct CircularProgressView: View {
+    @Binding public private(set) var viewState: ViewState
+    @State private var isVisible = false
+    public static let size: CGFloat = 32
+
+    public enum ViewState {
+        case progress(CGFloat)
+        case animating
+    }
+
+    public var body: some View {
+        ZStack {
+            switch viewState {
+            case .animating:
+                Circle()
+                    .stroke(
+                        Color.borderLight,
+                        lineWidth: 3
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                Circle()
+                    .trim(from: 0.15, to: 1)
+                    .stroke(
+                        Color.blue,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                    .rotationEffect(Angle(degrees: isVisible ? 359 : 0))
+                    .animation(
+                        .linear(duration: 2)
+                            .repeatForever(autoreverses: false),
+                        value: isVisible
+                    )
+                    .transition(.scale)
+                    .onAppear {
+                        isVisible = true
+                    }
+            case .progress(let progress):
+                Circle()
+                    .stroke(
+                        Color.borderLight,
+                        lineWidth: 3
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        Color.blue,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                    .rotationEffect(.degrees(-90))
+                    .animation(.none, value: progress)
+                    .transition(.scale)
+            }
+        }
+    }
+}
+
+struct CircularProgressView_Previews: PreviewProvider {
+    static var previews: some View {
+        CircularProgressView(viewState: .constant(.animating))
+            .preferredColorScheme(.light)
+            .previewLayout(.sizeThatFits)
+        CircularProgressView(viewState: .constant(.animating))
+            .preferredColorScheme(.dark)
+            .previewLayout(.sizeThatFits)
+        
+        CircularProgressView(viewState: .constant(.progress(0.25)))
+            .preferredColorScheme(.light)
+            .previewLayout(.sizeThatFits)
+        CircularProgressView(viewState: .constant(.progress(0.25)))
+            .preferredColorScheme(.dark)
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -1,0 +1,137 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+@available(iOSApplicationExtension 15.0, *)
+struct RefreshableView<Content: View>: View {
+    var content: () -> Content
+
+    @Environment(\.refresh) private var refresh
+    @State private var isVisible = false
+    @State private var isAnimating = false
+    @State private var progress: CGFloat = 0
+    @State private var viewState: CircularProgressView.ViewState = .animating
+    @State private var offset: CGFloat = 0
+    private let snappingPoint: CGFloat = 64
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if isVisible {
+                CircularProgressView(viewState: $viewState)
+                    .padding(.vertical, 16)
+                    .offset(x: 0, y: -offset)
+            }
+            content()
+                .offset(x: 0, y: isVisible ? -CircularProgressView.size : 0)
+        }
+        .animation(.default, value: isVisible)
+        .background(
+            GeometryReader {
+                Color.clear.preference(
+                    key: ViewOffsetKey.self,
+                    value: $0.frame(in: .global).origin.y
+                )
+            }
+        )
+        .onPreferenceChange(ViewOffsetKey.self) { newValue in
+            offset = newValue - 91
+            guard !isAnimating else { return }
+            progress = min(abs((newValue - 91) / snappingPoint), 1)
+            viewState = .progress(progress)
+            isVisible = progress > 0
+            if progress == 1 {
+                isAnimating = true
+                viewState = .animating
+                Task {
+                    await refresh?()
+                    await MainActor.run {
+                        isVisible = false
+                        isAnimating = false
+                        progress = 0
+                    }
+                }
+            }
+        }
+    }
+}
+
+public struct CircularProgressView: View {
+    @Binding public private(set) var viewState: ViewState
+    @State private var isVisible = false
+    public static let size: CGFloat = 32
+
+    public enum ViewState {
+        case progress(CGFloat)
+        case animating
+    }
+
+    public var body: some View {
+        ZStack {
+            switch viewState {
+            case .animating:
+                Circle()
+                    .stroke(
+                        Color.borderLight,
+                        lineWidth: 3
+                    )
+                Circle()
+                    .trim(from: 0.15, to: 1)
+                    .stroke(
+                        Color.blue,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                    .rotationEffect(Angle(degrees: isVisible ? 359 : 0))
+                    .animation(
+                        .linear(duration: 2)
+                            .repeatForever(autoreverses: false),
+                        value: isVisible
+                    )
+                    .transition(.scale)
+                    .onAppear {
+                        isVisible = true
+                    }
+            case .progress(let progress):
+                Circle()
+                    .stroke(
+                        Color.borderLight,
+                        lineWidth: 3
+                    )
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        Color.blue,
+                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
+                    )
+                    .frame(width: Self.size, height: Self.size)
+                    .rotationEffect(.degrees(-90))
+                    .animation(.none, value: progress)
+                    .transition(.scale)
+            }
+        }
+    }
+}
+
+private struct ViewOffsetKey: PreferenceKey {
+    public typealias Value = CGFloat
+    public static var defaultValue = CGFloat.zero
+    public static func reduce(value: inout Value, nextValue: () -> Value) {
+        value += nextValue()
+    }
+}

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -29,6 +29,7 @@ struct RefreshableView<Content: View>: View {
     @State private var viewState: CircularProgressView.ViewState = .animating
     @State private var offset: CGFloat = 0
     private let snappingPoint: CGFloat = 64
+    private let hapticGenerator = UIImpactFeedbackGenerator(style: .light)
 
     var body: some View {
         VStack(spacing: 0) {
@@ -56,6 +57,7 @@ struct RefreshableView<Content: View>: View {
             viewState = .progress(progress)
             isVisible = progress > 0
             if progress == 1 {
+                hapticGenerator.impactOccurred()
                 isAnimating = true
                 viewState = .animating
                 Task {

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -18,11 +18,10 @@
 
 import SwiftUI
 
-@available(iOSApplicationExtension 15.0, *)
 struct RefreshableView<Content: View>: View {
     var content: () -> Content
+    var refreshAction: (@escaping () -> Void) -> Void
 
-    @Environment(\.refresh) private var refresh
     @State private var isVisible = false
     @State private var isAnimating = false
     @State private var progress: CGFloat = 0
@@ -60,13 +59,10 @@ struct RefreshableView<Content: View>: View {
                 hapticGenerator.impactOccurred()
                 isAnimating = true
                 viewState = .animating
-                Task {
-                    await refresh?()
-                    await MainActor.run {
-                        isVisible = false
-                        isAnimating = false
-                        progress = 0
-                    }
+                refreshAction {
+                    isVisible = false
+                    isAnimating = false
+                    progress = 0
                 }
             }
         }

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -52,7 +52,7 @@ public struct RefreshableView<Content: View>: View {
         .onPreferenceChange(ViewOffsetKey.self) { newValue in
             offset = newValue - 91
             guard !isAnimating else { return }
-            progress = min(abs((newValue - 91) / snappingPoint), 1)
+            progress = min(abs((offset) / snappingPoint), 1)
             viewState = .progress(progress)
             isVisible = progress > 0
             if progress == 1 {

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -56,13 +56,21 @@ struct RefreshableView<Content: View>: View {
             viewState = .progress(progress)
             isVisible = progress > 0
             if progress == 1 {
+                let triggerStartDate = Date()
+
                 hapticGenerator.impactOccurred()
                 isAnimating = true
                 viewState = .animating
+
                 refreshAction {
-                    isVisible = false
-                    isAnimating = false
-                    progress = 0
+                    let triggerEndDate = Date()
+                    let timeElapsed = triggerEndDate.timeIntervalSince1970 - triggerStartDate.timeIntervalSince1970
+                    let additionalDuration = 1 - timeElapsed
+                    DispatchQueue.main.asyncAfter(deadline: .now() + additionalDuration) {
+                        isVisible = false
+                        isAnimating = false
+                        progress = 0
+                    }
                 }
             }
         }

--- a/Core/Core/SwiftUIViews/RefreshableView.swift
+++ b/Core/Core/SwiftUIViews/RefreshableView.swift
@@ -18,7 +18,7 @@
 
 import SwiftUI
 
-struct RefreshableView<Content: View>: View {
+public struct RefreshableView<Content: View>: View {
     var content: () -> Content
     var refreshAction: (@escaping () -> Void) -> Void
 
@@ -30,7 +30,7 @@ struct RefreshableView<Content: View>: View {
     private let snappingPoint: CGFloat = 64
     private let hapticGenerator = UIImpactFeedbackGenerator(style: .light)
 
-    var body: some View {
+    public var body: some View {
         VStack(spacing: 0) {
             if isVisible {
                 CircularProgressView(viewState: $viewState)
@@ -72,63 +72,6 @@ struct RefreshableView<Content: View>: View {
                         progress = 0
                     }
                 }
-            }
-        }
-    }
-}
-
-public struct CircularProgressView: View {
-    @Binding public private(set) var viewState: ViewState
-    @State private var isVisible = false
-    public static let size: CGFloat = 32
-
-    public enum ViewState {
-        case progress(CGFloat)
-        case animating
-    }
-
-    public var body: some View {
-        ZStack {
-            switch viewState {
-            case .animating:
-                Circle()
-                    .stroke(
-                        Color.borderLight,
-                        lineWidth: 3
-                    )
-                Circle()
-                    .trim(from: 0.15, to: 1)
-                    .stroke(
-                        Color.blue,
-                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
-                    )
-                    .frame(width: Self.size, height: Self.size)
-                    .rotationEffect(Angle(degrees: isVisible ? 359 : 0))
-                    .animation(
-                        .linear(duration: 2)
-                            .repeatForever(autoreverses: false),
-                        value: isVisible
-                    )
-                    .transition(.scale)
-                    .onAppear {
-                        isVisible = true
-                    }
-            case .progress(let progress):
-                Circle()
-                    .stroke(
-                        Color.borderLight,
-                        lineWidth: 3
-                    )
-                Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        Color.blue,
-                        style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round)
-                    )
-                    .frame(width: Self.size, height: Self.size)
-                    .rotationEffect(.degrees(-90))
-                    .animation(.none, value: progress)
-                    .transition(.scale)
             }
         }
     }


### PR DESCRIPTION
## Description
SwiftUI doesn't have a built-in support for pull to refresh in `ScrollViews`, so we had to use a wrapper around for `CircleRefreshControl` which is essentially a `UIRefreshControl`. 

This PR adds a new `CircularProgressView` which mimics the same behaviour but can be used in SwiftUI. 

## Notes
1. From iOS 15 and above we will be able to use a view modifier called `refreshable` which is an asynchronous handler that SwiftUI executes when the user requests a refresh. For now a simple closure pattern is provided. 
2. To avoid UI glitches, a minimum of a 1 second refresh animation is set. 

## How to test 
<details>
<summary>1. Copy to following git diff to your clipboard</summary>

```
diff --git a/Core/Core/Dashboard/View/DashboardCardView.swift b/Core/Core/Dashboard/View/DashboardCardView.swift
index e20f03b36..d5f929b83 100644
--- a/Core/Core/Dashboard/View/DashboardCardView.swift
+++ b/Core/Core/Dashboard/View/DashboardCardView.swift
@@ -52,14 +52,16 @@ public struct DashboardCardView: View {
     public var body: some View {
         GeometryReader { geometry in
             ScrollView {
-                VStack(spacing: 0) {
-                    CircleRefresh { endRefreshing in
-                        refresh(force: true, onComplete: endRefreshing)
+                RefreshableView {
+                    VStack(spacing: 0) {
+                        fileUploadNotificationCards()
+                        list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                     }
-                    fileUploadNotificationCards()
-                    list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
+                    .padding(.horizontal, verticalSpacing)
+                }
+                    refreshAction: { onComplete in
+                    refresh(force: true, onComplete: onComplete)
                 }
-                .padding(.horizontal, verticalSpacing)
             }
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))

```

</details>

2. Run `pbpaste | git apply`
3. You should be able to see the new refresher on the Dashboard

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><video src="https://user-images.githubusercontent.com/110813321/188607521-ea757fd2-131e-4b11-a768-b53cce4012ac.mp4" maxHeight=500></td>
<td><video src="https://user-images.githubusercontent.com/110813321/188607733-9045ce2d-f2d7-45e2-b63b-0eb545b2cdb1.mp4
" maxHeight=500></td>
</tr>
</table>


## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product or not needed
