### PR TITLE
Update dark mode switcher button height calculation

### DIFF
--- a/Core/Core/CoreWebView/CoreWebView.swift
+++ b/Core/Core/CoreWebView/CoreWebView.swift
@@ -552,8 +552,11 @@ extension CoreWebView {
 // MARK: - Color Scheme Switching
 
 extension CoreWebView {
-    public var themeSwitchButtonHeight: CGFloat { 38 }
-    public var themeSwitchButtonTopPadding: CGFloat { 16 }
+    public var themeSwitcherHeight: CGFloat {
+        isThemeDark ? themeSwitchButtonHeight + themeSwitchButtonTopPadding : 0
+    }
+    private var themeSwitchButtonHeight: CGFloat { 38 }
+    private var themeSwitchButtonTopPadding: CGFloat { 16 }
 
     private func updateHtmlContentView() {
 

--- a/Core/Core/CoreWebView/CoreWebView.swift
+++ b/Core/Core/CoreWebView/CoreWebView.swift
@@ -552,6 +552,8 @@ extension CoreWebView {
 // MARK: - Color Scheme Switching
 
 extension CoreWebView {
+    public var themeSwitchButtonHeight: CGFloat { 38 }
+    public var themeSwitchButtonTopPadding: CGFloat { 16 }
 
     private func updateHtmlContentView() {
 
@@ -571,17 +573,16 @@ extension CoreWebView {
     }
 
     public func pinWithThemeSwitchButton(inside parent: UIView?, leading: CGFloat? = 0, trailing: CGFloat? = 0, top: CGFloat? = 0, bottom: CGFloat? = 0) {
-
-        guard let parent = parent else { return }
+        guard let parent else { return }
 
         let padding: CGFloat = 16
 
         var buttonHeight: CGFloat {
-            isThemeDark ? 38 : 0
+            isThemeDark ? themeSwitchButtonHeight : 0
         }
 
         var buttonTopPadding: CGFloat {
-            isThemeDark ? 16 : 0
+            isThemeDark ? themeSwitchButtonTopPadding : 0
         }
 
         themeSwitcherButton.isHidden = !isThemeDark

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -176,7 +176,8 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
     }
 
     func heightChanged() {
-        let themeSwitchButtonOffset: CGFloat = traitCollection.userInterfaceStyle == .dark ? 38 : 0
+        let themeSwitcherHeight = webView.themeSwitchButtonHeight + webView.themeSwitchButtonTopPadding
+        let themeSwitchButtonOffset: CGFloat = traitCollection.userInterfaceStyle == .dark ? themeSwitcherHeight : 0
         let contentHeight = self.contentHeight.constant + themeSwitchButtonOffset
         webViewHeight.constant = isExpanded || contentHeight <= collapsedHeight ? contentHeight : collapsedHeight
         viewMoreButton.isHidden = contentHeight <= collapsedHeight

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -176,9 +176,7 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
     }
 
     func heightChanged() {
-        let themeSwitcherHeight = webView.themeSwitchButtonHeight + webView.themeSwitchButtonTopPadding
-        let themeSwitchButtonOffset: CGFloat = traitCollection.userInterfaceStyle == .dark ? themeSwitcherHeight : 0
-        let contentHeight = self.contentHeight.constant + themeSwitchButtonOffset
+        let contentHeight = self.contentHeight.constant + webView.themeSwitcherHeight
         webViewHeight.constant = isExpanded || contentHeight <= collapsedHeight ? contentHeight : collapsedHeight
         viewMoreButton.isHidden = contentHeight <= collapsedHeight
     }


### PR DESCRIPTION
refs: MBL-16504
affects: Student, Teacher
release note: Fixed discussion reply text being cut off.

test plan: Check discussion text in the discussion reply dialog.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/219385466-c5bb7d79-3474-456a-ba1e-c23ad59b8934.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/219385521-e102932e-3323-4f24-b6ce-f3ec4a281c34.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
