### PR TITLE
Fix non animating loading spinners

### DIFF
--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -130,7 +130,6 @@ public class CircleProgressView: UIView {
 
     public override func didMoveToWindow() {
         super.didMoveToWindow()
-        clearAnimation()
     }
 
     public func startAnimating() {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -109,7 +109,8 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
         // Loading
         scrollView?.isHidden = true
         scrollView?.backgroundColor = .backgroundLightest
-        loadingView?.color = Brand.shared.primary.ensureContrast(against: .backgroundLightest)
+        loadingView.color = Brand.shared.primary.ensureContrast(against: .backgroundLightest)
+        loadingView.startAnimating()
         let refreshControl = CircleRefreshControl()
         refreshControl.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         scrollView?.addSubview(refreshControl)
@@ -317,7 +318,7 @@ class AssignmentDetailsViewController: UIViewController, AssignmentDetailsViewPr
         updateQuizSettings(quiz)
 
         scrollView?.isHidden = false
-        loadingView.isHidden = true
+        loadingView.stopAnimating()
         refreshControl?.endRefreshing()
         UIAccessibility.post(notification: .screenChanged, argument: view)
     }


### PR DESCRIPTION
refs: MBL-16350
affects: Student
release note: Fixed non animating loading spinners

test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><video src="https://user-images.githubusercontent.com/110813321/201621466-5a8a87bc-036a-4dd8-a215-d97ce7e5b0f8.mp4" maxHeight=500></td>
<td><video src="https://user-images.githubusercontent.com/110813321/201621478-8b4da397-2460-42cf-a1c4-cf13c34a327d.mp4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
