### PR TITLE
Remove tableview header and footer re-set to avoid infinite cycle.

### DIFF
--- a/Core/Core/UIViews/ListBackgroundView.swift
+++ b/Core/Core/UIViews/ListBackgroundView.swift
@@ -34,9 +34,7 @@ public class ListBackgroundView: UIView {
         } else {
             frame.size.height = tableView.frame.height - tableView.adjustedContentInset.top - frame.minY
         }
-        // tableView caches the size of the header & footer views, this busts the cache
-        if tableView.tableHeaderView == self { tableView.tableHeaderView = self }
-        if tableView.tableFooterView == self { tableView.tableFooterView = self }
+
         super.layoutSubviews()
     }
 }


### PR DESCRIPTION
This change removes a hack from ListBackgroundView that causes an infinite layout cycle in some cases. This view is used on a lot of other places in the app so I marked all apps as affected. When testing please also take a look on these pages if the layout is still ok.

- Conferences
- Announcements
- Discussions
- Files
- Grades
- Modules
- Pages
- Peoples
- Calendar Filter
- Quizzes
- ToDos
- CourseList
- Students (parent app only)
- Alerts (parent app only)
- Submissions (teacher app only)

refs: MBL-16703
affects: Student, Teacher, Parent
release note: Fixed a crash on app start when landing page is set to the ToDo tab.

test plan:
- Use an iPhone with notch and iOS 16.
- Start the teacher app.
- Set the landing page to the ToDo tab.
- Restart the app.
- Check layout on affected pages.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet