### PR TITLE
Update grade display logic to display the score when there are no points possible

### DIFF
--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -99,11 +99,15 @@ public class GradeCircleView: UIView {
         circleComplete.isHidden = !isPassFail
 
         // Update grade circle
-        if let score = submission.score, let pointsPossible = assignment.pointsPossible {
+        if let score = submission.score {
             circlePoints.text = NumberFormatter.localizedString(from: NSNumber(value: score), number: .decimal)
-            gradeCircle.progress = CGFloat(score / pointsPossible)
 
-            gradeCircle.accessibilityLabel = assignment.scoreOutOfPointsPossibleText
+            if let pointsPossible = assignment.pointsPossible {
+                gradeCircle.progress = CGFloat(score / pointsPossible)
+                gradeCircle.accessibilityLabel = assignment.scoreOutOfPointsPossibleText
+            } else {
+                gradeCircle.accessibilityLabel = "\(score) \(assignment.pointsText ?? "")"
+            }
         }
 
         circleLabel.text = assignment.pointsText

--- a/Core/CoreTests/UIViews/GradeCircleViewTests.swift
+++ b/Core/CoreTests/UIViews/GradeCircleViewTests.swift
@@ -170,4 +170,23 @@ class GradeCircleViewTests: XCTestCase {
         XCTAssertFalse(view.displayGrade.isHidden)
         XCTAssertEqual(view.displayGrade.text, "Excused")
     }
+
+    func testItRendersScoreWhenNoPointsIsPossible() {
+        let a = Assignment.make(from: .make(grading_type: .points,
+                                            points_possible: nil,
+                                            submission: .make(grade: "77",
+                                                              score: 77,
+                                                              workflow_state: .graded)
+        ))
+        view.update(a)
+        XCTAssertFalse(view.isHidden)
+        XCTAssertFalse(view.circlePoints.isHidden)
+        XCTAssertEqual(view.circlePoints.text, "77")
+        XCTAssertFalse(view.circleLabel.isHidden)
+        XCTAssertTrue(view.circleComplete.isHidden)
+        XCTAssertEqual(view.gradeCircle?.progress, 1)
+        XCTAssertEqual(view.gradeCircle?.accessibilityLabel, "77.0 Points")
+        XCTAssertTrue(view.displayGrade.isHidden)
+        XCTAssertEqual(view.displayGrade.text, "77")
+    }
 }


### PR DESCRIPTION
refs: MBL-16715
affects: Student
release note: Fixed 89 points being displayed for assignments without any points possible no matter what the submission's score was.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://user-images.githubusercontent.com/72396990/236865926-06f4bf93-dbb1-4fad-ad5e-7762edfc3440.png" maxHeight=500></td>
<td><img src="https://user-images.githubusercontent.com/72396990/236865943-672a26a3-b62a-4768-af4f-4c705dc473ab.png" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet