### PR TITLE
Fix crash on force unwrap

### DIFF
--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -48,7 +48,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         courseCardListViewModel = DashboardCourseCardListAssembly.makeDashboardCourseCardListViewModel(showOnlyTeacherEnrollment: showOnlyTeacherEnrollment)
         self.shouldShowGroupList = shouldShowGroupList
         let env = AppEnvironment.shared
-        layoutViewModel = DashboardLayoutViewModel(interactor: DashboardSettingsInteractorLive(environment: env, defaults: env.userDefaults!))
+        layoutViewModel = DashboardLayoutViewModel(interactor: DashboardSettingsInteractorLive(environment: env, defaults: env.userDefaults))
         colors = env.subscribe(GetCustomColors())
         groups = env.subscribe(GetDashboardGroups())
         notifications = env.subscribe(GetAccountNotifications())

--- a/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
+++ b/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
@@ -34,7 +34,7 @@ public class DashboardContainerViewModel: ObservableObject {
     public init(environment: AppEnvironment) {
         settingsButtonTapped
             .map {
-                let interactor = DashboardSettingsInteractorLive(environment: environment, defaults: environment.userDefaults!)
+                let interactor = DashboardSettingsInteractorLive(environment: environment, defaults: environment.userDefaults)
                 let viewModel = DashboardSettingsViewModel(interactor: interactor)
                 let dashboard = CoreHostingController(DashboardSettingsView(viewModel: viewModel))
                 dashboard.addDoneButton(side: .left)

--- a/Core/Core/Dashboard/Settings/Model/DashboardSettingsInteractorLive.swift
+++ b/Core/Core/Dashboard/Settings/Model/DashboardSettingsInteractorLive.swift
@@ -30,22 +30,22 @@ public class DashboardSettingsInteractorLive: DashboardSettingsInteractor {
     public let isColorOverlaySwitchVisible: Bool
 
     // MARK: - Private
-    private let environment: AppEnvironment
     private var defaults: SessionDefaults
     private var subscriptions = Set<AnyCancellable>()
-    private lazy var userSettings = environment.subscribe(GetUserSettings(userID: "self")) { [weak self] in
-        self?.updateColorOverlay()
-    }
+    private var userSettings: Store<GetUserSettings>!
 
-    public init(environment: AppEnvironment, defaults: SessionDefaults) {
+    public init(environment: AppEnvironment, defaults: SessionDefaults?) {
+        let defaults = defaults ?? SessionDefaults(sessionID: "")
         let storedLayout: DashboardLayout = defaults.isDashboardLayoutGrid ? .grid : .list
-        self.environment = environment
         self.defaults = defaults
         self.layout = CurrentValueSubject<DashboardLayout, Never>(storedLayout)
         self.showGrades = CurrentValueSubject<Bool, Never>(defaults.showGradesOnDashboard ?? false)
         self.colorOverlay = CurrentValueSubject<Bool, Never>(true)
         self.isGradesSwitchVisible = (environment.app == .student)
         self.isColorOverlaySwitchVisible = (environment.app == .student || environment.app == .teacher)
+        self.userSettings = environment.subscribe(GetUserSettings(userID: "self")) { [weak self] in
+            self?.updateColorOverlay()
+        }
         userSettings.refresh()
 
         saveLayoutToDefaultsOnChange()


### PR DESCRIPTION
The crash happened during the initialization of the dashboard tab because a force unwrap failed on the session defaults. This session defaults property should be already set when the user reaches the dashboard so something went seriously wrong in this scenario. I couldn't reproduce the crash so I removed the force unwrap and created a dummy session defaults object in this case.

refs: MBL-16695
affects: Student, Teacher
release note: none

test plan: Since I couldn't reproduce the crash just test if the dashboard still loads after app start.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet