### PR TITLE
Change queue handling to work only with the currently logged-in user.

### DIFF
--- a/Core/Core/PageViewAnalytics/PageViewEventController.swift
+++ b/Core/Core/PageViewAnalytics/PageViewEventController.swift
@@ -197,9 +197,14 @@ public class PageViewEventController: NSObject {
 // MARK: - RN Logger methods
 extension PageViewEventController {
     @objc open func allEvents() -> String {
-        let count = persistency.queueCount
-        let events = persistency.batchOfEvents(count)
         let defaultReturnValue = "[]"
+        guard let userID = AppEnvironment.shared.currentSession?.userID else {
+            return defaultReturnValue
+        }
+
+        let count = persistency.queueCount(for: userID)
+        let events = persistency.batchOfEvents(count, userID: userID)
+
         guard let encodedData = try? JSONEncoder().encode(events) else {
             return defaultReturnValue
         }
@@ -208,7 +213,12 @@ extension PageViewEventController {
 
     // MARK: - Dev menu
     @objc open func clearAllEvents(handler: (() -> Void)?) {
-        persistency.dequeue(persistency.queueCount) {
+        guard let userID = AppEnvironment.shared.currentSession?.userID else {
+            handler?()
+            return
+        }
+
+        persistency.dequeue(persistency.queueCount(for: userID), userID: userID) {
             handler?()
         }
     }

--- a/Core/CoreTests/PageViewAnalytics/PageViewEventViewControllerLoggingProtocolTests.swift
+++ b/Core/CoreTests/PageViewAnalytics/PageViewEventViewControllerLoggingProtocolTests.swift
@@ -21,7 +21,7 @@ import TestsFoundation
 @testable import Core
 
 class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
-
+    let userID = "321"
     var start: Date!
     var end: Date!
     var dispatchQueue: DispatchQueue!
@@ -44,7 +44,7 @@ class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
         Persistency.persistencyFileName = persistenceTestFileName
         dispatchQueue = DispatchQueue(label: "test-pageviewevents-queue", attributes: .concurrent)
         p = Persistency(dispatchQueue: dispatchQueue)
-        p.dequeue(p.queueCount, handler: nil)
+        p.dequeue(p.queueCount(for: userID), userID: userID, handler: nil)
 
         PageViewEventController.instance.persistency = p
         PageViewEventController.instance.configure(backgroundAppHelper: TestAppBackgroundHelper())
@@ -58,7 +58,7 @@ class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
 
     func testTracking() {
 
-        let entry = LoginSession.make()
+        let entry = LoginSession.make(userID: userID)
         LoginSession.add(entry)
 
         screenViewTracker = ScreenViewTrackerLive(
@@ -66,7 +66,7 @@ class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
         )
         PageViewEventController.instance.appCanLogEvents = { return true }
 
-        XCTAssertEqual(p.queueCount, 0)
+        XCTAssertEqual(p.queueCount(for: userID), 0)
         //  when
         Clock.mockNow(start)
         screenViewTracker.startTrackingTimeOnViewController()
@@ -79,7 +79,7 @@ class PageViewEventViewControllerLoggingProtocolTests: XCTestCase {
 
         wait(for: [waitExpectation], timeout: 0.5)
         //  then
-        let events = p.batchOfEvents(1)
+        let events = p.batchOfEvents(1, userID: userID)
         XCTAssertEqual(events?.count, 1)
         XCTAssertEqual(events?.first?.eventName, "\(#function)")
     }


### PR DESCRIPTION
The issue was that all page events were stored in a single file and were uploaded using the currently logged in user's credentials even if those events were registered by another user. I modified the queue logic so that events are filtered based on the reporting user's ID when working with the queue.

refs: MBL-16692
affects: Student, Teacher
release note: none

test plan: 
- See ticket for usernames and passwords. (First two links in the additional details section.)
- Log in as Eliza Moran on the tudy domain to the student app.
- Switch user and log in as Augusta McDaniel to the zac domain.
- Visit a few screens in the app as either user.
- Switch user to the other one.
- You can repeat the screen visits and user switches a few times.
- Check both account's page views on web.
- There should be only page view events for the domain of the user you are currently looking at.

## Checklist

- [x] Tested on phone
