### PR TITLE
Fix submission list removing a submission on iPads after opening the SpeedGrader

### DIFF
--- a/Core/Core/Grades/GetAssignmentsByGroup.swift
+++ b/Core/Core/Grades/GetAssignmentsByGroup.swift
@@ -72,8 +72,10 @@ public class GetAssignmentsByGroup: APIUseCase {
     }
 
     public func write(response: [APIAssignmentGroup]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+        // For teacher roles this API doesn't return any submissions
+        let updateSubmission = AppEnvironment.shared.app != .teacher && include.contains(.submission)
         response?.forEach { item in
-            AssignmentGroup.save(item, courseID: courseID, in: client, updateSubmission: include.contains(.submission), updateScoreStatistics: include.contains(.score_statistics))
+            AssignmentGroup.save(item, courseID: courseID, in: client, updateSubmission: updateSubmission, updateScoreStatistics: include.contains(.score_statistics))
         }
     }
 }


### PR DESCRIPTION
refs: MBL-16714
affects: Teacher
release note: Fixed submission list removing a submission on iPads after opening the SpeedGrader.

test plan: See ticket. Only affects split view mode.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/1dc1b48e-3608-4dde-80d8-8dcd1c637cfd" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/7ffe506c-4f5c-431f-ba60-e7488182291c" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on tablet
