### PR TITLE
Long submission comments do not retain focus

### DIFF
--- a/Core/Core/Extensions/UITextViewExtensions.swift
+++ b/Core/Core/Extensions/UITextViewExtensions.swift
@@ -98,4 +98,15 @@ extension UITextView: NSTextStorageDelegate {
             placeholderLabel.isHidden = !text.isEmpty
         }
     }
+
+    public func adjustHeight(to desiredNumberOfLines: Int, heightConstraints: NSLayoutConstraint) {
+        let lineHeight = font!.lineHeight + 5
+        let numberOfLines = Int(contentSize.height / lineHeight)
+        let padding: CGFloat = 10
+        if numberOfLines <= desiredNumberOfLines {
+            heightConstraints.constant = CGFloat(numberOfLines) * lineHeight + padding
+        } else {
+            heightConstraints.constant = CGFloat(desiredNumberOfLines) * lineHeight + padding
+        }
+    }
 }

--- a/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
+++ b/Core/Core/SwiftUIViews/DynamicHeightTextEditor.swift
@@ -53,12 +53,19 @@ public struct DynamicHeightTextEditor: View {
                         key: ViewSizeKey.self,
                         value: $0.frame(in: .local).size.height
                     )
-                })
+                }).hidden()
             TextEditor(text: $text)
                 .foregroundColor(.textDarkest)
+                .background(Color.clear)
+                .iOS16HideListScrollContentBackground()
                 .frame(height: textEditorHeight)
                 .overlay(placeholderView, alignment: .leading)
                 .offset(y: -2)
+                .onAppear {
+                   UITextView.appearance().backgroundColor = .clear
+                 }.onDisappear {
+                   UITextView.appearance().backgroundColor = nil
+                 }
         }
         .onChange(of: text, perform: { newValue in
             textToMeasureHeight = newValue.isEmpty ? "Placeholder" : newValue

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -42,7 +42,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5Um-tb-BF2" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="206.5" y="28" width="100.5" height="20.5"/>
+                                                    <rect key="frame" x="223.5" y="28" width="83.5" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -52,7 +52,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="March 13 at 10:51 AM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brg-4l-HGS" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="143.5" y="48.5" width="163.5" height="20.5"/>
+                                                    <rect key="frame" x="187" y="45" width="120" height="14.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -61,7 +61,7 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium12"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kFW-ob-ndx" customClass="IconView" customModule="Student" customModuleProvider="target">
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="kFW-ob-ndx" customClass="IconView" customModule="Student" customModuleProvider="target">
                                                     <rect key="frame" x="319" y="59" width="40" height="40"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="electric"/>
@@ -98,7 +98,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6at-Xx-e6I" customClass="IconView" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="224" y="-5" width="135" height="34"/>
+                                                    <rect key="frame" x="245.5" y="-5" width="113.5" height="34"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="jWm-AB-N4T"/>
                                                     </constraints>
@@ -108,7 +108,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" layoutMarginsFollowReadableWidth="YES" text="Comment Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jQO-Zk-01K" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="236" y="12" width="111" height="9"/>
+                                                    <rect key="frame" x="257.5" y="12" width="89.5" height="9"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -159,7 +159,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </view>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Author Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Thz-j3-Y3K" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="68" y="28" width="100.5" height="20.5"/>
+                                                    <rect key="frame" x="68" y="28" width="83.5" height="17"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -169,7 +169,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="March 13 at 10:51 AM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="S2V-PQ-jCT" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="68" y="48.5" width="163.5" height="20.5"/>
+                                                    <rect key="frame" x="68" y="45" width="120" height="14.5"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -178,7 +178,7 @@
                                                         <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium12"/>
                                                     </userDefinedRuntimeAttributes>
                                                 </label>
-                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2V9-9A-X5r" customClass="IconView" customModule="Student" customModuleProvider="target">
+                                                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2V9-9A-X5r" customClass="IconView" customModule="Student" customModuleProvider="target">
                                                     <rect key="frame" x="16" y="59" width="40" height="40"/>
                                                     <userDefinedRuntimeAttributes>
                                                         <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="backgroundLight"/>
@@ -216,7 +216,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="893-hG-e0V" customClass="IconView" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="16" y="-5" width="135" height="34"/>
+                                                    <rect key="frame" x="16" y="-5" width="113.5" height="34"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="6G6-Mn-eLP"/>
                                                     </constraints>
@@ -227,7 +227,7 @@
                                                     </userDefinedRuntimeAttributes>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" layoutMarginsFollowReadableWidth="YES" text="Comment Text" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eMn-Vx-0Ll" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                    <rect key="frame" x="28" y="12" width="111" height="9"/>
+                                                    <rect key="frame" x="28" y="12" width="89.5" height="9"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -357,7 +357,7 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Have questions? Use this area to message your instructor about this assignment." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="vxN-b5-Dqx" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                        <rect key="frame" x="8.5" y="140" width="326" height="41"/>
+                                        <rect key="frame" x="26" y="140" width="291.5" height="34"/>
                                         <viewLayoutGuide key="safeArea" id="pIe-X1-3Uk"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
@@ -430,7 +430,7 @@
                                                 <rect key="frame" x="12" y="3" width="266" height="40"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.commentTextView"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" constant="40" id="iuz-Bm-PNt"/>
+                                                    <constraint firstAttribute="height" priority="700" constant="40" id="iuz-Bm-PNt"/>
                                                 </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
@@ -545,32 +545,44 @@
         </scene>
     </scenes>
     <designables>
+        <designable name="2V9-9A-X5r">
+            <size key="intrinsicContentSize" width="40" height="40"/>
+        </designable>
         <designable name="5Um-tb-BF2">
-            <size key="intrinsicContentSize" width="100.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="83.5" height="17"/>
+        </designable>
+        <designable name="6at-Xx-e6I">
+            <size key="intrinsicContentSize" width="40" height="40"/>
+        </designable>
+        <designable name="893-hG-e0V">
+            <size key="intrinsicContentSize" width="40" height="40"/>
         </designable>
         <designable name="S2V-PQ-jCT">
-            <size key="intrinsicContentSize" width="163.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="120" height="14.5"/>
         </designable>
         <designable name="Thz-j3-Y3K">
-            <size key="intrinsicContentSize" width="100.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="83.5" height="17"/>
         </designable>
         <designable name="brg-4l-HGS">
-            <size key="intrinsicContentSize" width="163.5" height="20.5"/>
+            <size key="intrinsicContentSize" width="120" height="14.5"/>
         </designable>
         <designable name="djV-o5-Xt6">
-            <size key="intrinsicContentSize" width="22" height="40"/>
+            <size key="intrinsicContentSize" width="46" height="46"/>
         </designable>
         <designable name="eMn-Vx-0Ll">
-            <size key="intrinsicContentSize" width="111" height="20.5"/>
+            <size key="intrinsicContentSize" width="89.5" height="17"/>
         </designable>
         <designable name="jQO-Zk-01K">
-            <size key="intrinsicContentSize" width="111" height="20.5"/>
+            <size key="intrinsicContentSize" width="89.5" height="17"/>
+        </designable>
+        <designable name="kFW-ob-ndx">
+            <size key="intrinsicContentSize" width="40" height="40"/>
         </designable>
         <designable name="uGc-Rr-ieQ">
-            <size key="intrinsicContentSize" width="30" height="30"/>
+            <size key="intrinsicContentSize" width="24" height="24"/>
         </designable>
         <designable name="vxN-b5-Dqx">
-            <size key="intrinsicContentSize" width="614" height="20.5"/>
+            <size key="intrinsicContentSize" width="497" height="17"/>
         </designable>
     </designables>
 </document>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -426,9 +426,12 @@
                                     <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
                                         <rect key="frame" x="40" y="4" width="319" height="43"/>
                                         <subviews>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" scrollEnabled="NO" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
+                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
                                                 <rect key="frame" x="12" y="3" width="266" height="40"/>
                                                 <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.commentTextView"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="40" id="iuz-Bm-PNt"/>
+                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                                                 <connections>
@@ -460,7 +463,6 @@
                                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstItem="uGc-Rr-ieQ" firstAttribute="leading" secondItem="3wp-xK-HJQ" secondAttribute="trailing" constant="4" id="0Iz-DT-rhP"/>
-                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="43" id="NC2-jr-fE4"/>
                                             <constraint firstItem="3wp-xK-HJQ" firstAttribute="top" secondItem="DjR-oA-G8w" secondAttribute="top" constant="3" id="NO7-l5-LaT"/>
                                             <constraint firstAttribute="bottom" secondItem="3wp-xK-HJQ" secondAttribute="bottom" id="SDb-vJ-ba3"/>
                                             <constraint firstItem="3wp-xK-HJQ" firstAttribute="leading" secondItem="DjR-oA-G8w" secondAttribute="leading" constant="12" id="exB-6M-zjV"/>
@@ -525,6 +527,7 @@
                         <outlet property="addCommentBorderView" destination="DjR-oA-G8w" id="rPk-Pa-8P4"/>
                         <outlet property="addCommentButton" destination="uGc-Rr-ieQ" id="ZMO-A6-RwV"/>
                         <outlet property="addCommentTextView" destination="3wp-xK-HJQ" id="bMw-4T-MvF"/>
+                        <outlet property="addCommentTextViewHeightConstraint" destination="iuz-Bm-PNt" id="rxd-KB-Xyo"/>
                         <outlet property="addCommentView" destination="SAr-z8-Qsj" id="CRp-Kv-sDB"/>
                         <outlet property="addMediaButton" destination="djV-o5-Xt6" id="bHF-6D-e2E"/>
                         <outlet property="addMediaHeight" destination="2PL-IE-MvI" id="47L-8j-BJq"/>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -280,7 +280,7 @@ extension SubmissionCommentsViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         addCommentButton.isEnabled = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         addCommentButton.alpha = addCommentButton.isEnabled ? 1 : 0.5
-        textView.adjustHeight(to: 5, heightConstraints: addCommentTextViewHeightConstraint)
+        textView.adjustHeight(to: 10, heightConstraints: addCommentTextViewHeightConstraint)
     }
 }
 

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -25,6 +25,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var addCommentBorderView: UIView!
     @IBOutlet weak var addCommentButton: UIButton!
     @IBOutlet weak var addCommentTextView: UITextView!
+    @IBOutlet weak var addCommentTextViewHeightConstraint: NSLayoutConstraint!
     @IBOutlet weak var addCommentView: UIView!
     @IBOutlet weak var addMediaButton: UIButton!
     @IBOutlet weak var addMediaHeight: NSLayoutConstraint!
@@ -279,6 +280,7 @@ extension SubmissionCommentsViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         addCommentButton.isEnabled = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         addCommentButton.alpha = addCommentButton.isEnabled ? 1 : 0.5
+        textView.adjustHeight(to: 5, heightConstraints: addCommentTextViewHeightConstraint)
     }
 }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -30,7 +30,7 @@ struct CommentEditor: View {
         HStack(alignment: .bottom) {
             DynamicHeightTextEditor(text: $text, placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
                 .font(.regular16)
-                .lineLimit(3)
+                .lineLimit(5)
                 .accessibility(label: Text("Comment"))
                 .identifier("SubmissionComments.commentTextView")
             Button(action: {

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -30,7 +30,7 @@ struct CommentEditor: View {
         HStack(alignment: .bottom) {
             DynamicHeightTextEditor(text: $text, placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
                 .font(.regular16)
-                .lineLimit(5)
+                .lineLimit(10)
                 .accessibility(label: Text("Comment"))
                 .identifier("SubmissionComments.commentTextView")
             Button(action: {


### PR DESCRIPTION
refs: MBL-16726
affects: Student, Teacher
release note: Improved submission comment entry field.
test plan: See ticket. Submission comments should grow up to 10 lines both on student submission and teacher speedgrader pages. Drawer should override the textview height. Comments should be scrollable.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
