### PR TITLE
Add alert confirmation helper entity

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		1B16EB5E9FB5B32051FD8DA1 /* ContextCardSubmissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B06A2D9A9EE66CA8A535524 /* ContextCardSubmissionsView.swift */; };
 		1B1E10C907CEE77971005E1E /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 13FCF13DF2AC3D5312FA82A4 /* .swiftlint.yml */; };
 		1B5E29BACBB50B9412A0693A /* MasteryPathAssignmentSetDivider.xib in Resources */ = {isa = PBXBuildFile; fileRef = 46F4E1F07CFEFEF8A2746A7B /* MasteryPathAssignmentSetDivider.xib */; };
+		1C489F06FA56A379700B0A40 /* ConfirmationAlertTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A1DD933B64BC34037A8D1FE /* ConfirmationAlertTests.swift */; };
 		1C58EFADDFA7D805D2A9AA94 /* UINavigationBarExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F9E952584BDF03F6E83581C /* UINavigationBarExtensions.swift */; };
 		1C86551DAD4BF63B6FC66C51 /* GetEnabledFeatureFlagsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D794CE2E7BC135AA6E5339F8 /* GetEnabledFeatureFlagsRequest.swift */; };
 		1CC61E3817A7FBADF5288AB5 /* Brand.swift in Sources */ = {isa = PBXBuildFile; fileRef = C43FDEDEAEDE882A7AFD945B /* Brand.swift */; };
@@ -1042,6 +1043,7 @@
 		BE46BFD1F5718B24DB93E1BD /* K5ScheduleEntryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E878EFC35C189D70F1DFC9DF /* K5ScheduleEntryViewModel.swift */; };
 		BE4EEF28DD05562FA1C28E17 /* SyllabusEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6AEEC1557E35A07662148D0F /* SyllabusEditorView.swift */; };
 		BE5E0D6C957CFD38D0155952 /* APIUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B251A6BBCC60FFF431C150DB /* APIUserTests.swift */; };
+		BE775653CCB1EF925E263040 /* ConfirmationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FB1FDE58D78AC3EFFDB0B4 /* ConfirmationAlert.swift */; };
 		BE9A702335DF64FBAA00F4E9 /* CourseDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E16677AE71E7A605D60C693 /* CourseDetailsViewModel.swift */; };
 		BF0A0F8A10BFDD7A5C19A2F3 /* K5ScheduleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D134AC5D975BF3D9C35BF2F /* K5ScheduleViewModelTests.swift */; };
 		BF40752F66B259254CDB927B /* GetEnvironmentFeatureFlagsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 972FD90722B1C2E476D08896 /* GetEnvironmentFeatureFlagsRequest.swift */; };
@@ -2168,6 +2170,7 @@
 		69C6ACB2CA1DA0D6FD08615A /* APIRubric.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRubric.swift; sourceTree = "<group>"; };
 		69C89BCD841FB189E85707E4 /* ContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextCardViewModel.swift; sourceTree = "<group>"; };
 		6A015403E7E12F833B8AC139 /* GetContextTabsTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextTabsTest.swift; sourceTree = "<group>"; };
+		6A1DD933B64BC34037A8D1FE /* ConfirmationAlertTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationAlertTests.swift; sourceTree = "<group>"; };
 		6A79D4D221B7A3F93B0976DE /* K5HomeroomViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5HomeroomViewModel.swift; sourceTree = "<group>"; };
 		6A7DE15F8119BAC967AB03C5 /* Assignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Assignment.swift; sourceTree = "<group>"; };
 		6A938C507337C7A77C47494D /* ConversationParticipant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationParticipant.swift; sourceTree = "<group>"; };
@@ -2944,6 +2947,7 @@
 		E63874B22907E4203CE202A6 /* AboutViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewModelTests.swift; sourceTree = "<group>"; };
 		E660BA17A87F6B0D17FB705F /* CourseSectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSectionTests.swift; sourceTree = "<group>"; };
 		E6EF16BAD60332D4C5D28CC5 /* QuizListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizListViewController.swift; sourceTree = "<group>"; };
+		E6FB1FDE58D78AC3EFFDB0B4 /* ConfirmationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfirmationAlert.swift; sourceTree = "<group>"; };
 		E6FF50829E8BB2D64C2C9ABA /* UIWindowExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWindowExtensionsTests.swift; sourceTree = "<group>"; };
 		E743B7C668F7B90BAD0C2F3A /* DispatchExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchExtensions.swift; sourceTree = "<group>"; };
 		E7AA5BF16FB919BFCDB3012A /* ModuleSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModuleSectionHeaderView.swift; sourceTree = "<group>"; };
@@ -3503,13 +3507,8 @@
 		14697E76F8F51718E58190BB /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
-				865ED83B496E0494D0FED015 /* Conference */,
-				383794BF3768CC1E4E2DB4A3 /* Container */,
-				ECED178A8F83AF16F544B33C /* FileUploadNotification */,
-				E3EB3033F22BC365C756FC4D /* Group */,
 				201B925BB996E09FB13AB767 /* K5 */,
 				C639C71D6B46ADFA6667258B /* Model */,
-				A8F849A655FD5415D8446EC4 /* Notification */,
 				EBA47E010C805E39105B9650 /* View */,
 				F57519FF26ED087BEC448ACD /* ViewModel */,
 			);
@@ -4117,13 +4116,6 @@
 				1215A854CF74D536518C189E /* K5ImportantDatesViewModelTests.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		383794BF3768CC1E4E2DB4A3 /* Container */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Container;
 			sourceTree = "<group>";
 		};
 		38552DB3DCD210AB726DEAB0 /* FilePicker */ = {
@@ -5310,13 +5302,6 @@
 			path = View;
 			sourceTree = "<group>";
 		};
-		865ED83B496E0494D0FED015 /* Conference */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Conference;
-			sourceTree = "<group>";
-		};
 		867BFABBF8E7FD67BEFFD103 /* Enrollments */ = {
 			isa = PBXGroup;
 			children = (
@@ -6006,13 +5991,6 @@
 				38CD30A59D9B28E1A04AAA50 /* FileProgressListViewPreview.swift */,
 			);
 			path = PreviewSupport;
-			sourceTree = "<group>";
-		};
-		A8F849A655FD5415D8446EC4 /* Notification */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Notification;
 			sourceTree = "<group>";
 		};
 		A92C485891E28C558D198BAD /* WrongApp */ = {
@@ -6849,6 +6827,7 @@
 			children = (
 				19CD1263396ED2F33ECCC0E8 /* TopBar */,
 				DDF8CCBE68133D937B373DC0 /* UIKitSwiftUIBridging */,
+				6A1DD933B64BC34037A8D1FE /* ConfirmationAlertTests.swift */,
 				886BAEE04736A54ECA573A63 /* CoreDatePickerTests.swift */,
 			);
 			path = SwiftUIViews;
@@ -6867,6 +6846,7 @@
 				ADE954EF8FBBD8539E8E77D5 /* ViewPreferences */,
 				CE063D98DE947BC659237F40 /* AccessIcon.swift */,
 				A54E2246CD24105513606843 /* Avatar.swift */,
+				E6FB1FDE58D78AC3EFFDB0B4 /* ConfirmationAlert.swift */,
 				17B0ECD8F56A853C45B9BD5C /* CoreDatePicker.swift */,
 				B0BCCB262F87C6FE1D7BF597 /* CustomTextField.swift */,
 				89D71DB3F2B3442B2DC96672 /* DisclosureIndicator.swift */,
@@ -6894,13 +6874,6 @@
 			children = (
 				FD257763C9A330776EE6CCB7 /* GroupContextCardView.swift */,
 				39B71BCCFA0C836F3827FFEE /* GroupContextCardViewModel.swift */,
-			);
-			path = Group;
-			sourceTree = "<group>";
-		};
-		E3EB3033F22BC365C756FC4D /* Group */ = {
-			isa = PBXGroup;
-			children = (
 			);
 			path = Group;
 			sourceTree = "<group>";
@@ -7081,13 +7054,6 @@
 				38552DB3DCD210AB726DEAB0 /* FilePicker */,
 			);
 			path = View;
-			sourceTree = "<group>";
-		};
-		ECED178A8F83AF16F544B33C /* FileUploadNotification */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = FileUploadNotification;
 			sourceTree = "<group>";
 		};
 		ED3F6B3732277FB180EA1F29 /* AccountNotifications */ = {
@@ -7861,6 +7827,7 @@
 				82369D84C18C81A912A19D74 /* ConferenceDetailsViewControllerTests.swift in Sources */,
 				F706A3F72D00E7D1A99AF177 /* ConferenceListViewControllerTests.swift in Sources */,
 				0CDF4F1AF2B3F4CA5452B55B /* ConferenceTests.swift in Sources */,
+				1C489F06FA56A379700B0A40 /* ConfirmationAlertTests.swift in Sources */,
 				F3CD0D39C3A913A8EB75B502 /* ContextCardTests.swift in Sources */,
 				C4B7303D48105DF4CDE2F7CD /* ContextColorTests.swift in Sources */,
 				C5691F7595579E11558DD2C0 /* ContextModelTests.swift in Sources */,
@@ -8403,6 +8370,7 @@
 				CE4487612FDBB05A6D2E99DE /* ConferenceDetailsViewController.swift in Sources */,
 				3B59052943074795463524AF /* ConferenceListViewController.swift in Sources */,
 				CE643DC03312A0867F0F7AAD /* ConferencesPanda.swift in Sources */,
+				BE775653CCB1EF925E263040 /* ConfirmationAlert.swift in Sources */,
 				AACE1DB9A0F7899C1F61A990 /* Context.swift in Sources */,
 				2D74FDC97C1A0A7EFFFB0065 /* ContextButton.swift in Sources */,
 				07CD554C64FBEC1E80134BF4 /* ContextCardBoxView.swift in Sources */,

--- a/Core/Core/SwiftUIViews/ConfirmationAlert.swift
+++ b/Core/Core/SwiftUIViews/ConfirmationAlert.swift
@@ -1,0 +1,120 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import SwiftUI
+
+public struct ConfirmationAlertViewModel {
+    public let title: String
+    public let message: Text
+    public let cancelButtonTitle: String
+    public let confirmButtonTitle: String
+    public let confirmButtonRole: ButtonRole?
+    public let confirmDidTap = PassthroughSubject<Void, Never>()
+
+    public init(title: String,
+                message: String,
+                cancelButtonTitle: String,
+                confirmButtonTitle: String,
+                isDestructive: Bool = false) {
+        self.title = title
+        self.message = Text(message)
+        self.cancelButtonTitle = cancelButtonTitle
+        self.confirmButtonTitle = confirmButtonTitle
+        self.confirmButtonRole = isDestructive ? .destructive : nil
+    }
+}
+
+public extension View {
+    func confirmationAlert(isPresented: Binding<Bool>,
+                           presenting viewModel: ConfirmationAlertViewModel)
+    -> some View {
+        alertConfirmation(isPresented: isPresented, presenting: viewModel)
+    }
+
+    func alertConfirmation(isPresented: Binding<Bool>,
+                           presenting viewModel: ConfirmationAlertViewModel)
+    -> some View {
+        alert(
+            viewModel.title,
+            isPresented: isPresented,
+            actions: {
+                Button(viewModel.cancelButtonTitle,
+                       role: .cancel,
+                       action: {})
+                Button(viewModel.confirmButtonTitle,
+                       role: viewModel.confirmButtonRole,
+                       action: viewModel.confirmDidTap.send)
+            }, message: {
+                viewModel.message
+            })
+    }
+}
+
+#if DEBUG
+
+struct ConfirmationAlertPreview: PreviewProvider {
+
+    class ConfirmDemoViewModel: ObservableObject {
+        @Published var statusText = ""
+        @Published var isShowingConfirmationDialog = false
+        let confirmDialog = ConfirmationAlertViewModel(title: "Confirm Selection",
+                                                       message: "This action needs to be confirmed",
+                                                       cancelButtonTitle: "Not Now",
+                                                       confirmButtonTitle: "I Confirm",
+                                                       isDestructive: true)
+
+        public init() {
+            confirmDialog.confirmDidTap
+                .map { "Confirmed!" }
+                .assign(to: &$statusText)
+        }
+
+        func showDidTap() {
+            statusText = ""
+            isShowingConfirmationDialog = true
+        }
+    }
+
+    struct ConfirmDemoView: View {
+        @StateObject var viewModel = ConfirmDemoViewModel()
+
+        var body: some View {
+            ZStack {
+                VStack {
+                    Text(viewModel.statusText).frame(height: 20)
+                    Spacer()
+                    Button {
+                        viewModel.showDidTap()
+                    } label: {
+                        Text("Show dialog")
+                    }
+                    .alertConfirmation(isPresented: $viewModel.isShowingConfirmationDialog,
+                                       presenting: viewModel.confirmDialog)
+                    Spacer()
+                }
+            }
+        }
+    }
+
+    static var previews: some View {
+        ConfirmDemoView()
+    }
+}
+
+#endif

--- a/Core/CoreTests/SwiftUIViews/ConfirmationAlertTests.swift
+++ b/Core/CoreTests/SwiftUIViews/ConfirmationAlertTests.swift
@@ -1,0 +1,61 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import SwiftUI
+import XCTest
+
+class ConfirmationAlertTests: XCTestCase {
+
+    func testViewModelProperties() {
+        let testee = ConfirmationAlertViewModel(title: "testTitle",
+                                                message: "testMessage",
+                                                cancelButtonTitle: "testCancel",
+                                                confirmButtonTitle: "testConfirm")
+        XCTAssertEqual(testee.title, "testTitle")
+        XCTAssertEqual(testee.message, Text(verbatim: "testMessage"))
+        XCTAssertEqual(testee.cancelButtonTitle, "testCancel")
+        XCTAssertEqual(testee.confirmButtonTitle, "testConfirm")
+    }
+
+    func testDestructiveConfirmButtonRole() {
+        let testee = ConfirmationAlertViewModel(title: "",
+                                                message: "",
+                                                cancelButtonTitle: "",
+                                                confirmButtonTitle: "",
+                                                isDestructive: true)
+        XCTAssertEqual(testee.confirmButtonRole, .destructive)
+    }
+
+    func testNonDestructiveConfirmButtonRole() {
+        let testee = ConfirmationAlertViewModel(title: "",
+                                                message: "",
+                                                cancelButtonTitle: "",
+                                                confirmButtonTitle: "",
+                                                isDestructive: false)
+        XCTAssertNil(testee.confirmButtonRole)
+    }
+
+    func testDefaultDestructiveParamBeingNonDestructive() {
+        let testee = ConfirmationAlertViewModel(title: "",
+                                                message: "",
+                                                cancelButtonTitle: "",
+                                                confirmButtonTitle: "")
+        XCTAssertNil(testee.confirmButtonRole)
+    }
+}


### PR DESCRIPTION
This PR adds some helpers to present confirmation dialogs which we will use in the offline mode UI. I also ran `make gen` to update the project file.

refs: MBL-16648
affects: none
release note: none

test plan: Check out the branch and play with the preview.

## Demo

https://user-images.githubusercontent.com/72396990/232091126-d5938871-647e-4dc4-809b-75404445c9d0.mov

