### PR TITLE
Use AppEnvironment's shared instance instead of Environment

### DIFF
--- a/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
+++ b/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
@@ -19,10 +19,10 @@
 import SwiftUI
 
 public class AssignmentCellViewModel: ObservableObject {
-    @Environment(\.appEnvironment) private var env
-
     public let assignment: Assignment
     public let courseColor: UIColor?
+
+    private let env = AppEnvironment.shared
 
     public init(assignment: Assignment, courseColor: UIColor?) {
         self.assignment = assignment

--- a/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentListViewModel.swift
+++ b/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentListViewModel.swift
@@ -35,7 +35,7 @@ public class AssignmentListViewModel: ObservableObject {
         self?.gradingPeriodsDidUpdate()
     }
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private let courseID: String
     private lazy var apiAssignments = env.subscribe(GetAssignmentsByGroup(courseID: courseID)) { [weak self] in
         self?.assignmentGroupsDidUpdate()

--- a/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 
 class StudentViewCellViewModel: CourseDetailsCellViewModel {
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private var studentViewStudentRequest: APITask?
     private let courseID: String
 

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsHeaderViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsHeaderViewModel.swift
@@ -31,7 +31,7 @@ public class CourseDetailsHeaderViewModel: ObservableObject {
 
     public let height: CGFloat = 235
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private lazy var settings: Store<GetUserSettings> = env.subscribe(GetUserSettings(userID: "self")) { [weak self] in
         self?.hideColorOverlay = self?.settings.first?.hideDashcardColorOverlays == true
     }

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -45,8 +45,7 @@ public class CourseDetailsViewModel: ObservableObject {
         return URL(string: "courses/\(course.id)/settings")
     }
 
-    @Environment(\.appEnvironment) private var env
-
+    private let env = AppEnvironment.shared
     private var isTeacher: Bool { env.app == .teacher }
     private let context: Context
     private var attendanceToolID: String?

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
@@ -35,7 +35,7 @@ public class CourseSettingsViewModel: ObservableObject {
     @Published public private(set) var imageURL: URL?
     @Published public private(set) var hideColorOverlay: Bool?
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private var isFirstAppearance = true
     private var context: Context
     private lazy var colors = env.subscribe(GetCustomColors())

--- a/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
+++ b/Core/Core/Courses/K5/ViewModel/K5SubjectViewModel.swift
@@ -33,7 +33,7 @@ public class K5SubjectViewModel: ObservableObject {
     /** The webview configuration to be used. In case of masquerading we can't use the default configuration because it will contain cookies with the original user's permissions. */
     public var config: WKWebViewConfiguration? { masqueradedSession.config }
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private let context: Context
     private let selectedTabId: String?
     private lazy var tabs = env.subscribe(GetContextTabs(context: context)) { [weak self] in self?.tabsUpdated() }

--- a/Core/Core/People/ContextCard/Course/ContextCardViewModel.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardViewModel.swift
@@ -37,7 +37,7 @@ public class ContextCardViewModel: ObservableObject {
     public let isModal: Bool
     public var enrollment: Enrollment?
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private var isFirstAppear = true
     private let courseID: String
     private let userID: String

--- a/Core/Core/People/ContextCard/Group/GroupContextCardViewModel.swift
+++ b/Core/Core/People/ContextCard/Group/GroupContextCardViewModel.swift
@@ -29,7 +29,7 @@ public class GroupContextCardViewModel: ObservableObject {
     public var shouldShowMessageButton: Bool { isViewingAnotherUser && permissions.first?.sendMessages == true }
     public let context: Context
 
-    @Environment(\.appEnvironment) private var env
+    private let env = AppEnvironment.shared
     private let isViewingAnotherUser: Bool
     private var isFirstAppear = true
     private let groupID: String

--- a/Core/Core/Profile/SideMenu/SideMenuHeaderView.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuHeaderView.swift
@@ -120,7 +120,7 @@ extension SideMenuHeaderView {
     }
 
     final class UserModel: ObservableObject {
-        @Environment(\.appEnvironment) var env
+        private let env = AppEnvironment.shared
 
         lazy var profile = env.subscribe(GetUserProfile(userID: "self")) { [weak self] in
             self?.profileUpdated()

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
@@ -19,7 +19,6 @@
 import SwiftUI
 
 public class QuizDetailsViewModel: QuizDetailsViewModelProtocol {
-    @Environment(\.appEnvironment) private var env
     @Published public private(set) var state: QuizDetailsViewModelState = .loading
 
     public private(set) var courseColor: UIColor?
@@ -44,6 +43,7 @@ public class QuizDetailsViewModel: QuizDetailsViewModelProtocol {
     @Published private var assignment: Assignment?
     @Published private var course: Course?
 
+    private let env = AppEnvironment.shared
     private let quizID: String
     private let courseID: String
     private var refreshCompletion: (() -> Void)?

--- a/rn/Teacher/ios/Teacher/SpeedGrader/ViewModel/SubmissionCommentLibraryViewModel.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/ViewModel/SubmissionCommentLibraryViewModel.swift
@@ -27,7 +27,6 @@ class SubmissionCommentLibraryViewModel: ObservableObject {
         case data(T)
     }
 
-    @Environment(\.appEnvironment) var env
     @Published public private(set) var state: ViewModelState<[LibraryComment]> = .loading
     private var settings = AppEnvironment.shared.subscribe(GetUserSettings(userID: "self"))
     public var shouldShow: Bool {
@@ -38,6 +37,7 @@ class SubmissionCommentLibraryViewModel: ObservableObject {
             updateFilteredComments()
         }
     }
+    private let env = AppEnvironment.shared
     private var filteredComments: [LibraryComment] = [] {
         didSet {
             withAnimation {


### PR DESCRIPTION
refs: MBL-16459
affects: Student, Teacher, Parent
release note: none

test plan: No warnings should appear about using an Environment variable outside of an installed view in Xcode.