### PR TITLE
Annotation comment page has dark text in textfield and white top section in dark mode

### DIFF
--- a/Core/Core/DocViewer/Comments/CommentListViewController.storyboard
+++ b/Core/Core/DocViewer/Comments/CommentListViewController.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -22,19 +23,19 @@
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="yjX-e4-Q78">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="8"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <color key="backgroundColor" name="backgroundLightest"/>
                                     <accessibility key="accessibilityConfiguration" identifier="CommentList.tableView"/>
                                 </view>
                                 <prototypes>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="none" indentationWidth="10" reuseIdentifier="CommentListCell" rowHeight="70" id="HMD-1H-deT" customClass="CommentListCell" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="36" width="375" height="70"/>
+                                        <rect key="frame" x="0.0" y="52.5" width="375" height="70"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="HMD-1H-deT" id="ZNu-ly-325">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="70"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="User Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z4f-qr-Ufx" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                    <rect key="frame" x="15" y="4" width="313" height="17.5"/>
+                                                    <rect key="frame" x="16" y="4" width="311" height="20.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -44,7 +45,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="253" verticalCompressionResistancePriority="749" text="Comment Goes Here" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zYq-qS-Ago" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                    <rect key="frame" x="15" y="25.5" width="313" height="17"/>
+                                                    <rect key="frame" x="16" y="28.5" width="311" height="14"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -54,7 +55,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Removed Sep 22 by Tommy Teacher" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Z39-qR-jlG" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                    <rect key="frame" x="15" y="46.5" width="313" height="19.5"/>
+                                                    <rect key="frame" x="16" y="46.5" width="311" height="19.5"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="19.5" id="tu6-eW-NiS"/>
                                                     </constraints>
@@ -66,8 +67,8 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular14Italic"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dtp-0T-6hf" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                                                    <rect key="frame" x="336" y="23" width="24" height="24"/>
+                                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dtp-0T-6hf" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
+                                                    <rect key="frame" x="335" y="23" width="24" height="24"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="24" id="ikB-fd-Wzy"/>
                                                         <constraint firstAttribute="width" constant="24" id="x50-8I-tdL"/>
@@ -125,7 +126,7 @@
                                         <rect key="frame" x="16" y="8" width="343" height="33"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Reply" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YMz-C0-d1c" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                <rect key="frame" x="9" y="8" width="36" height="17"/>
+                                                <rect key="frame" x="9" y="8" width="42.5" height="20.5"/>
                                                 <accessibility key="accessibilityConfiguration">
                                                     <accessibilityTraits key="traits" staticText="YES" notEnabled="YES"/>
                                                     <bool key="isElement" value="NO"/>
@@ -211,6 +212,7 @@
                                 </variation>
                             </view>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="mOL-K8-Aph"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="UPc-zE-qIy" firstAttribute="leading" secondItem="mOL-K8-Aph" secondAttribute="leading" id="aDi-OX-CPz"/>
@@ -221,7 +223,6 @@
                             <constraint firstItem="UPc-zE-qIy" firstAttribute="top" secondItem="p4x-V9-XfM" secondAttribute="top" id="vdt-qb-Mlj"/>
                             <constraint firstItem="pl0-mh-MEz" firstAttribute="top" secondItem="UPc-zE-qIy" secondAttribute="bottom" id="vf5-0a-X34"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="mOL-K8-Aph"/>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
@@ -241,4 +242,29 @@
             <point key="canvasLocation" x="8.8000000000000007" y="138.98050974512745"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="SgB-CQ-dNU">
+            <size key="intrinsicContentSize" width="30" height="34"/>
+        </designable>
+        <designable name="YMz-C0-d1c">
+            <size key="intrinsicContentSize" width="42.5" height="20.5"/>
+        </designable>
+        <designable name="Z39-qR-jlG">
+            <size key="intrinsicContentSize" width="277" height="20.5"/>
+        </designable>
+        <designable name="Z4f-qr-Ufx">
+            <size key="intrinsicContentSize" width="85.5" height="20.5"/>
+        </designable>
+        <designable name="dtp-0T-6hf">
+            <size key="intrinsicContentSize" width="30" height="30"/>
+        </designable>
+        <designable name="zYq-qS-Ago">
+            <size key="intrinsicContentSize" width="159.5" height="20.5"/>
+        </designable>
+    </designables>
+    <resources>
+        <namedColor name="backgroundLightest">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Core/Core/DocViewer/Comments/CommentListViewController.swift
+++ b/Core/Core/DocViewer/Comments/CommentListViewController.swift
@@ -59,6 +59,7 @@ class CommentListViewController: UIViewController {
         replyTextView.font(.scaledNamedFont(.regular14), lineHeight: .body)
         replyTextView.adjustsFontForContentSizeCategory = true
         replyTextView.accessibilityLabel = NSLocalizedString("Reply to the annotation or previous comments", bundle: .core, comment: "")
+        replyTextView.textColor = .textDarkest
         replyButton.accessibilityLabel = NSLocalizedString("Send comment", bundle: .core, comment: "")
         replyView.backgroundColor = .backgroundLight
 


### PR DESCRIPTION
refs: MBL-16301
affects: Student, Teacher
release note: Fix annotation comment page dark appearance.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/194236947-170db681-e938-4a79-aa45-c9e69611504d.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/194235866-22b69adb-19c4-4d8c-9b68-d745d2af5a28.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
