### PR TITLE
Remove edit button on Due Date Page

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1938,7 +1938,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BF8139D888212DC95299155 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
 		4C752E0B19740ED52EDFF264 /* CoursePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoursePickerViewModel.swift; sourceTree = "<group>"; };
@@ -2482,7 +2482,7 @@
 		A2BF01404113FB190130FEF2 /* APIListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIListTests.swift; sourceTree = "<group>"; };
 		A352C359FEF9F433F0479815 /* AppStoreReviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStoreReviewTests.swift; sourceTree = "<group>"; };
 		A39C7A23AEDFA7CAA2A6DDEB /* APIRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequestableTests.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };

--- a/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/AssignmentDueDates.js
@@ -135,13 +135,6 @@ export class AssignmentDueDates extends Component<AssignmentDueDatesProps, any> 
       <Screen
         title={i18n('Due Dates')}
         navBarStyle='context'
-        rightBarButtons={[
-          {
-            title: i18n('Edit'),
-            testID: 'assignment-due-dates.edit-btn',
-            action: this.editAssignment,
-          },
-        ]}
       >
         <View style={styles.container}>
           <ScrollView style={styles.scrollContainer}>

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
@@ -23,7 +23,6 @@ import 'react-native'
 import React from 'react'
 import { AssignmentDueDates } from '../AssignmentDueDates'
 import renderer from 'react-test-renderer'
-import explore from '../../../../test/helpers/explore'
 
 jest
   .mock('../../../routing')

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/AssignmentDueDates.test.js
@@ -102,38 +102,6 @@ test('renders with overrides and specific student ids and sections', () => {
   expect(refreshUsers).toBeCalled()
 })
 
-test('routes to assignment edit', () => {
-  const props = {
-    courseID: '1',
-    assignmentID: '1',
-    assignment: template.assignment({ id: '1' }),
-    navigator: template.navigator({ show: jest.fn() }),
-    refreshAssignment: jest.fn(),
-  }
-  let tree = renderer.create(
-    <AssignmentDueDates {...props} />
-  ).toJSON()
-  const editButton: any = explore(tree).selectRightBarButton('assignment-due-dates.edit-btn')
-  editButton.action()
-  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/assignments/1/edit', { modal: true })
-})
-
-test('routes to quiz edit', () => {
-  const props = {
-    courseID: '1',
-    quizID: '2',
-    assignment: template.assignment({ id: '1' }),
-    navigator: template.navigator({ show: jest.fn() }),
-    refreshAssignment: jest.fn(),
-  }
-  let tree = renderer.create(
-    <AssignmentDueDates {...props} />
-  ).toJSON()
-  const editButton: any = explore(tree).selectRightBarButton('assignment-due-dates.edit-btn')
-  editButton.action()
-  expect(props.navigator.show).toHaveBeenCalledWith('/courses/1/quizzes/2/edit', { modal: true })
-})
-
 test('null assignment', () => {
   const props = {
     courseID: '1',

--- a/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
+++ b/rn/Teacher/src/modules/assignment-due-dates/__tests__/__snapshots__/AssignmentDueDates.test.js.snap
@@ -3,15 +3,6 @@
 exports[`renders 1`] = `
 <Screen
   navBarStyle="context"
-  rightBarButtons={
-    Array [
-      Object {
-        "action": [Function],
-        "testID": "assignment-due-dates.edit-btn",
-        "title": "Edit",
-      },
-    ]
-  }
   title="Due Dates"
 >
   <View
@@ -39,15 +30,6 @@ exports[`renders 1`] = `
 exports[`renders with overrides 1`] = `
 <Screen
   navBarStyle="context"
-  rightBarButtons={
-    Array [
-      Object {
-        "action": [Function],
-        "testID": "assignment-due-dates.edit-btn",
-        "title": "Edit",
-      },
-    ]
-  }
   title="Due Dates"
 >
   <View


### PR DESCRIPTION
refs: MBL-16521
affects: Teacher
release note: Removed edit button on Due Date Page 
test plan: Open an assignment's due date page

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/110813321/220872161-9eafc565-405e-4a26-97e9-93245ffe22f0.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/110813321/220872152-4b4d65ef-0508-4d93-9cdc-9de735367c62.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product or not needed
