### PR TITLE
Add support to group discussions

### DIFF
--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -81,10 +81,12 @@ public class DiscussionListViewController: UIViewController, ColoredNavViewProto
         course?.refresh(force: true)
         group?.refresh { [context, weak group, weak env] _ in
             guard context.contextType == .group, let courseID = group?.first?.courseID else { return }
-            _ = env?.subscribe(GetEnabledFeatureFlags(context: Context.course(courseID)))
+            _ = env?.subscribe(GetEnabledFeatureFlags(context: Context.course(courseID))).refresh()
         }
         topics.exhaust()
-        featureFlags.refresh()
+        if context.contextType != .group {
+            featureFlags.refresh()
+        }
     }
 
     public override func viewWillAppear(_ animated: Bool) {

--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -79,7 +79,10 @@ public class DiscussionListViewController: UIViewController, ColoredNavViewProto
         colors.refresh()
         // We must force refresh because the GetCourses call deletes all existing Courses from the CoreData cache and since GetCourses response includes no permissions we lose that information.
         course?.refresh(force: true)
-        group?.refresh()
+        group?.refresh { [context, weak group, weak env] _ in
+            guard context.contextType == .group, let courseID = group?.first?.courseID else { return }
+            _ = env?.subscribe(GetEnabledFeatureFlags(context: Context.group(courseID)))
+        }
         topics.exhaust()
         featureFlags.refresh()
     }

--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -81,7 +81,7 @@ public class DiscussionListViewController: UIViewController, ColoredNavViewProto
         course?.refresh(force: true)
         group?.refresh { [context, weak group, weak env] _ in
             guard context.contextType == .group, let courseID = group?.first?.courseID else { return }
-            _ = env?.subscribe(GetEnabledFeatureFlags(context: Context.group(courseID)))
+            _ = env?.subscribe(GetEnabledFeatureFlags(context: Context.course(courseID)))
         }
         topics.exhaust()
         featureFlags.refresh()

--- a/Core/Core/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModel.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModel.swift
@@ -20,7 +20,15 @@ import Foundation
 
 public class DiscussionWebPageViewModel: EmbeddedWebPageViewModel {
     public static func isRedesignEnabled(in context: Context) -> Bool {
-        AppEnvironment.shared.subscribe(GetEnabledFeatureFlags(context: context)).first { $0.isDiscussionAndAnnouncementRedesign }?.enabled ?? false
+        var featureFlagContext = context
+
+        if context.contextType == .group {
+            let group = AppEnvironment.shared.subscribe(GetGroup(groupID: context.id))
+            if let courseID = group.first?.courseID {
+                featureFlagContext = Context.course(courseID)
+            }
+        }
+        return AppEnvironment.shared.subscribe(GetEnabledFeatureFlags(context: featureFlagContext)).first { $0.isDiscussionAndAnnouncementRedesign }?.enabled ?? false
     }
     @Published public private(set) var subTitle: String?
     @Published public private(set) var contextColor: UIColor?

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -203,6 +203,9 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
     "/:context/:contextID/discussions/:discussionID": discussionViewController,
     "/:context/:contextID/discussion_topics/:discussionID": discussionViewController,
 
+    "/groups/:groupID/discussions/:discussionID": discussionViewController,
+    "/groups/:groupID/discussion_topics/:discussionID": discussionViewController,
+
     "/courses/:courseID/external_tools/:toolID": { _, params, _ in
         guard let courseID = params["courseID"], let toolID = params["toolID"] else { return nil }
         guard let vc = HelmManager.shared.topMostViewController() else { return nil }

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -203,9 +203,6 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
     "/:context/:contextID/discussions/:discussionID": discussionViewController,
     "/:context/:contextID/discussion_topics/:discussionID": discussionViewController,
 
-    "/groups/:groupID/discussions/:discussionID": discussionViewController,
-    "/groups/:groupID/discussion_topics/:discussionID": discussionViewController,
-
     "/courses/:courseID/external_tools/:toolID": { _, params, _ in
         guard let courseID = params["courseID"], let toolID = params["toolID"] else { return nil }
         guard let vc = HelmManager.shared.topMostViewController() else { return nil }

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -103,6 +103,27 @@ class RoutesTests: XCTestCase {
         XCTAssert(router.match("/courses/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
     }
 
+    func testNativeGroupDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
+        XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is DiscussionDetailsViewController)
+        XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is DiscussionDetailsViewController)
+    }
+
+    func testHybridGroupDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
+        flag.name = "react_discussions_post"
+        flag.enabled = true
+        flag.context = .course("2")
+
+        let group: Group = AppEnvironment.shared.database.viewContext.insert()
+        group.id = "2"
+        group.courseID = "2"
+        try? AppEnvironment.shared.database.viewContext.save()
+        XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
+        XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
+    }
+
     // MARK: - K5 / non-K5 course detail route logic tests
 
     func testK5SubjectViewRoute() {

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -116,10 +116,10 @@ class RoutesTests: XCTestCase {
         flag.enabled = true
         flag.context = .course("2")
 
-        let group: Group = AppEnvironment.shared.database.viewContext.insert()
+        let group = Group(context: AppEnvironment.shared.database.viewContext)
         group.id = "2"
         group.courseID = "2"
-        try? AppEnvironment.shared.database.viewContext.save()
+
         XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
         XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
     }


### PR DESCRIPTION
Adds support to redesigned group discussion webview. 

refs: MBL-16028
affects: Student, Teacher
release note: none 

test plan: 
1. Enabled `react_discussions_post` on web
2. Enabled `hybrid_discussion_details` in the Developer menu

## Screenshots

<table>
<tr><th>Native</th><th>WebView</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/110813321/203821828-41ee0cd6-06e6-46e6-a566-1208976dcc69.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/110813321/203821842-83a34eda-00cb-45f1-93be-a57bb5f6ed03.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
