### PR TITLE
Module items with a "must view" requirements cause page to re-load

### DIFF
--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -259,6 +259,7 @@ extension ModuleListViewController: UITableViewDelegate {
             let viewController = MasteryPathViewController.create(masteryPath: masteryPath)
             viewController.delegate = self
             env.router.show(viewController, from: self)
+            return
         }
         guard let htmlURL = item.htmlURL else {
             tableView.deselectRow(at: indexPath, animated: true)


### PR DESCRIPTION
refs: MBL-16539
affects: Student, Teacher
release note: Fix viewed or marked module items reloading.
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
