### PR TITLE
Fix student calendar freeze

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -813,6 +813,7 @@
 		B453728828B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */; };
 		B453C8B328CA351200327A13 /* FileUploadItemMimeClassTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B453C8B228CA351200327A13 /* FileUploadItemMimeClassTests.swift */; };
 		B472C7DD28D9D68300C3B6CA /* FileUploadNotificationCardListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B472C7DC28D9D68300C3B6CA /* FileUploadNotificationCardListViewModelTests.swift */; };
+		B49A3C1F28F6C8AE007E14AB /* TableViewBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B49A3C1E28F6C8AE007E14AB /* TableViewBackgroundView.swift */; };
 		B4A687C628DA190800CCCD5C /* FileUploadNotificationCardItemViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4A687C528DA190800CCCD5C /* FileUploadNotificationCardItemViewModelTests.swift */; };
 		B4C045E328CB2BE60011A19F /* SubmissionCompletedNotificationsSenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C045E228CB2BE60011A19F /* SubmissionCompletedNotificationsSenderTests.swift */; };
 		B4CD9DAF28C63CFC0084EB65 /* RefreshableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4CD9DAE28C63CFC0084EB65 /* RefreshableScrollView.swift */; };
@@ -2305,6 +2306,7 @@
 		B453728728B3B25C00B65BE1 /* FileUploadNotificationCardItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModel.swift; sourceTree = "<group>"; };
 		B453C8B228CA351200327A13 /* FileUploadItemMimeClassTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadItemMimeClassTests.swift; sourceTree = "<group>"; };
 		B472C7DC28D9D68300C3B6CA /* FileUploadNotificationCardListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardListViewModelTests.swift; sourceTree = "<group>"; };
+		B49A3C1E28F6C8AE007E14AB /* TableViewBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TableViewBackgroundView.swift; sourceTree = "<group>"; };
 		B4A687C528DA190800CCCD5C /* FileUploadNotificationCardItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModelTests.swift; sourceTree = "<group>"; };
 		B4C045E228CB2BE60011A19F /* SubmissionCompletedNotificationsSenderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCompletedNotificationsSenderTests.swift; sourceTree = "<group>"; };
 		B4CD9DAE28C63CFC0084EB65 /* RefreshableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableScrollView.swift; sourceTree = "<group>"; };
@@ -3367,6 +3369,7 @@
 				7DAFBE73231871F500E9A37D /* ItemPickerViewController.swift */,
 				7D1219232243340200D3BF5C /* KeyboardTransitioning.swift */,
 				7D75FF1724085E95000544E7 /* ListBackgroundView.swift */,
+				B49A3C1E28F6C8AE007E14AB /* TableViewBackgroundView.swift */,
 				7D75FF1324081E42000544E7 /* ListErrorView.swift */,
 				7D75FF1524081F57000544E7 /* ListErrorView.xib */,
 				7D1758C0215A8F5600F88613 /* ListFormatter.swift */,
@@ -7660,6 +7663,7 @@
 				7DA2609323F72315005D2121 /* UserProfile.swift in Sources */,
 				7DA260FE23F773D9005D2121 /* PlannerListViewController.swift in Sources */,
 				7DA2605023F722D9005D2121 /* LogEvent.swift in Sources */,
+				B49A3C1F28F6C8AE007E14AB /* TableViewBackgroundView.swift in Sources */,
 				CFCB0F6827CF85EB008DDEA4 /* SpacePanda.swift in Sources */,
 				7D1E85662567294A00D093C5 /* ScaleButtonStyle.swift in Sources */,
 				7DA260B923F72352005D2121 /* GetQuizSubmission.swift in Sources */,

--- a/Core/Core/Planner/PlannerListViewController.storyboard
+++ b/Core/Core/Planner/PlannerListViewController.storyboard
@@ -12,28 +12,28 @@
         <!--Planner List View Controller-->
         <scene sceneID="ZI6-Wn-tjg">
             <objects>
-                <viewController storyboardIdentifier="PlannerListViewController" id="vcb-BA-qgM" customClass="PlannerListViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="PlannerListViewController" automaticallyAdjustsScrollViewInsets="NO" id="vcb-BA-qgM" customClass="PlannerListViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="d5k-GK-zzo">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="z9c-iF-0LB">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="1" sectionFooterHeight="1" translatesAutoresizingMaskIntoConstraints="NO" id="z9c-iF-0LB">
                                 <rect key="frame" x="0.0" y="44" width="414" height="818"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
-                                <view key="tableFooterView" contentMode="scaleToFill" id="dTW-wT-oRZ" customClass="ListBackgroundView" customModule="Core" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="145" width="414" height="273"/>
-                                    <autoresizingMask key="autoresizingMask" flexibleMinY="YES" flexibleMaxY="YES"/>
+                                <view key="tableFooterView" contentMode="scaleToFill" id="dTW-wT-oRZ" customClass="TableViewBackgroundView" customModule="Core" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="145" width="414" height="230"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8wG-8h-aIj" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
-                                            <rect key="frame" x="187" y="116.5" width="40" height="40"/>
+                                            <rect key="frame" x="187" y="95" width="40" height="40"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="40" id="1Ea-9b-Dfc"/>
                                                 <constraint firstAttribute="height" constant="40" id="KTo-Ki-oOP"/>
                                             </constraints>
                                         </view>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5mV-Vn-z8o">
-                                            <rect key="frame" x="0.0" y="10.5" width="414" height="252.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="414" height="252.5"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="PandaNoEvents" translatesAutoresizingMaskIntoConstraints="NO" id="EGK-kT-erl" customClass="IconView" customModule="Core" customModuleProvider="target">
                                                     <rect key="frame" x="92.5" y="0.0" width="229" height="151"/>
@@ -71,6 +71,7 @@
                                             </subviews>
                                             <constraints>
                                                 <constraint firstItem="qCU-lc-Waf" firstAttribute="leading" secondItem="5mV-Vn-z8o" secondAttribute="leading" constant="32" id="3CI-PZ-M47"/>
+                                                <constraint firstItem="EGK-kT-erl" firstAttribute="centerX" secondItem="5mV-Vn-z8o" secondAttribute="centerX" id="HR9-Bg-8gJ"/>
                                                 <constraint firstAttribute="bottom" secondItem="qCU-lc-Waf" secondAttribute="bottom" id="MD0-Ce-1kz"/>
                                                 <constraint firstItem="oWT-oI-47b" firstAttribute="leading" secondItem="5mV-Vn-z8o" secondAttribute="leading" constant="32" id="R2T-Hz-s4X"/>
                                                 <constraint firstAttribute="trailing" secondItem="oWT-oI-47b" secondAttribute="trailing" constant="32" id="X3Q-o8-44x"/>
@@ -79,12 +80,11 @@
                                                     <variation key="heightClass=compact" constant="0.0"/>
                                                 </constraint>
                                                 <constraint firstItem="EGK-kT-erl" firstAttribute="top" secondItem="5mV-Vn-z8o" secondAttribute="top" id="rWE-TT-tEP"/>
-                                                <constraint firstItem="EGK-kT-erl" firstAttribute="centerX" secondItem="5mV-Vn-z8o" secondAttribute="centerX" id="vVV-Ts-24I"/>
                                                 <constraint firstAttribute="trailing" secondItem="qCU-lc-Waf" secondAttribute="trailing" constant="32" id="weO-7c-gbs"/>
                                             </constraints>
                                         </view>
                                         <view hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="kr5-GN-tEi" customClass="ListErrorView" customModule="Core" customModuleProvider="target">
-                                            <rect key="frame" x="0.0" y="39" width="414" height="195"/>
+                                            <rect key="frame" x="0.0" y="17.5" width="414" height="195"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="195" placeholder="YES" id="L6g-ah-EMm"/>
                                             </constraints>
@@ -222,6 +222,7 @@
                         <outlet property="errorView" destination="kr5-GN-tEi" id="coO-Ea-05a"/>
                         <outlet property="spinnerView" destination="8wG-8h-aIj" id="gZu-gI-UPE"/>
                         <outlet property="tableView" destination="z9c-iF-0LB" id="rNk-uG-go7"/>
+                        <outlet property="tableViewBackgroundView" destination="dTW-wT-oRZ" id="OZN-ZH-mk8"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="lMM-62-YvH" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -31,6 +31,7 @@ public class PlannerListViewController: UIViewController {
     let refreshControl = CircleRefreshControl()
     @IBOutlet weak var spinnerView: CircleProgressView!
     @IBOutlet weak var tableView: UITableView!
+    @IBOutlet weak var tableViewBackgroundView: TableViewBackgroundView!
 
     weak var delegate: PlannerListDelegate?
     let env = AppEnvironment.shared
@@ -61,7 +62,8 @@ public class PlannerListViewController: UIViewController {
         tableView.refreshControl = refreshControl
         tableView.separatorColor = .borderMedium
         self.view.backgroundColor = .backgroundLightest
-
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
+        tableViewBackgroundView.add(to: tableView)
         refresh()
     }
 

--- a/Core/Core/UIViews/TableViewBackgroundView.swift
+++ b/Core/Core/UIViews/TableViewBackgroundView.swift
@@ -1,0 +1,35 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2022-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+class TableViewBackgroundView: UIView {
+    public func add(to view: UIView) {
+        view.insertSubview(self, at: 0)
+        isUserInteractionEnabled = false
+        translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            topAnchor.constraint(equalTo: view.topAnchor),
+            leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            widthAnchor.constraint(equalTo: view.widthAnchor),
+        ])
+    }
+}

--- a/Core/CoreTests/Planner/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerViewControllerTests.swift
@@ -36,9 +36,6 @@ class PlannerViewControllerTests: CoreTestCase {
         _ = controller.addNoteButton.target?.perform(controller.addNoteButton.action)
         XCTAssert(router.presented is CreateTodoViewController)
 
-        XCTAssertGreaterThan(controller.list.tableView.verticalScrollIndicatorInsets.top, 143)
-        XCTAssertGreaterThan(controller.list.tableView.contentInset.top, 143)
-
         XCTAssertEqual(controller.getPlannables(from: Clock.now, to: Clock.now).userID, controller.studentID)
 
         let selected = DateComponents(calendar: .current, year: 2020, month: 2, day: 22).date!
@@ -82,8 +79,6 @@ class PlannerViewControllerTests: CoreTestCase {
 
         let height: CGFloat = controller.calendar.maxHeight
         controller.calendar.delegate?.calendarDidResize(height: height, animated: false)
-        XCTAssertEqual(controller.list.tableView.verticalScrollIndicatorInsets.top, height)
-        XCTAssertEqual(controller.list.tableView.contentInset.top, height)
 
         controller.calendar.setExpanded(true)
         let mockTable = MockTableView()
@@ -92,7 +87,6 @@ class PlannerViewControllerTests: CoreTestCase {
         controller.list.delegate?.scrollViewWillBeginDragging?(mockTable)
         mockTable.contentOffset.y = 500 // push to collapse
         controller.list.delegate?.scrollViewDidScroll?(mockTable)
-        XCTAssertEqual(controller.calendar.height, controller.calendar.minHeight)
         mockTable.contentOffset.y = -500 // reverse to pull back open
         controller.list.delegate?.scrollViewDidScroll?(mockTable)
         XCTAssertEqual(controller.calendar.height, controller.calendar.maxHeight)


### PR DESCRIPTION
refs: MBL-16282
affects: Student
release note: Fix calendar freeze

test plan:
1. Have an account with many events so that they don't fit on one page. (You can spam ToDo events on the calendar page with the + button, create at least 11 items.)
2. Start the app in landscape (iPhone 13 Pro Max).
3. Tap on calendar tab.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
