### PR TITLE
Disable swipe and tap out dismiss for text entry submission view.

### DIFF
--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -140,7 +140,7 @@ class SubmissionButtonPresenter: NSObject {
                 courseID: courseID,
                 assignmentID: assignment.id,
                 userID: userID
-            ), from: view, options: .modal(embedInNav: true))
+            ), from: view, options: .modal(isDismissable: false, embedInNav: true))
         case .online_quiz:
             Analytics.shared.logEvent("assignment_detail_quizlaunch")
             guard let quizID = assignment.quizID else { return }


### PR DESCRIPTION
refs: MBL-16536
affects: Student
release note: Fixed text entry submission views can be dismissed with tap out or swipe down gestures.
test plan: See ticket.

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product or not needed
