### PR TITLE
Add check to mastery path locked state.

### DIFF
--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -34,7 +34,8 @@ class ModuleItemCell: UITableViewCell {
     func update(_ item: ModuleItem, indexPath: IndexPath, color: UIColor?) {
         backgroundColor = .backgroundLightest
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)
-        isUserInteractionEnabled = env.app == .teacher || !item.isLocked
+        let isLocked = item.isLocked || item.masteryPath?.locked == true
+        isUserInteractionEnabled = env.app == .teacher || !isLocked
         nameLabel.setText(item.title, style: .textCellTitle)
         nameLabel.isEnabled = isUserInteractionEnabled
         nameLabel.textColor = nameLabel.isEnabled ? .textDarkest : .textLight


### PR DESCRIPTION
refs: MBL-16505
affects: Student
release note: Fixed locked mastery path item displaying an empty screen when tapped.

test plan:
- Create a mastery path for an assignment.
- Add the assignment to a module.
- Log in to the app with a student assigned to the assignment.
- Go to course > modules.
- Observe locked mastery path cell below the mastery path assignment.
- Cell text color should be dimmed and taps on it should be ignored.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/217272815-a3015276-1ed0-4ddf-ab4a-951253d4fb7f.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/217272899-9612f0b1-52e0-43dc-8300-059d8a9bb9c7.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product or not needed
