### PR TITLE
Fix RCE editor remove image overlay button

### DIFF
--- a/Core/Core/RichContentEditor/RichContentEditor.js
+++ b/Core/Core/RichContentEditor/RichContentEditor.js
@@ -134,13 +134,15 @@ const editor = window.editor = {
             if (!overlay.image.parentNode) { overlay.remove() }
         }
         for (const img of content.querySelectorAll('img')) {
-            const bounds = img.getBoundingClientRect()
-            const overlay = img.overlay || (img.overlay = imgOverlay(img))
-            overlay.style.height = `${bounds.height}px`
-            overlay.style.left = `${scrollX + bounds.left}px`
-            overlay.style.top = `${scrollY + bounds.top}px`
-            overlay.style.width = `${bounds.width}px`
-            if (!overlay.parentNode) { document.body.appendChild(overlay) }
+            if (img.complete) {
+                const bounds = img.getBoundingClientRect()
+                const overlay = img.overlay || (img.overlay = imgOverlay(img))
+                overlay.style.height = `${bounds.height}px`
+                overlay.style.left = `${scrollX + bounds.left}px`
+                overlay.style.top = `${scrollY + bounds.top}px`
+                overlay.style.width = `${bounds.width}px`
+                if (!overlay.parentNode) { document.body.appendChild(overlay) }
+            }
         }
     },
 


### PR DESCRIPTION
refs: MBL-16583
affects: Student, Teacher
release note: none
test plan: 
1. Open a Page for Edit
2. You should see one remove button per image

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/110813321/225045113-6cd5eac2-c220-45b5-866b-70c385c13427.jpeg" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/110813321/225045062-4c3e90fa-97fc-4f59-961b-00423b19b28f.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created or not needed
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product or not needed
