### PR TITLE
Fix offline settings text layout

### DIFF
--- a/Core/Core/CourseSync/CourseSyncSettings/View/CourseSyncSettingsView.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/View/CourseSyncSettingsView.swift
@@ -106,6 +106,7 @@ struct CourseSyncSettingsView: View {
 
     private func description(_ text: String) -> some View {
         Text(text)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, 12)
             .padding(.bottom, 32)
             .padding(.horizontal, 16)


### PR DESCRIPTION
refs: MBL-16665
affects: Student
release note: none

test plan: Description texts on offline sync settings screen should be left aligned.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/5c49f624-d277-4850-b263-217c5eb7001f" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/6b5eac00-54c6-4efd-b903-db285d48a822" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet