### PR TITLE
Update course details cell layout for large dynamic types

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -29,7 +29,6 @@
 		04BA2764BEF7857998888D0C /* CoreWebViewJSInjections.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81A6A125E5A9F3D2E1E62640 /* CoreWebViewJSInjections.swift */; };
 		04C9CEB3DBC0B2DF0E18780D /* FileEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 065793EAB0372BF8F2BD9C33 /* FileEditorView.swift */; };
 		053F7EB1A384E2BEA503B658 /* APISubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8634CDF6D6C6D8A081E13FDB /* APISubmission.swift */; };
-		0563DE0A322485BB292457FE /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D43448BB5B79EDB6E16AE99 /* UIButtonExtensionTests.swift */; };
 		066E60EDF4BCC2E8A947CA99 /* GetCourseSingleUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41F5957C6091319417E638E2 /* GetCourseSingleUser.swift */; };
 		069ADE5FFD74EA7C53F5DC39 /* ConversationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E5C2BA04CDCAB0E73F111CA /* ConversationTests.swift */; };
 		06BB9A5DE911CB9B67C8216E /* DueViewable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F1C849E6FB194387C1E9BA /* DueViewable.swift */; };
@@ -572,6 +571,7 @@
 		69AC9E284C5B7DEE6D6C8783 /* GetAssignmentsByGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADB1EFF56D34098EFF57575A /* GetAssignmentsByGroup.swift */; };
 		69EED14272FCDD7E322AF9F3 /* InvertColorsInDarkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE3D5F8C27A915BA40A3956B /* InvertColorsInDarkMode.swift */; };
 		6A4D08279642B9D2362054B6 /* APIErrorReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 535C9130A59C029E8035DC7C /* APIErrorReport.swift */; };
+		6AC07507B246CE3B8812024A /* UIBarButtonItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56EAF3D66B717B437D1E6F24 /* UIBarButtonItemExtensionsTests.swift */; };
 		6AC45F72D79B375655EB8039 /* FileUploadNotificationCardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7F2D7AE0E5D8E3FF34E3452 /* FileUploadNotificationCardListViewModel.swift */; };
 		6B0939C84E309FAA683FC3D6 /* TestOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE282BDD1EFE56BE1CF9E3B6 /* TestOperationQueue.swift */; };
 		6B0FF4414CB67D2EE406F905 /* GetSubmissionComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC607226FEFE22FBD92C14D /* GetSubmissionComments.swift */; };
@@ -579,6 +579,7 @@
 		6B8A49BFF1CE18F3916E83EB /* QuizListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF62474862BFE3BDB075424A /* QuizListViewControllerTests.swift */; };
 		6B8D12C73ECEC194A243E905 /* SessionDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D7F20136B99ADD6EAB7F8B /* SessionDefaults.swift */; };
 		6BC1C4750A04F2F7DA4AA636 /* UITableViewCellExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A1DDE9B2E607CBB410A0A90 /* UITableViewCellExtensionsTests.swift */; };
+		6BCBC9F0F0222BF0D933CA9E /* DashboardContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0303BE0FCE992BD639CEFA4A /* DashboardContainerViewController.swift */; };
 		6BD284C2AC2C1A327A9C330B /* PSPDFAnnotationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5C4215D7D3A95216C8525 /* PSPDFAnnotationExtension.swift */; };
 		6C1964F51287CEE7F350577B /* APIPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E09CF06891A51A1C36E7099 /* APIPermissions.swift */; };
 		6C2C5D9DFB8F55397E71CB0E /* XCTestCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23D412CA36C4F3DDFF4DC75C /* XCTestCaseTests.swift */; };
@@ -748,6 +749,7 @@
 		88FE93F62257EEFC0BF87021 /* GetArc.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E9735AB298A611E00A778A /* GetArc.swift */; };
 		897256E32E4F109111B6A3C8 /* CourseListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75A116CCFFC865C346D20BF /* CourseListItem.swift */; };
 		89CFDEAFE78DEFF2563FFB6A /* MasteryPathViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0734D9CC65C6AAFF0F04B267 /* MasteryPathViewController.storyboard */; };
+		89DCD799B8FE9A6665C45CC8 /* UIButtonExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D8F68F1482BC9797395B3D4 /* UIButtonExtensionTests.swift */; };
 		8A8E936BF9016BFD4DCF5FC1 /* HorizontalMenuViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7481A170A9862C631E9B8C93 /* HorizontalMenuViewControllerTests.swift */; };
 		8B208F931F969AE797E94EAD /* ListSectionHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C045FFC7C7D5659187E841A /* ListSectionHeader.swift */; };
 		8B35211BBCAF0422D93E1162 /* DefaultViewProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBEFF2C32C437330362D01D4 /* DefaultViewProvider.swift */; };
@@ -984,6 +986,7 @@
 		B88EE911E44729038145845E /* SideMenuItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22ED04B8E5C949886BF43B82 /* SideMenuItem.swift */; };
 		B8BD2E06DC4D635103CD32C2 /* LoginNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DEBE188980E96F3EFB2CE01 /* LoginNavigationController.swift */; };
 		B91DF7FE7B6B005DC8A86B91 /* DashboardInvitationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20996E98A956057613DA11B0 /* DashboardInvitationViewModelTests.swift */; };
+		B9444E1C8AD29E2F6C887540 /* CGFloatExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42C757CFAFA99B487EB16DAD /* CGFloatExtensionsTests.swift */; };
 		B9960CDECC5BFADCDD81B3B7 /* ChatBubbleView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2FC77176D2EEBFA664AAA72E /* ChatBubbleView.xib */; };
 		B9D3EE1DDF8B439AB1D090F0 /* PairWithStudentQRCodeTutorialViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D9E7E9A48DA0928791BB51E9 /* PairWithStudentQRCodeTutorialViewController.storyboard */; };
 		B9E87F64AEBE05EF9B41E26E /* CalendarDayIconViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E00D00D4831C6E57A55982 /* CalendarDayIconViewTests.swift */; };
@@ -1045,6 +1048,7 @@
 		C30A0702D69F3254077BBBDD /* StudentViewCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69785420C99FD6DC939D24A6 /* StudentViewCellViewModel.swift */; };
 		C322B3C864D5830408D23668 /* APIDashboardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50BDA44D81991B13FACD0E39 /* APIDashboardTests.swift */; };
 		C32ACDB77E0F1BA38E7AAD85 /* FilePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 922AEFF724F9170942A14060 /* FilePicker.swift */; };
+		C3A2098297616AEE8CBC55CA /* CGFloatExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A4E9AE175537DC19E2BB239 /* CGFloatExtensions.swift */; };
 		C406485DE3B48D2D910E34F8 /* AudioRecorderViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 83A896AE378A6A1813117F78 /* AudioRecorderViewController.storyboard */; };
 		C4194A5C41933B17FB0DF695 /* PairWithObserverViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617AE70312B1FC5CC341AD98 /* PairWithObserverViewController.swift */; };
 		C41C54EEDFCCA7A563CBB705 /* Core.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4E249DD6423E938E1DE581C9 /* Core.framework */; };
@@ -1104,14 +1108,12 @@
 		CEB280DBA9591EE89AAE22B3 /* MDMManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E32A2422355ECEF9729235 /* MDMManagerTests.swift */; };
 		CEC97448F930BB18B9BE614A /* GetCourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA8B03B9279BBBDBCF285F /* GetCourseSections.swift */; };
 		CEEB69AC4E74B054E4F61BAB /* PageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88E31090C62EE2CD151388F /* PageTests.swift */; };
-		CF5CE3A629AE0EFD009053F3 /* DashboardContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5CE3A529AE0EFD009053F3 /* DashboardContainerViewController.swift */; };
 		CF77186DABC99EF4A2704BD3 /* APIEnrollmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79ED41813910F1C973820502 /* APIEnrollmentTests.swift */; };
 		CF78BC37E1EF05678E6831F1 /* UIFontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C87806EF88EDE9BB02134F7 /* UIFontExtensions.swift */; };
 		CF848A454985D319B862329B /* InboxCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534C5973089478FB911C2D40 /* InboxCourse.swift */; };
 		CFA8398A890008FC131E5659 /* PairWithStudentQRCodeTutorialViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B30F0A5FF24A16E638535AB /* PairWithStudentQRCodeTutorialViewController.swift */; };
 		CFB4F7D6AA0DFCC12C79CB03 /* DiscussionReplyViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54BAC19414BABEF1BE119505 /* DiscussionReplyViewControllerTests.swift */; };
 		CFDED43EFD2EFE248E2C0AD3 /* FileProgressListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E7A16122D559CDD2F497160 /* FileProgressListViewModel.swift */; };
-		CFF6CDA829B778B6006F451D /* UIBarButtonItemExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFF6CDA729B778B6006F451D /* UIBarButtonItemExtensionsTests.swift */; };
 		D01F1A0AB0AAF5643C03EFF1 /* ModuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F0C6A481F3EFC1B4F0777CB /* ModuleTests.swift */; };
 		D06B1B95D0FF65F7E7761F95 /* Hidden.swift in Sources */ = {isa = PBXBuildFile; fileRef = B408E358BA052F9B08697E7E /* Hidden.swift */; };
 		D0F8A60B23C9F14E0F18F68E /* K5ScheduleViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6985A169550DB5407617B325 /* K5ScheduleViewModel.swift */; };
@@ -1461,6 +1463,7 @@
 		026306C5D0B6912F2B1FC0C1 /* ViewModelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelState.swift; sourceTree = "<group>"; };
 		02A05573543CD504DA65350D /* AvatarGroupViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvatarGroupViewTests.swift; sourceTree = "<group>"; };
 		02AC4A482793512AE0211360 /* PageViewSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewSessionTests.swift; sourceTree = "<group>"; };
+		0303BE0FCE992BD639CEFA4A /* DashboardContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContainerViewController.swift; sourceTree = "<group>"; };
 		0360570966EB35CEC6F76DFA /* FileUploadProgressObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadProgressObserverTests.swift; sourceTree = "<group>"; };
 		03CE7996615CA5C57CC97364 /* K5ResourcesApplicationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ResourcesApplicationViewModelTests.swift; sourceTree = "<group>"; };
 		03D85F5BFDC15EF2CE3C1B00 /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -1731,7 +1734,6 @@
 		2C8819470380CD018127AADA /* ht */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ht; path = ht.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		2CC98BEC46F5FCBCC5ED85DC /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2D3018A2A850C1B54ED3BF7C /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.stringsdict"; sourceTree = "<group>"; };
-		2D43448BB5B79EDB6E16AE99 /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		2D6E49C0D49B041ACF4C5C07 /* FileSubmissionPreparation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSubmissionPreparation.swift; sourceTree = "<group>"; };
 		2E16677AE71E7A605D60C693 /* CourseDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseDetailsViewModel.swift; sourceTree = "<group>"; };
 		2E631CAA2C0C52B6D9FD3BDB /* es */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = es; path = es.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -1868,6 +1870,7 @@
 		4283F7620B3E6681A083F7B0 /* SyllabusEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyllabusEditorViewTests.swift; sourceTree = "<group>"; };
 		428C87C9B22A498638AABB58 /* DateExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateExtensions.swift; sourceTree = "<group>"; };
 		42A83CDE4BD96A8B66274F40 /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		42C757CFAFA99B487EB16DAD /* CGFloatExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatExtensionsTests.swift; sourceTree = "<group>"; };
 		42ED5F8D451890FE9CD85525 /* WrongAppViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WrongAppViewController.swift; sourceTree = "<group>"; };
 		42FBCF7BBB9A39DF0D23F928 /* PushNotificationErrorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationErrorTests.swift; sourceTree = "<group>"; };
 		4384A8CE204434E93A84C5E6 /* APIAssignmentList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIAssignmentList.swift; sourceTree = "<group>"; };
@@ -1943,6 +1946,7 @@
 		4CE169C6808A11C89C825E2E /* en-GB-instukhe */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-GB-instukhe"; path = "en-GB-instukhe.lproj/Main.strings"; sourceTree = "<group>"; };
 		4D163E504E7D08BC71EFA875 /* BackgroundSessionCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundSessionCompletionTests.swift; sourceTree = "<group>"; };
 		4D196EEA4A84A622D64A9DBF /* DiscussionReplyViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = DiscussionReplyViewController.storyboard; sourceTree = "<group>"; };
+		4D8F68F1482BC9797395B3D4 /* UIButtonExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIButtonExtensionTests.swift; sourceTree = "<group>"; };
 		4DBC6D5D2FBE72049B943C68 /* APIPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIPageTests.swift; sourceTree = "<group>"; };
 		4DC8F574F2D106A97A2EA7AD /* PageViewEventRequestManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewEventRequestManager.swift; sourceTree = "<group>"; };
 		4DE5E625618CE2A35186A3E3 /* TabBarMessageCountUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarMessageCountUpdaterTests.swift; sourceTree = "<group>"; };
@@ -1997,6 +2001,7 @@
 		55CCEDA5081E0D1AA08D7521 /* MenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuItems.swift; sourceTree = "<group>"; };
 		55D57D259BE94EEEA3ACE3C3 /* CreatePlannerNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePlannerNote.swift; sourceTree = "<group>"; };
 		562A0E1BA178E4D5780B67CD /* TypeSafeCodableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypeSafeCodableTests.swift; sourceTree = "<group>"; };
+		56EAF3D66B717B437D1E6F24 /* UIBarButtonItemExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensionsTests.swift; sourceTree = "<group>"; };
 		5713B03BE07999452D03B373 /* FlowStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowStack.swift; sourceTree = "<group>"; };
 		5716235AA7FDC7F8B2F01693 /* GetBrandVariablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetBrandVariablesTests.swift; sourceTree = "<group>"; };
 		5732F69BA2C53A23F2ADEF8F /* InboxViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxViewModel.swift; sourceTree = "<group>"; };
@@ -2231,6 +2236,7 @@
 		79E5E16BAF5752430FE95C22 /* NSErrorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSErrorExtensionsTests.swift; sourceTree = "<group>"; };
 		79ED41813910F1C973820502 /* APIEnrollmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEnrollmentTests.swift; sourceTree = "<group>"; };
 		79F06164E46550F7E51ABEAB /* GradeListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeListViewController.swift; sourceTree = "<group>"; };
+		7A4E9AE175537DC19E2BB239 /* CGFloatExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGFloatExtensions.swift; sourceTree = "<group>"; };
 		7A6A330243F43EF775C5CFD9 /* DocViewerPointAnnotationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerPointAnnotationTests.swift; sourceTree = "<group>"; };
 		7A7D0E388C0B114CEC3EFC24 /* K5ScheduleSubjectViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleSubjectViewModel.swift; sourceTree = "<group>"; };
 		7A97D0929500AD77E0224CC4 /* UploadFileComment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadFileComment.swift; sourceTree = "<group>"; };
@@ -2734,10 +2740,8 @@
 		CED26037996232D09E927A44 /* UIViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		CEF674B8F3F06D48AB2654C8 /* CourseListInteractorPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListInteractorPreview.swift; sourceTree = "<group>"; };
 		CF3B1A2B2EEDE4847384B3ED /* NSAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedString.swift; sourceTree = "<group>"; };
-		CF5CE3A529AE0EFD009053F3 /* DashboardContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContainerViewController.swift; sourceTree = "<group>"; };
 		CF76AA92A0745A9D16189BB8 /* GetDiscussionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDiscussionsTests.swift; sourceTree = "<group>"; };
 		CFAD2AE1CF6B4872E30170B5 /* FileEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditorViewTests.swift; sourceTree = "<group>"; };
-		CFF6CDA729B778B6006F451D /* UIBarButtonItemExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemExtensionsTests.swift; sourceTree = "<group>"; };
 		D071B9DCC3B9E16B1BEEFF35 /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D0795F7FD2E35FF931C3CEAD /* lato_black.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = lato_black.ttf; sourceTree = "<group>"; };
 		D08DFC503F7F8CBD23CB14B4 /* UITableViewHeaderFooterViewExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITableViewHeaderFooterViewExtensionsTests.swift; sourceTree = "<group>"; };
@@ -3804,6 +3808,7 @@
 			children = (
 				995AF66A8B5294FE7C37C54A /* ArrayExtensions.swift */,
 				77BB4861F6D63A7999F2B4A8 /* BundleExtensions.swift */,
+				7A4E9AE175537DC19E2BB239 /* CGFloatExtensions.swift */,
 				A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */,
 				775FA270908C6D93252CA678 /* ColorExtensions.swift */,
 				428C87C9B22A498638AABB58 /* DateExtensions.swift */,
@@ -6511,6 +6516,7 @@
 			children = (
 				B7B64C2C2D7F4C1B01FFCF42 /* Fixtures */,
 				4868EC4DA4B9B6C399990840 /* BundleExtensionsTests.swift */,
+				42C757CFAFA99B487EB16DAD /* CGFloatExtensionsTests.swift */,
 				69372FB53A07816565DD6E3C /* DateExtensionsTests.swift */,
 				935C6F219C3293285371C59E /* DispatchExtensionsTests.swift */,
 				C353E452D9DAAD387F504FBF /* FontExtensionTests.swift */,
@@ -6529,8 +6535,8 @@
 				A0BBA522B270D3DFAECD7142 /* SwiftUIExtensionsTests.swift */,
 				91D33F4B4C39D3F8136047FF /* TransactionExtensionTests.swift */,
 				70946E2F8572F3F35F328CEE /* UIApplicationDelegateExtensionTests.swift */,
-				CFF6CDA729B778B6006F451D /* UIBarButtonItemExtensionsTests.swift */,
-				2D43448BB5B79EDB6E16AE99 /* UIButtonExtensionTests.swift */,
+				56EAF3D66B717B437D1E6F24 /* UIBarButtonItemExtensionsTests.swift */,
+				4D8F68F1482BC9797395B3D4 /* UIButtonExtensionTests.swift */,
 				D4B0BEAD4AEE19256C2F3E8F /* UICollectionViewExtensionsTests.swift */,
 				E1E976A0DF72FDEBB510B418 /* UIColorExtensionsTests.swift */,
 				D28C5442AE5762F62033B501 /* UIFontExtensionsTests.swift */,
@@ -6779,7 +6785,7 @@
 				4004B65E8D9D50E2360818F0 /* CourseInvitationCard.swift */,
 				AA48E5A15FEE12B8EA2B4A3F /* CustomizeCourseView.swift */,
 				684C8ED5F41CF838AF7ECC7B /* DashboardCardView.swift */,
-				CF5CE3A529AE0EFD009053F3 /* DashboardContainerViewController.swift */,
+				0303BE0FCE992BD639CEFA4A /* DashboardContainerViewController.swift */,
 				1C05317CCF442A7CCF842F47 /* DashboardGrid.swift */,
 				123357F799E9B3D659FB8D75 /* DashboardSettingsView.swift */,
 				6AC4CC235B2F8EFCDDA0156F /* FileUploadNotificationCard.swift */,
@@ -7513,7 +7519,6 @@
 				AFD67D63B8A754EE23636870 /* APIPlannableTests.swift in Sources */,
 				C709B820F30042646163E6DF /* APIPostPolicyInfoTests.swift in Sources */,
 				A7F6B9D7E21707B5C3316894 /* APIQuizTests.swift in Sources */,
-				CFF6CDA829B778B6006F451D /* UIBarButtonItemExtensionsTests.swift in Sources */,
 				D7258E79BE6A2C08C8B09EB3 /* APIRequestableTests.swift in Sources */,
 				E886A9FBD9377D6C439C6B81 /* APISearchRecipientsTests.swift in Sources */,
 				DA9DFE454859799465B4AEA9 /* APISubmissionTests.swift in Sources */,
@@ -7559,6 +7564,7 @@
 				0948878740C9C9E92F870058 /* BottomSheetPickerViewControllerTests.swift in Sources */,
 				6CCDF3C7162AABC016149CC5 /* BrandTests.swift in Sources */,
 				46C82F85D716900838D9AF24 /* BundleExtensionsTests.swift in Sources */,
+				B9444E1C8AD29E2F6C887540 /* CGFloatExtensionsTests.swift in Sources */,
 				8F5220A029A069D2BA513E02 /* CacheManagerTests.swift in Sources */,
 				B9E87F64AEBE05EF9B41E26E /* CalendarDayIconViewTests.swift in Sources */,
 				5197C59BB41BCF6A23649A38 /* CalendarDaysViewControllerTests.swift in Sources */,
@@ -7910,7 +7916,8 @@
 				304585FFAF87E0963AC01B1A /* TypeSafeCodableTests.swift in Sources */,
 				876855987DD2F81A32204ED6 /* UIAccessibilityAnnouncementTests.swift in Sources */,
 				12768DE1B5D36EBB16F7FFDA /* UIApplicationDelegateExtensionTests.swift in Sources */,
-				0563DE0A322485BB292457FE /* UIButtonExtensionTests.swift in Sources */,
+				6AC07507B246CE3B8812024A /* UIBarButtonItemExtensionsTests.swift in Sources */,
+				89DCD799B8FE9A6665C45CC8 /* UIButtonExtensionTests.swift in Sources */,
 				13FEFB92FC536C3052636713 /* UICollectionViewExtensionsTests.swift in Sources */,
 				A40977BAAAEA83EC24CF5D5F /* UIColorExtensionsTests.swift in Sources */,
 				2A86F529C7788329407AB888 /* UIFontExtensionsTests.swift in Sources */,
@@ -8076,6 +8083,7 @@
 				34315163771A99BB22748631 /* Bounds.swift in Sources */,
 				1CC61E3817A7FBADF5288AB5 /* Brand.swift in Sources */,
 				0C5177CB965D53E3CE545031 /* BundleExtensions.swift in Sources */,
+				C3A2098297616AEE8CBC55CA /* CGFloatExtensions.swift in Sources */,
 				E3B56207EB13EB0C58615656 /* CacheManager.swift in Sources */,
 				2087D8AB89343D4CE2ED6EE7 /* CalendarDayIconView.swift in Sources */,
 				024704F565C61DECF256418E /* CalendarDaysViewController.swift in Sources */,
@@ -8155,7 +8163,6 @@
 				D8283172E7428154135B5FB4 /* CourseSectionStatus.swift in Sources */,
 				C9139B41E63986BD683531F8 /* CourseSettingsView.swift in Sources */,
 				A8A8A93DE637ABB16758B5E2 /* CourseSettingsViewModel.swift in Sources */,
-				CF5CE3A629AE0EFD009053F3 /* DashboardContainerViewController.swift in Sources */,
 				BBF7387BD0DC0EE94DDE8190 /* CreateConversation.swift in Sources */,
 				AA83EE551264437D8544C621 /* CreatePlannerNote.swift in Sources */,
 				2954539C4875336BDCF4DC2A /* CreateTextComment.swift in Sources */,
@@ -8167,6 +8174,7 @@
 				3E4CBD0BDF51890BF630FE86 /* DashboardCardView.swift in Sources */,
 				798C7DDE16B49FBE15D18C66 /* DashboardCardsViewModel.swift in Sources */,
 				835B304EB8979C9F680C3849 /* DashboardConferencesViewModel.swift in Sources */,
+				6BCBC9F0F0222BF0D933CA9E /* DashboardContainerViewController.swift in Sources */,
 				0A55C2E484E06BA3ABD32870 /* DashboardGrid.swift in Sources */,
 				1AEB7D1F3EF755C2EAEB0CE4 /* DashboardInvitationAPIItem.swift in Sources */,
 				3B4500ACF5B30E813D4074B4 /* DashboardInvitationName.swift in Sources */,

--- a/Core/Core.xcodeproj/xcshareddata/xcschemes/Core.xcscheme
+++ b/Core/Core.xcodeproj/xcshareddata/xcschemes/Core.xcscheme
@@ -4,7 +4,8 @@
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -26,7 +27,14 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:../TestPlans/CoreTests.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -36,12 +44,6 @@
             ReferencedContainer = "container:Core.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <TestPlans>
-         <TestPlanReference
-            reference = "container:../TestPlans/CoreTests.xctestplan"
-            default = "YES">
-         </TestPlanReference>
-      </TestPlans>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -64,6 +66,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
@@ -19,9 +19,9 @@
 import SwiftUI
 
 public struct CourseDetailsCellView: View {
-
     @Environment(\.appEnvironment) private var env
     @Environment(\.viewController) private var controller
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @ObservedObject private var viewModel: CourseDetailsCellViewModel
 
@@ -30,13 +30,11 @@ public struct CourseDetailsCellView: View {
     }
 
     public var body: some View {
-        Button(action: {
+        Button {
             viewModel.selected(router: env.router, viewController: controller)
-        }, label: {
+        } label: {
             HStack(spacing: 12) {
-                Image(uiImage: viewModel.iconImage)
-                    .frame(width: 20, height: 20)
-                    .foregroundColor(Color(viewModel.courseColor))
+                leadingIcon
                 VStack(alignment: .leading) {
                     Text(viewModel.label)
                         .font(.semibold16)
@@ -55,13 +53,26 @@ public struct CourseDetailsCellView: View {
             .padding(.horizontal, 16)
             .fixedSize(horizontal: false, vertical: true)
             .contentShape(Rectangle())
-            .frame(height: 54)
-        })
+            .frame(minHeight: 54)
+        }
         .buttonStyle(ContextButton(contextColor: viewModel.courseColor, isHighlighted: viewModel.isHighlighted))
         .accessibility(identifier: viewModel.a11yIdentifier)
         .accessibility(addTraits: viewModel.isHighlighted ? .isSelected : [])
         .alert(isPresented: $viewModel.showGenericError) {
             Alert(title: Text("Something went wrong", bundle: .core), message: Text("There was an error while communicating with the server", bundle: .core))
+        }
+    }
+
+    @ViewBuilder
+    private var leadingIcon: some View {
+        // We hide the leading icon on the last two dynamic sizes.
+        // At this scale the text hardly fits into the iPhone SE width
+        // so we free up some space by not displaying the icon.
+        if dynamicTypeSize != .accessibility4,
+            dynamicTypeSize != .accessibility5 {
+            Image(uiImage: viewModel.iconImage)
+                .frame(width: 20, height: 20)
+                .foregroundColor(Color(viewModel.courseColor))
         }
     }
 
@@ -115,14 +126,18 @@ struct CourseDetailsCellView_Previews: PreviewProvider {
     }
 
     static var previews: some View {
-        CourseDetailsCellView(viewModel: StudentViewCellViewModel(course: Course.save(.make(), in: context)))
-            .previewLayout(.sizeThatFits)
-        CourseDetailsCellView(viewModel: defaultButtonViewModel)
-            .previewLayout(.sizeThatFits)
-        CourseDetailsCellView(viewModel: attendanceButtonViewModel)
-            .previewLayout(.sizeThatFits)
-        CourseDetailsCellView(viewModel: loadingButtonViewModel)
-            .previewLayout(.sizeThatFits)
+        VStack(spacing: 0) {
+            Divider()
+            CourseDetailsCellView(viewModel: StudentViewCellViewModel(course: Course.save(.make(), in: context)))
+            Divider()
+            CourseDetailsCellView(viewModel: defaultButtonViewModel)
+            Divider()
+            CourseDetailsCellView(viewModel: attendanceButtonViewModel)
+            Divider()
+            CourseDetailsCellView(viewModel: loadingButtonViewModel)
+            Divider()
+        }
+        .previewLayout(.sizeThatFits)
     }
 }
 

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
@@ -21,7 +21,7 @@ import SwiftUI
 public struct CourseDetailsCellView: View {
     @Environment(\.appEnvironment) private var env
     @Environment(\.viewController) private var controller
-    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+    @ScaledMetric private var uiScale: CGFloat = 1
 
     @ObservedObject private var viewModel: CourseDetailsCellViewModel
 
@@ -34,7 +34,11 @@ public struct CourseDetailsCellView: View {
             viewModel.selected(router: env.router, viewController: controller)
         } label: {
             HStack(spacing: 12) {
-                leadingIcon
+                Image(uiImage: viewModel.iconImage)
+                    .resizable()
+                    .frame(width: uiScale.iconScale * 20,
+                           height: uiScale.iconScale * 20)
+                    .foregroundColor(Color(viewModel.courseColor))
                 VStack(alignment: .leading) {
                     Text(viewModel.label)
                         .font(.semibold16)
@@ -64,19 +68,6 @@ public struct CourseDetailsCellView: View {
     }
 
     @ViewBuilder
-    private var leadingIcon: some View {
-        // We hide the leading icon on the last two dynamic sizes.
-        // At this scale the text hardly fits into the iPhone SE width
-        // so we free up some space by not displaying the icon.
-        if dynamicTypeSize != .accessibility4,
-            dynamicTypeSize != .accessibility5 {
-            Image(uiImage: viewModel.iconImage)
-                .frame(width: 20, height: 20)
-                .foregroundColor(Color(viewModel.courseColor))
-        }
-    }
-
-    @ViewBuilder
     private var accessoryIcon: some View {
         switch viewModel.accessoryIconType {
         case .disclosure:
@@ -85,14 +76,15 @@ public struct CourseDetailsCellView: View {
             Image.externalLinkLine
                 .resizable()
                 .scaledToFit()
-                .frame(width: 20, height: 20)
+                .frame(width: uiScale.iconScale * 20,
+                       height: uiScale.iconScale * 20)
                 .foregroundColor(.textDarkest)
         case .loading:
             ProgressView()
                 .progressViewStyle(
                     .indeterminateCircle(
-                        size: 20,
-                        lineWidth: 2
+                        size: uiScale.iconScale * 20,
+                        lineWidth: uiScale.iconScale * 2
                     )
                 )
         }

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsCellView.swift
@@ -43,14 +43,17 @@ public struct CourseDetailsCellView: View {
                     Text(viewModel.label)
                         .font(.semibold16)
                         .foregroundColor(.textDarkest)
+                        .lineLimit(1)
 
                     if let subTitle = viewModel.subtitle {
                         Text(subTitle)
                             .font(.regular14)
                             .foregroundColor(.textDark)
+                            .lineLimit(1)
                     }
                 }
-                Spacer()
+                .frame(maxWidth: .infinity, alignment: .leading)
+
                 accessoryIcon
             }
             .padding(.vertical, 13)

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsView.swift
@@ -68,11 +68,11 @@ public struct CourseDetailsView: View, ScreenViewTrackable {
 
     @ViewBuilder
     private var settingsButton: some View {
-        Button(action: {
+        Button {
             if let url = viewModel.settingsRoute {
                 env.router.route(to: url, from: controller, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             }
-        }) {
+        } label: {
             Image.settingsLine.foregroundColor(.textLightest)
         }
         .accessibility(label: Text("Edit course settings", bundle: .core))
@@ -80,12 +80,12 @@ public struct CourseDetailsView: View, ScreenViewTrackable {
 
     @ViewBuilder
     private var homeView: some View {
-        Button(action: {
+        Button {
             if let url = viewModel.homeRoute {
                 selectionViewModel.cellTapped(at: 0)
                 env.router.route(to: url, from: controller, options: .detail)
             }
-        }) {
+        } label: {
             HStack(spacing: 13) {
                 VStack(alignment: .leading, spacing: 3) {
                     Text(viewModel.homeLabel ?? "")
@@ -100,7 +100,7 @@ public struct CourseDetailsView: View, ScreenViewTrackable {
                 Spacer()
                 InstDisclosureIndicator()
             }
-            .frame(height: 76)
+            .frame(minHeight: 76)
             .padding(.horizontal, 16)
             .fixedSize(horizontal: false, vertical: true)
             .contentShape(Rectangle())

--- a/Core/Core/Extensions/CGFloatExtensions.swift
+++ b/Core/Core/Extensions/CGFloatExtensions.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2020-present  Instructure, Inc.
+// Copyright (C) 2023-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,27 +16,20 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import SwiftUI
+import Foundation
 
-public struct DisclosureIndicator: View {
-    public init() {}
+public extension CGFloat {
 
-    public var body: some View {
-        Image(systemName: "chevron.right")
-            .flipsForRightToLeftLayoutDirection(true)
-            .foregroundColor(.borderMedium)
-    }
-}
-
-public struct InstDisclosureIndicator: View {
-    @ScaledMetric private var uiScale: CGFloat = 1
-
-    public var body: some View {
-        Image.arrowOpenRightSolid
-            .resizable()
-            .scaledToFit()
-            .frame(width: uiScale.iconScale * 16,
-                   height: uiScale.iconScale * 16)
-            .foregroundColor(.textDark)
+    /**
+     This variable can be used to scale icons on the UI based on the dynamic type setting of the user.
+     Create an environment variable `@ScaledMetric private var uiScale: CGFloat = 1`
+     and multiply `uiScale.iconScale` with the width and height of the image.
+     */
+    var iconScale: CGFloat {
+        if self > 1 {
+            return 1 + 0.5 * (self - 1)
+        } else {
+            return self
+        }
     }
 }

--- a/Core/CoreTests/Extensions/CGFloatExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/CGFloatExtensionsTests.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2020-present  Instructure, Inc.
+// Copyright (C) 2023-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -16,27 +16,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import SwiftUI
+import Core
+import XCTest
 
-public struct DisclosureIndicator: View {
-    public init() {}
+class CGFloatExtensionsTests: XCTestCase {
 
-    public var body: some View {
-        Image(systemName: "chevron.right")
-            .flipsForRightToLeftLayoutDirection(true)
-            .foregroundColor(.borderMedium)
-    }
-}
-
-public struct InstDisclosureIndicator: View {
-    @ScaledMetric private var uiScale: CGFloat = 1
-
-    public var body: some View {
-        Image.arrowOpenRightSolid
-            .resizable()
-            .scaledToFit()
-            .frame(width: uiScale.iconScale * 16,
-                   height: uiScale.iconScale * 16)
-            .foregroundColor(.textDark)
+    func testIconScales() {
+        XCTAssertEqual((0.8 as CGFloat).iconScale, 0.8)
+        XCTAssertEqual(  (1 as CGFloat).iconScale, 1)
+        XCTAssertEqual((1.2 as CGFloat).iconScale, 1.1)
+        XCTAssertEqual(  (3 as CGFloat).iconScale, 2)
     }
 }


### PR DESCRIPTION
refs: MBL-16574
affects: Student, Teacher
release note: Fixed course details list layout on large accessibility sizes.

test plan:
- Set text accessibility size to the largest possible value.
- Go to course details.
- Cell contents shouldn't overlap.
- Cell icons should also scale with the text.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/226343360-d48216d8-682a-4fc5-aec7-56d3e8422b4d.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/226545083-2351195f-66ff-419a-a8a3-f6d30265c417.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Approve from product or not needed
