### PR TITLE
Student UI test updates

### DIFF
--- a/TestPlans/NightlyTests.xctestplan
+++ b/TestPlans/NightlyTests.xctestplan
@@ -74,13 +74,6 @@
     },
     {
       "target" : {
-        "containerPath" : "container:Student.xcodeproj",
-        "identifier" : "B1CA092D22C4237C008AA352",
-        "name" : "SubmitAssignmentTests"
-      }
-    },
-    {
-      "target" : {
         "containerPath" : "container:..\/rn\/Teacher\/ios\/Teacher.xcodeproj",
         "identifier" : "B15CA25C221DDB820014FB02",
         "name" : "TeacherTests"

--- a/TestPlans/PRTests.xctestplan
+++ b/TestPlans/PRTests.xctestplan
@@ -63,6 +63,9 @@
       }
     },
     {
+      "skippedTests" : [
+        "DiscussionReplyTests\/testReplyingWithAttachment()"
+      ],
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "7DC5716F22F8B16200F2E9BB",

--- a/TestPlans/StudentE2E.xctestplan
+++ b/TestPlans/StudentE2E.xctestplan
@@ -35,6 +35,7 @@
     {
       "skippedTests" : [
         "DiscussionEditorTests\/testCreateDiscussionWithAttachment()",
+        "DiscussionReplyTests\/testReplyingWithAttachment()",
         "IPadAssignmentsTest\/testAssignments()",
         "InboxTests\/testCanMessageAttachment()",
         "SpringBoardTests\/testMultitaskingSetup()",


### PR DESCRIPTION
- `testReplyingWithAttachment` was disabled because it fails on bitrise but it was still enabled in some test plans. Now it's disabled in every test plan.
- There was a non-existing test bundle called SubmitAssignmentTests in the Nightly test plan, I removed it.

[ignore-commit-lint]