### PR TITLE
Refresh elementary modules page on app foreground event.

### DIFF
--- a/Core/CoreTests/Courses/K5/ViewModel/K5SubjectViewModelTests.swift
+++ b/Core/CoreTests/Courses/K5/ViewModel/K5SubjectViewModelTests.swift
@@ -72,4 +72,39 @@ class K5SubjectViewModelTests: CoreTestCase {
         wait(for: [expectation], timeout: 0.5)
         reloadListener.cancel()
     }
+
+    func testReloadsWhenAppMovesToForegroundOnModulesPage() {
+        Tab.make(from: .make(id: "home", type: .internal, position: 0), context: context)
+        Tab.make(from: .make(id: "modules", type: .internal, position: 1), context: context)
+
+        let testee = K5SubjectViewModel(context: context, selectedTabId: "modules")
+        let expectation = self.expectation(description: "WebView reload trigger received")
+        expectation.expectedFulfillmentCount = 1
+
+        let reloadListener = testee.reloadWebView.sink {
+            expectation.fulfill()
+        }
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        wait(for: [expectation], timeout: 0.5)
+        reloadListener.cancel()
+    }
+
+    func testNotReloadsWhenAppMovesToForegroundAndNotOnModulesPage() {
+        Tab.make(from: .make(id: "home", type: .internal, position: 0), context: context)
+        Tab.make(from: .make(id: "modules", type: .internal, position: 1), context: context)
+
+        let testee = K5SubjectViewModel(context: context, selectedTabId: "home")
+        let expectation = self.expectation(description: "WebView reload trigger received")
+        expectation.expectedFulfillmentCount = 1
+        expectation.isInverted = true
+
+        let reloadListener = testee.reloadWebView.sink {
+            expectation.fulfill()
+        }
+        NotificationCenter.default.post(name: UIApplication.willEnterForegroundNotification, object: nil)
+
+        wait(for: [expectation], timeout: 0.5)
+        reloadListener.cancel()
+    }
 }


### PR DESCRIPTION
refs: MBL-16229
affects: Student
release note: Fixed elementary module progress not updating when submitting a module assignment with the share extension.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><video src="https://user-images.githubusercontent.com/72396990/192723721-13111410-48a6-4778-b026-8dbfdedcd1a9.mov" maxHeight=500></td>
<td><video src="https://user-images.githubusercontent.com/72396990/192723797-6c0e2c6e-4c74-4dbc-8bae-c077471824f8.mov" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
