### PR TITLE
Empty view's nav color not darkened enough

### DIFF
--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -138,7 +138,7 @@ public class CourseDetailsViewModel: ObservableObject {
         // Even if there's no home view for the course we still want to reset the split detail view when moving back/to the course details
         if !showHome {
             // We need to drop the # from color otherwise it will be treated as the fragment of the url and not the value of contextColor
-            homeRoute = URL(string: "/empty?contextColor=\(courseColor.hexString.dropFirst())")
+            homeRoute = URL(string: "/empty?contextColor=\(courseColor.resolvedColor(with: .light).darkenToEnsureContrast(against: .textLightest).hexString.dropFirst())")
             return
         }
 


### PR DESCRIPTION
refs: MBL-16565
affects: Student, Teacher
release note: none
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
