### PR TITLE
Certain hex colors will not show in the app and appear invisible

### DIFF
--- a/Core/Core/AppEnvironment/Brand.swift
+++ b/Core/Core/AppEnvironment/Brand.swift
@@ -68,8 +68,7 @@ public struct Brand: Equatable {
         UIColor.getColor(dark: primaryDark, light: primaryLight)
     }
     public var tabBarHighlightColor: UIColor {
-        let hasEnoughContrast = self.primary.contrast(against: .backgroundLightest) >= 3
-        return hasEnoughContrast ? self.primary : self.navTextColor
+        primary.darkenToEnsureContrast(against: .backgroundLightest)
     }
 
     private var buttonPrimaryBackgroundDark: UIColor = .black

--- a/Core/CoreTests/Extensions/UITabBarExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UITabBarExtensionsTests.swift
@@ -48,6 +48,6 @@ class UITabBarExtensionsTests: XCTestCase {
             primary: "#ffffff"
         ), baseURL: URL(string: "https://canvas.instructure.com")!)
         tabBar.useGlobalNavStyle(brand: shiny)
-        XCTAssertEqual(tabBar.standardAppearance.stackedLayoutAppearance.selected.iconColor?.hexString, shiny.navTextColor.hexString)
+        XCTAssertEqual(tabBar.standardAppearance.stackedLayoutAppearance.selected.iconColor?.hexString, shiny.primary.darkenToEnsureContrast(against: .backgroundLightest).hexString)
     }
 }


### PR DESCRIPTION
refs: MBL-16823
affects: Student, Teacher
release note: Fixed tab bar bright selection color.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/0e2859b9-30d8-45bb-8118-617da14ac364" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/b4c5ccb7-71bb-481b-998c-d52083b34d4b" maxHeight=500></td>
</tr>
</table>


## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
