### PR TITLE
Fix syllabus edit button not being visible

### DIFF
--- a/Core/Core/Constants/PermissionName.swift
+++ b/Core/Core/Constants/PermissionName.swift
@@ -65,6 +65,7 @@ public enum PermissionName: String {
     case manageAssignments = "manage_assignments"
     case manageCalendar = "manage_calendar"
     case manageContent = "manage_content"
+    case manageCourseContentEdit = "manage_course_content_edit"
     case manageFiles = "manage_files"
     case manageGrades = "manage_grades"
     case manageGroups = "manage_groups"

--- a/Core/Core/Contexts/APIPermissions.swift
+++ b/Core/Core/Contexts/APIPermissions.swift
@@ -64,6 +64,7 @@ public struct APIPermissions: Codable, Equatable {
     let manage_assignments: Bool?
     let manage_calendar: Bool?
     let manage_content: Bool?
+    let manage_course_content_edit: Bool?
     let manage_files: Bool?
     let manage_grades: Bool?
     let manage_groups: Bool?
@@ -138,6 +139,7 @@ extension APIPermissions {
         manage_assignments: Bool? = nil,
         manage_calendar: Bool? = nil,
         manage_content: Bool? = nil,
+        manage_course_content_edit: Bool? = nil,
         manage_files: Bool? = nil,
         manage_grades: Bool? = nil,
         manage_groups: Bool? = nil,
@@ -209,6 +211,7 @@ extension APIPermissions {
             manage_assignments: manage_assignments,
             manage_calendar: manage_calendar,
             manage_content: manage_content,
+            manage_course_content_edit: manage_course_content_edit,
             manage_files: manage_files,
             manage_grades: manage_grades,
             manage_groups: manage_groups,

--- a/Core/Core/Contexts/Permissions.swift
+++ b/Core/Core/Contexts/Permissions.swift
@@ -69,6 +69,7 @@ public class Permissions: NSManagedObject {
     @NSManaged public var manageAssignments: Bool
     @NSManaged public var manageCalendar: Bool
     @NSManaged public var manageContent: Bool
+    @NSManaged public var manageCourseContentEdit: Bool
     @NSManaged public var manageFiles: Bool
     @NSManaged public var manageGrades: Bool
     @NSManaged public var manageGroups: Bool
@@ -144,6 +145,7 @@ public class Permissions: NSManagedObject {
         model.manageAssignments = item.manage_assignments ?? model.manageAssignments
         model.manageCalendar = item.manage_calendar ?? model.manageCalendar
         model.manageContent = item.manage_content ?? model.manageContent
+        model.manageCourseContentEdit = item.manage_course_content_edit ?? model.manageCourseContentEdit
         model.manageFiles = item.manage_files ?? model.manageFiles
         model.manageGrades = item.manage_grades ?? model.manageGrades
         model.manageGroups = item.manage_groups ?? model.manageGroups

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -697,6 +697,7 @@
         <attribute name="manageCalendar" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="manageCatalog" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="manageContent" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="manageCourseContentEdit" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="manageCourses" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="manageDeveloperKeys" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="manageFeatureFlags" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/Core/CoreTests/Contexts/PermissionsTests.swift
+++ b/Core/CoreTests/Contexts/PermissionsTests.swift
@@ -64,6 +64,7 @@ class PermissionsTests: CoreTestCase {
         XCTAssertFalse(model.manageAssignments)
         XCTAssertFalse(model.manageCalendar)
         XCTAssertFalse(model.manageContent)
+        XCTAssertFalse(model.manageCourseContentEdit)
         XCTAssertFalse(model.manageFiles)
         XCTAssertFalse(model.manageGrades)
         XCTAssertFalse(model.manageGroups)
@@ -103,7 +104,7 @@ class PermissionsTests: CoreTestCase {
             view_error_reports: true, view_grade_changes: true, view_jobs: true, view_notifications: true, view_statistics: true,
             undelete_courses: true, change_course_state: true, comment_on_others_submissions: true, create_collaborations: true,
             create_conferences: true, create_forum: true, generate_observer_pairing_code: true, import_outcomes: true, lti_add_edit: true,
-            manage_admin_users: true, manage_assignments: true, manage_calendar: true, manage_content: true, manage_files: true,
+            manage_admin_users: true, manage_assignments: true, manage_calendar: true, manage_content: true, manage_course_content_edit: true, manage_files: true,
             manage_grades: true, manage_groups: true, manage_interaction_alerts: true, manage_outcomes: true, manage_sections: true,
             manage_students: true, manage_user_notes: true, manage_rubrics: true, manage_wiki: true, moderate_forum: true,
             post_to_forum: true, read_announcements: true, read_email_addresses: true, read_forum: true, read_question_banks: true,
@@ -160,6 +161,7 @@ class PermissionsTests: CoreTestCase {
         XCTAssertTrue(permissions.manageAssignments)
         XCTAssertTrue(permissions.manageCalendar)
         XCTAssertTrue(permissions.manageContent)
+        XCTAssertTrue(permissions.manageCourseContentEdit)
         XCTAssertTrue(permissions.manageFiles)
         XCTAssertTrue(permissions.manageGrades)
         XCTAssertTrue(permissions.manageGroups)

--- a/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
+++ b/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
@@ -22,7 +22,7 @@ class TeacherSyllabusTabViewController: SyllabusTabViewController {
 
     var context: Context?
 
-    lazy var permissions = env.subscribe(GetContextPermissions(context: .course(courseID), permissions: [.manageContent])) { [weak self] in
+    lazy var permissions = env.subscribe(GetContextPermissions(context: .course(courseID), permissions: [.manageContent, .manageCourseContentEdit])) { [weak self] in
         self?.updateNavBar()
     }
 
@@ -44,7 +44,7 @@ class TeacherSyllabusTabViewController: SyllabusTabViewController {
     }
 
     func updateNavBar() {
-        guard permissions.first?.manageContent == true else { return }
+        guard permissions.first?.manageContent == true || permissions.first?.manageCourseContentEdit == true else { return }
         editButton.accessibilityIdentifier = "Syllabus.editButton"
         navigationItem.rightBarButtonItem = editButton
     }

--- a/rn/Teacher/ios/TeacherTests/Syllabus/TeacherSyllabusTabViewController.swift
+++ b/rn/Teacher/ios/TeacherTests/Syllabus/TeacherSyllabusTabViewController.swift
@@ -24,14 +24,24 @@ import XCTest
 class TeacherSyllabusTabViewControllerTests: TeacherTestCase {
     lazy var controller = TeacherSyllabusTabViewController.create(context: .course("1"), courseID: "1")
 
-    func testEditAvailable() {
-        api.mock(controller.permissions, value: .make(manage_content: false))
+    func testEditNotAvailableWithoutPermission() {
+        api.mock(controller.permissions, value: .make(manage_content: false, manage_course_content_edit: false))
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-
         XCTAssertNil(controller.navigationItem.rightBarButtonItem)
-        api.mock(controller.permissions, value: .make(manage_content: true))
-        controller.permissions.refresh(force: true)
+    }
+
+    func testEditAvailableForManageContentPermission() {
+        api.mock(controller.permissions, value: .make(manage_content: true, manage_course_content_edit: false))
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+        XCTAssertEqual(controller.navigationItem.rightBarButtonItem?.title, "Edit")
+    }
+
+    func testEditAvailableForManageCourseContentPermission() {
+        api.mock(controller.permissions, value: .make(manage_content: false, manage_course_content_edit: true))
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
         XCTAssertEqual(controller.navigationItem.rightBarButtonItem?.title, "Edit")
     }
 

--- a/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
+++ b/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
@@ -64,7 +64,7 @@ class TeacherTestCase: XCTestCase {
 }
 
 extension TeacherTestCase {
-    open func hostSwiftUIController<V: View>(_ view: V) -> CoreHostingController<V> {
+    public func hostSwiftUIController<V: View>(_ view: V) -> CoreHostingController<V> {
         let controller = CoreHostingController(view)
         window.rootViewController = controller
         var count = 0
@@ -76,7 +76,8 @@ extension TeacherTestCase {
         }
         return controller
     }
-    open func hostSwiftUI<V: View>(_ view: V) -> V {
+
+    public func hostSwiftUI<V: View>(_ view: V) -> V {
         return hostSwiftUIController(view).rootView.content
     }
 }


### PR DESCRIPTION
refs: MBL-16478
affects: Teacher
release note: Fixed syllabus edit button not being visible.

test plan:
- Log in to the teacher app.
- Go to syllabus.
- Edit button should be present on the top right corner.
- Tapping it should display the edit syllabus screen.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/214335364-00e172f8-ba14-496a-9e29-bd8df5b0bca4.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/214335428-0be482bb-ee67-4124-90e4-202d9e32754f.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet