### PR TITLE
Add error message to deleted files

### DIFF
--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -318,7 +318,7 @@ extension FileDetailsViewController: URLSessionDownloadDelegate {
 
     private func showFileNoLongerExistsDialog() {
         let alert = UIAlertController(title: NSLocalizedString("File No Longer Exists", comment: ""),
-                                      message: NSLocalizedString("The file have been deleted by its author.", comment: ""),
+                                      message: NSLocalizedString("The file has been deleted by the author.", comment: ""),
                                       preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: NSLocalizedString("Close", comment: ""),
                                       style: .default,

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -253,6 +253,8 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
     }
 }
 
+// MARK: - URLSessionDownloadDelegate
+
 extension FileDetailsViewController: URLSessionDownloadDelegate {
     /// This must be called to set `localURL` before initiating download, otherwise there
     /// will be a threading issue with trying to access core data from a different thread.
@@ -284,11 +286,17 @@ extension FileDetailsViewController: URLSessionDownloadDelegate {
     public func urlSession(_ session: URLSession, downloadTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard let localURL = localURL else { return }
         if let status = (downloadTask.response as? HTTPURLResponse)?.statusCode, status >= 400 {
-            return showError(APIError.from(
-                data: try? Data(contentsOf: location),
-                response: downloadTask.response,
-                error: NSError.internalError()
-            ))
+            if status == 404 {
+                return performUIUpdate {
+                    self.showFileNoLongerExistsDialog()
+                }
+            } else {
+                return showError(APIError.from(
+                    data: try? Data(contentsOf: location),
+                    response: downloadTask.response,
+                    error: NSError.internalError()
+                ))
+            }
         }
         do {
             try FileManager.default.createDirectory(at: localURL.deletingLastPathComponent(), withIntermediateDirectories: true)
@@ -306,6 +314,18 @@ extension FileDetailsViewController: URLSessionDownloadDelegate {
         downloadTask = nil
         performUIUpdate { self.downloadComplete() }
         session.finishTasksAndInvalidate()
+    }
+
+    private func showFileNoLongerExistsDialog() {
+        let alert = UIAlertController(title: NSLocalizedString("File No Longer Exists", comment: ""),
+                                      message: NSLocalizedString("The file have been deleted by its author.", comment: ""),
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Close", comment: ""),
+                                      style: .default,
+                                      handler: { [env] _ in
+            env.router.dismiss(self)
+        }))
+        env.router.show(alert, from: self, options: .modal())
     }
 
     func downloadComplete() {


### PR DESCRIPTION
refs: MBL-16582
affects: Student, Teacher
release note: none

test plan:
- In the teacher app add a file as a comment in the SpeedGrader, then delete it.
- Open student app and go to the comment in submission & rubric.
- Tap on the deleted file.
- An appropriate error message should be displayed.
- Tapping close should dismiss the file dialog.
- The same should happen if you tap on the deleted file in SpeedGrader in the teacher app.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/227218215-49aa9386-9876-4c21-a1e3-734f93527b0e.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/227535687-3d565df2-7826-4bc5-a062-ac5a87c5d330.png" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/227519393-661e85bd-d944-4c7d-90dd-dcf265856770.PNG" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/227519437-6edcb0e1-2509-4889-a9a8-2341f6209c0f.PNG" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
- [ ] Approve from product or not needed
