### PR TITLE
Dark Mode | + Button in "To" field is dark on black

### DIFF
--- a/rn/Teacher/src/modules/inbox/Compose.js
+++ b/rn/Teacher/src/modules/inbox/Compose.js
@@ -321,7 +321,7 @@ export class Compose extends PureComponent<ComposeProps & OwnProps, ComposeState
                 </View>
                 { Boolean(this.props.canAddRecipients) &&
                   <TouchableOpacity testID='compose.add-recipient' onPress={this._openAddressBook} style={{ height: 54, justifyContent: 'center' }} accessibilityTraits={['button']} accessibilityLabel={i18n('Add recipient')}>
-                    <Image source={Images.add} style={{ tintColor: colors.primaryButton }} />
+                    <Image source={Images.add} style={{ tintColor: colors.textDark }} />
                   </TouchableOpacity>
                 }
               </View>

--- a/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
+++ b/rn/Teacher/src/modules/inbox/__tests__/__snapshots__/Compose.test.js.snap
@@ -389,7 +389,7 @@ exports[`Compose renders after picking a course 1`] = `
             }
             style={
               Object {
-                "tintColor": undefined,
+                "tintColor": "#556572",
               }
             }
           />
@@ -664,7 +664,7 @@ exports[`Compose renders reply 1`] = `
             }
             style={
               Object {
-                "tintColor": undefined,
+                "tintColor": "#556572",
               }
             }
           />


### PR DESCRIPTION
refs: MBL-16222
affects: Student
release note: none
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/190637059-8006d8d7-5d61-47a2-b599-a18df18dd856.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/190637061-7e5ef3e9-c469-406a-ad8c-bc41c88e922a.png" maxHeight=500></td>
</tr>
</table>
## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
