### PR TITLE
Update edit page dialog presentation options.

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -326,6 +326,7 @@ open class HelmManager: NSObject {
             if let modalPresentationStyle = options[PropKeys.modalPresentationStyle] as? String {
                 switch modalPresentationStyle {
                 case "fullscreen": viewController.modalPresentationStyle = .fullScreen
+                case "pagesheet": viewController.modalPresentationStyle = .pageSheet
                 case "formsheet": viewController.modalPresentationStyle = .formSheet
                 case "currentContext": viewController.modalPresentationStyle = .currentContext
                 case "overCurrentContext": viewController.modalPresentationStyle = .overCurrentContext

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -46,7 +46,7 @@ public struct AssignmentDetailsView: View {
                 Button(action: { env.router.route(
                     to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
                     from: controller,
-                    options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+                    options: .modal(isDismissable: false, embedInNav: true)
                 ) }, label: {
                     Text("Edit", bundle: .core)
                         .fontWeight(.regular)

--- a/Core/Core/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Discussions/AnnouncementListViewController.swift
@@ -141,7 +141,7 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
         env.router.route(
             to: "\(context.pathComponent)/announcements/new",
             from: self,
-            options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+            options: .modal(isDismissable: false, embedInNav: true)
         )
     }
 

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -588,7 +588,7 @@ extension DiscussionDetailsViewController {
 
     func editTopic() {
         let path = "\(context.pathComponent)/\(isAnnouncement ? "announcements" : "discussion_topics")/\(topicID)/edit"
-        env.router.route(to: path, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
+        env.router.route(to: path, from: self, options: .modal(isDismissable: false, embedInNav: true))
     }
 
     func markAllRead(isRead: Bool) {

--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -145,7 +145,7 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
         env.router.route(
             to: "\(context.pathComponent)/discussion_topics/new",
             from: self,
-            options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+            options: .modal(isDismissable: false, embedInNav: true)
         )
     }
 

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -215,7 +215,7 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         env.router.route(
             to: "\(context?.pathComponent ?? "")/files/\(fileID)/edit",
             from: self,
-            options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+            options: .modal(isDismissable: false, embedInNav: true)
         )
     }
 

--- a/Core/Core/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Files/View/FileList/FileListViewController.swift
@@ -296,7 +296,7 @@ extension FileListViewController: FilePickerDelegate {
 
     @objc func edit() {
         guard let folderID = folder.first?.id else { return }
-        env.router.route(to: "/folders/\(folderID)/edit", from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
+        env.router.route(to: "/folders/\(folderID)/edit", from: self, options: .modal(isDismissable: false, embedInNav: true))
     }
 
     var canAddItem: Bool {

--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -129,7 +129,7 @@ public class PageDetailsViewController: UIViewController, ColoredNavViewProtocol
         alert.addAction(AlertAction(NSLocalizedString("Edit", bundle: .core, comment: ""), style: .default) { [weak self] _ in
             guard let self = self, let page = self.page else { return }
             guard let url = page.htmlURL?.appendingPathComponent("edit") else { return }
-            self.env.router.route(to: url, from: self, options: .modal(.formSheet, embedInNav: true))
+            self.env.router.route(to: url, from: self, options: .modal(isDismissable: false, embedInNav: true))
         })
         if canDelete {
             alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in

--- a/Core/Core/Pages/PageList/PageListViewController.swift
+++ b/Core/Core/Pages/PageList/PageListViewController.swift
@@ -131,7 +131,7 @@ public class PageListViewController: ScreenViewTrackableViewController, ColoredN
     }
 
     @objc func createPage() {
-        env.router.route(to: "\(context.pathComponent)/pages/new", from: self, options: .modal(embedInNav: true))
+        env.router.route(to: "\(context.pathComponent)/pages/new", from: self, options: .modal(isDismissable: false, embedInNav: true))
     }
 
     @objc func refresh() {

--- a/Core/Core/Planner/PlannerViewController.swift
+++ b/Core/Core/Planner/PlannerViewController.swift
@@ -114,7 +114,7 @@ public class PlannerViewController: UIViewController {
     }
 
     @objc func addNote() {
-        env.router.show(CreateTodoViewController.create(), from: self, options: .modal(embedInNav: true), analyticsRoute: "/calendar/new")
+        env.router.show(CreateTodoViewController.create(), from: self, options: .modal(isDismissable: false, embedInNav: true), analyticsRoute: "/calendar/new")
     }
 
     @objc func selectToday() {

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
@@ -76,7 +76,7 @@ public class QuizDetailsViewModel: QuizDetailsViewModelProtocol {
         router.route(
             to: "courses/\(courseID)/quizzes/\(quizID)/edit",
             from: viewController,
-            options: .modal(.formSheet, isDismissable: false, embedInNav: true)
+            options: .modal(isDismissable: false, embedInNav: true)
         )
     }
 

--- a/Core/CoreTests/Discussions/AnnouncementListViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/AnnouncementListViewControllerTests.swift
@@ -130,7 +130,7 @@ class AnnouncementListViewControllerTests: CoreTestCase {
         XCTAssertNotNil(controller.navigationItem.rightBarButtonItem)
 
         _ = controller.addButton.target?.perform(controller.addButton.action)
-        XCTAssert(router.lastRoutedTo("groups/1/announcements/new", withOptions: .modal(.formSheet, isDismissable: false, embedInNav: true)))
+        XCTAssert(router.lastRoutedTo("groups/1/announcements/new", withOptions: .modal(isDismissable: false, embedInNav: true)))
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 1)
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? AnnouncementListCell

--- a/Core/CoreTests/Discussions/DiscussionListViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionListViewControllerTests.swift
@@ -158,7 +158,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
         XCTAssertNotNil(controller.navigationItem.rightBarButtonItem)
 
         _ = controller.addButton.target?.perform(controller.addButton.action)
-        XCTAssert(router.lastRoutedTo("groups/1/discussion_topics/new", withOptions: .modal(.formSheet, isDismissable: false, embedInNav: true)))
+        XCTAssert(router.lastRoutedTo("groups/1/discussion_topics/new", withOptions: .modal(isDismissable: false, embedInNav: true)))
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 1)
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? Core.DiscussionListCell

--- a/Core/CoreTests/Files/View/FileList/FileListViewControllerTests.swift
+++ b/Core/CoreTests/Files/View/FileList/FileListViewControllerTests.swift
@@ -130,7 +130,7 @@ class FileListViewControllerTests: CoreTestCase {
 
         XCTAssertEqual(controller.navigationItem.rightBarButtonItems?.contains(controller.editButton), true)
         _ = controller.editButton.target?.perform(controller.editButton.action)
-        XCTAssert(router.lastRoutedTo("/folders/2/edit", withOptions: .modal(.formSheet, isDismissable: false, embedInNav: true)))
+        XCTAssert(router.lastRoutedTo("/folders/2/edit", withOptions: .modal(isDismissable: false, embedInNav: true)))
 
         controller.tableView.selectRow(at: index, animated: false, scrollPosition: .none)
         XCTAssertNoThrow(controller.viewWillDisappear(false))

--- a/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
+++ b/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
@@ -63,6 +63,6 @@ class TeacherSyllabusTabViewController: SyllabusTabViewController {
 
     @objc func edit() {
         env.router.route(
-            to: "\(context?.pathComponent ?? "")/syllabus/edit", from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
+            to: "\(context?.pathComponent ?? "")/syllabus/edit", from: self, options: .modal(isDismissable: false, embedInNav: true))
     }
 }

--- a/rn/Teacher/src/modules/quizzes/details/QuizDetails.js
+++ b/rn/Teacher/src/modules/quizzes/details/QuizDetails.js
@@ -236,7 +236,7 @@ export class QuizDetails extends Component<Props, any> {
 
   _editQuiz = () => {
     if (this.props.quiz) {
-      this.props.navigator.show(`/courses/${this.props.courseID}/quizzes/${this.props.quiz.id}/edit`, { modal: true, modalPresentationStyle: 'formsheet' })
+      this.props.navigator.show(`/courses/${this.props.courseID}/quizzes/${this.props.quiz.id}/edit`, { modal: true, modalPresentationStyle: 'pagesheet' })
     }
   }
 

--- a/rn/Teacher/src/modules/quizzes/details/__tests__/QuizDetails.test.js
+++ b/rn/Teacher/src/modules/quizzes/details/__tests__/QuizDetails.test.js
@@ -189,7 +189,7 @@ describe('QuizDetails', () => {
     const tree = render(props).toJSON()
     const editButton: any = explore(tree).selectRightBarButton('quizzes.details.editButton')
     editButton.action()
-    expect(props.navigator.show).toHaveBeenCalledWith(`/courses/${props.courseID}/quizzes/${props.quizID}/edit`, { 'modal': true, 'modalPresentationStyle': 'formsheet' })
+    expect(props.navigator.show).toHaveBeenCalledWith(`/courses/${props.courseID}/quizzes/${props.quizID}/edit`, { 'modal': true, 'modalPresentationStyle': 'pagesheet' })
   })
 
   it('renders assignment group', () => {


### PR DESCRIPTION
refs: MBL-16583
affects: Student, Teacher
release note: none

test plan:
- Edit a page in iPad.
- The dialog shouldn't be dismissible with a swipe down gesture nor with a tap outside of the dialog.
- Dialog size should match the New Page dialog's size.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/225021428-3f107217-a5b9-4de5-9ff2-9d968aafe554.PNG" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/225021481-6ebf8f73-69d6-4783-9928-e8d3bab7b536.PNG" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet