### PR TITLE
Fix assignment list page view name.

### DIFF
--- a/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
+++ b/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
@@ -28,7 +28,7 @@ public struct AssignmentListView: View, ScreenViewTrackable {
     public init(viewModel: AssignmentListViewModel) {
         self.viewModel = viewModel
         screenViewTrackingParameters = ScreenViewTrackingParameters(
-            eventName: "/courses/\(viewModel.courseID))/assignments"
+            eventName: "/courses/\(viewModel.courseID)/assignments"
         )
     }
 


### PR DESCRIPTION
I noticed this typo while working on another ticket.

[ignore-commit-lint]

<img width="1270" alt="Screenshot 2023-06-05 at 15 44 56" src="https://github.com/instructure/canvas-ios/assets/72396990/0d9e06e0-9895-471b-bd83-340c0e382b2c">

