### PR TITLE
Update file upload API for self-hosted institutions

### DIFF
--- a/Core/Core/API/API.swift
+++ b/Core/Core/API/API.swift
@@ -60,7 +60,7 @@ public class API {
 
                 // If the request is rejected due to the rate limit being exhausted we retry and hope that the quota is restored in the meantime
                 if response?.exceededLimit(responseData: data) == true {
-                    DispatchQueue.main.async {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(1)) {
                         self?.makeRequest(requestable, callback: callback)
                     }
                     return

--- a/Core/CoreTests/API/APITests.swift
+++ b/Core/CoreTests/API/APITests.swift
@@ -373,10 +373,10 @@ class APITests: XCTestCase {
             XCTAssertEqual((response as? HTTPURLResponse)?.statusCode, 200)
             responseExpectation.fulfill()
         }
-        RunLoop.main.run(until: Date())
+        RunLoop.main.run(until: Date() + 0.1)
 
         let normalResponse = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
         api.mock(url, data: nil, response: normalResponse, error: nil)
-        wait(for: [responseExpectation], timeout: 0.5)
+        wait(for: [responseExpectation], timeout: 1)
     }
 }

--- a/rn/Teacher/src/canvas-api/apis/file-uploads.js
+++ b/rn/Teacher/src/canvas-api/apis/file-uploads.js
@@ -73,7 +73,7 @@ async function postFile (uri: string, target: UploadTarget, options: UploadOptio
   formdata.append('file', {
     uri,
     type: 'multipart/form-data',
-    name: upload_params['filename'] || '',
+    name: upload_params['filename'] || upload_params['Filename'] || '',
   })
 
   const uploading = httpClient.post(upload_url, formdata, {


### PR DESCRIPTION
- Update file upload API to work with uppercase parameter name in file upload target response.
- Increase rate-limit timeout to avoid API requests being retried in an infinite cycle.

refs: MBL-16697
affects: Student, Teacher
release note: Fixed Inbox attachments not uploaded correctly on some self-hosted instances.

test plan: Test if file attachments from inbox upload correctly on the account in the ticket and on a regular canvas-hosted account.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
