### PR TITLE
Dashboard course card images are flickering on refresh

### DIFF
--- a/Core/Core/SwiftUIViews/RemoteImage.swift
+++ b/Core/Core/SwiftUIViews/RemoteImage.swift
@@ -40,7 +40,7 @@ public struct RemoteImage: View {
 
     public var body: some View {
         if let image = image?.image.images?[currentFrameIndex] ?? image?.image {
-            let isURLChanged = (url != loadedURL)
+            let isURLChanged = (url.pathComponents != loadedURL?.pathComponents)
 
             if isURLChanged {
                 emptyState.onAppear {


### PR DESCRIPTION
refs: MBL-16394
affects: Student, Teacher
release note: Fixed course header images are flickering on refresh.
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product or not needed
