### PR TITLE
Fix file picker dialog not always dismissed after a successful submission

### DIFF
--- a/Core/Core/API/APIMock.swift
+++ b/Core/Core/API/APIMock.swift
@@ -259,7 +259,7 @@ class APIMock {
         if mock.data != nil || mock.http != nil || mock.error != nil {
             print("💌 \(task.request.key)")
         } else {
-            print("⚠️ \(task.request.key) mock not found")
+            print("⚠️ mocked response not set for \(task.request.key)")
         }
         guard !mock.noCallback, task.state == .running else { return }
 

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -104,6 +104,7 @@ class AssignmentDetailsPresenter {
         }
     }
     private var fileCleanupPending = true
+    private var submissionFinishedNotification: NSObjectProtocol?
 
     init(view: AssignmentDetailsViewProtocol, courseID: String, assignmentID: String, fragment: String? = nil) {
         self.view = view
@@ -113,6 +114,17 @@ class AssignmentDetailsPresenter {
         self.submissionButtonPresenter = SubmissionButtonPresenter(view: view, assignmentID: assignmentID)
         if let session = env.currentSession {
             self.userID = session.userID
+        }
+        subscribeToSuccessfulSubmissionNotification(assignmentID: assignmentID)
+    }
+
+    private func subscribeToSuccessfulSubmissionNotification(assignmentID: String) {
+        submissionFinishedNotification = NotificationCenter.default.addObserver(forName: UploadManager.AssignmentSubmittedNotification,
+                                                                                object: nil,
+                                                                                queue: OperationQueue.main) { [weak self] notification in
+            if notification.userInfo?["assignmentID"] as? String == assignmentID {
+                self?.onlineUploadState = .completed
+            }
         }
     }
 
@@ -160,6 +172,8 @@ class AssignmentDetailsPresenter {
         } else if onlineUpload.allSatisfy({ $0.isUploaded }) {
             // A file uploaded to the file server doesn't mean it's also submitted to the assignment so we check both
             if let submission = assignment?.submission, submission.status == .submitted {
+                // This state is not always reached because the file is deleted after a successful upload.
+                // We listen to the successful upload notification to work around this.
                 onlineUploadState = .completed
             } else {
                 onlineUploadState = .uploading

--- a/Student/StudentUITests/Submissions/SubmissionButton/SubmissionButtonTests.swift
+++ b/Student/StudentUITests/Submissions/SubmissionButton/SubmissionButtonTests.swift
@@ -24,7 +24,6 @@ class SubmissionButtonTests: CoreUITestCase {
     lazy var course = mock(course: .make())
 
     func testOnlineUpload() {
-        // Disabled test, passes locally but fails on bitrise. To re-enable it, right click on the test symbol and select enabled or edit NightlyTests.xctestplan
         mockBaseRequests()
         let assignment = mock(assignment: .make(submission_types: [ .online_upload ]))
         let target = FileUploadTarget.make()
@@ -33,13 +32,15 @@ class SubmissionButtonTests: CoreUITestCase {
             body: .init(name: "", on_duplicate: .overwrite, parent_folder_id: nil, size: 0)
         ), value: target)
         mockData(PostFileUploadRequest(fileURL: URL(string: "data:text/plain,")!, target: target), value: .make())
-        mockData(CreateSubmissionRequest(context: .course("1"), assignmentID: "1", body: nil))
+        mockData(CreateSubmissionRequest(context: .course("1"), assignmentID: "1", body: nil), value: .make())
 
         logIn()
         show("/courses/\(course.id)/assignments/\(assignment.id)")
         AssignmentDetails.submitAssignmentButton.tap()
         TestsFoundation.FilePicker.libraryButton.tap()
-        app.find(labelContaining: "Photo, ").tapUntil { TestsFoundation.FilePicker.submitButton.isVisible }
+        let photo = app.find(labelContaining: "Photo, ")
+        photo.tap()
+        photo.waitToVanish()
         TestsFoundation.FilePicker.submitButton.tap()
         TestsFoundation.FilePicker.submitButton.waitToVanish()
     }

--- a/TestPlans/NightlyTests.xctestplan
+++ b/TestPlans/NightlyTests.xctestplan
@@ -61,7 +61,7 @@
     {
       "target" : {
         "containerPath" : "container:..\/Core\/Core.xcodeproj",
-        "identifier" : "2C964836211E2F1A002C3255",
+        "identifier" : "73B1A2AD90A7970B7DB39CDC",
         "name" : "CoreTests"
       }
     },
@@ -86,7 +86,6 @@
         "IPadAssignmentsTest",
         "InboxTests\/testCanMessageAttachment()",
         "SpringBoardTests",
-        "SubmissionButtonTests\/testOnlineUpload()",
         "UserFilesTests\/testAddFileAudio()",
         "UserFilesTests\/testAddFileFiles()"
       ],

--- a/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
+++ b/TestsFoundation/TestsFoundation/UITests/CoreUITestCase.swift
@@ -682,7 +682,9 @@ open class CoreUITestCase: XCTestCase {
         XCTAssert(useMocks, "Mocks not allowed for E2E tests!")
         let key = request.key
         if httpMocks[key] != nil {
-            print("💫 \(key) overwriting mock")
+            print("💫 mock overwritten \(key)")
+        } else {
+            print("✅ mock added \(key)")
         }
         httpMocks[key] = response
     }


### PR DESCRIPTION
refs: MBL-16743
affects: Student
release note: Fixed file picker dialog not always dismissed after a successful submission.

test plan:
- Submit a file to a file submission.
- After successful submission the file picker dialog should disappear.
- Related UI test should pass on CI.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/bbd28343-3911-4b67-9573-8da1f8ef6974" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/fe995928-e98a-4429-a36f-b93aa36ac813" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet