### PR TITLE
Fix invalid token user not being logged out properly.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1123,6 +1123,8 @@
 		CFB9B30228A2B03300C18C79 /* preview_test.png in Resources */ = {isa = PBXBuildFile; fileRef = CFB9B30128A2B03300C18C79 /* preview_test.png */; };
 		CFB9B30428A2B03E00C18C79 /* preview_test.pdf in Resources */ = {isa = PBXBuildFile; fileRef = CFB9B30328A2B03E00C18C79 /* preview_test.pdf */; };
 		CFB9B30628A2B13500C18C79 /* preview_test.bin in Resources */ = {isa = PBXBuildFile; fileRef = CFB9B30528A2B13500C18C79 /* preview_test.bin */; };
+		CFBC104E2982819E00338136 /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBC104D2982819E00338136 /* LoginViewModel.swift */; };
+		CFBC10512982AA5700338136 /* LoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBC10502982AA5700338136 /* LoginViewModelTests.swift */; };
 		CFBF1DF7281FE20200DA99F7 /* DocViewerAnnotationPutResponseHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF1DF6281FE20200DA99F7 /* DocViewerAnnotationPutResponseHandler.swift */; };
 		CFBF1DF9281FE48200DA99F7 /* DocViewerAnnotationPutResponseHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF1DF8281FE48200DA99F7 /* DocViewerAnnotationPutResponseHandlerTests.swift */; };
 		CFBF1DFB281FE5B500DA99F7 /* MockDocViewerAnnotationProviderDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFBF1DFA281FE5B500DA99F7 /* MockDocViewerAnnotationProviderDelegate.swift */; };
@@ -2700,6 +2702,8 @@
 		CFB9B30128A2B03300C18C79 /* preview_test.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = preview_test.png; sourceTree = "<group>"; };
 		CFB9B30328A2B03E00C18C79 /* preview_test.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = preview_test.pdf; sourceTree = "<group>"; };
 		CFB9B30528A2B13500C18C79 /* preview_test.bin */ = {isa = PBXFileReference; lastKnownFileType = archive.macbinary; path = preview_test.bin; sourceTree = "<group>"; };
+		CFBC104D2982819E00338136 /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		CFBC10502982AA5700338136 /* LoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModelTests.swift; sourceTree = "<group>"; };
 		CFBF1DF6281FE20200DA99F7 /* DocViewerAnnotationPutResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationPutResponseHandler.swift; sourceTree = "<group>"; };
 		CFBF1DF8281FE48200DA99F7 /* DocViewerAnnotationPutResponseHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationPutResponseHandlerTests.swift; sourceTree = "<group>"; };
 		CFBF1DFA281FE5B500DA99F7 /* MockDocViewerAnnotationProviderDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDocViewerAnnotationProviderDelegate.swift; sourceTree = "<group>"; };
@@ -3205,6 +3209,7 @@
 		3B346747213051CC00F9BC2E /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				CFBC104C2982818E00338136 /* ViewModel */,
 				7D80AC22212B8A2100C40ECE /* APIAccount.swift */,
 				3B3467D721360A7C00F9BC2E /* APILoginWeb.swift */,
 				7D80AC2A212C77C600C40ECE /* APIOAuth.swift */,
@@ -3232,6 +3237,7 @@
 		3B3467512130527000F9BC2E /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				CFBC104F2982AA4B00338136 /* ViewModel */,
 				B164DC1E22DE2AB30037FA86 /* APIAccountTests.swift */,
 				3B3467D92136FFBA00F9BC2E /* APILoginWebTests.swift */,
 				7D80AC2C212C801600C40ECE /* APIOAuthTests.swift */,
@@ -6194,6 +6200,22 @@
 			path = TestAssets;
 			sourceTree = "<group>";
 		};
+		CFBC104C2982818E00338136 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CFBC104D2982819E00338136 /* LoginViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		CFBC104F2982AA4B00338136 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				CFBC10502982AA5700338136 /* LoginViewModelTests.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		CFBF1DF4281FDBE200DA99F7 /* AnnotationUpload */ = {
 			isa = PBXGroup;
 			children = (
@@ -7384,6 +7406,7 @@
 				CF941B14267B427300700DE9 /* K5GradesViewModelTests.swift in Sources */,
 				7D4C3D59222D9E41001B1198 /* LTIToolsTests.swift in Sources */,
 				3BE2C76F219335FA004B8E5E /* ColoredNavViewProtocol.swift in Sources */,
+				CFBC10512982AA5700338136 /* LoginViewModelTests.swift in Sources */,
 				CF5234ED28B9019500D2D3B9 /* FileUploadProgressObserverTests.swift in Sources */,
 				7DFB2CF921C978D40077DEEE /* GetCustomColorsTests.swift in Sources */,
 				7D63F78E215D7B8100151E49 /* DynamicButtonTests.swift in Sources */,
@@ -8000,6 +8023,7 @@
 				7DA2600A23F7227A005D2121 /* NSManagedObjectContextExtensions.swift in Sources */,
 				7DA260CD23F72359005D2121 /* BottomSheetTransitioning.swift in Sources */,
 				7DA260C223F72352005D2121 /* UploadFileComment.swift in Sources */,
+				CFBC104E2982819E00338136 /* LoginViewModel.swift in Sources */,
 				CF0075E22875E4AF00588E40 /* OutputStreamExtensions.swift in Sources */,
 				D97020C52581013C002B7B73 /* ContextCardHeaderView.swift in Sources */,
 				CFAD0D15281839FC0017D07B /* DocViewerAnnotationUploader.swift in Sources */,

--- a/Core/Core/Login/ViewModel/LoginViewModel.swift
+++ b/Core/Core/Login/ViewModel/LoginViewModel.swift
@@ -1,0 +1,31 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+public class LoginViewModel {
+
+    public init() {}
+
+    public func showLoginView(on window: UIWindow, loginDelegate: LoginDelegate, app: App) {
+        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft) {
+            window.rootViewController = LoginNavigationController.create(loginDelegate: loginDelegate, app: app)
+            Analytics.shared.logScreenView(route: "/login", viewController: window.rootViewController)
+        }
+    }
+}

--- a/Core/CoreTests/Login/ViewModel/LoginViewModelTests.swift
+++ b/Core/CoreTests/Login/ViewModel/LoginViewModelTests.swift
@@ -1,0 +1,38 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import TestsFoundation
+import XCTest
+
+class LoginViewModelTests: XCTestCase {
+
+    func testLoginShown() {
+        let window = UIWindow()
+        let mockDelegate = TestLoginDelegate()
+        let testee = LoginViewModel()
+
+        testee.showLoginView(on: window, loginDelegate: mockDelegate, app: .student)
+
+        guard let view = window.rootViewController as? LoginNavigationController else {
+            return XCTFail("No login view found.")
+        }
+        XCTAssertEqual(view.app, .student)
+        XCTAssertTrue(view.loginDelegate === mockDelegate)
+    }
+}

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -76,34 +76,36 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
 
     func setup(session: LoginSession, wasReload: Bool = false) {
         environment.userDidLogin(session: session)
-        environmentFeatureFlags = environment.subscribe(GetEnvironmentFeatureFlags(context: Context.currentUser))
-        environmentFeatureFlags?.refresh(force: true) { _ in
-            guard let envFlags = self.environmentFeatureFlags, envFlags.error == nil else { return }
-            self.initializeTracking()
-        }
-        updateInterfaceStyle(for: window)
-        CoreWebView.keepCookieAlive(for: environment)
-        NotificationManager.shared.subscribeToPushChannel()
 
         let getProfile = GetUserProfileRequest(userID: "self")
-        environment.api.makeRequest(getProfile) { apiProfile, urlResponse, error in
+        environment.api.makeRequest(getProfile) { apiProfile, urlResponse, error in performUIUpdate {
             guard let apiProfile = apiProfile, error == nil else {
                 if urlResponse?.isUnauthorized == true {
-                    DispatchQueue.main.async { self.userDidLogout(session: session) }
+                    self.userDidLogout(session: session)
+                    LoginViewModel().showLoginView(on: self.window!, loginDelegate: self, app: .teacher)
                 }
                 return
             }
-            self.isK5User = apiProfile.k5_user == true
 
-            DispatchQueue.main.async {
-                LocalizationManager.localizeForApp(UIApplication.shared, locale: apiProfile.locale) {
-                    GetBrandVariables().fetch(environment: self.environment) { _, _, _ in performUIUpdate {
-                        NativeLoginManager.login(as: session)
-                    }}
-                }
+            self.environmentFeatureFlags = self.environment.subscribe(GetEnvironmentFeatureFlags(context: Context.currentUser))
+            self.environmentFeatureFlags?.refresh(force: true) { _ in
+                guard let envFlags = self.environmentFeatureFlags, envFlags.error == nil else { return }
+                self.initializeTracking()
             }
-        }
-        Analytics.shared.logSession(session)
+
+            self.updateInterfaceStyle(for: self.window)
+            CoreWebView.keepCookieAlive(for: self.environment)
+            NotificationManager.shared.subscribeToPushChannel()
+
+            self.isK5User = apiProfile.k5_user == true
+            Analytics.shared.logSession(session)
+
+            LocalizationManager.localizeForApp(UIApplication.shared, locale: apiProfile.locale) {
+                GetBrandVariables().fetch(environment: self.environment) { _, _, _ in performUIUpdate {
+                    NativeLoginManager.login(as: session)
+                }}
+            }
+        }}
     }
 
     @objc func prepareReactNative() {
@@ -254,10 +256,7 @@ extension TeacherAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
     func changeUser() {
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
         disableTracking()
-        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromLeft, animations: {
-            window.rootViewController = LoginNavigationController.create(loginDelegate: self, app: .teacher)
-            Analytics.shared.logScreenView(route: "/login", viewController: window.rootViewController)
-        }, completion: nil)
+        LoginViewModel().showLoginView(on: window, loginDelegate: self, app: .teacher)
     }
 
     func stopActing() {


### PR DESCRIPTION
There is a crash that is caused by dropping a user to the dashboard without it being logged in. I couldn't reproduce the crash but found an inconsistency which could cause such issue. What I could always reproduce was an in finite loading spinner.

refs: MBL-16453
affects: Teacher, Student
release note: none

test plan:
- Test login, user switching, masquerade, student view in general.
--
- Login to the app.
- Login to web, go to Settings and delete token that was just created for the app.
- In the app tap change user.
- Tap on the account you used to activate it.
- App should return to start page after failing the token validity checks instead of loading infinitely.