### PR TITLE
Fix unauthorized error popup when edit communication channel is disabled

### DIFF
--- a/Core/Core/Notifications/NotificationManager.swift
+++ b/Core/Core/Notifications/NotificationManager.swift
@@ -105,7 +105,12 @@ extension NotificationManager {
                 return self.createPushChannel(token: token, session: session, retriesLeft: retriesLeft - 1)
             }
             guard let channelID = channel?.id.value, error == nil else {
-                return AppEnvironment.shared.reportError(error)
+                // Hide error alert when "Users can edit their communication channels" setting is turned off
+                if let apiError = error as? APIError, case .unauthorized = apiError {
+                    return
+                } else {
+                    return AppEnvironment.shared.reportError(error)
+                }
             }
             api.makeRequest(GetNotificationDefaultsFlagRequest()) { data, _, error in
                 guard data == nil || error != nil else { return } // already set up defaults


### PR DESCRIPTION
refs: MBL-16455
affects: Student, Teacher
release note: Fixed an error where disabling the edit communication channel setting causes Unauthorized Error message on startup
test plan: See ticket

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product or not needed
