### PR TITLE
Show Acceptable Use Policy (AUP) when needed

### DIFF
--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -90,7 +90,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
             self?.update()
             return true
         }
-
+        NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: 0, viewController: self)
     }
 
@@ -99,6 +99,12 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         navigationController?.navigationBar.useContextColor(currentColor)
         navigationController?.setNavigationBarHidden(true, animated: true)
         updateBadge()
+        checkForPolicyChanges()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     @IBAction func showProfile() {
@@ -249,6 +255,12 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         let map = ["courses", "calendar", "alerts"]
         let event = map[tabIndex]
         Analytics.shared.logScreenView(route: "/tabs/" + event, viewController: viewController)
+    }
+
+    @objc private func checkForPolicyChanges() {
+        LoginUsePolicy.checkAcceptablePolicy(from: self, cancelled: {
+            AppEnvironment.shared.loginDelegate?.changeUser()
+        })
     }
 }
 


### PR DESCRIPTION
refs: MBL-16608
affects: Parent
release note: Added an acceptable use policy screen on login.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/79920680/227897087-e49a27a1-e353-4f7a-8ee5-9348aefe9919.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/79920680/227897083-1633dbb1-2c68-4dea-b989-8d04c00a1c73.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product or not needed
