### PR TITLE
Soft-concluded enrollments still appear in Inbox list

### DIFF
--- a/Core/Core/Profile/SideMenu/SideMenuItem.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuItem.swift
@@ -82,7 +82,7 @@ private struct Badge: View {
     }
 
     func clampedValueText() -> Text {
-        guard value < 100 else { return Text("99+") }
+        guard value < 100 else { return Text(verbatim: "99+") }
         return Text("\(value)")
     }
 }

--- a/rn/Teacher/src/canvas-api/apis/courses.js
+++ b/rn/Teacher/src/canvas-api/apis/courses.js
@@ -30,7 +30,7 @@ export function getCourses (): ApiPromise<Course[]> {
   }
   const courses = paginate('courses', {
     params: {
-      include: [ 'course_image', 'current_grading_period_scores', 'grading_periods', 'favorites', 'needs_grading_count', 'observed_users', 'sections', 'syllabus_body', 'tabs', 'term', 'total_scores' ],
+      include: [ 'course_image', 'concluded', 'current_grading_period_scores', 'grading_periods', 'favorites', 'needs_grading_count', 'observed_users', 'sections', 'syllabus_body', 'tabs', 'term', 'total_scores' ],
       state,
       per_page: 10,
     },

--- a/rn/Teacher/src/modules/inbox/CourseSelect.js
+++ b/rn/Teacher/src/modules/inbox/CourseSelect.js
@@ -127,6 +127,7 @@ export function mapStateToProps (state: AppState): CourseSelectDataProps {
     .map(id => state.entities.courses[id].course)
     .filter(App.current().filterCourse)
     .filter(course => course.workflow_state === 'available')
+    .filter(course => course.concluded === false)
   let pending = !!state.favoriteCourses.pending
 
   const favoriteCourses = courses.filter((course) => course.is_favorite)

--- a/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
+++ b/rn/Teacher/src/modules/inbox/__tests__/CourseSelect.test.js
@@ -41,19 +41,31 @@ let template = {
 let c1 = template.course({
   is_favorite: true,
   id: '1',
+  concluded: false,
 })
 
 let c2 = template.course({
   is_favorite: false,
   id: '2',
+  concluded: false,
 })
 
 let c3 = template.course({
   is_favorite: false,
   id: '3',
+  concluded: false,
 })
 
-let c4 = template.course({ id: '4', workflow_state: 'completed' })
+let c4 = template.course({
+  id: '4',
+  workflow_state: 'completed',
+  concluded: false,
+})
+
+let c5 = template.course({
+  id: '5',
+  concluded: true,
+})
 
 let defaultProps = {
   navigator: template.navigator({
@@ -125,6 +137,9 @@ describe('CourseSelect', () => {
           },
           [c4.id]: {
             course: c4,
+          },
+          [c5.id]: {
+            course: c5,
           },
         },
       },


### PR DESCRIPTION
refs: MBL-16248, MBL-16279
affects: Student, Teacher
release note: Fixed soft-concluded enrollments still appear in Inbox course list.
test plan: See ticket.

## Screenshots

### Student
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/193039298-6770b908-9c92-4637-a077-84840691648a.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/193039288-ad3da3ed-31a7-439d-a88a-0f25078bec11.png" maxHeight=500></td>
</tr>
</table>

### Teacher
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/193039527-2dada17c-5b00-4d70-ab9a-45ca8fe3f6f7.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/193039537-ffb45e5f-5e07-47a9-8c94-5eec8e2e88a7.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
