### PR TITLE
Fetch only active courses for homeroom resources

### DIFF
--- a/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModel.swift
@@ -27,7 +27,7 @@ public class K5ResourcesViewModel: ObservableObject {
         return homeroomInfos.count > 1
     }
 
-    private lazy var courses = AppEnvironment.shared.subscribe(GetCourses(enrollmentState: nil)) { [weak self] in
+    private lazy var courses = AppEnvironment.shared.subscribe(GetCourses(enrollmentState: .active)) { [weak self] in
         self?.coursesRefreshed()
     }
     private var applicationsRequest: APITask?

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Resources/K5ResourcesViewModelTests.swift
@@ -29,7 +29,7 @@ class K5ResourcesViewModelTests: CoreTestCase {
             APICourse.make(id: "2", name: "Homeroom 2", syllabus_body: "<b>IMPORTANT</b><p>Read the previous note</p>", homeroom_course: true),
             APICourse.make(id: "3", name: "Math", homeroom_course: false),
         ]
-        api.mock(GetCourses(enrollmentState: nil), value: courses)
+        api.mock(GetCourses(enrollmentState: .active), value: courses)
     }
 
     func testHomeroomInfoFetch() {


### PR DESCRIPTION
refs: MBL-16298
affects: Student
release note: Fixed homeroom resources tab not loading for elementary accounts in some cases.

test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/194063747-d63b34e8-e1a6-47c2-803f-70ee71d252f2.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/194063794-858a84da-58b5-4448-ab93-1484efb0be1f.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Approve from product or not needed
