### PR TITLE
Add support for course filtered offline sync UI

### DIFF
--- a/CanvasCore/CanvasCore/ReactNativeModules/CanvasCrashlytics.m
+++ b/CanvasCore/CanvasCore/ReactNativeModules/CanvasCrashlytics.m
@@ -36,7 +36,7 @@ RCT_EXPORT_MODULE();
         assert(NO);
     }];
 
-    RCTSetLogThreshold(RCTLogLevelInfo);
+    RCTSetLogThreshold(RCTLogLevelFatal);
     RCTSetLogFunction(^(RCTLogLevel level, RCTLogSource source, NSString *fileName, NSNumber *lineNumber, NSString *message) {
 
         NSString *log = RCTFormatLog([NSDate date], level, fileName, lineNumber, message);

--- a/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
@@ -21,7 +21,7 @@ import Foundation
 public enum CourseSyncSelectorAssembly {
 
     public static func makeViewController(env: AppEnvironment, courseID: String? = nil) -> UIViewController {
-        let selectorInteractor = CourseSyncSelectorInteractorLive()
+        let selectorInteractor = CourseSyncSelectorInteractorLive(courseID: courseID)
         let syncInteractor = CourseSyncInteractorLive()
         let diskSpaceInteractor = DiskSpaceInteractorLive()
         let viewModel = CourseSyncSelectorViewModel(

--- a/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public enum CourseSyncSelectorAssembly {
 
-    public static func makeViewController(env: AppEnvironment) -> UIViewController {
+    public static func makeViewController(env: AppEnvironment, courseID: String? = nil) -> UIViewController {
         let selectorInteractor = CourseSyncSelectorInteractorLive()
         let syncInteractor = CourseSyncInteractorLive()
         let diskSpaceInteractor = DiskSpaceInteractorLive()

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -29,6 +29,7 @@ protocol CourseSyncSelectorInteractor {
     func setCollapsed(selection: CourseEntrySelection, isCollapsed: Bool)
     func toggleAllCoursesSelection(isSelected: Bool)
     func getSelectedCourseEntries() -> AnyPublisher<[CourseSyncSelectorEntry], Never>
+    func observeCourseName() -> AnyPublisher<String, Never>
 }
 
 final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
@@ -129,6 +130,20 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             .map { $0.filter { $0.selectionState == .selected || $0.selectionState == .partiallySelected } }
             .replaceError(with: [])
             .first()
+            .eraseToAnyPublisher()
+    }
+
+    func observeCourseName() -> AnyPublisher<String, Never> {
+        guard let courseID else {
+            return Just(NSLocalizedString("All Courses", comment: "")).eraseToAnyPublisher()
+        }
+
+        return courseSyncEntries
+            .map { syncEntries in
+                syncEntries.first { $0.id == courseID }?.name
+            }
+            .replaceNil(with: "")
+            .replaceError(with: "")
             .eraseToAnyPublisher()
     }
 

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -21,6 +21,7 @@ import CombineExt
 import Foundation
 
 protocol CourseSyncSelectorInteractor {
+    init(courseID: String?)
     func getCourseSyncEntries() -> AnyPublisher<[CourseSyncSelectorEntry], Error>
     func observeSelectedCount() -> AnyPublisher<Int, Never>
     func observeIsEverythingSelected() -> AnyPublisher<Bool, Never>
@@ -36,6 +37,9 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
     )
     private let courseSyncEntries = CurrentValueSubject<[CourseSyncSelectorEntry], Error>(.init())
     private var subscriptions = Set<AnyCancellable>()
+
+    init(courseID: String? = nil) {
+    }
 
     // MARK: - Public Interface
 

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -29,7 +29,7 @@ protocol CourseSyncSelectorInteractor {
     func setCollapsed(selection: CourseEntrySelection, isCollapsed: Bool)
     func toggleAllCoursesSelection(isSelected: Bool)
     func getSelectedCourseEntries() -> AnyPublisher<[CourseSyncSelectorEntry], Never>
-    func observeCourseName() -> AnyPublisher<String, Never>
+    func getCourseName() -> AnyPublisher<String, Never>
 }
 
 final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
@@ -133,12 +133,13 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             .eraseToAnyPublisher()
     }
 
-    func observeCourseName() -> AnyPublisher<String, Never> {
+    func getCourseName() -> AnyPublisher<String, Never> {
         guard let courseID else {
             return Just(NSLocalizedString("All Courses", comment: "")).eraseToAnyPublisher()
         }
 
         return courseSyncEntries
+            .first { !$0.isEmpty }
             .map { syncEntries in
                 syncEntries.first { $0.id == courseID }?.name
             }

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
@@ -87,6 +87,10 @@ class CourseSyncSelectorInteractorPreview: CourseSyncSelectorInteractor {
             .replaceEmpty(with: [])
             .eraseToAnyPublisher()
     }
+
+    func observeCourseName() -> AnyPublisher<String, Never> {
+        Just("").eraseToAnyPublisher()
+    }
 }
 
 #endif

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
@@ -88,7 +88,7 @@ class CourseSyncSelectorInteractorPreview: CourseSyncSelectorInteractor {
             .eraseToAnyPublisher()
     }
 
-    func observeCourseName() -> AnyPublisher<String, Never> {
+    func getCourseName() -> AnyPublisher<String, Never> {
         Just("").eraseToAnyPublisher()
     }
 }

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
@@ -24,7 +24,7 @@ import CombineExt
 class CourseSyncSelectorInteractorPreview: CourseSyncSelectorInteractor {
     private let mockData: CurrentValueRelay<[CourseSyncSelectorEntry]>
 
-    init() {
+    required init(courseID: String? = nil) {
         mockData = CurrentValueRelay<[CourseSyncSelectorEntry]>([
             .init(name: "Black Hole",
                   id: "0",

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -76,7 +76,7 @@ struct CourseSyncSelectorView: View {
             Text("Offline Content", bundle: .core)
                 .font(.semibold16)
                 .foregroundColor(.textDarkest)
-            Text("All Courses", bundle: .core)
+            Text(viewModel.navBarSubtitle)
                 .font(.regular12)
                 .foregroundColor(.textDark)
         }

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -76,7 +76,7 @@ class CourseSyncSelectorViewModel: ObservableObject {
 
     private func updateNavBarSubtitle(_ interactor: CourseSyncSelectorInteractor) {
         interactor
-            .observeCourseName()
+            .getCourseName()
             .assign(to: &$navBarSubtitle)
     }
 

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -31,6 +31,7 @@ class CourseSyncSelectorViewModel: ObservableObject {
 
     @Published public private(set) var state = State.loading
     @Published public private(set) var items: [Item] = []
+    @Published public private(set) var navBarSubtitle = ""
     @Published public private(set) var syncButtonDisabled = true
     @Published public private(set) var leftNavBarTitle = ""
     @Published public private(set) var leftNavBarButtonVisible = false
@@ -63,6 +64,7 @@ class CourseSyncSelectorViewModel: ObservableObject {
         updateSyncButtonState(selectorInteractor)
         updateConfirmationDialogMessage(selectorInteractor)
         updateSelectAllButtonTitle(selectorInteractor)
+        updateNavBarSubtitle(selectorInteractor)
 
         handleLeftNavBarTap(selectorInteractor)
         handleSyncButtonTap(
@@ -70,6 +72,12 @@ class CourseSyncSelectorViewModel: ObservableObject {
             syncInteractor: syncInteractor,
             confirmAlert: confirmAlert
         )
+    }
+
+    private func updateNavBarSubtitle(_ interactor: CourseSyncSelectorInteractor) {
+        interactor
+            .observeCourseName()
+            .assign(to: &$navBarSubtitle)
     }
 
     private func updateSyncButtonState(_ interactor: CourseSyncSelectorInteractor) {

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -164,7 +164,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         .accessibilityLabel(Text("Dashboard Options", bundle: .core))
         .confirmationDialog("", isPresented: $isShowingKebabDialog) {
             Button {
-                env.router.route(to: "/offline/settings", from: controller, options: .modal(isDismissable: false, embedInNav: true))
+                env.router.route(to: "/offline/sync_picker", from: controller, options: .modal(isDismissable: false, embedInNav: true))
             } label: {
                 Text("Manage Offline Content", bundle: .core)
             }

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -37,6 +37,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
 
     public var screenViewTrackingParameters = ScreenViewTrackingParameters(eventName: "/")
 
+    @State private var isShowingKebabDialog = false
     @State var showGrade = AppEnvironment.shared.userDefaults?.showGradesOnDashboard == true
 
     private var activeGroups: [Group] { groups.all.filter { $0.isActive } }
@@ -71,7 +72,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
         .navigationBarGlobal()
-        .navigationBarItems(leading: menuButton, trailing: rightNavBarButtons)
+        .navigationBarItems(leading: profileMenuButton, trailing: rightNavBarButtons)
         .onAppear {
             refresh(force: false) {
                 let env = AppEnvironment.shared
@@ -120,10 +121,12 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         )
     }
 
-    private var menuButton: some View {
-        Button(action: {
+    // MARK: - Nav Bar Buttons
+
+    private var profileMenuButton: some View {
+        Button {
             env.router.route(to: "/profile", from: controller, options: .modal())
-        }) {
+        } label: {
             Image.hamburgerSolid
                 .foregroundColor(Color(Brand.shared.navTextColor))
         }
@@ -134,44 +137,67 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
 
     @ViewBuilder
     private var rightNavBarButtons: some View {
-        HStack(spacing: 0) {
-            offlineConfigButton
-            settingsButton
+        if courseCardListViewModel.shouldShowSettingsButton {
+            if ExperimentalFeature.offlineMode.isEnabled, env.app == .student {
+                optionsKebabButton
+            } else {
+                dashboardSettingsButton
+            }
         }
     }
 
     @ViewBuilder
-    private var offlineConfigButton: some View {
-        if courseCardListViewModel.shouldShowSettingsButton, ExperimentalFeature.offlineMode.isEnabled, env.app == .student {
+    private var optionsKebabButton: some View {
+        Button {
+            // Dismiss dashboard settings popover
+            guard controller.value.presentedViewController == nil else {
+                controller.value.presentedViewController?.dismiss(animated: true)
+                return
+            }
+
+            isShowingKebabDialog.toggle()
+        } label: {
+            Image.moreSolid
+                .foregroundColor(Color(Brand.shared.navTextColor))
+        }
+        .frame(width: 44, height: 44).padding(.trailing, -6)
+        .accessibilityLabel(Text("Dashboard Options", bundle: .core))
+        .confirmationDialog("", isPresented: $isShowingKebabDialog) {
             Button {
                 env.router.route(to: "/offline/settings", from: controller, options: .modal(isDismissable: false, embedInNav: true))
             } label: {
-                Image.cloudLockLine
-                    .foregroundColor(Color(Brand.shared.navTextColor))
+                Text("Manage Offline Content", bundle: .core)
             }
-            .frame(width: 44, height: 44).padding(.trailing, -6)
-            .accessibilityLabel(Text("Offline settings", bundle: .core))
-        }
-    }
-
-    @ViewBuilder
-    private var settingsButton: some View {
-        if courseCardListViewModel.shouldShowSettingsButton {
             Button {
                 guard controller.value.presentedViewController == nil else {
                     controller.value.presentedViewController?.dismiss(animated: true)
                     return
                 }
-
                 viewModel.settingsButtonTapped.send()
             } label: {
-                Image.settingsLine
-                    .foregroundColor(Color(Brand.shared.navTextColor))
+                Text("Edit Dashboard", bundle: .core)
             }
-            .frame(width: 44, height: 44).padding(.trailing, -6)
-            .accessibilityLabel(Text("Dashboard settings", bundle: .core))
         }
     }
+
+    @ViewBuilder
+    private var dashboardSettingsButton: some View {
+        Button {
+            guard controller.value.presentedViewController == nil else {
+                controller.value.presentedViewController?.dismiss(animated: true)
+                return
+            }
+
+            viewModel.settingsButtonTapped.send()
+        } label: {
+            Image.settingsLine
+                .foregroundColor(Color(Brand.shared.navTextColor))
+        }
+        .frame(width: 44, height: 44).padding(.trailing, -6)
+        .accessibilityLabel(Text("Dashboard settings", bundle: .core))
+    }
+
+    // MARK: Nav Bar Buttons -
 
     @ViewBuilder func fileUploadNotificationCards() -> some View {
         ForEach(fileUploadNotificationCardViewModel.items) { viewModel in

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -128,7 +128,13 @@ struct DashboardCourseCardView: View {
         .identifier("DashboardCourseCell.\(courseCard.id).optionsButton")
         .confirmationDialog("", isPresented: $isShowingKebabDialog) {
             Button {
-                env.router.route(to: "/offline/settings",
+                var route = "/offline/sync_picker"
+
+                if let courseID = courseCard.course?.id {
+                    route.append("/\(courseID)")
+                }
+
+                env.router.route(to: route,
                                  from: controller,
                                  options: .modal(isDismissable: false, embedInNav: true))
             } label: {

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -27,6 +27,8 @@ struct DashboardCourseCardView: View {
     /** Wide layout puts the course image to the left of the cell while the course name and code will be next to it on the right. */
     let isWideLayout: Bool
 
+    @State private var isShowingKebabDialog = false
+
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
@@ -90,7 +92,7 @@ struct DashboardCourseCardView: View {
                 .clipped()
                 // Fix big course image consuming tap events.
                 .contentShape(Path(CGRect(x: 0, y: 0, width: width, height: height)))
-            customizeButton
+            optionsKebabButton
                 .offset(x: width - 44, y: 0)
         }
     }
@@ -110,23 +112,45 @@ struct DashboardCourseCardView: View {
         .padding(.horizontal, 10).padding(.top, 8)
     }
 
-    private var customizeButton: some View {
+    @ViewBuilder
+    private var optionsKebabButton: some View {
         Button {
-            guard let course = courseCard.course else { return }
-            env.router.show(
-                CoreHostingController(CustomizeCourseView(course: course, hideColorOverlay: hideColorOverlay)),
-                from: controller,
-                options: .modal(.formSheet, isDismissable: false, embedInNav: true),
-                analyticsRoute: "/dashboard/customize_course"
-            )
+            if ExperimentalFeature.offlineMode.isEnabled, env.app == .student {
+                isShowingKebabDialog.toggle()
+            } else {
+                openDashboardCardCustomizeSheet()
+            }
         } label: {
-            Image.moreSolid.foregroundColor(Color(contextColor))
-                .background(Circle().fill(Color.backgroundLightest).frame(width: 28, height: 28)
-                )
-                .frame(width: 44, height: 44)
+            kebabIcon
         }
-        .accessibility(label: Text("Open \(courseCard.shortName) user preferences", bundle: .core))
+        .frame(width: 44, height: 44).padding(.trailing, -6)
+        .accessibilityLabel(Text("Course Card Options", bundle: .core))
         .identifier("DashboardCourseCell.\(courseCard.id).optionsButton")
+        .confirmationDialog("", isPresented: $isShowingKebabDialog) {
+            Button {
+                env.router.route(to: "/offline/settings",
+                                 from: controller,
+                                 options: .modal(isDismissable: false, embedInNav: true))
+            } label: {
+                Text("Manage Offline Content", bundle: .core)
+            }
+            Button {
+                openDashboardCardCustomizeSheet()
+            } label: {
+                Text("Customize Course", bundle: .core)
+            }
+        }
+    }
+
+    private var kebabIcon: some View {
+        Image.moreSolid
+            .foregroundColor(Color(contextColor))
+            .background(
+                Circle()
+                    .fill(Color.backgroundLightest)
+                    .frame(width: 28, height: 28)
+            )
+            .frame(width: 44, height: 44)
     }
 
     @ViewBuilder
@@ -144,6 +168,16 @@ struct DashboardCourseCardView: View {
             .background(RoundedRectangle(cornerRadius: 10).fill(Color.backgroundLightest))
             .frame(maxWidth: 120, alignment: .leading)
         }
+    }
+
+    private func openDashboardCardCustomizeSheet() {
+        guard let course = courseCard.course else { return }
+        env.router.show(
+            CoreHostingController(CustomizeCourseView(course: course, hideColorOverlay: hideColorOverlay)),
+            from: controller,
+            options: .modal(.formSheet, isDismissable: false, embedInNav: true),
+            analyticsRoute: "/dashboard/customize_course"
+        )
     }
 }
 

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -17,6 +17,7 @@
 //
 
 @testable import Core
+import Combine
 import Foundation
 import TestsFoundation
 import XCTest
@@ -252,6 +253,59 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(entries[1].selectedTabsCount, 1)
         XCTAssertEqual(entries[1].selectedFilesCount, 1)
         subscription1.cancel()
+    }
+
+    func testCourseNameWithoutCourseFilter() {
+        let testee = CourseSyncSelectorInteractorLive()
+        var subscriptions = Set<AnyCancellable>()
+
+        mockCourseList(
+            courseList: [
+                .make(id: "1", name: "course 1"),
+                .make(id: "2", name: "course 2"),
+            ]
+        )
+
+        let expectation = expectation(description: "Publisher sends value")
+        testee.observeCourseName()
+            .sink { courseName in
+                XCTAssertEqual(courseName, "All Courses")
+                expectation.fulfill()
+            }
+            .store(in: &subscriptions)
+
+        testee.getCourseSyncEntries()
+            .sink()
+            .store(in: &subscriptions)
+
+        waitForExpectations(timeout: 0.1)
+        subscriptions.removeAll()
+    }
+
+    func testCourseNameWithCourseFilter() {
+        let testee = CourseSyncSelectorInteractorLive(courseID: "2")
+        var subscriptions = Set<AnyCancellable>()
+
+        mockCourseList(
+            courseList: [
+                .make(id: "1", name: "course 1"),
+                .make(id: "2", name: "course 2"),
+            ]
+        )
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee.observeCourseName()
+            .dropFirst()
+            .sink { courseName in
+                XCTAssertEqual(courseName, "course 2")
+                expectation.fulfill()
+            }
+        testee.getCourseSyncEntries()
+            .sink()
+            .store(in: &subscriptions)
+
+        waitForExpectations(timeout: 0.1)
+        subscription.cancel()
     }
 
     private func mockCourseList(

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -43,6 +43,31 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         subscription.cancel()
     }
 
+    func testCourseListWithCourseFilter() {
+        let testee = CourseSyncSelectorInteractorLive(courseID: "2")
+        let expectation = expectation(description: "Publisher sends value")
+
+        mockCourseList(courseList: [
+            .make(id: "1"),
+            .make(id: "2"),
+        ])
+
+        var entries = [CourseSyncSelectorEntry]()
+        let subscription = testee.getCourseSyncEntries()
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: {
+                    entries = $0
+                    expectation.fulfill()
+                }
+            )
+
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(entries.count, 1)
+        XCTAssertEqual(entries.first?.id, "2")
+        subscription.cancel()
+    }
+
     func testTabList() {
         let testee = CourseSyncSelectorInteractorLive()
         let expectation = expectation(description: "Publisher sends value")

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -267,7 +267,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         )
 
         let expectation = expectation(description: "Publisher sends value")
-        testee.observeCourseName()
+        testee.getCourseName()
             .sink { courseName in
                 XCTAssertEqual(courseName, "All Courses")
                 expectation.fulfill()
@@ -294,18 +294,18 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         )
 
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.observeCourseName()
-            .dropFirst()
+        testee.getCourseName()
             .sink { courseName in
                 XCTAssertEqual(courseName, "course 2")
                 expectation.fulfill()
             }
+            .store(in: &subscriptions)
         testee.getCourseSyncEntries()
             .sink()
             .store(in: &subscriptions)
 
         waitForExpectations(timeout: 0.1)
-        subscription.cancel()
+        subscriptions.removeAll()
     }
 
     private func mockCourseList(

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -219,6 +219,9 @@ private class MockCourseSyncSelectorInteractor: CourseSyncSelectorInteractor {
     private(set) var lastSelected: (selection: Core.CourseEntrySelection, isSelected: Bool)?
     private(set) var lastCollapsed: (selection: Core.CourseEntrySelection, isCollapsed: Bool)?
 
+    required init(courseID: String? = nil) {
+    }
+
     func getCourseSyncEntries() -> AnyPublisher<[Core.CourseSyncSelectorEntry], Error> {
         Just<[Core.CourseSyncSelectorEntry]>([])
             .setFailureType(to: Error.self)

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -252,4 +252,8 @@ private class MockCourseSyncSelectorInteractor: CourseSyncSelectorInteractor {
             .setFailureType(to: Never.self)
             .eraseToAnyPublisher()
     }
+
+    func observeCourseName() -> AnyPublisher<String, Never> {
+        Just("").eraseToAnyPublisher()
+    }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -253,7 +253,7 @@ private class MockCourseSyncSelectorInteractor: CourseSyncSelectorInteractor {
             .eraseToAnyPublisher()
     }
 
-    func observeCourseName() -> AnyPublisher<String, Never> {
+    func getCourseName() -> AnyPublisher<String, Never> {
         Just("").eraseToAnyPublisher()
     }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -146,7 +146,7 @@ class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
         toggleAllCoursesSelectionParam = isSelected
     }
 
-    func observeCourseName() -> AnyPublisher<String, Never> {
+    func getCourseName() -> AnyPublisher<String, Never> {
         Just("Test Name").eraseToAnyPublisher()
     }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -110,6 +110,10 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
 }
 
 class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
+
+    required init(courseID: String? = nil) {
+    }
+
     let courseSyncEntriesSubject = PassthroughSubject<[CourseSyncSelectorEntry], Error>()
     func getCourseSyncEntries() -> AnyPublisher<[Core.CourseSyncSelectorEntry], Error> {
         courseSyncEntriesSubject.eraseToAnyPublisher()

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -141,6 +141,10 @@ class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
     func toggleAllCoursesSelection(isSelected: Bool) {
         toggleAllCoursesSelectionParam = isSelected
     }
+
+    func observeCourseName() -> AnyPublisher<String, Never> {
+        Just("").eraseToAnyPublisher()
+    }
 }
 
 class CourseSyncInteractorMock: CourseSyncInteractor {

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -107,6 +107,10 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(testee.items[0].id, "course-test")
         XCTAssertTrue(testee.leftNavBarButtonVisible)
     }
+
+    func testUpdatesNavBarSubtitle() {
+        XCTAssertEqual(testee.navBarSubtitle, "Test Name")
+    }
 }
 
 class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
@@ -143,7 +147,7 @@ class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
     }
 
     func observeCourseName() -> AnyPublisher<String, Never> {
-        Just("").eraseToAnyPublisher()
+        Just("Test Name").eraseToAnyPublisher()
     }
 }
 

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -367,8 +367,11 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
         return LogEventListViewController.create()
     },
 
-    "/offline/settings": { _, _, _ in
+    "/offline/sync_picker": { _, _, _ in
         CourseSyncSelectorAssembly.makeViewController(env: .shared)
+    },
+    "/offline/sync_picker/:courseID": { _, params, _ in
+        CourseSyncSelectorAssembly.makeViewController(env: .shared, courseID: params["courseID"])
     },
 
     "/push-notifications": { _, _, _ in

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -158,6 +158,11 @@ class RoutesTests: XCTestCase {
         XCTAssert(router.match("/groups/2/announcements/3?origin=module_item_details") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
     }
 
+    func testOfflineScreenRoutes() {
+        XCTAssert(router.match("/offline/sync_picker/132") is CoreHostingController<CourseSyncSelectorView>)
+        XCTAssert(router.match("/offline/sync_picker") is CoreHostingController<CourseSyncSelectorView>)
+    }
+
     // MARK: - K5 / non-K5 course detail route logic tests
 
     func testK5SubjectViewRoute() {


### PR DESCRIPTION
refs: MBL-16738
affects: Student
release note: none

test plan:
- Added kebab menu to dashboard nav bar and to the customize course button. These appear in the student app if the offline feature flag is enabled.
- Added a filtering option to the offline selector screen. Opening this screen from a course should display only that course in the selector.
- The navigation bar subtitle should also reflect if course filtering is enabled or not. I couldn't work out the clipped subtitle so far.
- Raised react log level to maximum, this should eliminate all the annoying console logs.

## Screenshots

<table>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/4d450e54-ebb6-483f-92b3-fee1231c5cdd" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/0483882c-5d57-450a-8860-8e78b8b0e0fc" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/c580e3e9-7437-465f-9a3a-017086b50499" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/9862ca65-ebe2-4a49-9f75-9ce2487421c0" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/35b77b2b-5875-4978-ace7-7c0400af91a6" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet