### PR TITLE
Fixed some embedded LTI tools not opening

### DIFF
--- a/Core/Core/LTI/APIExternalTool.swift
+++ b/Core/Core/LTI/APIExternalTool.swift
@@ -91,6 +91,7 @@ public struct GetSessionlessLaunchURLRequest: APIRequestable {
     let assignmentID: String?
     let moduleItemID: String?
     let launchType: LaunchType?
+    let resourceLinkLookupUUID: String?
 
     public enum LaunchType: String {
         case assessment, module_item, course_navigation
@@ -121,6 +122,10 @@ public struct GetSessionlessLaunchURLRequest: APIRequestable {
 
         if let moduleItemID = moduleItemID {
             query.append(.value("module_item_id", moduleItemID))
+        }
+
+        if let resourceLinkLookupUUID = resourceLinkLookupUUID {
+            query.append(.value("resource_link_lookup_uuid", resourceLinkLookupUUID))
         }
 
         return query

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -104,7 +104,7 @@ public class LTITools: NSObject {
         }()
         let resourceLinkUUID = components.queryValue(for: "resource_link_lookup_uuid")
 
-        guard url != nil || resourceLinkUUID != nil else {
+        if url == nil, resourceLinkUUID == nil {
             return nil
         }
 

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -29,6 +29,7 @@ public class LTITools: NSObject {
     let assignmentID: String?
     let moduleID: String?
     let moduleItemID: String?
+    let resourceLinkLookupUUID: String?
 
     var request: GetSessionlessLaunchURLRequest {
         GetSessionlessLaunchURLRequest(
@@ -37,7 +38,8 @@ public class LTITools: NSObject {
             url: url,
             assignmentID: assignmentID,
             moduleItemID: moduleItemID,
-            launchType: launchType
+            launchType: launchType,
+            resourceLinkLookupUUID: resourceLinkLookupUUID
         )
     }
 
@@ -70,7 +72,8 @@ public class LTITools: NSObject {
         launchType: GetSessionlessLaunchURLRequest.LaunchType? = nil,
         assignmentID: String? = nil,
         moduleID: String? = nil,
-        moduleItemID: String? = nil
+        moduleItemID: String? = nil,
+        resourceLinkLookupUUID: String? = nil
     ) {
         self.env = env
         self.context = context ?? url.flatMap { Context(url: $0) } ?? .account("self")
@@ -80,6 +83,7 @@ public class LTITools: NSObject {
         self.assignmentID = assignmentID
         self.moduleID = moduleID
         self.moduleItemID = moduleItemID
+        self.resourceLinkLookupUUID = resourceLinkLookupUUID
     }
 
     var openInSafari: Bool { UserDefaults.standard.bool(forKey: "open_lti_safari") }
@@ -87,13 +91,25 @@ public class LTITools: NSObject {
     public convenience init?(env: AppEnvironment = .shared, link: URL?) {
         guard
             let retrieve = link, retrieve.host == env.api.baseURL.host,
-            retrieve.path.hasSuffix("/external_tools/retrieve"),
-            let query = URLComponents.parse(retrieve).queryItems,
-            let value = query.first(where: { $0.name == "url" })?.value,
-            let url = URL(string: value)
+            retrieve.path.hasSuffix("/external_tools/retrieve")
         else { return nil }
+
+        let components = URLComponents.parse(retrieve)
+
+        let url: URL? = {
+            guard let urlQueryItem = components.queryValue(for: "url") else {
+                return nil
+            }
+            return URL(string: urlQueryItem)
+        }()
+        let resourceLinkUUID = components.queryValue(for: "resource_link_lookup_uuid")
+
+        guard url != nil || resourceLinkUUID != nil else {
+            return nil
+        }
+
         let context = Context(url: retrieve) ?? .account("self")
-        self.init(env: env, context: context, url: url)
+        self.init(env: env, context: context, url: url, resourceLinkLookupUUID: resourceLinkUUID)
     }
 
     public func presentTool(from view: UIViewController, animated: Bool = true, completionHandler: ((Bool) -> Void)? = nil) {

--- a/Core/CoreTests/LTI/APIExternalToolTests.swift
+++ b/Core/CoreTests/LTI/APIExternalToolTests.swift
@@ -27,7 +27,8 @@ class APIExternalToolTests: XCTestCase {
             url: URL(string: "https://google.com")!,
             assignmentID: "3",
             moduleItemID: "4",
-            launchType: .module_item
+            launchType: .module_item,
+            resourceLinkLookupUUID: "5"
         )
 
         XCTAssertEqual(request.path, "courses/1/external_tools/sessionless_launch")
@@ -37,6 +38,7 @@ class APIExternalToolTests: XCTestCase {
             URLQueryItem(name: "url", value: "https://google.com"),
             URLQueryItem(name: "assignment_id", value: "3"),
             URLQueryItem(name: "module_item_id", value: "4"),
+            URLQueryItem(name: "resource_link_lookup_uuid", value: "5"),
         ])
     }
 

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -68,7 +68,13 @@ class LTIToolsTests: CoreTestCase {
             assignmentID: nil,
             moduleItemID: nil
         )
-        let request = GetSessionlessLaunchURLRequest(context: .course("1"), id: nil, url: nil, assignmentID: nil, moduleItemID: nil, launchType: nil)
+        let request = GetSessionlessLaunchURLRequest(context: .course("1"),
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: nil,
+                                                     launchType: nil,
+                                                     resourceLinkLookupUUID: nil)
         let actualURL = URL(string: "/someplace")!
 
         api.mock(request, value: nil)
@@ -110,7 +116,13 @@ class LTIToolsTests: CoreTestCase {
             assignmentID: nil,
             moduleItemID: nil
         )
-        let request = GetSessionlessLaunchURLRequest(context: .course("1"), id: nil, url: nil, assignmentID: nil, moduleItemID: nil, launchType: nil)
+        let request = GetSessionlessLaunchURLRequest(context: .course("1"),
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: nil,
+                                                     launchType: nil,
+                                                     resourceLinkLookupUUID: nil)
         let actualURL = URL(string: "https://canvas.instructure.com")!
 
         api.mock(request, value: nil)
@@ -148,7 +160,13 @@ class LTIToolsTests: CoreTestCase {
 
     func testPresentToolInSafariProper() {
         let tools = LTITools()
-        let request = GetSessionlessLaunchURLRequest(context: tools.context, id: nil, url: nil, assignmentID: nil, moduleItemID: nil, launchType: nil)
+        let request = GetSessionlessLaunchURLRequest(context: tools.context,
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: nil,
+                                                     launchType: nil,
+                                                     resourceLinkLookupUUID: nil)
         let url = URL(string: "https://canvas.instructure.com")!
         api.mock(request, value: .make(url: url))
         UserDefaults.standard.set(true, forKey: "open_lti_safari")
@@ -159,7 +177,13 @@ class LTIToolsTests: CoreTestCase {
 
     func testPresentGoogleApp() throws {
         let tools = LTITools()
-        let request = GetSessionlessLaunchURLRequest(context: tools.context, id: nil, url: nil, assignmentID: nil, moduleItemID: nil, launchType: nil)
+        let request = GetSessionlessLaunchURLRequest(context: tools.context,
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: nil,
+                                                     launchType: nil,
+                                                     resourceLinkLookupUUID: nil)
         let url = URL(string: "https://canvas.instructure.com")!
         api.mock(request, value: .make(name: "Google Apps", url: url))
         tools.presentTool(from: mockView, animated: true)
@@ -170,7 +194,13 @@ class LTIToolsTests: CoreTestCase {
     func testMarksModuleItemAsRead() {
         api.mock(PostMarkModuleItemRead(courseID: "1", moduleID: "2", moduleItemID: "3"))
         let tools = LTITools(context: .course("1"), launchType: .module_item, moduleID: "2", moduleItemID: "3")
-        let request = GetSessionlessLaunchURLRequest(context: tools.context, id: nil, url: nil, assignmentID: nil, moduleItemID: "3", launchType: .module_item)
+        let request = GetSessionlessLaunchURLRequest(context: tools.context,
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: "3",
+                                                     launchType: .module_item,
+                                                     resourceLinkLookupUUID: nil)
         api.mock(request, value: .make())
         let expectation = XCTestExpectation(description: "notification was sent")
         let observer = NotificationCenter.default.addObserver(forName: .CompletedModuleItemRequirement, object: nil, queue: nil) { _ in
@@ -202,5 +232,17 @@ class LTIToolsTests: CoreTestCase {
         }
         wait(for: [done], timeout: 1)
         XCTAssertTrue(success)
+    }
+
+    func testConvenienceInitSucceedingWithResourceLinkLookupUUID() {
+        let url = URL(string: "https://canvas.instructure.com/courses/1/external_tools/retrieve?resource_link_lookup_uuid=123")!
+        let testee = LTITools(env: environment, link: url)
+
+        guard let testee = testee else {
+            return XCTFail()
+        }
+
+        XCTAssertEqual(testee.resourceLinkLookupUUID, "123")
+        XCTAssertEqual(testee.request.resourceLinkLookupUUID, "123")
     }
 }

--- a/Student/StudentUITests/Submissions/SubmissionButton/SubmissionButtonTests.swift
+++ b/Student/StudentUITests/Submissions/SubmissionButton/SubmissionButtonTests.swift
@@ -53,7 +53,8 @@ class SubmissionButtonTests: CoreUITestCase {
             url: nil,
             assignmentID: assignment.id.value,
             moduleItemID: nil,
-            launchType: .assessment
+            launchType: .assessment,
+            resourceLinkLookupUUID: nil
         ), value: .make(url: URL(string: "https://canvas.instructure.com")!))
 
         show("/courses/\(course.id)/assignments/\(assignment.id)")
@@ -70,7 +71,8 @@ class SubmissionButtonTests: CoreUITestCase {
             url: nil,
             assignmentID: assignment.id.value,
             moduleItemID: nil,
-            launchType: .assessment
+            launchType: .assessment,
+            resourceLinkLookupUUID: nil
         ), value: .make(url: URL(string: "https://canvas.instructure.com")!))
 
         show("/courses/\(course.id)/assignments/\(assignment.id)")

--- a/Student/StudentUITests/Submissions/SubmissionDetails/SubmissionDetailsTests.swift
+++ b/Student/StudentUITests/Submissions/SubmissionDetails/SubmissionDetailsTests.swift
@@ -324,7 +324,8 @@ class SubmissionDetailsTests: CoreUITestCase {
                 url: nil,
                 assignmentID: assignment.id.value,
                 moduleItemID: nil,
-                launchType: .assessment
+                launchType: .assessment,
+                resourceLinkLookupUUID: nil
             ),
             value: .make()
         )

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -150,7 +150,8 @@ class SubmissionButtonPresenterTests: StudentTestCase {
             url: nil,
             assignmentID: "1",
             moduleItemID: nil,
-            launchType: .assessment
+            launchType: .assessment,
+            resourceLinkLookupUUID: nil
         )
         api.mock(request, value: .make(url: URL(string: "https://instructure.com")!))
         presenter.submitType(.external_tool, for: a, button: UIView())

--- a/rn/Teacher/ios/TeacherTests/Attendance/RollCallSessionTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Attendance/RollCallSessionTests.swift
@@ -37,7 +37,13 @@ class RollCallSessionTests: TeacherTestCase, RollCallSessionDelegate {
     }
 
     let context = Context(.course, id: "1")
-    lazy var launchRequest = GetSessionlessLaunchURLRequest(context: context, id: "2", url: nil, assignmentID: nil, moduleItemID: nil, launchType: .course_navigation)
+    lazy var launchRequest = GetSessionlessLaunchURLRequest(context: context,
+                                                            id: "2",
+                                                            url: nil,
+                                                            assignmentID: nil,
+                                                            moduleItemID: nil,
+                                                            launchType: .course_navigation,
+                                                            resourceLinkLookupUUID: nil)
 
     lazy var session: RollCallSession = {
         let session = RollCallSession(context: context, toolID: "2", delegate: self)


### PR DESCRIPTION
Add a check for resource_link_lookup_uuid in url and forward it to API.

refs: MBL-16454
affects: Student
release note: Fixed some embedded LTI tools not opening.

test plan: See my comment in the ticket.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet