### PR TITLE
Fix calendar course color contrast

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1300,6 +1300,7 @@
 		EB24231128521EF00058A100 /* UIWindowExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB24231028521EF00058A100 /* UIWindowExtensionsTests.swift */; };
 		EB2460262728380E00E4F331 /* K5SubjectHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2460252728380E00E4F331 /* K5SubjectHeaderView.swift */; };
 		EB24672F297AC68300091B04 /* LoginUsePolicyViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB24672E297AC68300091B04 /* LoginUsePolicyViewModelTests.swift */; };
+		EB28D7052990F44E00653998 /* UITraitCollectionExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB28D7042990F44E00653998 /* UITraitCollectionExtensions.swift */; };
 		EB2A9BBD2632E18C00A19A5A /* SideMenuMainSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2A9BBC2632E18C00A19A5A /* SideMenuMainSection.swift */; };
 		EB2A9BC02632E27300A19A5A /* SideMenuOptionsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2A9BBF2632E27300A19A5A /* SideMenuOptionsSection.swift */; };
 		EB2A9BC32632E2D000A19A5A /* SideMenuBottomSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2A9BC22632E2D000A19A5A /* SideMenuBottomSection.swift */; };
@@ -2892,6 +2893,7 @@
 		EB24231028521EF00058A100 /* UIWindowExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtensionsTests.swift; sourceTree = "<group>"; };
 		EB2460252728380E00E4F331 /* K5SubjectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5SubjectHeaderView.swift; sourceTree = "<group>"; };
 		EB24672E297AC68300091B04 /* LoginUsePolicyViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUsePolicyViewModelTests.swift; sourceTree = "<group>"; };
+		EB28D7042990F44E00653998 /* UITraitCollectionExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITraitCollectionExtensions.swift; sourceTree = "<group>"; };
 		EB2A9BBC2632E18C00A19A5A /* SideMenuMainSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuMainSection.swift; sourceTree = "<group>"; };
 		EB2A9BBF2632E27300A19A5A /* SideMenuOptionsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuOptionsSection.swift; sourceTree = "<group>"; };
 		EB2A9BC22632E2D000A19A5A /* SideMenuBottomSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuBottomSection.swift; sourceTree = "<group>"; };
@@ -4151,6 +4153,7 @@
 				7DCF202C216D461B003AF358 /* UITableViewExtensions.swift */,
 				E8E070F124E1983E00B37176 /* UITableViewHeaderFooterViewExtensions.swift */,
 				3B4D89402450AD58004ED120 /* UITextViewExtensions.swift */,
+				EB28D7042990F44E00653998 /* UITraitCollectionExtensions.swift */,
 				CF490F31285CAA790065D242 /* UIUserInterfaceStyleExtensions.swift */,
 				3B5425FB21B074500009D069 /* UIViewControllerExtensions.swift */,
 				7DD6948421951FD700BA4984 /* UIViewExtensions.swift */,
@@ -7894,6 +7897,7 @@
 				7DA260CE23F72359005D2121 /* CalendarDayIconView.swift in Sources */,
 				7DA25FEA23F721DE005D2121 /* Conversation.swift in Sources */,
 				CF60CC372645525400C1C173 /* K5HomeroomView.swift in Sources */,
+				EB28D7052990F44E00653998 /* UITraitCollectionExtensions.swift in Sources */,
 				CF7D4A892937678100463FBD /* TabBarMessageCountUpdater.swift in Sources */,
 				CF0894FB26FA218C0051A1BA /* AssignmentPickerViewModel.swift in Sources */,
 				7DA2600323F7227A005D2121 /* BundleExtensions.swift in Sources */,

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -59,9 +59,9 @@ final public class Course: NSManagedObject, WriteableModel {
 
     public var color: UIColor {
         if AppEnvironment.shared.k5.isK5Enabled {
-            return UIColor(hexString: courseColor)?.ensureContrast() ?? .oxford
+            return UIColor(hexString: courseColor)?.ensureContrast(against: .backgroundLightest) ?? .oxford
         } else {
-            return contextColor?.color.ensureContrast() ?? .ash
+            return contextColor?.color.ensureContrast(against: .backgroundLightest) ?? .ash
         }
     }
 

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsHeaderView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsHeaderView.swift
@@ -29,7 +29,7 @@ struct CourseDetailsHeaderView: View {
 
     public var body: some View {
         ZStack {
-            Color(viewModel.courseColor.darkenToEnsureContrast(against: .white)).frame(width: width, height: viewModel.height)
+            Color(viewModel.courseColor.resolvedColor(with: .light).darkenToEnsureContrast(against: .textLightest)).frame(width: width, height: viewModel.height)
             if let url = viewModel.imageURL {
                 RemoteImage(url, width: width, height: viewModel.height)
                     .opacity(viewModel.imageOpacity)

--- a/Core/Core/Dashboard/Model/DashboardCard.swift
+++ b/Core/Core/Dashboard/Model/DashboardCard.swift
@@ -39,7 +39,7 @@ public final class DashboardCard: NSManagedObject {
     @NSManaged public var subtitle: String
     @NSManaged public var term: String?
 
-    public var color: UIColor { contextColor?.color.ensureContrast() ?? .ash }
+    public var color: UIColor { contextColor?.color.ensureContrast(against: .backgroundLightest) ?? .ash }
 
     public var isTeacherEnrollment: Bool {
         let teacherRoles = ["teacher", "ta"]

--- a/Core/Core/Dashboard/View/CourseCard.swift
+++ b/Core/Core/Dashboard/View/CourseCard.swift
@@ -89,9 +89,8 @@ struct CourseCard: View {
                 analyticsRoute: "/dashboard/customize_course"
             )
         }, label: {
-            Image.moreSolid.foregroundColor(.white)
-                .background(card.imageURL == nil || !hideColorOverlay ? nil :
-                                Circle().fill(Color.accentColor).frame(width: 28, height: 28)
+            Image.moreSolid.foregroundColor(Color(contextColor))
+                .background(Circle().fill(Color.backgroundLightest).frame(width: 28, height: 28)
                 )
                 .frame(width: 44, height: 44)
         })
@@ -108,9 +107,9 @@ struct CourseCard: View {
                     Text(course.displayGrade).font(.semibold14)
                 }
             }
-            .foregroundColor(.accentColor)
+            .foregroundColor(Color(contextColor))
             .padding(.horizontal, 6).frame(height: 20)
-            .background(RoundedRectangle(cornerRadius: 10).fill(Color.white))
+            .background(RoundedRectangle(cornerRadius: 10).fill(Color.backgroundLightest))
             .frame(maxWidth: 120, alignment: .leading)
         }
     }

--- a/Core/Core/Extensions/UIColorExtensions.swift
+++ b/Core/Core/Extensions/UIColorExtensions.swift
@@ -60,11 +60,6 @@ extension UIColor {
         )
     }
 
-    /** Returns enhanced contrast colors against different light and dark counter-colors. */
-    public func ensureContrast(_ forLightAgainst: UIColor = .backgroundLightest, forDarkAgainst: UIColor = .backgroundLightest) -> UIColor {
-        UIColor.getColor(dark: self.ensureContrast(against: forDarkAgainst), light: self.ensureContrast(against: forLightAgainst))
-    }
-
     /** Returns the given color for the current interface style. */
     public static func getColor(dark: UIColor, light: UIColor) -> UIColor {
         return UIColor { traitCollection  in
@@ -155,9 +150,18 @@ extension UIColor {
 
     /// Get a sufficiently contrasting color based on the current color.
     ///
+    /// This ensures that the corresponding interface style color is being used as an against color.
+    public func ensureContrast(against: UIColor) -> UIColor {
+        let light = UITraitCollection(userInterfaceStyle: .light)
+        let dark = UITraitCollection(userInterfaceStyle: .dark)
+        return UIColor.getColor(dark: self.ensureStyleContrast(against: against.resolvedColor(with: dark)), light: self.ensureStyleContrast(against: against.resolvedColor(with: light)))
+    }
+
+    /// Get a sufficiently contrasting color based on the current color.
+    ///
     /// If the user asked for more contrast, and there isn't enough, return a high enough contrasting color.
     /// This is intended to be used with branding colors
-    public func ensureContrast(against: UIColor) -> UIColor {
+    private func ensureStyleContrast(against: UIColor) -> UIColor {
         let minRatio: CGFloat = 4.5
         guard contrast(against: against) < minRatio else {
             return self

--- a/Core/Core/Extensions/UINavigationBarExtensions.swift
+++ b/Core/Core/Extensions/UINavigationBarExtensions.swift
@@ -36,8 +36,8 @@ extension UINavigationBar {
 
     public func useContextColor(_ color: UIColor?, isTranslucent: Bool = false) {
         guard let color = color else { return }
-        let foreground = UIColor.white // always white, even in dark mode
-        let background = color.darkenToEnsureContrast(against: foreground)
+        let foreground = UIColor.textLightest // always white, even in dark mode
+        let background = color.resolvedColor(with: .light)).darkenToEnsureContrast(against: foreground)
         titleTextAttributes = [.foregroundColor: foreground]
         tintColor = foreground
         barTintColor = background

--- a/Core/Core/Extensions/UINavigationBarExtensions.swift
+++ b/Core/Core/Extensions/UINavigationBarExtensions.swift
@@ -37,7 +37,7 @@ extension UINavigationBar {
     public func useContextColor(_ color: UIColor?, isTranslucent: Bool = false) {
         guard let color = color else { return }
         let foreground = UIColor.textLightest // always white, even in dark mode
-        let background = color.resolvedColor(with: .light)).darkenToEnsureContrast(against: foreground)
+        let background = color.resolvedColor(with: .light).darkenToEnsureContrast(against: foreground)
         titleTextAttributes = [.foregroundColor: foreground]
         tintColor = foreground
         barTintColor = background

--- a/Core/Core/Extensions/UITraitCollectionExtensions.swift
+++ b/Core/Core/Extensions/UITraitCollectionExtensions.swift
@@ -20,15 +20,15 @@ import UIKit
 
 extension UITraitCollection {
 
-    static var light: UITraitCollection {
+    public static var light: UITraitCollection {
         return UITraitCollection(userInterfaceStyle: .light)
     }
 
-    static var dark: UITraitCollection {
+    public static var dark: UITraitCollection {
         return UITraitCollection(userInterfaceStyle: .dark)
     }
 
-    static var current: UITraitCollection {
+    public static var current: UITraitCollection {
         return UITraitCollection(userInterfaceStyle: .current)
     }
 }

--- a/Core/Core/Extensions/UITraitCollectionExtensions.swift
+++ b/Core/Core/Extensions/UITraitCollectionExtensions.swift
@@ -18,17 +18,17 @@
 
 import UIKit
 
-extension UITraitCollection {
+public extension UITraitCollection {
 
-    public static var light: UITraitCollection {
-        return UITraitCollection(userInterfaceStyle: .light)
+    static var light: UITraitCollection {
+        UITraitCollection(userInterfaceStyle: .light)
     }
 
-    public static var dark: UITraitCollection {
-        return UITraitCollection(userInterfaceStyle: .dark)
+    static var dark: UITraitCollection {
+        UITraitCollection(userInterfaceStyle: .dark)
     }
 
-    public static var current: UITraitCollection {
-        return UITraitCollection(userInterfaceStyle: .current)
+    static var current: UITraitCollection {
+        UITraitCollection(userInterfaceStyle: .current)
     }
 }

--- a/Core/Core/Extensions/UITraitCollectionExtensions.swift
+++ b/Core/Core/Extensions/UITraitCollectionExtensions.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+extension UITraitCollection {
+
+    static var light: UITraitCollection {
+        return UITraitCollection(userInterfaceStyle: .light)
+    }
+
+    static var dark: UITraitCollection {
+        return UITraitCollection(userInterfaceStyle: .dark)
+    }
+
+    static var current: UITraitCollection {
+        return UITraitCollection(userInterfaceStyle: .current)
+    }
+}

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -166,8 +166,8 @@ class PlannerListCell: UITableViewCell {
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
         if !Bundle.main.isParentApp, let color = p?.color {
-            courseCode.textColor = color.ensureContrast()
-            icon.tintColor = color.ensureContrast()
+            courseCode.textColor = color.ensureContrast(against: .backgroundLightest)
+            icon.tintColor = color.ensureContrast(against: .backgroundLightest)
         }
         accessoryType = .disclosureIndicator
     }

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -166,8 +166,8 @@ class PlannerListCell: UITableViewCell {
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
         if !Bundle.main.isParentApp, let color = p?.color {
-            courseCode.textColor = color.ensureContrast( .white, forDarkAgainst: .backgroundLightest)
-            icon.tintColor = color.ensureContrast( .white, forDarkAgainst: .backgroundLightest)
+            courseCode.textColor = color.ensureContrast(.white, forDarkAgainst: .backgroundLightest)
+            icon.tintColor = color.ensureContrast(.white, forDarkAgainst: .backgroundLightest)
         }
         accessoryType = .disclosureIndicator
     }

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -166,8 +166,8 @@ class PlannerListCell: UITableViewCell {
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
         if !Bundle.main.isParentApp, let color = p?.color {
-            courseCode.textColor = color
-            icon.tintColor = color
+            courseCode.textColor = color.ensureContrast( .white, forDarkAgainst: .backgroundLightest)
+            icon.tintColor = color.ensureContrast( .white, forDarkAgainst: .backgroundLightest)
         }
         accessoryType = .disclosureIndicator
     }

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -166,8 +166,8 @@ class PlannerListCell: UITableViewCell {
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
         if !Bundle.main.isParentApp, let color = p?.color {
-            courseCode.textColor = color.ensureContrast(.white, forDarkAgainst: .backgroundLightest)
-            icon.tintColor = color.ensureContrast(.white, forDarkAgainst: .backgroundLightest)
+            courseCode.textColor = color.ensureContrast(.backgroundLightest, forDarkAgainst: .backgroundLightest)
+            icon.tintColor = color.ensureContrast(.backgroundLightest, forDarkAgainst: .backgroundLightest)
         }
         accessoryType = .disclosureIndicator
     }

--- a/Core/Core/Planner/PlannerListViewController.swift
+++ b/Core/Core/Planner/PlannerListViewController.swift
@@ -166,8 +166,8 @@ class PlannerListCell: UITableViewCell {
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
         if !Bundle.main.isParentApp, let color = p?.color {
-            courseCode.textColor = color.ensureContrast(.backgroundLightest, forDarkAgainst: .backgroundLightest)
-            icon.tintColor = color.ensureContrast(.backgroundLightest, forDarkAgainst: .backgroundLightest)
+            courseCode.textColor = color.ensureContrast()
+            icon.tintColor = color.ensureContrast()
         }
         accessoryType = .disclosureIndicator
     }

--- a/Core/Core/SwiftUIViews/ButtonStyles/ContextButton.swift
+++ b/Core/Core/SwiftUIViews/ButtonStyles/ContextButton.swift
@@ -31,7 +31,7 @@ public struct ContextButton: ButtonStyle {
         - isHighlighted: If this parameter is true, then the button will show its highlighted state even if it isn't pressed down. Useful to indicate selected state.
      */
     public init(contextColor: UIColor?, isHighlighted: Bool = false) {
-        self.contextColor = contextColor?.ensureContrast() ?? selectionBackgroundColor
+        self.contextColor = contextColor?.ensureContrast(against: .backgroundLightest) ?? selectionBackgroundColor
         self.forceHighlight = isHighlighted
     }
 

--- a/Core/CoreTests/Assignments/AssignmentList/ViewModel/AssignmentListViewModelTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentList/ViewModel/AssignmentListViewModelTests.swift
@@ -39,7 +39,7 @@ class AssignmentListViewModelTests: CoreTestCase {
         testee.viewDidAppear()
 
         XCTAssertEqual(testee.courseName, "Test Course")
-        XCTAssertEqual(testee.courseColor!.hexString, UIColor.red.ensureContrast().hexString)
+        XCTAssertEqual(testee.courseColor!.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testFilterButtonVisibleWhenTwoGradingPeriodsAvailable() {

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseDetailsHeaderViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseDetailsHeaderViewModelTests.swift
@@ -36,7 +36,7 @@ class CourseDetailsHeaderViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.imageOpacity, 0.4)
         XCTAssertEqual(testee.titleOpacity, 1)
         XCTAssertEqual(testee.courseName, "Course One")
-        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast().hexString)
+        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(testee.termName, "Term One")
         XCTAssertEqual(testee.imageURL, nil)
     }

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseDetailsViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseDetailsViewModelTests.swift
@@ -33,7 +33,7 @@ class CourseDetailsViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.state, .loading)
         testee.viewDidAppear()
 
-        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast().hexString)
+        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(testee.homeLabel, nil)
         XCTAssertEqual(testee.homeSubLabel, nil)
         XCTAssertEqual(testee.homeRoute, URL(string: "/empty?contextColor=ed0000")!)
@@ -59,7 +59,7 @@ class CourseDetailsViewModelTests: CoreTestCase {
         testee.viewDidAppear()
         drainMainQueue()
 
-        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast().hexString)
+        XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(testee.homeLabel, nil)
         XCTAssertEqual(testee.homeSubLabel, "Syllabus")
         XCTAssertEqual(testee.homeRoute, URL(string: "courses/1/syllabus")!)

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -25,7 +25,7 @@ class CourseTests: CoreTestCase {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1"))
 
-        XCTAssertEqual(a.color.hexString, UIColor.red.ensureContrast().hexString)
+        XCTAssertEqual(a.color.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testDefaultK5Color() {
@@ -43,7 +43,7 @@ class CourseTests: CoreTestCase {
         environment.k5.userDidLogin(isK5Account: true)
         ExperimentalFeature.K5Dashboard.isEnabled = true
 
-        XCTAssertEqual(a.color.hexString, UIColor(hexString: "#0DEAD0")!.ensureContrast().hexString)
+        XCTAssertEqual(a.color.hexString, UIColor(hexString: "#0DEAD0")!.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testDefaultView() {

--- a/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
+++ b/Core/CoreTests/Dashboard/Model/DashboardCardTests.swift
@@ -33,7 +33,7 @@ class DashboardCardTests: CoreTestCase {
         ), ])
         useCase.fetch()
         let card: DashboardCard? = databaseClient.fetch(scope: useCase.scope).first
-        XCTAssertEqual(card?.color.hexString, UIColor.red.ensureContrast().hexString)
+        XCTAssertEqual(card?.color.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(card?.course?.id, "1")
         XCTAssertEqual(card?.shortName, "Course One")
         XCTAssertEqual(card?.isK5Subject, true)

--- a/Core/CoreTests/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModelTests.swift
+++ b/Core/CoreTests/EmbeddedWebPage/ViewModel/DiscussionWebPageViewModelTests.swift
@@ -50,7 +50,7 @@ class DiscussionWebPageViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee.navTitle, "Discussion Details")
         XCTAssertEqual(testee.subTitle, "Test Name")
-        XCTAssertEqual(testee.contextColor!.hexString, UIColor(hexString: "#BEEF00")!.ensureContrast().hexString)
+        XCTAssertEqual(testee.contextColor!.hexString, UIColor(hexString: "#BEEF00")!.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testGroupProperties() {

--- a/Core/CoreTests/Extensions/UINavigationBarExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UINavigationBarExtensionsTests.swift
@@ -24,9 +24,9 @@ class UINavigationBarExtensionsTests: XCTestCase {
     func testUseContextColor() {
         let bar = UINavigationBar(frame: .zero)
         bar.useContextColor(.licorice)
-        XCTAssertEqual(bar.titleTextAttributes?[.foregroundColor] as? UIColor, .white)
-        XCTAssertEqual(bar.tintColor, .white)
-        XCTAssertEqual(bar.barTintColor, .licorice)
+        XCTAssertEqual((bar.titleTextAttributes?[.foregroundColor] as? UIColor)?.hexString, UIColor.white.hexString)
+        XCTAssertEqual(bar.tintColor.hexString, UIColor.white.hexString)
+        XCTAssertEqual(bar.barTintColor?.hexString, UIColor.licorice.hexString)
         XCTAssertEqual(bar.barStyle, .black)
         XCTAssertFalse(bar.isTranslucent)
     }

--- a/Core/CoreTests/Planner/PlannableTests.swift
+++ b/Core/CoreTests/Planner/PlannableTests.swift
@@ -93,7 +93,7 @@ class PlannableTests: CoreTestCase {
         ContextColor.make(canvasContextID: "group_7", color: .red)
         ContextColor.make(canvasContextID: "user_3", color: .brown)
 
-        XCTAssertEqual(Plannable.make(from: .make(course_id: "2", context_type: "Course")).color.hexString, UIColor(hexString: "#0DEAD0")!.ensureContrast().hexString)
+        XCTAssertEqual(Plannable.make(from: .make(course_id: "2", context_type: "Course")).color.hexString, UIColor(hexString: "#0DEAD0")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(Plannable.make(from: .make(group_id: "7", context_type: "Group")).color, .red)
         XCTAssertEqual(Plannable.make(from: .make(group_id: "8", context_type: "Group")).color, .ash)
         XCTAssertEqual(Plannable.make(from: .make(user_id: "3", context_type: "User")).color, .brown)

--- a/Core/CoreTests/Planner/PlannerListViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerListViewControllerTests.swift
@@ -74,7 +74,7 @@ class PlannerListViewControllerTests: CoreTestCase, PlannerListDelegate {
         let cell = controller.tableView.cellForRow(at: index0) as? PlannerListCell
         XCTAssertEqual(cell?.title.text, "assignment a")
         XCTAssertEqual(cell?.courseCode.text, "Assignment Grades")
-        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor.red.ensureContrast(.white, forDarkAgainst: .backgroundLightest).hexString)
+        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(cell?.dueDate.text, DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .short) )
         XCTAssertEqual(cell?.points.text, "1 point")
         XCTAssertEqual(cell?.pointsDivider.isHidden, false)

--- a/Core/CoreTests/Planner/PlannerListViewControllerTests.swift
+++ b/Core/CoreTests/Planner/PlannerListViewControllerTests.swift
@@ -74,7 +74,7 @@ class PlannerListViewControllerTests: CoreTestCase, PlannerListDelegate {
         let cell = controller.tableView.cellForRow(at: index0) as? PlannerListCell
         XCTAssertEqual(cell?.title.text, "assignment a")
         XCTAssertEqual(cell?.courseCode.text, "Assignment Grades")
-        XCTAssertEqual(cell?.courseCode.textColor, .red)
+        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor.red.ensureContrast(.white, forDarkAgainst: .backgroundLightest).hexString)
         XCTAssertEqual(cell?.dueDate.text, DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .short) )
         XCTAssertEqual(cell?.points.text, "1 point")
         XCTAssertEqual(cell?.pointsDivider.isHidden, false)

--- a/Core/CoreTests/Presenter/ColoredNavViewProtocol.swift
+++ b/Core/CoreTests/Presenter/ColoredNavViewProtocol.swift
@@ -44,8 +44,8 @@ class ColoredNavViewProtocolTests: XCTestCase, ColoredNavViewProtocol {
 
         XCTAssertEqual(color, expectedColor)
         XCTAssertEqual(titleSubtitleView.subtitle, subtitle)
-        XCTAssertEqual(navigationController?.navigationBar.barTintColor, expectedColor)
-        XCTAssertEqual(navigationController?.navigationBar.tintColor, .white)
+        XCTAssertEqual(navigationController?.navigationBar.barTintColor?.hexString, expectedColor.hexString)
+        XCTAssertEqual(navigationController?.navigationBar.tintColor.hexString, UIColor.white.hexString)
         XCTAssertEqual(navigationController?.navigationBar.barStyle, .black)
     }
 }

--- a/Core/CoreTests/Todos/TodoListViewControllerTests.swift
+++ b/Core/CoreTests/Todos/TodoListViewControllerTests.swift
@@ -50,7 +50,7 @@ class TodoListViewControllerTests: CoreTestCase {
         XCTAssertNoThrow(controller.viewWillDisappear(false))
 
         var cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? TodoListCell
-        XCTAssertEqual(cell?.contextLabel.textColor.hexString, UIColor(hexString: "#f00")!.ensureContrast().hexString)
+        XCTAssertEqual(cell?.contextLabel.textColor.hexString, UIColor(hexString: "#f00")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(cell?.contextLabel.text, "Course One")
         cell = controller.tableView.cellForRow(at: IndexPath(row: 1, section: 0)) as? TodoListCell
         XCTAssertEqual(cell?.contextLabel.textColor, UIColor(hexString: "#0f0"))

--- a/Parent/ParentUnitTests/AccountNotifications/AccountNotificationDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/AccountNotifications/AccountNotificationDetailsViewControllerTests.swift
@@ -36,7 +36,7 @@ class AccountNotificationDetailsViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white))
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.title, "Announcement")
         XCTAssertEqual(controller.titleLabel.text, "Pandemic")
 

--- a/Parent/ParentUnitTests/Assignments/AssignmentDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Assignments/AssignmentDetailsViewControllerTests.swift
@@ -38,7 +38,7 @@ class AssignmentDetailsViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white))
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.title, "Course One")
         XCTAssertEqual(controller.titleLabel.text, "some assignment")
         XCTAssertEqual(controller.dateLabel.text, dueAt.dateTimeString)

--- a/Parent/ParentUnitTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -37,7 +37,7 @@ class DiscussionDetailsViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color)
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.title, "Course One")
         XCTAssertEqual(controller.titleLabel.text, "Pandemic")
 

--- a/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
@@ -78,7 +78,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color)
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 4)
 

--- a/Parent/ParentUnitTests/Planner/CalendarEventDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Planner/CalendarEventDetailsViewControllerTests.swift
@@ -42,7 +42,7 @@ class CalendarEventDetailsViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color.ensureContrast(against: .white))
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.ensureContrast(against: .white).hexString)
         XCTAssertEqual(controller.titleSubtitleView.title, "Course One")
         XCTAssertEqual(controller.titleLabel.text, "It's happening")
         XCTAssertEqual(controller.dateLabel.text, "Jul 14, 2020")

--- a/Parent/ParentUnitTests/Students/StudentDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Students/StudentDetailsViewControllerTests.swift
@@ -37,7 +37,7 @@ class StudentDetailsViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observee("1").color)
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.nameLabel.text, "Legion (They/Them)")
 
         for (index, type) in AlertThresholdType.allCases.enumerated() {

--- a/Parent/ParentUnitTests/Students/StudentListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Students/StudentListViewControllerTests.swift
@@ -37,7 +37,7 @@ class StudentListViewControllerTests: ParentTestCase {
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
 
-        XCTAssertEqual(nav.navigationBar.barTintColor, ColorScheme.observeeBlue.color.darkenToEnsureContrast(against: .white))
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observeeBlue.color.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.navigationItem.rightBarButtonItem?.action, #selector(controller.addStudentController.addStudent))
 
         let index0 = IndexPath(row: 0, section: 0)

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -82,7 +82,7 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         ContextColor.make(canvasContextID: c.canvasContextID)
 
         presenter.colors.eventHandler()
-        XCTAssertEqual(resultingBackgroundColor!.hexString, UIColor.red.ensureContrast().hexString)
+        XCTAssertEqual(resultingBackgroundColor!.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testLoadAssignment() {

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
@@ -74,7 +74,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
 
         viewController.updateNavBar(subtitle: "hello", backgroundColor: .red)
         XCTAssertEqual(viewController.titleSubtitleView.subtitle, "hello")
-        XCTAssertEqual(viewController.navigationController?.navigationBar.barTintColor, .red.darkenToEnsureContrast(against: .white))
+        XCTAssertEqual(viewController.navigationController?.navigationBar.barTintColor?.hexString, UIColor.red.darkenToEnsureContrast(against: .white).hexString)
     }
 
     func testShowSubmitAssignmentButton() {

--- a/Student/StudentUnitTests/Courses/CourseNavigation/CourseNavigationPresenterTests.swift
+++ b/Student/StudentUnitTests/Courses/CourseNavigation/CourseNavigationPresenterTests.swift
@@ -52,7 +52,7 @@ class CourseNavigationPresenterTests: StudentTestCase {
         ContextColor.make()
 
         presenter.color.eventHandler()
-        XCTAssertEqual(resultingBackgroundColor!.hexString, UIColor.red.ensureContrast().hexString)
+        XCTAssertEqual(resultingBackgroundColor!.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testLoadCourse() {

--- a/Student/StudentUnitTests/Groups/GroupNavigation/GroupNavigationViewControllerTests.swift
+++ b/Student/StudentUnitTests/Groups/GroupNavigation/GroupNavigationViewControllerTests.swift
@@ -40,7 +40,7 @@ class GroupNavigationViewControllerTests: StudentTestCase {
         let navigation = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(navigation.navigationBar.barTintColor, UIColor(hexString: "#f00")?.darkenToEnsureContrast(against: .white))
+        XCTAssertEqual(navigation.navigationBar.barTintColor?.hexString, UIColor(hexString: "#f00")?.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.tableView.backgroundColor, .backgroundLightest)
         XCTAssertEqual(controller.titleSubtitleView.title, "Tests")
     }

--- a/Student/StudentUnitTests/Notifications/ActivityStreamViewControllerTests.swift
+++ b/Student/StudentUnitTests/Notifications/ActivityStreamViewControllerTests.swift
@@ -59,7 +59,7 @@ class ActivityStreamViewControllerTests: StudentTestCase {
         let expectedDateCell2 = ActivityStreamViewController.dateFormatter.string(from: mockNow.addDays(-4))
 
         var cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? ActivityCell
-        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor(hexString: "#f00")!.ensureContrast().hexString)
+        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor(hexString: "#f00")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(cell?.courseCode.text, "Code")
         XCTAssertEqual(cell?.titleLabel.text, "title")
         XCTAssertEqual(cell?.subTitleLabel.text, expectedDateCell0)
@@ -71,7 +71,7 @@ class ActivityStreamViewControllerTests: StudentTestCase {
         XCTAssertEqual(cell?.subTitleLabel.text, expectedDateCell1)
 
         cell = controller.tableView.cellForRow(at: IndexPath(row: 2, section: 0)) as? ActivityCell
-        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor(hexString: "#0f0")!.ensureContrast().hexString)
+        XCTAssertEqual(cell?.courseCode.textColor.hexString, UIColor(hexString: "#0f0")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(cell?.courseCode.text, "Code2")
         XCTAssertEqual(cell?.titleLabel.text, "title2")
         XCTAssertEqual(cell?.subTitleLabel.text, expectedDateCell2)

--- a/Student/StudentUnitTests/Planner/CalendarEventDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Planner/CalendarEventDetailsViewControllerTests.swift
@@ -70,7 +70,7 @@ class CalendarEventDetailsViewControllerTests: StudentTestCase {
             context_code: "group_1"
         ))
         controller.scrollView.refreshControl?.sendActions(for: .primaryActionTriggered)
-        XCTAssertEqual(nav.navigationBar.barTintColor, .ash)
+        XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, UIColor.ash.darkenToEnsureContrast(against: .white).hexString)
         XCTAssertEqual(controller.dateLabel.text, "Jun 24, 2020 at 11:00 AM")
     }
 }

--- a/rn/Teacher/ios/TeacherTests/Attendance/AttendanceViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Attendance/AttendanceViewControllerTests.swift
@@ -62,7 +62,7 @@ class AttendanceViewControllerTests: TeacherTestCase {
     func testStatusDisplay() {
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-        XCTAssertEqual(controller.navigationController?.navigationBar.barTintColor!.hexString, UIColor(hexString: "#008EE2")!.ensureContrast().hexString)
+        XCTAssertEqual(controller.navigationController?.navigationBar.barTintColor!.hexString, UIColor(hexString: "#008EE2")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(controller.view.backgroundColor, .backgroundLightest)
         XCTAssertEqual(controller.tableView.refreshControl?.isRefreshing, true)
         RunLoop.main.run(until: Date() + 1)

--- a/rn/Teacher/ios/TeacherTests/Submissions/PostGradesPresenterTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/PostGradesPresenterTests.swift
@@ -163,7 +163,7 @@ class PostGradesPresenterTests: TeacherTestCase {
         presenter.viewIsReady()
         wait(for: [colorExpectation], timeout: 0.5)
 
-        XCTAssertEqual(resultingColor!.hexString, expectedColor.color.ensureContrast().hexString)
+        XCTAssertEqual(resultingColor!.hexString, expectedColor.color.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testAllGradesPosted() {

--- a/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -74,7 +74,7 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         window.makeKeyAndVisible()
         XCTAssertEqual(controller.titleSubtitleView.title, "Submissions")
         XCTAssertEqual(controller.titleSubtitleView.subtitle, "some assignment")
-        XCTAssertEqual(nav.navigationBar.barTintColor!.hexString, UIColor(hexString: "#f00")!.ensureContrast().hexString)
+        XCTAssertEqual(nav.navigationBar.barTintColor!.hexString, UIColor(hexString: "#f00")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(controller.navigationItem.rightBarButtonItems?.count, 2)
 
         var cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? SubmissionListCell


### PR DESCRIPTION
refs: MBL-16509
affects: Student
release note: Fixed the Course color contrast ratio on the Calendar screen.
test plan: See ticket.

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/216339532-c41ece0c-b1ee-4517-a2cd-fc4771647052.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/216339539-3f5a107d-b919-4182-89c3-aa4e6c049ded.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
