### PR TITLE
Interprocess notifications center

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1005,6 +1005,8 @@
 		CF941B14267B427300700DE9 /* K5GradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF941B13267B427300700DE9 /* K5GradesViewModelTests.swift */; };
 		CF941B19267B433700700DE9 /* K5ResourcesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF941B18267B433700700DE9 /* K5ResourcesViewModelTests.swift */; };
 		CF941B1E267B439600700DE9 /* K5ScheduleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF941B1D267B439600700DE9 /* K5ScheduleViewModelTests.swift */; };
+		CF99CB1128D9D2CD001BBDF1 /* InterprocessNotificationCenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF99CB1028D9D2CC001BBDF1 /* InterprocessNotificationCenter.swift */; };
+		CF99CB1528D9D99D001BBDF1 /* InterprocessNotificationCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF99CB1428D9D99D001BBDF1 /* InterprocessNotificationCenterTests.swift */; };
 		CF9A0EDE27E2497E00762228 /* ListSelectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9A0EDD27E2497E00762228 /* ListSelectionViewModel.swift */; };
 		CF9A0EE027E38CFC00762228 /* SyllabusCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9A0EDF27E38CFC00762228 /* SyllabusCellViewModel.swift */; };
 		CF9A0EE427E494BE00762228 /* ListSelectionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9A0EE327E494BE00762228 /* ListSelectionViewModelTests.swift */; };
@@ -2486,6 +2488,8 @@
 		CF941B13267B427300700DE9 /* K5GradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesViewModelTests.swift; sourceTree = "<group>"; };
 		CF941B18267B433700700DE9 /* K5ResourcesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ResourcesViewModelTests.swift; sourceTree = "<group>"; };
 		CF941B1D267B439600700DE9 /* K5ScheduleViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleViewModelTests.swift; sourceTree = "<group>"; };
+		CF99CB1028D9D2CC001BBDF1 /* InterprocessNotificationCenter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InterprocessNotificationCenter.swift; sourceTree = "<group>"; };
+		CF99CB1428D9D99D001BBDF1 /* InterprocessNotificationCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterprocessNotificationCenterTests.swift; sourceTree = "<group>"; };
 		CF9A0EDD27E2497E00762228 /* ListSelectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectionViewModel.swift; sourceTree = "<group>"; };
 		CF9A0EDF27E38CFC00762228 /* SyllabusCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyllabusCellViewModel.swift; sourceTree = "<group>"; };
 		CF9A0EE327E494BE00762228 /* ListSelectionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectionViewModelTests.swift; sourceTree = "<group>"; };
@@ -2955,6 +2959,7 @@
 				7D63F78B215D4BD300151E49 /* Brand.swift */,
 				B191D5E5226E28E100D02948 /* CacheManager.swift */,
 				B17F23B02137981B00771F86 /* Clock.swift */,
+				CF99CB1028D9D2CC001BBDF1 /* InterprocessNotificationCenter.swift */,
 				7D52D8AA2301BA5100684932 /* ExperimentalFeature.swift */,
 				7D63F789215D46AB00151E49 /* GetBrandVariables.swift */,
 				CFB3A1E3269C8D4A00429B3E /* K5State.swift */,
@@ -4069,6 +4074,7 @@
 				B1A7849024412101001A2B50 /* BackgroundVideoPlayerTests.swift */,
 				7D8B78FA215EC9BE005E08F1 /* BrandTests.swift */,
 				B191D5E7226E2CBA00D02948 /* CacheManagerTests.swift */,
+				CF99CB1428D9D99D001BBDF1 /* InterprocessNotificationCenterTests.swift */,
 				7D52D8AC2301C0A400684932 /* ExperimentalFeatureTests.swift */,
 				7D63F791215D8EEC00151E49 /* GetBrandVariablesTests.swift */,
 				CFB3A1E7269D8B0600429B3E /* K5StateTests.swift */,
@@ -7010,6 +7016,7 @@
 				CFC2C2852735961E006CA3E0 /* AttachmentCopyServiceTests.swift in Sources */,
 				7D4F44FD241BFB2300233B92 /* APIConferenceTests.swift in Sources */,
 				CF9A0F4B27ECA3CF00762228 /* DefaultViewProviderTests.swift in Sources */,
+				CF99CB1528D9D99D001BBDF1 /* InterprocessNotificationCenterTests.swift in Sources */,
 				E86CFBD823A2F7CD00EAE487 /* APIDashboardTests.swift in Sources */,
 				3B8F23CD23274FC500788730 /* AlertThresholdTests.swift in Sources */,
 				CF8D5362280EC41B0038B0B2 /* FeatureFlagTests.swift in Sources */,
@@ -7666,6 +7673,7 @@
 				B16E05E22423DF83006B6ADB /* LoginQRCodeTutorialViewController.swift in Sources */,
 				CFEC7F3826B3F7F9008B9F77 /* K5ScheduleDayViewModel.swift in Sources */,
 				D9D7EBE427BC0A3000544339 /* CourseSettingsViewModel.swift in Sources */,
+				CF99CB1128D9D2CD001BBDF1 /* InterprocessNotificationCenter.swift in Sources */,
 				7DA2600E23F7227A005D2121 /* ProcessInfoExtensions.swift in Sources */,
 				7DA2604423F722D9005D2121 /* DiscussionTopic.swift in Sources */,
 				EB2A9BC62632E31F00A19A5A /* SideMenuFooterView.swift in Sources */,

--- a/Core/Core/AppEnvironment/InterprocessNotificationCenter.swift
+++ b/Core/Core/AppEnvironment/InterprocessNotificationCenter.swift
@@ -1,0 +1,107 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+
+public class InterprocessNotificationCenter {
+    public static let shared = InterprocessNotificationCenter()
+
+    /** This publisher publishes all notifications this class receives after its registered subscribers. */
+    public lazy var notifications: AnyPublisher<String, Never> = notificationsSubject.eraseToAnyPublisher()
+    private let notificationsSubject = PassthroughSubject<String, Never>()
+    private var subscriberCountByNotificationName: [String: Int] = [:]
+    private let synchronizer = DispatchQueue(label: "com.instructure.icanvas.darwinnotificationcenter")
+
+    private init() {
+    }
+
+    /**
+     This method subscribes this class to inter process notifications for the given name and returns
+     a `Publisher` that emits an event each time a notification with the given name received.
+     */
+    public func subscribe(forName name: String) -> AnyPublisher<Void, Never> {
+        addSubscriber(name)
+        let publisher = notifications
+            .filter { $0 == name }
+            .map { _ in () }
+            .handleEvents(receiveCancel: { self.removeSubscriber(name) })
+            .eraseToAnyPublisher()
+        return publisher
+    }
+
+    public func post(name: String) {
+        CFNotificationCenterPostNotification(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            CFNotificationName(name as CFString),
+            nil,
+            nil,
+            true
+        )
+    }
+
+    private func addSubscriber(_ name: String) {
+        synchronizer.sync {
+            var subscriberCount = subscriberCountByNotificationName[name] ?? 0
+
+            if subscriberCount == 0 {
+                registerNotificationObserver(for: name)
+            }
+
+            subscriberCount += 1
+            subscriberCountByNotificationName[name] = subscriberCount
+        }
+    }
+
+    private func removeSubscriber(_ name: String) {
+        synchronizer.sync {
+            guard var subscriberCount = subscriberCountByNotificationName[name] else { return }
+            subscriberCount -= 1
+            subscriberCountByNotificationName[name] = subscriberCount
+
+            if subscriberCount == 0 {
+                deleteNotificationObserver(for: name)
+            }
+        }
+    }
+
+    private func registerNotificationObserver(for name: String) {
+        // This is a C function pointer so we can't use self inside.
+        let callback: CFNotificationCallback = { _, _, name, _, _ in
+            guard let name = name?.rawValue as String? else { return }
+            InterprocessNotificationCenter.shared.notificationsSubject.send(name)
+        }
+
+        CFNotificationCenterAddObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            callback,
+            name as CFString,
+            nil,
+            .deliverImmediately
+        )
+    }
+
+    private func deleteNotificationObserver(for name: String) {
+        CFNotificationCenterRemoveObserver(
+            CFNotificationCenterGetDarwinNotifyCenter(),
+            Unmanaged.passUnretained(self).toOpaque(),
+            CFNotificationName(name as CFString),
+            nil
+        )
+    }
+}

--- a/Core/CoreTests/AppEnvironment/InterprocessNotificationCenterTests.swift
+++ b/Core/CoreTests/AppEnvironment/InterprocessNotificationCenterTests.swift
@@ -1,0 +1,136 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Core
+import XCTest
+
+class InterprocessNotificationCenterTests: XCTestCase {
+    private let testee = InterprocessNotificationCenter.shared
+    private var subscriptions = Set<AnyCancellable>()
+
+    override func tearDown() {
+        subscriptions.removeAll()
+        super.tearDown()
+    }
+
+    func testSubscription() {
+        // MARK: - GIVEN
+        let subscription1Received = expectation(description: "Subscription received value")
+        testee
+            .subscribe(forName: "test1")
+            .sink { subscription1Received.fulfill() }
+            .store(in: &subscriptions)
+
+        let subscription2NotReceived = expectation(description: "Subscription not received value")
+        subscription2NotReceived.isInverted = true
+        testee
+            .subscribe(forName: "test2")
+            .sink { subscription2NotReceived.fulfill() }
+            .store(in: &subscriptions)
+
+        // MARK: - WHEN
+        testee.post(name: "test1")
+
+        // MARK: - THEN
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testMultipleSubscriptions() {
+        // MARK: - GIVEN
+        let subscription1Received = expectation(description: "Subscription received value")
+        testee
+            .subscribe(forName: "test")
+            .sink { subscription1Received.fulfill() }
+            .store(in: &subscriptions)
+
+        let subscription2Received = expectation(description: "Subscription received value")
+        testee
+            .subscribe(forName: "test")
+            .sink { subscription2Received.fulfill() }
+            .store(in: &subscriptions)
+
+        let singleNotificationReceived = expectation(description: "Notification received")
+        testee
+            .notifications
+            .sink { _ in singleNotificationReceived.fulfill() }
+            .store(in: &subscriptions)
+
+        // MARK: - WHEN
+        testee.post(name: "test")
+
+        // MARK: - THEN
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testMultipleSubscriptionsWhenOneCancelled() {
+        // MARK: - GIVEN
+        let subscription1Received = expectation(description: "Subscription received value")
+        testee
+            .subscribe(forName: "test")
+            .sink { subscription1Received.fulfill() }
+            .store(in: &subscriptions)
+
+        let subscription2Received = expectation(description: "Subscription received value")
+        subscription2Received.isInverted = true
+        var secondSubscription: AnyCancellable? = testee
+            .subscribe(forName: "test")
+            .sink { subscription2Received.fulfill() }
+
+        let singleNotificationReceived = expectation(description: "Notification received")
+        testee
+            .notifications
+            .sink { _ in singleNotificationReceived.fulfill() }
+            .store(in: &subscriptions)
+
+        // MARK: - WHEN
+        secondSubscription = nil
+        testee.post(name: "test")
+
+        // MARK: - THEN
+        waitForExpectations(timeout: 0.1)
+        secondSubscription?.cancel()
+    }
+
+    func testSubscriptionCancel() {
+        // MARK: - GIVEN
+        let subscriptionNotReceived = expectation(description: "Subscription not received value")
+        subscriptionNotReceived.isInverted = true
+        var subscription: AnyCancellable? = testee
+            .subscribe(forName: "test")
+            .sink { subscriptionNotReceived.fulfill() }
+
+        let noNotificationReceived = expectation(description: "Notification not received")
+        noNotificationReceived.isInverted = true
+        testee
+            .notifications
+            .sink { _ in
+                noNotificationReceived.fulfill()
+            }
+            .store(in: &subscriptions)
+
+        // MARK: - WHEN
+        subscription = nil
+        testee.post(name: "test")
+
+        // MARK: - THEN
+        drainMainQueue()
+        waitForExpectations(timeout: 0.1)
+        subscription?.cancel()
+    }
+}


### PR DESCRIPTION
This PR adds a notification center class to support communication between the app and its share extension. This will be used to communicate file upload state changes between the app and the file share extension. So far it's not used anywhere yet.

refs: MBL-16144
affects: none
release note: none

test plan: none