### PR TITLE
Pull to refresh background is black when theme switched to light

### DIFF
--- a/Core/Core/CoreWebView/CoreWebView.swift
+++ b/Core/Core/CoreWebView/CoreWebView.swift
@@ -644,6 +644,7 @@ extension CoreWebView {
             buttonHeightConstraint.constant = buttonHeight
             buttonTopConstraint.constant = buttonTopPadding
             button.superview?.backgroundColor = .backgroundLightest.resolvedColor(with: traitCollection)
+            self.backgroundColor = .backgroundLightest.resolvedColor(with: traitCollection)
         }
 
         parent.addSubview(themeSwitcherButton)


### PR DESCRIPTION
refs: MBL-16616
affects: Student, Teacher, Parent
release note: none
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
