### PR TITLE
fix: Nightly Tests by uninstalling the app before each run

### DIFF
--- a/Core/CoreTests/AppEnvironment/BackgroundVideoPlayerTests.swift
+++ b/Core/CoreTests/AppEnvironment/BackgroundVideoPlayerTests.swift
@@ -22,7 +22,17 @@ import AVKit
 @testable import Core
 
 class BackgroundVideoPlayerTests: XCTestCase {
-    let player = BackgroundVideoPlayer.shared
+    var player: BackgroundVideoPlayer!
+
+    override func setUp() {
+        player = BackgroundVideoPlayer.shared
+        super.setUp()
+    }
+
+    override func tearDown() {
+        player = nil
+        super.tearDown()
+    }
 
     func testBackgroundReconnect() {
         XCTAssertNil(player.viewController)

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -73,6 +73,7 @@
 		B1E789B821B1B06F0087FE4A /* TestLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789B721B1B06F0087FE4A /* TestLogger.swift */; };
 		B1E789BA21B1D0D30087FE4A /* LogEventFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1E789B921B1D0D30087FE4A /* LogEventFixture.swift */; };
 		B1F13296224BFE03002C0555 /* ModuleItemFixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F13295224BFE03002C0555 /* ModuleItemFixture.swift */; };
+		B4C39744299A658100E98A12 /* XCUIApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C39743299A658100E98A12 /* XCUIApplication.swift */; };
 		C909F7C827BA7E9A00CB89DE /* DSPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7C727BA7E9A00CB89DE /* DSPage.swift */; };
 		C909F7CA27BA7F8D00CB89DE /* CreateDSPageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7C927BA7F8D00CB89DE /* CreateDSPageRequest.swift */; };
 		C909F7CC27BA81F200CB89DE /* DataSeeder+DSPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = C909F7CB27BA81F200CB89DE /* DataSeeder+DSPage.swift */; };
@@ -239,6 +240,7 @@
 		B1E789B721B1B06F0087FE4A /* TestLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestLogger.swift; sourceTree = "<group>"; };
 		B1E789B921B1D0D30087FE4A /* LogEventFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventFixture.swift; sourceTree = "<group>"; };
 		B1F13295224BFE03002C0555 /* ModuleItemFixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleItemFixture.swift; sourceTree = "<group>"; };
+		B4C39743299A658100E98A12 /* XCUIApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCUIApplication.swift; sourceTree = "<group>"; };
 		C909F7C727BA7E9A00CB89DE /* DSPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSPage.swift; sourceTree = "<group>"; };
 		C909F7C927BA7F8D00CB89DE /* CreateDSPageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateDSPageRequest.swift; sourceTree = "<group>"; };
 		C909F7CB27BA81F200CB89DE /* DataSeeder+DSPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataSeeder+DSPage.swift"; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 				5859560B4512977756206840 /* MiniCanvasUITestCase.swift */,
 				C9A3C045269D7D3100DAE8E1 /* K5UITestCase.swift */,
 				C9A23D2127A3D6E400A1EE3B /* E2ETestCase.swift */,
+				B4C39743299A658100E98A12 /* XCUIApplication.swift */,
 			);
 			path = UITests;
 			sourceTree = "<group>";
@@ -1239,6 +1242,7 @@
 				C9299FE128102238003A47C2 /* CreateDSDiscussionRequest.swift in Sources */,
 				E80936D224C2480B00D15E9A /* ItemPickerItem.swift in Sources */,
 				C9B4F0A728C1EDDB0085DF28 /* DSAccountNotification.swift in Sources */,
+				B4C39744299A658100E98A12 /* XCUIApplication.swift in Sources */,
 				CFA078BF2799A7800078B27B /* DSCourse.swift in Sources */,
 				C909F7D327C3831F00CB89DE /* DataSeeder+DSSubmission.swift in Sources */,
 				C909F7C827BA7E9A00CB89DE /* DSPage.swift in Sources */,

--- a/TestsFoundation/TestsFoundation/Element/Element.swift
+++ b/TestsFoundation/TestsFoundation/Element/Element.swift
@@ -319,3 +319,14 @@ public struct XCUIElementQueryWrapper: Element {
         return false
     }
 }
+
+public extension XCUIElement {
+    func forceTapElement() {
+        if isHittable {
+            tap()
+        } else {
+            let coordinate: XCUICoordinate = coordinate(withNormalizedOffset: CGVector())
+            coordinate.tap()
+        }
+    }
+}

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -94,6 +94,9 @@ open class CoreUITestCase: XCTestCase {
     public static var needsLaunch = true
     public var doLoginAfterSetup: Bool = true
     open override func setUp() {
+        XCTContext.runActivity(named: "Uninstalling app") { _ in
+            app.uninstall()
+        }
         super.setUp()
         LoginSession.useTestKeychain()
         continueAfterFailure = false

--- a/TestsFoundation/TestsFoundation/UITests/XCUIApplication.swift
+++ b/TestsFoundation/TestsFoundation/UITests/XCUIApplication.swift
@@ -32,8 +32,6 @@ extension XCUIApplication {
         let executable = e2eRunner.replacingOccurrences(of: "E2ETests-Runner", with: "")
         appName = "Canvas \(executable)"
 
-
-        /// use `firstMatch` because icon may appear in iPad dock
         let appIcon = springboard.icons[appName].firstMatch
         if appIcon.waitForExistence(timeout: timeout) {
             appIcon.press(forDuration: 2)

--- a/TestsFoundation/TestsFoundation/UITests/XCUIApplication.swift
+++ b/TestsFoundation/TestsFoundation/UITests/XCUIApplication.swift
@@ -1,0 +1,65 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import XCTest
+
+extension XCUIApplication {
+    func uninstall() {
+        terminate()
+
+        let timeout = TimeInterval(5)
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+
+        var appName = ""
+
+        let e2eRunner = Bundle.main.infoDictionary?["CFBundleExecutable"] as! String
+        let executable = e2eRunner.replacingOccurrences(of: "E2ETests-Runner", with: "")
+        appName = "Canvas \(executable)"
+
+
+        /// use `firstMatch` because icon may appear in iPad dock
+        let appIcon = springboard.icons[appName].firstMatch
+        if appIcon.waitForExistence(timeout: timeout) {
+            appIcon.press(forDuration: 2)
+        } else {
+            return
+        }
+
+        let removeAppButton = springboard.buttons["Remove App"]
+        if removeAppButton.waitForExistence(timeout: timeout) {
+            removeAppButton.tap()
+        } else {
+            XCTFail("Failed to find 'Remove App'")
+        }
+
+        let deleteAppButton = springboard.alerts.buttons["Delete App"]
+        if deleteAppButton.waitForExistence(timeout: timeout) {
+            deleteAppButton.tap()
+        } else {
+            XCTFail("Failed to find 'Delete App'")
+        }
+
+        let finalDeleteButton = springboard.alerts.buttons["Delete"]
+        if finalDeleteButton.waitForExistence(timeout: timeout) {
+            finalDeleteButton.tap()
+        } else {
+            XCTFail("Failed to find 'Delete'")
+        }
+    }
+}

--- a/rn/Teacher/ios/TeacherE2ETests/Assignments/DSAssignmentsE2ETests.swift
+++ b/rn/Teacher/ios/TeacherE2ETests/Assignments/DSAssignmentsE2ETests.swift
@@ -37,7 +37,7 @@ class DSAssignmentsE2ETests: E2ETestCase {
 
         Dashboard.courseCard(id: course.id).waitToExist()
         Dashboard.courseCard(id: course.id).tap()
-        CourseNavigation.assignments.tap()
+        CourseNavigation.assignments.waitToExist().tap()
         AssignmentsList.assignment(id: assignment.id).tap()
         XCTAssertEqual(AssignmentDetails.name.label(), assignment.name)
         AssignmentDetails.description(assignmentDescription).waitToExist(5)

--- a/rn/Teacher/ios/TeacherE2ETests/Assignments/DSContextCardE2ETests.swift
+++ b/rn/Teacher/ios/TeacherE2ETests/Assignments/DSContextCardE2ETests.swift
@@ -79,7 +79,7 @@ class DSContextCardE2ETests: E2ETestCase {
         NavBar.backButton.tap()
 
         // Check the students context cards via SpeedGrader
-        CourseNavigation.assignments.tap()
+        CourseNavigation.assignments.rawElement.forceTapElement()
         AssignmentsList.assignment(id: assignment.id).tap()
         AssignmentDetails.viewAllSubmissionsButton.tap()
         SubmissionsListPage.cell(userID: student.id).tap()


### PR DESCRIPTION
Fix NightlyTests by adding a function that uninstalls the app before each run. 

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
