### PR TITLE
Hide non-relevant menu items in teacher app

### DIFF
--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -229,17 +229,20 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     }
 
     private func refreshTermsOfService() {
+        if AppEnvironment.shared.app == .teacher {
+            if isPairingWithObserverAllowed {
+                isPairingWithObserverAllowed = false
+            }
+            return
+        }
+
         termsOfServiceRequest = env.api.makeRequest(GetAccountTermsOfServiceRequest()) { [weak self] response, _, _ in
             self?.termsOfServiceRequest = nil
-            var isPairingAllowed: Bool
+            let isPairingAllowed: Bool
 
             if let self_registration = response?.self_registration_type {
                 isPairingAllowed = [APISelfRegistrationType.all, .observer].contains(self_registration)
             } else {
-                isPairingAllowed = false
-            }
-
-            if AppEnvironment.shared.app == .teacher {
                 isPairingAllowed = false
             }
 

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -148,11 +148,18 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
         rows.append(contentsOf: k5DashboardSwitch)
         rows.append(contentsOf: channelTypeRows ?? [])
         rows.append(contentsOf: pairWithObserverButton)
-        rows.append(contentsOf: [Row(NSLocalizedString("Subscribe to Calendar Feed", bundle: .core, comment: ""), hasDisclosure: false) { [weak self] in
-            guard let url = self?.profile.first?.calendarURL else { return }
-            self?.env.loginDelegate?.openExternalURL(url)
-       },
-    ])
+
+        if AppEnvironment.shared.app == .student {
+            let row = Row(NSLocalizedString("Subscribe to Calendar Feed",
+                                            bundle: .core,
+                                            comment: ""),
+                          hasDisclosure: false) { [weak self] in
+                guard let url = self?.profile.first?.calendarURL else { return }
+                self?.env.loginDelegate?.openExternalURL(url)
+            }
+            rows.append(contentsOf: [row])
+        }
+
         return rows
     }
 
@@ -224,11 +231,15 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     private func refreshTermsOfService() {
         termsOfServiceRequest = env.api.makeRequest(GetAccountTermsOfServiceRequest()) { [weak self] response, _, _ in
             self?.termsOfServiceRequest = nil
-            let isPairingAllowed: Bool
+            var isPairingAllowed: Bool
 
             if let self_registration = response?.self_registration_type {
                 isPairingAllowed = [APISelfRegistrationType.all, .observer].contains(self_registration)
             } else {
+                isPairingAllowed = false
+            }
+
+            if AppEnvironment.shared.app == .teacher {
                 isPairingAllowed = false
             }
 

--- a/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
+++ b/Core/CoreTests/Profile/Settings/ProfileSettingsViewControllerTests.swift
@@ -35,6 +35,32 @@ class ProfileSettingsViewControllerTests: CoreTestCase {
         vc.viewWillAppear(false)
     }
 
+    func testSelfRegistrationRowVisibility() {
+        api.mock(GetAccountTermsOfServiceRequest(), value: .make(self_registration_type: .all))
+        load()
+
+        AppEnvironment.shared.app = .teacher
+        vc.refresh(sender: self)
+        XCTAssertFalse(isCellExists(title: "Pair with Observer", section: 0))
+
+        AppEnvironment.shared.app = .student
+        vc.refresh(sender: self)
+        XCTAssertTrue(isCellExists(title: "Pair with Observer", section: 0))
+    }
+
+    func testCalendarFeedRowVisibility() {
+        api.mock(GetAccountTermsOfServiceRequest(), value: .make(self_registration_type: .all))
+        load()
+
+        AppEnvironment.shared.app = .teacher
+        vc.refresh(sender: self)
+        XCTAssertFalse(isCellExists(title: "Subscribe to Calendar Feed", section: 0))
+
+        AppEnvironment.shared.app = .student
+        vc.refresh(sender: self)
+        XCTAssertTrue(isCellExists(title: "Subscribe to Calendar Feed", section: 0))
+    }
+
     func testRender() {
         let channels = [
             APICommunicationChannel.make(address: "a", id: ID(1), position: 1, type: .email, workflow_state: .active),
@@ -101,6 +127,23 @@ class ProfileSettingsViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.textLabel?.text, "Canvas on GitHub")
         vc.tableView(vc.tableView, didSelectRowAt: IndexPath(row: 2, section: 1))
         XCTAssert(router.lastRoutedTo(.parse("https://github.com/instructure/canvas-ios")))
+    }
+
+    private func isCellExists(title: String, section: Int) -> Bool {
+        let cellCount = vc.tableView.numberOfRows(inSection: section)
+
+        for rowIndex in 0..<cellCount {
+            let indexPath = IndexPath(row: rowIndex, section: section)
+            guard let cell = vc.tableView.cellForRow(at: indexPath) as? RightDetailTableViewCell else {
+                continue
+            }
+
+            if cell.textLabel?.text == title {
+                return true
+            }
+        }
+
+        return false
     }
 }
 


### PR DESCRIPTION
refs: MBL-15480, MBL-16523
affects: Teacher
release note: none

test plan:
- Open Settings in side menu.
- Subscribe to Calendar Feed and Pair with Observer menu items shouldn't be visible.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/223727388-75ed7a00-2c01-4cc0-ad4b-a1eafcacc6a1.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/223727426-bae2d5a2-1771-4fa2-8eff-59a07c287bcc.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
