### PR TITLE
Disable moving of non-editable annotations.

### DIFF
--- a/Core/Core/DocViewer/ViewModel/AnnotationDrag/Gesture/DragStartViewModel.swift
+++ b/Core/Core/DocViewer/ViewModel/AnnotationDrag/Gesture/DragStartViewModel.swift
@@ -40,6 +40,7 @@ extension AnnotationDragGestureViewModel {
         public func startDragGesture() -> DragInfo? {
             guard
                 let tappedAnnotation = tappedAnnotation(on: pageView),
+                tappedAnnotation.isEditable,
                 let annotationClone = tappedAnnotation.createCloneImage(frame: annotationFrame(tappedAnnotation, on: pageView), addTo: pageView)
             else {
                 gestureRecognizer.cancel()


### PR DESCRIPTION
refs: MBL-16280
affects: Teacher
release note: Fixed read-only student annotations being movable in SpeedGrader.

test plan:
- Create a student annotation assignment.
- As a student add a text annotation and submit the document.
- As a teacher open this submission in SpeedGrader.
- Select hand tool and try to move the student’s annotation.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
