### PR TITLE
Add support to hybrid announcement details

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1012,7 +1012,7 @@
 		CF8D53532806FB490038B0B2 /* WebSitePreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D53522806FB490038B0B2 /* WebSitePreviewViewModel.swift */; };
 		CF8D5356280851A70038B0B2 /* EmbeddedWebPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D5355280851A70038B0B2 /* EmbeddedWebPageView.swift */; };
 		CF8D535A280866CD0038B0B2 /* EmbeddedWebPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D5359280866CD0038B0B2 /* EmbeddedWebPageViewModel.swift */; };
-		CF8D535C280869820038B0B2 /* DiscussionWebPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D535B280869820038B0B2 /* DiscussionWebPageViewModel.swift */; };
+		CF8D535C280869820038B0B2 /* EmbeddedWebPageViewModelLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D535B280869820038B0B2 /* EmbeddedWebPageViewModelLive.swift */; };
 		CF8D536028086C110038B0B2 /* DiscussionWebPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D535F28086C110038B0B2 /* DiscussionWebPageViewModelTests.swift */; };
 		CF8D5362280EC41B0038B0B2 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D5361280EC41B0038B0B2 /* FeatureFlagTests.swift */; };
 		CF8D53642812D3340038B0B2 /* UISearchTextFieldExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF8D53632812D3340038B0B2 /* UISearchTextFieldExtensions.swift */; };
@@ -2549,7 +2549,7 @@
 		CF8D53522806FB490038B0B2 /* WebSitePreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebSitePreviewViewModel.swift; sourceTree = "<group>"; };
 		CF8D5355280851A70038B0B2 /* EmbeddedWebPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedWebPageView.swift; sourceTree = "<group>"; };
 		CF8D5359280866CD0038B0B2 /* EmbeddedWebPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedWebPageViewModel.swift; sourceTree = "<group>"; };
-		CF8D535B280869820038B0B2 /* DiscussionWebPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionWebPageViewModel.swift; sourceTree = "<group>"; };
+		CF8D535B280869820038B0B2 /* EmbeddedWebPageViewModelLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedWebPageViewModelLive.swift; sourceTree = "<group>"; };
 		CF8D535F28086C110038B0B2 /* DiscussionWebPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionWebPageViewModelTests.swift; sourceTree = "<group>"; };
 		CF8D5361280EC41B0038B0B2 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CF8D53632812D3340038B0B2 /* UISearchTextFieldExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISearchTextFieldExtensions.swift; sourceTree = "<group>"; };
@@ -5646,7 +5646,7 @@
 			isa = PBXGroup;
 			children = (
 				CF8D5359280866CD0038B0B2 /* EmbeddedWebPageViewModel.swift */,
-				CF8D535B280869820038B0B2 /* DiscussionWebPageViewModel.swift */,
+				CF8D535B280869820038B0B2 /* EmbeddedWebPageViewModelLive.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -7773,7 +7773,7 @@
 				B14707B82437CC9000CE1DBD /* ModuleItemDetailsViewController.swift in Sources */,
 				7DCA320F2541D43900458651 /* FileViewer.swift in Sources */,
 				CFCBB891266A27150026CEDF /* K5HomeroomSubjectCardViewModel.swift in Sources */,
-				CF8D535C280869820038B0B2 /* DiscussionWebPageViewModel.swift in Sources */,
+				CF8D535C280869820038B0B2 /* EmbeddedWebPageViewModelLive.swift in Sources */,
 				3B4D892B2450A8E9004ED120 /* ComposeViewController.swift in Sources */,
 				CF8ADC562563D96400F3DBA9 /* HelpItemView.swift in Sources */,
 				7DA2606923F722D9005D2121 /* TTL.swift in Sources */,

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
@@ -66,7 +66,9 @@ public class EmbeddedWebPageViewModelLive: EmbeddedWebPageViewModel {
         var urlPathComponent: String
         switch webPageType {
         case .announcement(let id):
-            urlPathComponent = "announcements/\(id)"
+            // announcements/\(id) shows a navigation bar at the top
+            // so we need to use discussion topics
+            urlPathComponent = "discussion_topics/\(id)"
             navTitle = NSLocalizedString("Announcement Details", comment: "")
         case .discussion(let id):
             urlPathComponent = "discussion_topics/\(id)"

--- a/Core/CoreTests/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModelTests.swift
+++ b/Core/CoreTests/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModelTests.swift
@@ -25,19 +25,19 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
 
     func testURLWithoutSession() {
         AppEnvironment.shared.currentSession = nil
-        let testee = DiscussionWebPageViewModel(context: .course("1"), topicID: "123")
+        let testee = EmbeddedWebPageViewModelLive(context: .course("1"), webPageType: .discussion(id: "123"))
         XCTAssertEqual(testee.url, URL(string: "/")!)
     }
 
     func testCourseURL() {
         AppEnvironment.shared.currentSession = .init(baseURL: URL(string: "https://instructure.com")!, userID: "", userName: "")
-        let testee = DiscussionWebPageViewModel(context: .course("1"), topicID: "123")
+        let testee = EmbeddedWebPageViewModelLive(context: .course("1"), webPageType: .discussion(id: "123"))
         XCTAssertEqual(testee.url, URL(string: "https://instructure.com/courses/1/discussion_topics/123?embed=true&session_timezone=\(timezoneName)&session_locale=\(locale)")!)
     }
 
     func testGroupURL() {
         AppEnvironment.shared.currentSession = .init(baseURL: URL(string: "https://instructure.com")!, userID: "", userName: "")
-        let testee = DiscussionWebPageViewModel(context: .group("1"), topicID: "123")
+        let testee = EmbeddedWebPageViewModelLive(context: .group("1"), webPageType: .discussion(id: "123"))
         XCTAssertEqual(testee.url, URL(string: "https://instructure.com/groups/1/discussion_topics/123?embed=true&session_timezone=\(timezoneName)&session_locale=\(locale)")!)
     }
 
@@ -46,7 +46,7 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
         api.mock(GetCourse(courseID: "1"), value: .make(name: "Test Name"))
 
         AppEnvironment.shared.currentSession = .init(baseURL: URL(string: "https://instructure.com")!, userID: "", userName: "")
-        let testee = DiscussionWebPageViewModel(context: .course("1"), topicID: "123")
+        let testee = EmbeddedWebPageViewModelLive(context: .course("1"), webPageType: .discussion(id: "123"))
 
         XCTAssertEqual(testee.navTitle, "Discussion Details")
         XCTAssertEqual(testee.subTitle, "Test Name")
@@ -58,7 +58,7 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
         api.mock(GetGroup(groupID: "1"), value: .make(name: "Test Group Name"))
 
         AppEnvironment.shared.currentSession = .init(baseURL: URL(string: "https://instructure.com")!, userID: "", userName: "")
-        let testee = DiscussionWebPageViewModel(context: .group("1"), topicID: "123")
+        let testee = EmbeddedWebPageViewModelLive(context: .group("1"), webPageType: .discussion(id: "123"))
 
         XCTAssertEqual(testee.navTitle, "Discussion Details")
         XCTAssertEqual(testee.subTitle, "Test Group Name")
@@ -71,7 +71,7 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
         flag.enabled = true
         flag.context = .course("1")
 
-        XCTAssertTrue(DiscussionWebPageViewModel.isRedesignEnabled(in: .course("1")))
+        XCTAssertTrue(EmbeddedWebPageViewModelLive.isRedesignEnabled(in: .course("1")))
     }
 
     func testDisabledRedesignFeatureFlag() {
@@ -80,7 +80,7 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
         flag.enabled = false
         flag.context = .course("1")
 
-        XCTAssertFalse(DiscussionWebPageViewModel.isRedesignEnabled(in: .course("1")))
+        XCTAssertFalse(EmbeddedWebPageViewModelLive.isRedesignEnabled(in: .course("1")))
     }
 
     func testMissingRedesignFeatureFlag() {
@@ -89,6 +89,6 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
         flag.enabled = true
         flag.context = .course("1")
 
-        XCTAssertFalse(DiscussionWebPageViewModel.isRedesignEnabled(in: .course("1")))
+        XCTAssertFalse(EmbeddedWebPageViewModelLive.isRedesignEnabled(in: .course("1")))
     }
 }

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -99,8 +99,8 @@ class RoutesTests: XCTestCase {
         flag.enabled = true
         flag.context = .course("2")
 
-        XCTAssert(router.match("/courses/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
-        XCTAssert(router.match("/courses/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
+        XCTAssert(router.match("/courses/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+        XCTAssert(router.match("/courses/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
     }
 
     func testNativeGroupDiscussionDetailsRoute() {
@@ -120,8 +120,42 @@ class RoutesTests: XCTestCase {
         group.id = "2"
         group.courseID = "2"
 
-        XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
-        XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
+        XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+        XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+    }
+
+    func testNativeAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
+        XCTAssert(router.match("/courses/2/announcements/3?origin=module_item_details") is DiscussionDetailsViewController)
+    }
+
+    func testHybridAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
+        flag.name = "react_discussions_post"
+        flag.enabled = true
+        flag.context = .course("2")
+
+        XCTAssert(router.match("/courses/2/announcements/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+    }
+
+    func testNativeGroupAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
+        XCTAssert(router.match("/groups/2/announcements/3") is DiscussionDetailsViewController)
+    }
+
+    func testHybridGroupAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
+        flag.name = "react_discussions_post"
+        flag.enabled = true
+        flag.context = .course("2")
+
+        let group = Group(context: AppEnvironment.shared.database.viewContext)
+        group.id = "2"
+        group.courseID = "2"
+
+        XCTAssert(router.match("/groups/2/announcements/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
     }
 
     // MARK: - K5 / non-K5 course detail route logic tests

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -65,10 +65,7 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
         return CoreHostingController(DiscussionEditorView(context: context, topicID: topicID, isAnnouncement: true))
     },
 
-    "/:context/:contextID/announcements/:announcementID": { url, params, _ in
-        guard let context = Context(path: url.path), let topicID = params["announcementID"] else { return nil }
-        return DiscussionDetailsViewController.create(context: context, topicID: topicID, isAnnouncement: true)
-    },
+    "/:context/:contextID/announcements/:announcementID": discussionDetails,
 
     "/courses/:courseID/assignments": { url, _, _ in
         guard let context = Context(path: url.path) else { return nil }
@@ -329,13 +326,22 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
 ]))
 
 private func discussionDetails(url: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
-    guard let context = Context(path: url.path), let topicID = params["discussionID"] else { return nil }
+    guard let context = Context(path: url.path) else { return nil }
+
+    var webPageType: EmbeddedWebPageViewModelLive.EmbeddedWebPageType
+    if let discussionID = params["discussionID"] {
+        webPageType = .discussion(id: discussionID)
+    } else if let announcementID = params["announcementID"] {
+        webPageType = .announcement(id: announcementID)
+    } else {
+        return nil
+    }
 
     if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
-       DiscussionWebPageViewModel.isRedesignEnabled(in: context) {
-        let viewModel = DiscussionWebPageViewModel(
+       EmbeddedWebPageViewModelLive.isRedesignEnabled(in: context) {
+        let viewModel = EmbeddedWebPageViewModelLive(
             context: context,
-            topicID: topicID
+            webPageType: webPageType
         )
         return CoreHostingController(
             EmbeddedWebPageView(
@@ -344,7 +350,7 @@ private func discussionDetails(url: URLComponents, params: [String: String], use
             )
         )
     } else {
-        return DiscussionDetailsViewController.create(context: context, topicID: topicID)
+        return DiscussionDetailsViewController.create(context: context, topicID: webPageType.assetID)
     }
 }
 

--- a/rn/Teacher/ios/TeacherTests/RoutesTests.swift
+++ b/rn/Teacher/ios/TeacherTests/RoutesTests.swift
@@ -112,7 +112,22 @@ class RoutesTests: XCTestCase {
         flag.enabled = true
         flag.context = .course("2")
 
-        XCTAssert(router.match("/courses/2/discussions/3") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
-        XCTAssert(router.match("/courses/2/discussion_topics/3") is CoreHostingController<EmbeddedWebPageView<DiscussionWebPageViewModel>>)
+        XCTAssert(router.match("/courses/2/discussions/3") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+        XCTAssert(router.match("/courses/2/discussion_topics/3") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+    }
+
+    func testNativeAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
+        XCTAssert(router.match("/courses/2/announcements/3") is DiscussionDetailsViewController)
+    }
+
+    func testHybridAnnouncementDiscussionDetailsRoute() {
+        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
+        flag.name = "react_discussions_post"
+        flag.enabled = true
+        flag.context = .course("2")
+
+        XCTAssert(router.match("/courses/2/announcements/3") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
     }
 }


### PR DESCRIPTION
## Description
Added extra functionality and renamed the `DiscussionWebPageViewModel` to a more generic class that configures itself based on the `EmbeddedWebPageType`. 

---
refs: MBL-16027
affects: Student, Teacher
release note: none 
test plan: See ticket

## Screenshots

<table>
<tr><th>Native</th><th>WebView</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/110813321/205073562-fe49c95e-934b-4bff-8390-4dcb6c008491.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/110813321/205073571-8bf9a565-aeb1-4afd-a524-b00b5b4a5682.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
