### PR TITLE
Update router to always try to open urls from push notifications natively

### DIFF
--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -159,7 +159,7 @@ open class Router {
     open func route(to url: URLComponents, userInfo: [String: Any]? = nil, from: UIViewController, options: RouteOptions = DefaultRouteOptions) {
         let url = cleanURL(url)
 
-        if url.isExternalWebsite, let url = url.url {
+        if url.isExternalWebsite, !url.originIsNotification, let url = url.url {
             Analytics.shared.logScreenView(route: "/external_url")
             AppEnvironment.shared.loginDelegate?.openExternalURL(url)
             return

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -484,6 +484,25 @@ class RouterTests: CoreTestCase {
         testee.route(to: externalURL, from: mockViewController)
 
         XCTAssertEqual(login.externalURL?.absoluteURL, URL(string: "https://example.com/courses")!)
+        XCTAssertNil(mockViewController.shown)
+    }
+
+    func testExternalURLsFromPushOpenedNatively() {
+        AppEnvironment.shared.currentSession = LoginSession(baseURL: URL(string: "https://canvas.com")!,
+                                                            userID: "",
+                                                            userName: "")
+        let mockViewController = MockViewController()
+        var externalURLComponents = URLComponents(string: "https://example.com/courses")!
+        externalURLComponents.originIsNotification = true
+        let externalURL = externalURLComponents.url!
+        let testee = Router(routes: [
+            RouteHandler("/courses") { _, _, _ in UIViewController() },
+        ])
+
+        testee.route(to: externalURL, from: mockViewController)
+
+        XCTAssertNil(login.externalURL)
+        XCTAssertNotNil(mockViewController.shown)
     }
 
     func testExternalWebsitePopupReportedToAnalytics() {


### PR DESCRIPTION
refs: MBL-16663
affects: Student, Teacher, Parent
release note: Fixed push notifications not opening screens inside the app for institutes with multiple domains.

test plan: See ticket.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
