### PR TITLE
Do not show hidden events in syllabus summary

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -119,6 +119,7 @@
         <attribute name="htmlURL" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="isAllDay" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isHidden" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="locationAddress" optional="YES" attributeType="String"/>
         <attribute name="locationName" optional="YES" attributeType="String"/>
         <attribute name="startAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -979,7 +980,7 @@
         <element name="AssignmentDate" positionX="-540" positionY="-18" width="128" height="148"/>
         <element name="AssignmentGroup" positionX="-540" positionY="-27" width="128" height="120"/>
         <element name="AssignmentOverride" positionX="-540" positionY="-18" width="128" height="193"/>
-        <element name="CalendarEvent" positionX="-531" positionY="-18" width="128" height="253"/>
+        <element name="CalendarEvent" positionX="-531" positionY="-18" width="128" height="254"/>
         <element name="CommonCourse" positionX="-540" positionY="-18" width="128" height="103"/>
         <element name="CommunicationChannel" positionX="-531" positionY="-9" width="128" height="133"/>
         <element name="Conference" positionX="-540" positionY="-18" width="128" height="298"/>

--- a/Core/Core/Planner/CalendarEvent.swift
+++ b/Core/Core/Planner/CalendarEvent.swift
@@ -35,6 +35,7 @@ final public class CalendarEvent: NSManagedObject, WriteableModel {
     @NSManaged public var startAt: Date?
     @NSManaged public var endAt: Date?
     @NSManaged public var isAllDay: Bool
+    @NSManaged public var isHidden: Bool
     @NSManaged public var typeRaw: String
     @NSManaged public var htmlURL: URL?
     @NSManaged public var contextRaw: String
@@ -73,6 +74,7 @@ final public class CalendarEvent: NSManagedObject, WriteableModel {
         model.startAt = item.start_at
         model.endAt = item.end_at
         model.isAllDay = item.all_day
+        model.isHidden = item.isHidden
         model.type = item.type
         model.htmlURL = item.html_url
         model.contextRaw = item.context_code

--- a/Core/Core/Syllabus/SyllabusSummaryViewController.swift
+++ b/Core/Core/Syllabus/SyllabusSummaryViewController.swift
@@ -37,7 +37,12 @@ public class SyllabusSummaryViewController: UITableViewController {
     }
 
     public lazy var summary: Store<LocalUseCase<CalendarEvent>> = {
-        let predicate = NSPredicate(format: "%K == %@", #keyPath(CalendarEvent.contextRaw), self.context.canvasContextID)
+        let contextPredicate = NSPredicate(format: "%K == %@", #keyPath(CalendarEvent.contextRaw), self.context.canvasContextID)
+        let notHiddenPredicate = NSPredicate(format: "%K == false", #keyPath(CalendarEvent.isHidden))
+        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            contextPredicate,
+            notHiddenPredicate,
+        ])
         let hasStartAt = NSSortDescriptor(key: #keyPath(CalendarEvent.hasStartAt), ascending: false)
         let startAt = NSSortDescriptor(key: #keyPath(CalendarEvent.startAt), ascending: true)
         let title = NSSortDescriptor(key: #keyPath(CalendarEvent.title), ascending: true, naturally: true)

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/FilePreviewProviderTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/FilePreviewProviderTests.swift
@@ -91,7 +91,7 @@ class FilePreviewProviderTests: XCTestCase {
             XCTAssertNotNil(data.image)
         }
         testee.load()
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 5)
         subscription.cancel()
     }
 

--- a/Core/CoreTests/Syllabus/SyllabusSummaryViewControllerTests.swift
+++ b/Core/CoreTests/Syllabus/SyllabusSummaryViewControllerTests.swift
@@ -42,15 +42,23 @@ class SyllabusSummaryViewControllerTests: CoreTestCase {
             type: .event,
             context_code: "course_\(courseID)"
         )
-        let nilDate = APICalendarEvent.make(
+        let hiddenEvent = APICalendarEvent.make(
             id: "3",
+            title: "event",
+            start_at: date.addDays(1),
+            type: .event,
+            context_code: "course_\(courseID)",
+            hidden: true
+        )
+        let nilDate = APICalendarEvent.make(
+            id: "4",
             title: "nil date",
             start_at: nil,
             type: .assignment,
             context_code: "course_\(courseID)"
         )
         api.mock(controller.assignments, value: [assignment, nilDate])
-        api.mock(controller.events, value: [event])
+        api.mock(controller.events, value: [event, hiddenEvent])
         api.mock(controller.course, value: .make(id: ID(courseID)))
 
         controller.view.layoutIfNeeded()


### PR DESCRIPTION
refs: MBL-16258
affects: Student, Teacher
release note: Fixed calendar events from other course sections showing up in syllabus summary.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/193298073-787b8f6c-4bf0-41a9-9f61-56472bccc30c.PNG" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/193298126-5ea4fa7c-a58d-4020-a112-440e2e156836.PNG" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
