### PR TITLE
Work around text box rendered out of screen when button shapes is enabled.

### DIFF
--- a/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
+++ b/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
@@ -22,73 +22,59 @@ import SwiftUI
  This text editor starts as a one line height component, then as text is entered it grows until its maximum height is reached.
  */
 public struct DynamicHeightTextEditor: View {
+    // MARK: - Dependencies
+
     @Binding private var text: String
-    /** The height of the TextEditor. Calculated by manually measuring the text's rendered size and adding paddings.*/
-    @State private var height: CGFloat
-    /** The measured available width. The initial value is just a placeholder until the view is actually rendered. */
-    @State private var width: CGFloat = 300
-    @Environment(\.accessibilityShowButtonShapes) private var isButtonShapesEnabled
-    private let maxHeight: CGFloat
-    private let minHeight: CGFloat
     private let placeholder: String?
-    /** This is required to measure the text's height with `NSString`'s `boundingRect` method. We can't use `Font` or get it from `Environment` because `SwiftUI.Font` cannot be converted into `UIFont.` */
-    private let font: UIFont
+
+    // MARK: - Private properties
+
+    /** The height of the TextEditor. Calculated by  measuring the text's rendered size and adding paddings. */
+    @State private var textEditorHeight: CGFloat = 33.5
     // These are estimated values. SwiftUI.TextEditor has some internal paddings which we cannot influence nor measure.
     private let textEditorVerticalPadding: CGFloat = 7
-    private let textEditorHorizontalPadding: CGFloat = 5
+    private let textEditorHorizontalPadding: CGFloat = 4
+    @State private var textToMeasureHeight: String = "Placeholder"
 
-    public init(text: Binding<String>, maxLines: Int, font: UIFont, placeholder: String? = nil) {
-        let minHeight = font.lineHeight + 2 * textEditorVerticalPadding
-        self._text = text
-        self.minHeight = minHeight
-        self.maxHeight = CGFloat(maxLines) * font.lineHeight + 2 * textEditorVerticalPadding
+    // MARK: - Init
+
+    public init(text: Binding<String>, placeholder: String? = nil) {
+        _text = text
         self.placeholder = placeholder
-        self.font = font
-        self.height = minHeight
-        updateHeight()
     }
 
     public var body: some View {
-        GeometryReader { geometry in // Just to measure the available width
+        ZStack(alignment: .leading) {
+            Text(textToMeasureHeight)
+                .padding(.vertical, textEditorVerticalPadding)
+                .background(GeometryReader {
+                    Color.clear.preference(
+                        key: ViewSizeKey.self,
+                        value: $0.frame(in: .local).size.height
+                    )
+                })
             TextEditor(text: $text)
-                .font(Font(font))
                 .foregroundColor(.textDarkest)
-                .frame(height: height)
-                .preference(key: ViewSizeKey.self, value: CGSize(width: geometry.size.width - 2 * textEditorHorizontalPadding, height: 0))
-                .overlay(placeholderView, alignment: .topLeading)
+                .frame(height: textEditorHeight)
+                .overlay(placeholderView, alignment: .leading)
         }
-        .frame(maxHeight: height) // height must be limited to the text height, otherwise the geometry reader fills all available space vertically
-        .onChange(of: text) { _ in updateHeight() }
-        .onAppear(perform: updateHeight)
-        .onPreferenceChange(ViewSizeKey.self, perform: { size in
-            self.width = size.width
-            updateHeight()
+        .onChange(of: text, perform: { newValue in
+            textToMeasureHeight = newValue.isEmpty ? "Placeholder" : newValue
         })
+        .onPreferenceChange(ViewSizeKey.self) {
+            textEditorHeight = $0
+        }
     }
 
     @ViewBuilder
     private var placeholderView: some View {
         if text.isEmpty, let placeholder = placeholder, #available(iOS 15, *) {
             Text(placeholder)
-                .font(Font(font))
                 .foregroundColor(.textDark)
-                .padding(.top, textEditorVerticalPadding)
                 .padding(.leading, textEditorHorizontalPadding)
                 .accessibility(hidden: true)
                 .allowsHitTesting(false) // Make sure taps go through to the TextEditor, doesn't work on iOS 14
         }
-    }
-
-    /**
-     This method renders the text offscreen to measure its height for the current width. This measured height will be the height of the TextEditor.
-     */
-    private func updateHeight() {
-        let sizeConstraint = CGSize(width: width, height: .greatestFiniteMagnitude)
-        var measuredTextHeight = NSString(string: text).boundingRect(with: sizeConstraint, options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil).height
-        measuredTextHeight += 2 * textEditorVerticalPadding
-        // For some reason if button shapes are enabled then TextEditor is rendered below its original position like about 30 points.
-        // If we increase the height by 5 points it's rendered at its desired position. ¯\_(ツ)_/¯
-        height = (isButtonShapesEnabled ? 5 : 0) + min(maxHeight, max(minHeight, measuredTextHeight))
     }
 }
 
@@ -96,29 +82,37 @@ public struct DynamicHeightTextEditor: View {
 
 struct DynamicHeightTextEditor_Previews: PreviewProvider {
     static var previews: some View {
-        DynamicHeightTextEditor(text: .constant(""), maxLines: 3, font: .scaledNamedFont(.regular14), placeholder: "Placeholder")
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant(""), placeholder: "Placeholder")
+            .font(.regular14)
+            .previewLayout(.sizeThatFits)
+            .border(Color.red)
 
-        DynamicHeightTextEditor(text: .constant("Placeholder"), maxLines: 3, font: .scaledNamedFont(.regular14), placeholder: "Placeholder")
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant("Placeholder"), placeholder: "Placeholder")
+            .font(.regular14)
+            .previewLayout(.sizeThatFits)
+            .border(Color.red)
 
-        DynamicHeightTextEditor(text: .constant("1"), maxLines: 3, font: .scaledNamedFont(.regular14))
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant("1"))
+            .font(.regular14)
+            .previewLayout(.sizeThatFits)
+            .border(Color.red)
 
-        DynamicHeightTextEditor(text: .constant("1\n2"), maxLines: 3, font: .scaledNamedFont(.regular14))
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant("1\n2"))
+            .previewLayout(.sizeThatFits)
+            .font(.regular14)
+            .border(Color.red)
 
-        DynamicHeightTextEditor(text: .constant("1\n2\n3"), maxLines: 3, font: .scaledNamedFont(.regular14))
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant("1\n2\n3"))
+            .font(.regular14)
+            .lineLimit(2)
+            .previewLayout(.sizeThatFits)
+            .border(Color.red)
 
-        DynamicHeightTextEditor(text: .constant("1\n2\n3\n4\n5\n6\n7\n8\n9"), maxLines: 3, font: .scaledNamedFont(.regular14))
-        .previewLayout(.sizeThatFits)
-        .border(Color.red)
+        DynamicHeightTextEditor(text: .constant("1\n2\n3\n4\n5\n6\n7\n8\n9"))
+            .font(.regular14)
+            .lineLimit(3)
+            .previewLayout(.sizeThatFits)
+            .border(Color.red)
     }
 }
 

--- a/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
+++ b/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
@@ -27,6 +27,7 @@ public struct DynamicHeightTextEditor: View {
     @State private var height: CGFloat
     /** The measured available width. The initial value is just a placeholder until the view is actually rendered. */
     @State private var width: CGFloat = 300
+    @Environment(\.accessibilityShowButtonShapes) private var isButtonShapesEnabled
     private let maxHeight: CGFloat
     private let minHeight: CGFloat
     private let placeholder: String?
@@ -85,7 +86,9 @@ public struct DynamicHeightTextEditor: View {
         let sizeConstraint = CGSize(width: width, height: .greatestFiniteMagnitude)
         var measuredTextHeight = NSString(string: text).boundingRect(with: sizeConstraint, options: .usesLineFragmentOrigin, attributes: [.font: font], context: nil).height
         measuredTextHeight += 2 * textEditorVerticalPadding
-        height = min(maxHeight, max(minHeight, measuredTextHeight))
+        // For some reason if button shapes are enabled then TextEditor is rendered below its original position like about 30 points.
+        // If we increase the height by 5 points it's rendered at its desired position. ¯\_(ツ)_/¯
+        height = (isButtonShapesEnabled ? 5 : 0) + min(maxHeight, max(minHeight, measuredTextHeight))
     }
 }
 

--- a/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
+++ b/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
@@ -64,11 +64,11 @@ public struct ViewBoundsKey: PreferenceKey {
  This key allows one to save a view's size to the preference store.
  */
 public struct ViewSizeKey: PreferenceKey {
-    public typealias Value = CGSize
+    public typealias Value = CGFloat
 
-    public static var defaultValue = CGSize.zero
+    public static var defaultValue: CGFloat = 0
 
-    public static func reduce(value: inout CGSize, nextValue: () -> CGSize) {
-        value = nextValue()
+    public static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value += nextValue()
     }
 }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -28,7 +28,9 @@ struct CommentEditor: View {
 
     var body: some View {
         HStack(alignment: .bottom) {
-            DynamicHeightTextEditor(text: $text, maxLines: 3, font: .scaledNamedFont(.regular16), placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
+            DynamicHeightTextEditor(text: $text, placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
+                .font(.regular16)
+                .lineLimit(3)
                 .accessibility(label: Text("Comment"))
                 .identifier("SubmissionComments.commentTextView")
             Button(action: {


### PR DESCRIPTION
refs: MBL-15705
affects: Teacher
release note: Fixed comment text box not being tappable in SpeedGrader when Button Shapes a11y feature is enabled.

test plan:
- Disable comment library in the web based SpeedGrader.
- Go to iOS Settings > Accessibility > Display & Text Size, turn on Button Shapes toggle
- Start the teacher app, go to an assignment.
- Check if comment text field if visible and tappable.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/192989227-15f5bc5f-7e4f-41fb-99aa-03dd566258e7.PNG" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/192989276-c063be1f-843b-472b-8ed6-30a6ea1023e3.PNG" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product or not needed
