### PR TITLE
Save assignment name to file submission.

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -434,6 +434,7 @@
     </entity>
     <entity name="FileSubmission" representedClassName="Core.FileSubmission" syncable="YES">
         <attribute name="assignmentID" attributeType="String"/>
+        <attribute name="assignmentName" attributeType="String" defaultValueString=""/>
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="courseID" attributeType="String"/>
         <attribute name="isSubmitted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -998,7 +999,7 @@
         <element name="ExternalToolLaunchPlacement" positionX="-513" positionY="0" width="128" height="120"/>
         <element name="FeatureFlag" positionX="-540" positionY="-27" width="128" height="90"/>
         <element name="File" positionX="-162.1640625" positionY="69.79296875" width="128" height="688"/>
-        <element name="FileSubmission" positionX="-549" positionY="-18" width="128" height="119"/>
+        <element name="FileSubmission" positionX="-549" positionY="-18" width="128" height="149"/>
         <element name="FileUploadItem" positionX="160" positionY="192" width="128" height="149"/>
         <element name="Folder" positionX="-540" positionY="-18" width="128" height="328"/>
         <element name="FolderItem" positionX="-540" positionY="-18" width="128" height="118"/>

--- a/Core/Core/Files/FileSubmission/Model/Entities/FileSubmission.swift
+++ b/Core/Core/Files/FileSubmission/Model/Entities/FileSubmission.swift
@@ -25,6 +25,7 @@ import CoreData
 public final class FileSubmission: NSManagedObject {
     @NSManaged public var courseID: String
     @NSManaged public var assignmentID: String
+    @NSManaged public var assignmentName: String
     /** The user entered comment for the submission. **/
     @NSManaged public var comment: String?
     @NSManaged public var files: Set<FileUploadItem>

--- a/Core/Core/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposer.swift
+++ b/Core/Core/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposer.swift
@@ -31,13 +31,14 @@ public class FileSubmissionComposer {
     /**
      - returns: The `objectID` of the created `FileSubmission` object.
      */
-    public func makeNewSubmission(courseId: String, assignmentId: String, comment: String?, files: [URL]) -> NSManagedObjectID {
+    public func makeNewSubmission(courseId: String, assignmentId: String, assignmentName: String, comment: String?, files: [URL]) -> NSManagedObjectID {
         var result: NSManagedObjectID!
 
         context.performAndWait {
             let fileSubmission: FileSubmission = context.insert()
             fileSubmission.courseID = courseId
             fileSubmission.assignmentID = assignmentId
+            fileSubmission.assignmentName = assignmentName
             fileSubmission.comment = comment
             fileSubmission.files = Set(files.map {
                 let item: FileUploadItem = context.insert()

--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentSubmissionService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentSubmissionService.swift
@@ -29,12 +29,12 @@ public class AttachmentSubmissionService {
     /**
      - returns: The `FileSubmission` CoreData object for the newly created submission.
      */
-    public func submit(urls: [URL], courseID: String, assignmentID: String, comment: String?) -> NSManagedObjectID {
+    public func submit(urls: [URL], courseID: String, assignmentID: String, assignmentName: String, comment: String?) -> NSManagedObjectID {
         if let existingSubmissionID = existingSubmissionID {
             submissionAssembly.composer.deleteSubmission(submissionID: existingSubmissionID)
         }
 
-        let submissionID = submissionAssembly.composer.makeNewSubmission(courseId: courseID, assignmentId: assignmentID, comment: comment, files: urls)
+        let submissionID = submissionAssembly.composer.makeNewSubmission(courseId: courseID, assignmentId: assignmentID, assignmentName: assignmentName, comment: comment, files: urls)
         existingSubmissionID = submissionID
         submissionAssembly.start(fileSubmissionID: submissionID)
         return submissionID

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModel.swift
@@ -75,6 +75,7 @@ public class SubmitAssignmentExtensionViewModel: ObservableObject {
         let submissionID = submissionService.submit(urls: selectedFileURLs,
                                                     courseID: coursePickerViewModel.selectedCourse!.id,
                                                     assignmentID: assignmentPickerViewModel.selectedAssignment!.id,
+                                                    assignmentName: assignmentPickerViewModel.selectedAssignment!.name,
                                                     comment: comment)
         let fileProgressViewModel = FileProgressListViewModel(submissionID: submissionID, dismiss: { [shareCompleted] in
             shareCompleted()

--- a/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
@@ -40,7 +40,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
     func testSubmission() {
         // MARK: - GIVEN
         let testee = FileSubmissionAssembly.makeShareExtensionAssembly()
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", comment: "testComment", files: [testFileURL])
+        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", files: [testFileURL])
         let submission = try! databaseClient.existingObject(with: submissionID) as! FileSubmission
         XCTAssertEqual(databaseClient.registeredObjects.count, 2) // submission + item
 
@@ -83,7 +83,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
 
     func testCancelDeletesSubmission() {
         let testee = FileSubmissionAssembly.makeShareExtensionAssembly()
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", comment: "testComment", files: [])
+        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", files: [])
         XCTAssertEqual(databaseClient.registeredObjects.count, 1)
         testee.cancel(submissionID: submissionID)
         drainMainQueue()
@@ -98,7 +98,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
         testee.setupShareUIDismissBlock {
             shareCompletedCallback.fulfill()
         }
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", comment: "testComment", files: [testFileURL])
+        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", files: [testFileURL])
         let submission = try! databaseClient.existingObject(with: submissionID) as! FileSubmission
 
         // MARK: File target request API mock

--- a/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
@@ -25,6 +25,7 @@ class FileSubmissionComposerTests: CoreTestCase {
         let testee = FileSubmissionComposer(context: databaseClient)
         let submissionID = testee.makeNewSubmission(courseId: "testCourseID",
                                                     assignmentId: "testAssignmentID",
+                                                    assignmentName: "testName",
                                                     comment: "testComment",
                                                     files: [
                                                         URL(string: "/test")!,
@@ -37,6 +38,7 @@ class FileSubmissionComposerTests: CoreTestCase {
 
         XCTAssertEqual(submission.courseID, "testCourseID")
         XCTAssertEqual(submission.assignmentID, "testAssignmentID")
+        XCTAssertEqual(submission.assignmentName, "testName")
         XCTAssertEqual(submission.comment, "testComment")
 
         guard submission.files.count == 2 else {
@@ -55,6 +57,7 @@ class FileSubmissionComposerTests: CoreTestCase {
         let testee = FileSubmissionComposer(context: databaseClient)
         let submissionID = testee.makeNewSubmission(courseId: "testCourseID",
                                                     assignmentId: "testAssignmentID",
+                                                    assignmentName: "testName",
                                                     comment: "testComment",
                                                     files: [
                                                         URL(string: "/test")!,
@@ -77,6 +80,7 @@ class FileSubmissionComposerTests: CoreTestCase {
         let testee = FileSubmissionComposer(context: databaseClient)
         let submissionID = testee.makeNewSubmission(courseId: "testCourseID",
                                                     assignmentId: "testAssignmentID",
+                                                    assignmentName: "testName",
                                                     comment: "testComment",
                                                     files: [
                                                         URL(string: "/test")!,

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentSubmissionServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentSubmissionServiceTests.swift
@@ -44,12 +44,13 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
 
         // MARK: - WHEN
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
 
         // MARK: - THEN
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmissionID, submissionID)
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.courseId, "testCourseID")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentId, "testAssignmentID")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentName, "testName")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.comment, "testComment")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.files, [fileURL])
         XCTAssertEqual(mockAssembly.startedSubmission, submissionID)
@@ -60,14 +61,15 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
 
         // MARK: - WHEN
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", comment: "testComment")
-        let submissionID2 = testee.submit(urls: [fileURL], courseID: "testCourseID2", assignmentID: "testAssignmentID2", comment: "testComment2")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID2 = testee.submit(urls: [fileURL], courseID: "testCourseID2", assignmentID: "testAssignmentID2", assignmentName: "testName2", comment: "testComment2")
 
         // MARK: - THEN
         XCTAssertEqual(mockAssembly.mockComposer.deletedSubmission, submissionID)
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmissionID, submissionID2)
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.courseId, "testCourseID2")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentId, "testAssignmentID2")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentName, "testName2")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.comment, "testComment2")
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.files, [fileURL])
         XCTAssertEqual(mockAssembly.startedSubmission, submissionID2)
@@ -76,7 +78,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testCancel() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
 
         // MARK: - WHEN
         testee.fileProgressViewModelCancel(FileProgressListViewModel(submissionID: submissionID, dismiss: {}))
@@ -88,7 +90,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testRetry() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
 
         // MARK: - WHEN
         testee.fileProgressViewModelRetry(FileProgressListViewModel(submissionID: submissionID, dismiss: {}))
@@ -100,7 +102,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testItemDeletion() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
         let itemID = NSManagedObjectID()
 
         // MARK: - WHEN
@@ -134,11 +136,12 @@ class MockFileSubmissionAssembly: FileSubmissionAssembly {
 class MockFileSubmissionComposer: FileSubmissionComposer {
     var deletedSubmission: NSManagedObjectID?
     var deletedItem: NSManagedObjectID?
-    var startedSubmission: (courseId: String, assignmentId: String, comment: String?, files: [URL])?
+    // swiftlint:disable:next large_tuple
+    var startedSubmission: (courseId: String, assignmentId: String, assignmentName: String, comment: String?, files: [URL])?
     var startedSubmissionID: NSManagedObjectID?
 
-    public override func makeNewSubmission(courseId: String, assignmentId: String, comment: String?, files: [URL]) -> NSManagedObjectID {
-        startedSubmission = (courseId: courseId, assignmentId: assignmentId, comment: comment, files: files)
+    public override func makeNewSubmission(courseId: String, assignmentId: String, assignmentName: String, comment: String?, files: [URL]) -> NSManagedObjectID {
+        startedSubmission = (courseId: courseId, assignmentId: assignmentId, assignmentName: assignmentName, comment: comment, files: files)
         let startedSubmissionID = NSManagedObjectID()
         self.startedSubmissionID = startedSubmissionID
         return startedSubmissionID


### PR DESCRIPTION
This code change adds the assignment name to the file submission CoreData object so that it can be used in the future to display a progress indicator on the dashboard for that particular assignment. 
This PR doesn't change the way the submission feature works.

refs: MBL-16144
affects: Student
release note: none

test plan: none