### PR TITLE
Update file annotation toolbar icon color for better readability

### DIFF
--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -445,10 +445,15 @@ extension FileDetailsViewController: PDFViewControllerDelegate {
             builder.overrideClass(AnnotationToolbar.self, with: AnnotationToolbar.self)
         })
         controller.annotationToolbarController?.toolbar.toolbarPosition = .left
+
         let appearance = UIToolbarAppearance()
         appearance.configureWithOpaqueBackground()
         appearance.backgroundColor = navigationController?.navigationBar.barTintColor
         controller.annotationToolbarController?.toolbar.standardAppearance = appearance
+
+        let annotationToolbarProxy = AnnotationToolbar.appearance()
+        annotationToolbarProxy.tintColor = navigationController?.navigationBar.tintColor
+
         controller.delegate = self
         embed(controller, in: contentView)
         addPDFAnnotationChangeNotifications()


### PR DESCRIPTION
refs: MBL-16662
affects: Student, Teacher
release note: Updated file annotation toolbar icon color for better readability.

test plan:
- Open a pdf file. The easiest is to find/add one in the Files menu in the hamburger menu.
- Turn on editing mode in the navigation bar.
- Observe annotation toolbar icon color.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/233679068-622d5152-02be-463f-82cb-a702cb28cc48.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/233679083-e5b0d998-9318-447e-80d6-56bc1f3f859a.png" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/233679101-d17fa0aa-96ad-4b8b-8a78-4d317df56568.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/233679118-c39fb9cd-0f0e-4eaf-b12c-120f461751e6.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
