### PR TITLE
Add HeapID and Access Token to developer menu

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -37,6 +37,7 @@ open class AppEnvironment {
     public var logger: LoggerProtocol
     public var router: Router
     public var currentSession: LoginSession?
+    public var heapID: String?
     public var userDefaults: SessionDefaults? {
         didSet {
             k5.sessionDefaults = userDefaults

--- a/Core/Core/DeveloperMenu/DeveloperMenuView.swift
+++ b/Core/Core/DeveloperMenu/DeveloperMenuView.swift
@@ -25,34 +25,7 @@ public struct DeveloperMenuView: View {
 
     @StateObject private var snackBarViewModel = SnackBarViewModel()
 
-    private var items: [DeveloperMenuItem] { [
-        DeveloperMenuItem("View Experimental Features") {
-            router.route(to: "/dev-menu/experimental-features", from: controller)
-        },
-        DeveloperMenuItem("Website Preview") {
-            router.route(to: "/dev-menu/website-preview", from: controller, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
-        },
-        DeveloperMenuItem("Panda Gallery") {
-            router.route(to: "/dev-menu/pandas", from: controller)
-        },
-        DeveloperMenuItem("SnackBar Test") {
-            router.route(to: "/dev-menu/snackbar", from: controller, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
-        },
-        DeveloperMenuItem("View Push Notifications") {
-            router.route(to: "/push-notifications", from: controller)
-        },
-        DeveloperMenuItem("View Logs") {
-            router.route(to: "/logs", from: controller)
-        },
-        DeveloperMenuItem("Copy HeapID to Clipboard") {
-            UIPasteboard.general.string = env.heapID
-            snackBarViewModel.showSnack("HeapID copied to clipboard.\n\(env.heapID ?? "N/A")")
-        },
-        DeveloperMenuItem("Copy Access Token to Clipboard") {
-            UIPasteboard.general.string = env.currentSession?.accessToken
-            snackBarViewModel.showSnack("Access Token copied to clipboard.\n\(env.currentSession?.accessToken ?? "N/A")")
-        },
-    ] }
+    @State private var items: [DeveloperMenuItem] = []
 
     public init() {}
 
@@ -82,6 +55,50 @@ public struct DeveloperMenuView: View {
             })
         })
         .snackBar(viewModel: snackBarViewModel)
+        .onAppear {
+            setupItems()
+        }
+    }
+
+    private func setupItems() {
+        unowned let router = router
+        unowned let controller = controller
+        unowned let env = env
+        unowned let snackBarViewModel = snackBarViewModel
+
+        items.append(contentsOf: [
+            DeveloperMenuItem("View Experimental Features") {
+                router.route(to: "/dev-menu/experimental-features", from: controller)
+            },
+            DeveloperMenuItem("Website Preview") {
+                router.route(to: "/dev-menu/website-preview", from: controller, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
+            },
+            DeveloperMenuItem("Panda Gallery") {
+                router.route(to: "/dev-menu/pandas", from: controller)
+            },
+            DeveloperMenuItem("SnackBar Test") {
+                router.route(to: "/dev-menu/snackbar", from: controller, options: .modal(.fullScreen, embedInNav: true, addDoneButton: true))
+            },
+            DeveloperMenuItem("View Push Notifications") {
+                router.route(to: "/push-notifications", from: controller)
+            },
+            DeveloperMenuItem("View Logs") {
+                router.route(to: "/logs", from: controller)
+            },
+            DeveloperMenuItem("HeapID: \(env.heapID ?? "N/A")\n---\nTap to Copy") {
+                UIPasteboard.general.string = env.heapID
+                snackBarViewModel.showSnack("HeapID copied to clipboard.\n\(env.heapID ?? "N/A")")
+            },
+        ])
+
+        #if DEBUG
+        items.append(
+            DeveloperMenuItem("Access Token: \(env.currentSession?.accessToken ?? "N/A")\n---\nTap to Copy") {
+                UIPasteboard.general.string = env.currentSession?.accessToken
+                snackBarViewModel.showSnack("Access Token copied to clipboard.\n\(env.currentSession?.accessToken ?? "N/A")")
+            }
+        )
+        #endif
     }
 
     private struct DeveloperMenuItem: Identifiable {
@@ -90,7 +107,7 @@ public struct DeveloperMenuView: View {
         public let action: () -> Void
 
         public init(_ title: String, action: @escaping () -> Void) {
-            self.id = title
+            id = title
             self.title = title
             self.action = action
         }

--- a/Core/Core/DeveloperMenu/DeveloperMenuView.swift
+++ b/Core/Core/DeveloperMenu/DeveloperMenuView.swift
@@ -19,8 +19,11 @@
 import SwiftUI
 
 public struct DeveloperMenuView: View {
+    @Environment(\.appEnvironment) var env
     @Environment(\.appEnvironment.router) var router
     @Environment(\.viewController) var controller
+
+    @StateObject private var snackBarViewModel = SnackBarViewModel()
 
     private var items: [DeveloperMenuItem] { [
         DeveloperMenuItem("View Experimental Features") {
@@ -40,6 +43,14 @@ public struct DeveloperMenuView: View {
         },
         DeveloperMenuItem("View Logs") {
             router.route(to: "/logs", from: controller)
+        },
+        DeveloperMenuItem("Copy HeapID to Clipboard") {
+            UIPasteboard.general.string = env.heapID
+            snackBarViewModel.showSnack("HeapID copied to clipboard.\n\(env.heapID ?? "N/A")")
+        },
+        DeveloperMenuItem("Copy Access Token to Clipboard") {
+            UIPasteboard.general.string = env.currentSession?.accessToken
+            snackBarViewModel.showSnack("Access Token copied to clipboard.\n\(env.currentSession?.accessToken ?? "N/A")")
         },
     ] }
 
@@ -70,6 +81,7 @@ public struct DeveloperMenuView: View {
                 Text("Done", bundle: .core).fontWeight(.regular)
             })
         })
+        .snackBar(viewModel: snackBarViewModel)
     }
 
     private struct DeveloperMenuItem: Identifiable {

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -293,6 +293,7 @@ extension ParentAppDelegate: AnalyticsHandler {
         options.disableTracking = !isSendUsageMetricsEnabled
         Heap.initialize(heapID, with: options)
         Heap.setTrackingEnabled(isSendUsageMetricsEnabled)
+        environment.heapID = Heap.userId()
     }
 
     private func disableTracking() {

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -260,6 +260,7 @@ extension StudentAppDelegate: Core.AnalyticsHandler {
         options.disableTracking = !isSendUsageMetricsEnabled
         Heap.initialize(heapID, with: options)
         Heap.setTrackingEnabled(isSendUsageMetricsEnabled)
+        environment.heapID = Heap.userId()
     }
 
     private func disableTracking() {

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -173,20 +173,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		5B116AB32A1B4C7B00AAF152 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		5B116AB52A1B4C7B00AAF152 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
-		};
 		ADD0BD039DBE20C141DFDF5E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
@@ -754,8 +740,6 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				5B116AB42A1B4C7B00AAF152 /* CoreTester.app */,
-				5B116AB62A1B4C7B00AAF152 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1166,20 +1150,6 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5B116AB42A1B4C7B00AAF152 /* CoreTester.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CoreTester.app;
-			remoteRef = 5B116AB32A1B4C7B00AAF152 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		5B116AB62A1B4C7B00AAF152 /* CoreTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CoreTests.xctest;
-			remoteRef = 5B116AB52A1B4C7B00AAF152 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -274,6 +274,7 @@ extension TeacherAppDelegate: AnalyticsHandler {
         options.disableTracking = !isSendUsageMetricsEnabled
         Heap.initialize(heapID, with: options)
         Heap.setTrackingEnabled(isSendUsageMetricsEnabled)
+        environment.heapID = Heap.userId()
     }
 
     private func disableTracking() {


### PR DESCRIPTION
HeapID and Access Token is now available in the Developer Menu. 

refs: MBL-16732
affects: Student, Teacher, Parent
release note: none 
test plan:  See ticket

## Screenshots

<table>
<tr><th>HeapID</th><th>Access Token</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/7d96ec05-baa6-475e-ba5c-3a756ab795e2" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/bc5502c6-647c-4263-aabd-031463636847" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
