### PR TITLE
Navigation bar color mismatch on empty detail view presentation

### DIFF
--- a/Core/Core/UIViews/EmptyViewController.swift
+++ b/Core/Core/UIViews/EmptyViewController.swift
@@ -39,6 +39,13 @@ public class EmptyViewController: UIViewController {
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        navigationController?.navigationBar.useStyle(navBarStyle)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.1) {
+            if let parent = self.navigationController?.parent as? UISplitViewController {
+                self.navigationController?.navigationBar.useContextColor(parent.masterNavigationController?.navigationBar.barTintColor)
+                return
+            }
+            self.navigationController?.navigationBar.useStyle(self.navBarStyle)
+        }
+
     }
 }


### PR DESCRIPTION
refs: MBL-16595
affects: Student, Teacher
release note: none
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created or not needed
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product or not needed
