### PR TITLE
Observer pairing directs to login page instead of parent sign up page

### DIFF
--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -210,7 +210,9 @@ extension LoginWebViewController: WKNavigationDelegate {
             form.submit()
             """)
         } else if let pairingCode = pairingCode {
-            showSelfRegistration(pairingCode: pairingCode)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.showSelfRegistration(pairingCode: pairingCode)
+            }
         }
     }
 
@@ -228,7 +230,7 @@ extension LoginWebViewController: WKNavigationDelegate {
                 registerLink.click()
                 return
             }
-            let enrollLink = document.querySelector('#coenrollment_link a') || document.querySelector('a#signup_parent')
+            let enrollLink = document.querySelector('a[data-template="newParentDialog"]') || document.querySelector('#coenrollment_link a') || document.querySelector('a#signup_parent')
             if (!enrollLink) {
                 window.webkit.messageHandlers.selfRegistrationError.postMessage('')
                 return

--- a/Core/Core/UIViews/ScannerViewController.swift
+++ b/Core/Core/UIViews/ScannerViewController.swift
@@ -190,11 +190,21 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
     }
 
     private func updateCameraPreviewOrientation() {
+
+        var orientation: UIDeviceOrientation
+        let supportedOrientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations"] as? [String]
+        if supportedOrientations?.count == 1,
+            supportedOrientations?.first?.contains("UIInterfaceOrientationPortrait") != nil {
+            orientation = .portrait
+        } else {
+            orientation = UIDevice.current.orientation
+        }
+
         guard
             let previewLayer = previewLayer,
             let connection = previewLayer.connection,
             connection.isVideoOrientationSupported,
-            let videoOrientation = AVCaptureVideoOrientation(rawValue: UIDevice.current.orientation.rawValue)
+            let videoOrientation = AVCaptureVideoOrientation(rawValue: orientation.rawValue)
         else { return }
 
         previewLayer.frame = view.layer.bounds


### PR DESCRIPTION
refs: MBL-16534
affects: Parent
release note: Fix observer pairing directs to login page instead of parent sign up page.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/223453473-290e4865-a883-4f16-ae29-c118ab18b7e8.PNG" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/223453489-c9b9e57f-a5bb-4f06-ae05-6551c2a76547.PNG" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
