### PR TITLE
Fix non-canvas urls opening native screens if the path matches a valid route in the app.

### DIFF
--- a/Core/Core/Extensions/URLComponentsExtensions.swift
+++ b/Core/Core/Extensions/URLComponentsExtensions.swift
@@ -128,6 +128,24 @@ public extension URLComponents {
         return color
     }
 
+    /**
+     - returns: True if the ``host`` of this component exists and is different than of the current user's host
+     and the url uses the http(s) protocol.
+     */
+    var isExternalWebsite: Bool {
+        guard let scheme = scheme, scheme.hasPrefix("http") else {
+            return false
+        }
+        guard let host = host,
+              let session = AppEnvironment.shared.currentSession,
+              let sessionHost = session.baseURL.host
+        else {
+            return false
+        }
+
+        return host != sessionHost
+    }
+
     func queryValue(for queryName: String) -> String? {
         queryItems?.first(where: { $0.name == queryName })?.value
     }

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -159,6 +159,10 @@ open class Router {
     open func route(to url: URLComponents, userInfo: [String: Any]? = nil, from: UIViewController, options: RouteOptions = DefaultRouteOptions) {
         let url = cleanURL(url)
 
+        if handleExternalWebsiteInDialog(url: url, from: from) {
+            return
+        }
+
         #if DEBUG
         DeveloperMenuViewController.recordRouteInHistory(url.url?.absoluteString)
         #endif
@@ -282,6 +286,23 @@ open class Router {
     }
 
     // MARK: - Private Methods
+
+    /**
+     - returns: True if this method handled the url and no further routing actions are necessary.
+     */
+    private func handleExternalWebsiteInDialog(url: URLComponents, from: UIViewController) -> Bool {
+        guard url.isExternalWebsite, let url = url.url else {
+            return false
+        }
+
+        let webController = CoreWebViewController()
+        webController.webView.load(URLRequest(url: url))
+        show(webController,
+             from: from,
+             options: .modal(.formSheet, isDismissable: false, embedInNav: true, addDoneButton: true),
+             analyticsRoute: "/external_url")
+        return true
+    }
 
     private func cleanURL(_ url: URLComponents) -> URLComponents {
         // URLComponents does all the encoding we care about except we often have + meaning space in query

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -299,7 +299,7 @@ open class Router {
         webController.webView.load(URLRequest(url: url))
         show(webController,
              from: from,
-             options: .modal(.formSheet, isDismissable: false, embedInNav: true, addDoneButton: true),
+             options: .modal(.pageSheet, isDismissable: false, embedInNav: true, addDoneButton: true),
              analyticsRoute: "/external_url")
         return true
     }

--- a/Core/CoreTests/Extensions/URLComponentsExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLComponentsExtensionsTests.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import Core
 import XCTest
 
 class URLComponentsExtensionsTests: XCTestCase {
@@ -110,5 +111,31 @@ class URLComponentsExtensionsTests: XCTestCase {
     func testContextColor() {
         let testee = URLComponents.parse("/empty?contextColor=001122")
         XCTAssertEqual(testee.contextColor, UIColor(hexString: "#001122"))
+    }
+
+    func testExternalURLs() {
+        AppEnvironment.shared.currentSession = LoginSession(baseURL: URL(string: "https://canvas.com")!,
+                                                            userID: "",
+                                                            userName: "")
+        let relativeURL = URLComponents.parse("/courses")
+        XCTAssertFalse(relativeURL.isExternalWebsite)
+
+        let canvasHttpsURL = URLComponents.parse("https://canvas.com/courses")
+        XCTAssertFalse(canvasHttpsURL.isExternalWebsite)
+
+        let canvasHttpURL = URLComponents.parse("http://canvas.com/courses")
+        XCTAssertFalse(canvasHttpURL.isExternalWebsite)
+
+        let canvasFtpURL = URLComponents.parse("ftp://canvas.com/courses")
+        XCTAssertFalse(canvasFtpURL.isExternalWebsite)
+
+        let externalFtpURL = URLComponents.parse("ftp://example.com/courses")
+        XCTAssertFalse(externalFtpURL.isExternalWebsite)
+
+        let telURL = URLComponents.parse("tel://123456789")
+        XCTAssertFalse(telURL.isExternalWebsite)
+
+        let externalURL = URLComponents.parse("https://example.com/courses")
+        XCTAssertTrue(externalURL.isExternalWebsite)
     }
 }

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -472,4 +472,42 @@ class RouterTests: CoreTestCase {
         XCTAssertEqual(testee.isRegisteredRoute(URL(string: "/courses/1234/assignments")!), true)
         XCTAssertEqual(testee.isRegisteredRoute(URL(string: "/courses/1234/assignments/4321")!), false)
     }
+
+    func testExternalWebsiteURLsOpenedInPopup() {
+        AppEnvironment.shared.currentSession = LoginSession(baseURL: URL(string: "https://canvas.com")!,
+                                                            userID: "",
+                                                            userName: "")
+        let mockViewController = MockViewController()
+        let externalURL = URL(string: "https://example.com/courses")!
+        let testee = Router(routes: [
+            RouteHandler("/courses") { _, _, _ in UIViewController() },
+        ])
+
+        testee.route(to: externalURL, from: mockViewController)
+
+        guard let navController = mockViewController.presented as? HelmNavigationController else {
+            return XCTFail()
+        }
+
+        XCTAssertEqual(navController.children.count, 1)
+        XCTAssertTrue(navController.children.first is CoreWebViewController)
+    }
+
+    func testExternalWebsitePopupReportedToAnalytics() {
+        let mockViewController = MockViewController()
+        let testee = Router(routes: []) { _, _, _, _ in }
+        let externalURL = URL(string: "https://example.com/courses")!
+        let analyticsHandler = MockAnalyticsHandler()
+        Analytics.shared.handler = analyticsHandler
+
+        testee.route(to: externalURL, from: mockViewController)
+
+        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEventName, "screen_view")
+        XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], [
+            "application": "student",
+            "screen_name": "/external_url",
+            "screen_class": "CoreWebViewController",
+        ])
+    }
 }

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -260,9 +260,12 @@ class RoutesTests: XCTestCase {
     }
 
     func testFallbackAbsoluteHTTPs() {
+        AppEnvironment.shared.currentSession = LoginSession(baseURL: URL(string: "https://canvas.com")!,
+                                                            userID: "",
+                                                            userName: "")
         let expected = URL(string: "https://instructure.com")!
-        api.mock(GetWebSessionRequest(to: URL(string: "https://google.com")!), value: .init(session_url: expected))
-        router.route(to: "https://google.com", from: UIViewController())
+        api.mock(GetWebSessionRequest(to: URL(string: "https://canvas.com")!), value: .init(session_url: expected))
+        router.route(to: "https://canvas.com", from: UIViewController())
         XCTAssertEqual(login.opened, expected)
     }
 
@@ -277,9 +280,12 @@ class RoutesTests: XCTestCase {
     }
 
     func testFallbackAuthenticatedError() {
-        let expected = URL(string: "https://google.com")!
+        AppEnvironment.shared.currentSession = LoginSession(baseURL: URL(string: "https://canvas.com")!,
+                                                            userID: "",
+                                                            userName: "")
+        let expected = URL(string: "https://canvas.com")!
         api.mock(GetWebSessionRequest(to: expected), error: NSError.internalError())
-        router.route(to: "https://google.com", from: UIViewController())
+        router.route(to: "https://canvas.com", from: UIViewController())
         XCTAssertEqual(login.opened, expected)
     }
 }


### PR DESCRIPTION
refs: MBL-16427
affects: Student, Teacher, Parent
release note: Fixed some external website urls opening in-app screens instead of the actual url.

test plan:
- See ticket for test data.
- From now on all external http(s) urls passed to the router will open a modal webview with the contents of that url.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product or not needed
