### PR TITLE
Remove the usage of the test keychain.

### DIFF
--- a/Core/Core/AppEnvironment/Keychain.swift
+++ b/Core/Core/AppEnvironment/Keychain.swift
@@ -21,7 +21,7 @@ import Foundation
 public class Keychain {
     private let serviceName: String
     private let accessGroup: String?
-    public static var app = Keychain(serviceName: "com.instructure.shared-credentials", accessGroup: Bundle.main.appGroupID())
+    public static let app = Keychain(serviceName: "com.instructure.shared-credentials", accessGroup: Bundle.main.appGroupID())
     public static var shared = Keychain(serviceName: "com.instructure.shared-credentials", accessGroup: "group.instructure.shared")
 
     init(serviceName: String = Bundle.main.bundleIdentifier ?? "com.instructure.general-purpose-keychain", accessGroup: String? = nil) {

--- a/Core/Core/UITestHelpers/UITestHelpers.swift
+++ b/Core/Core/UITestHelpers/UITestHelpers.swift
@@ -115,7 +115,6 @@ public class UITestHelpers {
         self.appDelegate = appDelegate
         self.window = appDelegate.window as? ActAsUserWindow
 
-        Keychain.app = Keychain(serviceName: "com.instructure.shared-credentials.tests")
         CacheManager.clear()
         UserDefaults.standard.set(true, forKey: "IS_UI_TEST")
         if let portName = ProcessInfo.processInfo.environment["APP_IPC_PORT_NAME"] {

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -54,7 +54,7 @@ class CoreTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         API.resetMocks()
-        LoginSession.useTestKeychain()
+        LoginSession.clearAll()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
         router = environment.router as? TestRouter
         logger = environment.logger as? TestLogger

--- a/Student/StudentUnitTests/StudentTestCase.swift
+++ b/Student/StudentUnitTests/StudentTestCase.swift
@@ -42,7 +42,7 @@ class StudentTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         API.resetMocks()
-        LoginSession.useTestKeychain()
+        LoginSession.clearAll()
         queue = OperationQueue()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
         env = TestEnvironment()

--- a/TestsFoundation/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
+++ b/TestsFoundation/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
@@ -50,9 +50,4 @@ extension LoginSession {
             clientSecret: clientSecret
         )
     }
-
-    public static func useTestKeychain() {
-        Keychain.app = Keychain(serviceName: "com.instructure.shared-credentials.tests")
-        clearAll()
-    }
 }

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -95,7 +95,7 @@ open class CoreUITestCase: XCTestCase {
     public var doLoginAfterSetup: Bool = true
     open override func setUp() {
         super.setUp()
-        LoginSession.useTestKeychain()
+        LoginSession.clearAll()
         continueAfterFailure = false
         if CoreUITestCase.needsLaunch || app.state != .runningForeground || isRetry {
             CoreUITestCase.needsLaunch = false

--- a/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
+++ b/rn/Teacher/ios/TeacherTests/TeacherTestCase.swift
@@ -41,7 +41,7 @@ class TeacherTestCase: XCTestCase {
     override func setUp() {
         super.setUp()
         API.resetMocks()
-        LoginSession.useTestKeychain()
+        LoginSession.clearAll()
         TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
         environment = TestEnvironment()
         AppEnvironment.shared = environment


### PR DESCRIPTION
In case of testing the regular keychain ID was replaced by a test keychain ID in order not to delete already logged in users on the test device and separate test users from manually logged in users.
This had multiple downsides:
- The test ID wasn't shared so its contents were't visible by the share extension or the widgets.
- It added extra logic to the app and tests were running in an altered app state.
- In order to add support to share extension or widget testing some code would have had to be added to production code within these modules.

Our decision was to remove this extra code so now we can test the share extension or the widgets.

refs: MBL-16261
affects: Student, Parent, Teacher
release note: none

test plan: E2E tests should run just as before.