### PR TITLE
Use waitUntil instead of running the main RunLoop for a fixed amount of time in unit tests.

### DIFF
--- a/Core/CoreTests/Dashboard/ViewModel/Invitations/DashboardInvitationsViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/ViewModel/Invitations/DashboardInvitationsViewModelTests.swift
@@ -50,8 +50,9 @@ class DashboardInvitationsViewModelTests: CoreTestCase {
 
         invitation.accept()
         XCTAssertEqual(testee.items.count, 1)
-        RunLoop.main.run(until: Date() + 2)
-        XCTAssertEqual(testee.items.count, 0)
+        waitUntil(shouldFail: true) {
+            testee.items.count == 0
+        }
     }
 
     private func setupMocks() {

--- a/Core/CoreTests/Files/FileSubmission/Model/BackgroundActivityTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/BackgroundActivityTests.swift
@@ -19,6 +19,7 @@
 import Combine
 import Core
 import XCTest
+import TestsFoundation
 
 class BackgroundActivityTests: XCTestCase {
     let mockProcessManager = MockProcessManager()
@@ -91,8 +92,9 @@ class BackgroundActivityTests: XCTestCase {
         // MARK: - WHEN
         mockProcessManager.startActivity()
         waitForExpectations(timeout: 1)
-        RunLoop.main.run(until: Date() + 0.5)
-        XCTAssertTrue(mockProcessManager.isExecutingBackgroundBlock)
+        waitUntil(shouldFail: true) {
+            mockProcessManager.isExecutingBackgroundBlock
+        }
         mockProcessManager.expireActivity()
 
         // MARK: - THEN
@@ -115,8 +117,9 @@ class BackgroundActivityTests: XCTestCase {
         mockProcessManager.startActivity()
         waitForExpectations(timeout: 1)
 
-        RunLoop.main.run(until: Date() + 0.5)
-        XCTAssertTrue(mockProcessManager.isExecutingBackgroundBlock)
+        waitUntil(shouldFail: true) {
+            mockProcessManager.isExecutingBackgroundBlock
+        }
 
         let stopFinished = expectation(description: "Future finished")
         testee

--- a/Core/CoreTests/UIViews/CoreActivityViewControllerTests.swift
+++ b/Core/CoreTests/UIViews/CoreActivityViewControllerTests.swift
@@ -18,6 +18,7 @@
 
 import Core
 import XCTest
+import TestsFoundation
 
 class CoreActivityViewControllerTests: CoreTestCase {
 
@@ -33,8 +34,9 @@ class CoreActivityViewControllerTests: CoreTestCase {
         NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)
 
         // MARK: - THEN
-        RunLoop.main.run(until: Date() + 1)
-        XCTAssertNil(host.presentedViewController)
+        waitUntil(shouldFail: true) {
+            host.presentedViewController == nil
+        }
     }
 
     func testDoNotDismissWhenAnotherViewControllerIsPresented() {
@@ -46,8 +48,9 @@ class CoreActivityViewControllerTests: CoreTestCase {
         host.present(testee, animated: false)
         testee.present(presentedOnTestee, animated: false)
         XCTAssertEqual(host.presentedViewController, testee)
-        RunLoop.main.run(until: Date() + 0.5)
-        XCTAssertEqual(testee.presentedViewController, presentedOnTestee)
+        waitUntil(shouldFail: true) {
+            testee.presentedViewController == presentedOnTestee
+        }
 
         // MARK: - WHEN
         NotificationCenter.default.post(name: UIApplication.willResignActiveNotification, object: nil)

--- a/TestsFoundation/TestsFoundation/Element/Element.swift
+++ b/TestsFoundation/TestsFoundation/Element/Element.swift
@@ -236,6 +236,9 @@ public extension Element {
     }
 }
 
+/**
+ This method blocks further test execution and runs the main runloop until the given predicate doesn't return true.
+ */
 public func waitUntil(
     _ timeout: TimeInterval = 10,
     shouldFail: Bool = false,


### PR DESCRIPTION
[ignore-commit-lint]