### PR TITLE
Fix pull to refresh circle not disappearing when syllabus is empty.

### DIFF
--- a/Core/Core/Syllabus/SyllabusSummaryViewController.swift
+++ b/Core/Core/Syllabus/SyllabusSummaryViewController.swift
@@ -25,8 +25,12 @@ public class SyllabusSummaryViewController: UITableViewController {
     public weak var colorDelegate: ColorDelegate?
     public var titleSubtitleView: TitleSubtitleView = TitleSubtitleView.create()
 
-    public lazy var assignments = env.subscribe(GetCalendarEvents(context: context, type: .assignment)) {}
-    public lazy var events = env.subscribe(GetCalendarEvents(context: context, type: .event)) {}
+    public lazy var assignments = env.subscribe(GetCalendarEvents(context: context, type: .assignment)) { [weak self] in
+        self?.update()
+    }
+    public lazy var events = env.subscribe(GetCalendarEvents(context: context, type: .event)) { [weak self] in
+        self?.update()
+    }
 
     lazy var course = env.subscribe(GetCourse(courseID: courseID)) { [weak self] in
         self?.update()

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -137,7 +137,7 @@ public class CircleProgressView: UIView {
         progress = nil
     }
 
-    public func stopAninating() {
+    public func stopAnimating() {
         progress = 0
     }
 }

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -135,11 +135,9 @@ public class CircleProgressView: UIView {
 
     public func startAnimating() {
         progress = nil
-        isHidden = false
     }
 
     public func stopAninating() {
         progress = 0
-        isHidden = true
     }
 }

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -130,7 +130,9 @@ public class CircleProgressView: UIView {
 
     public override func didMoveToWindow() {
         super.didMoveToWindow()
-        updateProgress() // Make sure animations are re-added once visible
+        fill.removeAnimation(forKey: morphKey)
+        layer.removeAnimation(forKey: rotateKey)
+        fill.strokeEnd = 0
     }
 
     public func startAnimating() {

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -130,9 +130,7 @@ public class CircleProgressView: UIView {
 
     public override func didMoveToWindow() {
         super.didMoveToWindow()
-        fill.removeAnimation(forKey: morphKey)
-        layer.removeAnimation(forKey: rotateKey)
-        fill.strokeEnd = 0
+        clearAnimation()
     }
 
     public func startAnimating() {
@@ -140,6 +138,12 @@ public class CircleProgressView: UIView {
     }
 
     public func stopAnimating() {
-        progress = 0
+        clearAnimation()
+    }
+
+    private func clearAnimation() {
+        fill.removeAnimation(forKey: morphKey)
+        layer.removeAnimation(forKey: rotateKey)
+        fill.strokeEnd = 0
     }
 }

--- a/Core/Core/UIViews/CircleRefreshControl.swift
+++ b/Core/Core/UIViews/CircleRefreshControl.swift
@@ -109,8 +109,9 @@ public class CircleRefreshControl: UIRefreshControl {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + additionalDuration) {
             super.endRefreshing()
+            self.progressView.alpha = 0
             self.isAnimating = false
-            self.progressView.stopAninating()
+            self.progressView.stopAnimating()
             self.triggerStartDate = nil
         }
     }

--- a/Core/Core/UIViews/CircleRefreshControl.swift
+++ b/Core/Core/UIViews/CircleRefreshControl.swift
@@ -71,18 +71,25 @@ public class CircleRefreshControl: UIRefreshControl {
             self?.updateProgress(scrollView)
         }
         super.didMoveToSuperview()
+        setNeedsLayout()
     }
 
     private func updateProgress(_ scrollView: UIScrollView) {
-        guard !isAnimating, !isRefreshing, scrollView.isDragging else { return }
         let offset = scrollView.contentOffset.y
         guard offset <= 0 else { return }
-        let progress = min(abs((offset) / snappingPoint), 1)
+        let progress = min(abs(offset / snappingPoint), 1)
+
+        guard !isAnimating, scrollView.isDragging else {
+            if progressView.progress != nil {
+                progressView.progress = progress
+            }
+            return
+        }
 
         progressView.progress = progress
         progressView.isHidden = progress == 0
-
-        if !isRefreshing, progress == 1 {
+        progressView.alpha = progress
+        if progress == 1 {
             sendActions(for: .valueChanged)
             beginRefreshing()
             triggerStartDate = Date()

--- a/Core/Core/UIViews/CircleRefreshControl.swift
+++ b/Core/Core/UIViews/CircleRefreshControl.swift
@@ -82,6 +82,7 @@ public class CircleRefreshControl: UIRefreshControl {
         guard !isAnimating, scrollView.isDragging else {
             if progressView.progress != nil {
                 progressView.progress = progress
+                progressView.alpha = progress
             }
             return
         }

--- a/Core/Core/UIViews/CircleRefreshControl.swift
+++ b/Core/Core/UIViews/CircleRefreshControl.swift
@@ -24,7 +24,7 @@ public class CircleRefreshControl: UIRefreshControl {
     public private(set) var offsetObservation: NSKeyValueObservation?
     public let progressView = CircleProgressView()
     private var selfAdding = false
-    private let snappingPoint: CGFloat = 112
+    private let snappingPoint: CGFloat = 100
     public private(set) var isAnimating = false
     private var triggerStartDate: Date?
 
@@ -61,7 +61,7 @@ public class CircleRefreshControl: UIRefreshControl {
             progressView.centerXAnchor.constraint(equalTo: centerXAnchor),
             progressView.centerYAnchor.constraint(equalTo: centerYAnchor),
         ])
-        progressView.isHidden = true
+        progressView.alpha = 0
     }
 
     override public func didMoveToSuperview() {
@@ -87,7 +87,6 @@ public class CircleRefreshControl: UIRefreshControl {
         }
 
         progressView.progress = progress
-        progressView.isHidden = progress == 0
         progressView.alpha = progress
         if progress == 1 {
             sendActions(for: .valueChanged)

--- a/Core/CoreTests/UIViews/CircleProgressViewTests.swift
+++ b/Core/CoreTests/UIViews/CircleProgressViewTests.swift
@@ -74,7 +74,7 @@ class CircleProgressViewTests: CoreTestCase {
         view.layer.removeAllAnimations()
         view.fill.removeAllAnimations()
         view.didMoveToWindow()
-        XCTAssertNotNil(view.layer.animation(forKey: view.rotateKey))
-        XCTAssertNotNil(view.fill.animation(forKey: view.morphKey))
+        XCTAssertNil(view.layer.animation(forKey: view.rotateKey))
+        XCTAssertNil(view.fill.animation(forKey: view.morphKey))
     }
 }

--- a/Core/CoreTests/UIViews/CircleRefreshControlTests.swift
+++ b/Core/CoreTests/UIViews/CircleRefreshControlTests.swift
@@ -35,17 +35,18 @@ class CircleRefreshControlTests: CoreTestCase {
         scrollView.refreshControl = refreshControl
         refreshControl.didMoveToSuperview()
 
-        XCTAssertEqual(refreshControl.progressView.isHidden, true)
+        XCTAssertEqual(refreshControl.progressView.alpha, 0)
         XCTAssertEqual(refreshControl.isRefreshing, false)
         XCTAssertEqual(refreshControl.isAnimating, false)
 
         scrollView.contentOffset.y = -5
-        XCTAssertEqual(refreshControl.progressView.isHidden, false)
+        XCTAssertEqual(refreshControl.progressView.alpha.rounded(), refreshControl.progressView.progress)
         XCTAssertEqual(refreshControl.isRefreshing, false)
         XCTAssertEqual(refreshControl.isAnimating, false)
 
-        scrollView.contentOffset.y = -112
+        scrollView.contentOffset.y = -100
         refreshControl.beginRefreshing()
+        XCTAssertEqual(refreshControl.progressView.alpha, 1)
         XCTAssertEqual(refreshControl.isRefreshing, true)
         XCTAssertEqual(refreshControl.isAnimating, true)
 
@@ -54,17 +55,24 @@ class CircleRefreshControlTests: CoreTestCase {
 
         RunLoop.main.run(until: Date().advanced(by: 1))
 
-        XCTAssertEqual(refreshControl.progressView.isHidden, true)
+        XCTAssertEqual(refreshControl.progressView.alpha, 0)
         XCTAssertEqual(refreshControl.isRefreshing, false)
         XCTAssertEqual(refreshControl.isAnimating, false)
 
         scrollView.contentOffset.y = 32
-        XCTAssertEqual(refreshControl.progressView.isHidden, true)
+        XCTAssertEqual(refreshControl.progressView.alpha, 0)
         XCTAssertEqual(refreshControl.isRefreshing, false)
         XCTAssertEqual(refreshControl.isAnimating, false)
     }
 
     class MockScrollView: UIScrollView {
         override var isDragging: Bool { true }
+    }
+}
+
+private extension CGFloat {
+    func rounded() -> CGFloat {
+        let divisor = pow(10.0, Double(2))
+        return (self * divisor).rounded() / divisor
     }
 }

--- a/Core/CoreTests/UIViews/CircleRefreshControlTests.swift
+++ b/Core/CoreTests/UIViews/CircleRefreshControlTests.swift
@@ -40,7 +40,7 @@ class CircleRefreshControlTests: CoreTestCase {
         XCTAssertEqual(refreshControl.isAnimating, false)
 
         scrollView.contentOffset.y = -5
-        XCTAssertEqual(refreshControl.progressView.alpha.rounded(), refreshControl.progressView.progress)
+        XCTAssertEqual(refreshControl.progressView.alpha, refreshControl.progressView.progress!, accuracy: 0.01)
         XCTAssertEqual(refreshControl.isRefreshing, false)
         XCTAssertEqual(refreshControl.isAnimating, false)
 
@@ -67,12 +67,5 @@ class CircleRefreshControlTests: CoreTestCase {
 
     class MockScrollView: UIScrollView {
         override var isDragging: Bool { true }
-    }
-}
-
-private extension CGFloat {
-    func rounded() -> CGFloat {
-        let divisor = pow(10.0, Double(2))
-        return (self * divisor).rounded() / divisor
     }
 }


### PR DESCRIPTION
refs: MBL-16300
affects: Student, Teacher
release note: none

test plan: See ticket.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
