### PR TITLE
Offline sync selection persistency

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1221,6 +1221,7 @@
 		D2FD9F0CE35154CDA63EB588 /* APIAssignmentPickerListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C977681048E778C187FD119 /* APIAssignmentPickerListItem.swift */; };
 		D31E83925422BBA1373AB854 /* ContextCardGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B361985FD0F05D7C61646 /* ContextCardGradesView.swift */; };
 		D3325F79CCA32071098A7DA9 /* GetQuizSubmissionUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DFFDB020E0A5A5ED8973F0 /* GetQuizSubmissionUsers.swift */; };
+		D3F2C000008898A8049AFEF7 /* CourseSyncItemSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B3812EED19B5A501744522 /* CourseSyncItemSelection.swift */; };
 		D484C74E299214157F4B69BC /* PageDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B36ECA65D3C45F7DE5084 /* PageDetailsViewController.swift */; };
 		D48E46F5E6C2592884967912 /* CourseListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39383A471A137E1F27CA151C /* CourseListInteractor.swift */; };
 		D499D498B873614658D91549 /* SideMenuToggleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB50F2545E4E672477BD0ADC /* SideMenuToggleItem.swift */; };
@@ -3188,6 +3189,7 @@
 		F72E71DA8A77B49B3274B733 /* ColoredNavViewProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColoredNavViewProtocol.swift; sourceTree = "<group>"; };
 		F7321F059BB1734662C0D355 /* AssignmentDateSectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDateSectionViewModel.swift; sourceTree = "<group>"; };
 		F77B3DAC05B4FF5456DBBF89 /* LoginQRCodeTutorialViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginQRCodeTutorialViewController.swift; sourceTree = "<group>"; };
+		F7B3812EED19B5A501744522 /* CourseSyncItemSelection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncItemSelection.swift; sourceTree = "<group>"; };
 		F7EB97A1F0B4F87E87F621CC /* K5SubjectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5SubjectHeaderView.swift; sourceTree = "<group>"; };
 		F81AF8A0805ED859A7380EFB /* GetCourseNavigationToolsRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCourseNavigationToolsRequest.swift; sourceTree = "<group>"; };
 		F8393F724BDD07494D142FCE /* DashboardContainerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardContainerViewModel.swift; sourceTree = "<group>"; };
@@ -7904,6 +7906,7 @@
 		F5BB733EFEEDA38D78E82C46 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				F7B3812EED19B5A501744522 /* CourseSyncItemSelection.swift */,
 				9A60CB2B3811373D99B9DAD4 /* CourseSyncSelectorCourse.swift */,
 			);
 			path = Entities;
@@ -9208,6 +9211,7 @@
 				5F5C9FFE1C34DA339C4969B5 /* CourseSyncFrequency.swift in Sources */,
 				FB56546AE20484C238756BD1 /* CourseSyncInteractor.swift in Sources */,
 				BC15AF79D482FDB0D0984A99 /* CourseSyncInteractorPreview.swift in Sources */,
+				D3F2C000008898A8049AFEF7 /* CourseSyncItemSelection.swift in Sources */,
 				993C351BF3C293409D77C1D0 /* CourseSyncPagesInteractor.swift in Sources */,
 				59DE22DC65F969B9AAEB2721 /* CourseSyncProgressAssembly.swift in Sources */,
 				ECCFFB637A701934877CDF78 /* CourseSyncProgressInfoView.swift in Sources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1226,6 +1226,7 @@
 		D48E46F5E6C2592884967912 /* CourseListInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39383A471A137E1F27CA151C /* CourseListInteractor.swift */; };
 		D499D498B873614658D91549 /* SideMenuToggleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB50F2545E4E672477BD0ADC /* SideMenuToggleItem.swift */; };
 		D4BD3B0D9B06347A0503843F /* GradeCircleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3C5228820111819B5BD53E /* GradeCircleView.swift */; };
+		D4BDF1EE353A18DF24F5E7E3 /* CourseSyncItemSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2696D625006609C12EF424F /* CourseSyncItemSelectionTests.swift */; };
 		D4CA35BA9FC9018B4A46065F /* AnnotationDragGestureDelegateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3003A9825A81AD1868398D5 /* AnnotationDragGestureDelegateTests.swift */; };
 		D4D31354957AF4E8D7AEF9D5 /* EditComposeRecipientsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90F90110AF4BEBB028266CE8 /* EditComposeRecipientsViewControllerTests.swift */; };
 		D55AEA12B5F46ED0C58FA60B /* ReactiveStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFDD1E1B04BCE0A3513A061A /* ReactiveStore.swift */; };
@@ -2950,6 +2951,7 @@
 		D216096E1F65E2A59B10896D /* DiscussionDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionDetailsViewController.swift; sourceTree = "<group>"; };
 		D224E7FEACCB75418C391BFD /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		D24715C56FC9C045B256FAB7 /* LoginSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSessionTests.swift; sourceTree = "<group>"; };
+		D2696D625006609C12EF424F /* CourseSyncItemSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncItemSelectionTests.swift; sourceTree = "<group>"; };
 		D275488A717F022056172B8A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D28C5442AE5762F62033B501 /* UIFontExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIFontExtensionsTests.swift; sourceTree = "<group>"; };
 		D2A10B77E9E886A71F13AAB6 /* EditComposeRecipientsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditComposeRecipientsViewController.swift; sourceTree = "<group>"; };
@@ -3934,6 +3936,7 @@
 		271E97E603E50B8811DEBE91 /* Entities */ = {
 			isa = PBXGroup;
 			children = (
+				D2696D625006609C12EF424F /* CourseSyncItemSelectionTests.swift */,
 				CBD38BCA699C5556356C1577 /* CourseSyncSelectorEntryTests.swift */,
 			);
 			path = Entities;
@@ -8615,6 +8618,7 @@
 				8CF9E9E06C406257E41639EC /* CourseSyncFilesInteractorLiveTests.swift in Sources */,
 				D2858F51E538A08862878D47 /* CourseSyncFrequencyTests.swift in Sources */,
 				E612373CABC74630F99BAAF5 /* CourseSyncInteractorLiveTests.swift in Sources */,
+				D4BDF1EE353A18DF24F5E7E3 /* CourseSyncItemSelectionTests.swift in Sources */,
 				322EB518CAA5C15100366E6B /* CourseSyncPagesInteractorLiveTests.swift in Sources */,
 				4F46F1953E6835A413D1E58B /* CourseSyncProgressInfoViewModelTests.swift in Sources */,
 				CCA6A018E547CC1C8E12BD95 /* CourseSyncProgressViewModelItemTests.swift in Sources */,

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -19,15 +19,11 @@
 import Foundation
 
 public struct SessionDefaults {
-    private var userDefaults: UserDefaults {
-        return UserDefaults(suiteName: Bundle.main.appGroupID()) ?? .standard
-    }
-
-    private var sessionDefaults: [String: Any]? {
-        get { return userDefaults.dictionary(forKey: sessionID) }
-        set { userDefaults.set(newValue, forKey: sessionID) }
-    }
-
+    /**
+     This is a shared session storage with an empty string as `sessionID`.
+     Can be used for testing/preview/fallback purposes.
+     */
+    public static let fallback = SessionDefaults(sessionID: "")
     public let sessionID: String
 
     /** This property is used by the file share extension to automatically select the course of the last viewed file in the app. The use-case is that the user views the assignment's file in the app, saves it to iOS Photos app, annotates it there and shares it back to the assignment. */
@@ -178,5 +174,14 @@ public struct SessionDefaults {
             }
             sessionDefaults = defaults
         }
+    }
+
+    private var userDefaults: UserDefaults {
+        return UserDefaults(suiteName: Bundle.main.appGroupID()) ?? .standard
+    }
+
+    private var sessionDefaults: [String: Any]? {
+        get { return userDefaults.dictionary(forKey: sessionID) }
+        set { userDefaults.set(newValue, forKey: sessionID) }
     }
 }

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -150,7 +150,7 @@ public struct SessionDefaults {
     public var offlineSyncSelections: [CourseSyncItemSelection] {
         get {
             let rawData: [String] = self["offlineSyncSelections"] as? [String] ?? []
-            return rawData.compactMap { CourseSyncItemSelection($0) }
+            return rawData.compactMap { CourseSyncItemSelection(encodedValue: $0) }
         }
         set {
             self["offlineSyncSelections"] = newValue.map { $0.encodedValue }

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -149,11 +149,10 @@ public struct SessionDefaults {
 
     public var offlineSyncSelections: [CourseSyncItemSelection] {
         get {
-            let rawData: [String] = self["offlineSyncSelections"] as? [String] ?? []
-            return rawData.compactMap { CourseSyncItemSelection(encodedValue: $0) }
+            self["offlineSyncSelections"] as? [String] ?? []
         }
         set {
-            self["offlineSyncSelections"] = newValue.map { $0.encodedValue }
+            self["offlineSyncSelections"] = newValue
         }
     }
 

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -134,6 +134,8 @@ public struct SessionDefaults {
         set { self["collapsedModules"] = newValue }
     }
 
+    // MARK: - Offline Settings
+
     public var isOfflineAutoSyncEnabled: Bool? {
         get { self["isOfflineAutoSyncEnabled"] as? Bool }
         set { self["isOfflineAutoSyncEnabled"] = newValue }
@@ -148,6 +150,18 @@ public struct SessionDefaults {
         get { self["isOfflineWifiOnlySyncEnabled"] as? Bool }
         set { self["isOfflineWifiOnlySyncEnabled"] = newValue }
     }
+
+    public var offlineSyncSelections: [CourseSyncItemSelection] {
+        get {
+            let rawData: [String] = self["offlineSyncSelections"] as? [String] ?? []
+            return rawData.compactMap { CourseSyncItemSelection($0) }
+        }
+        set {
+            self["offlineSyncSelections"] = newValue.map { $0.toString }
+        }
+    }
+
+    // MARK: Offline Settings -
 
     public mutating func reset() {
         sessionDefaults = nil

--- a/Core/Core/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/AppEnvironment/SessionDefaults.swift
@@ -157,7 +157,7 @@ public struct SessionDefaults {
             return rawData.compactMap { CourseSyncItemSelection($0) }
         }
         set {
-            self["offlineSyncSelections"] = newValue.map { $0.toString }
+            self["offlineSyncSelections"] = newValue.map { $0.encodedValue }
         }
     }
 

--- a/Core/Core/CourseSync/Common/Models/Entities/CourseSyncEntry.swift
+++ b/Core/Core/CourseSync/Common/Models/Entities/CourseSyncEntry.swift
@@ -33,7 +33,11 @@ struct CourseSyncEntry {
     }
 
     struct File {
+        /**
+         The unique identifier of the sync entry in a form of "courses/:courseId/files/:fileId". Doesn't correspond to the file ID on API. Use the `fileId` property if you need the API id.
+         */
         let id: String
+        var fileId: String { String(id.split(separator: "/").last ?? "") }
         let displayName: String
         let fileName: String
         let url: URL
@@ -43,7 +47,11 @@ struct CourseSyncEntry {
     }
 
     let name: String
+    /**
+     The unique identifier of the sync entry in a form of "courses/:courseId". Doesn't correspond to the course ID on API. Use the `courseId` property if you need the API id.
+     */
     let id: String
+    var courseId: String { String(id.split(separator: "/").last ?? "") }
 
     var tabs: [Self.Tab]
     var selectedTabsCount: Int {

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -109,7 +109,7 @@ final class CourseSyncInteractorLive: CourseSyncInteractor {
             .flatMap { fileIndex, element in
                 unownedSelf.filesInteractor.getFile(
                     url: element.url,
-                    fileID: element.id,
+                    fileID: element.fileId,
                     fileName: element.fileName,
                     mimeClass: element.mimeClass
                 )
@@ -158,7 +158,7 @@ final class CourseSyncInteractorLive: CourseSyncInteractor {
         if let tabIndex = entry.tabs.firstIndex(where: { $0.type == tabName }),
            entry.tabs[tabIndex].selectionState == .selected,
            let interactor = contentInteractors.first(where: { $0.associatedTabType == tabName }) {
-            return interactor.getContent(courseId: entry.id)
+            return interactor.getContent(courseId: entry.courseId)
                 .updateErrorState {
                     unownedSelf.setState(
                         selection: .tab(index, tabIndex),

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModelItem.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModelItem.swift
@@ -110,7 +110,7 @@ extension Array where Element == CourseSyncEntry {
 extension CourseSyncEntry {
 
     func makeSyncProgressViewModelItem() -> CourseSyncProgressViewModel.Item {
-        .init(id: "course-\(id)",
+        .init(id: id,
               title: name,
               subtitle: nil,
               isCollapsed: isCollapsed,
@@ -122,7 +122,7 @@ extension CourseSyncEntry {
 extension CourseSyncEntry.Tab {
 
     func makeSyncProgressViewModelItem() -> CourseSyncProgressViewModel.Item {
-        .init(id: "courseTab-\(id)",
+        .init(id: id,
               title: name,
               subtitle: nil,
               isCollapsed: type == .files ? isCollapsed : nil,
@@ -134,7 +134,7 @@ extension CourseSyncEntry.Tab {
 extension CourseSyncEntry.File {
 
     func makeSyncProgressViewModelItem() -> CourseSyncProgressViewModel.Item {
-        .init(id: "file-\(id)",
+        .init(id: id,
               title: displayName,
               subtitle: nil,
               cellStyle: .listItem,

--- a/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
@@ -21,7 +21,8 @@ import Foundation
 public enum CourseSyncSelectorAssembly {
 
     public static func makeViewController(env: AppEnvironment, courseID: String? = nil) -> UIViewController {
-        let selectorInteractor = CourseSyncSelectorInteractorLive(courseID: courseID)
+        let selectorInteractor = CourseSyncSelectorInteractorLive(courseID: courseID,
+                                                                  sessionDefaults: env.userDefaults ?? .fallback)
         let syncInteractor = CourseSyncInteractorLive()
         let diskSpaceInteractor = DiskSpaceInteractorLive()
         let viewModel = CourseSyncSelectorViewModel(
@@ -37,7 +38,7 @@ public enum CourseSyncSelectorAssembly {
 #if DEBUG
 
     static func makePreview(env: AppEnvironment, isEmpty: Bool) -> CourseSyncSelectorView {
-        let selectorInteractor = CourseSyncSelectorInteractorPreview()
+        let selectorInteractor = CourseSyncSelectorInteractorPreview(sessionDefaults: .fallback)
 
         if isEmpty {
             selectorInteractor.mockEmptyState()

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -43,7 +43,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
     private let courseSyncEntries = CurrentValueSubject<[CourseSyncEntry], Error>(.init())
     private var subscriptions = Set<AnyCancellable>()
     private let courseID: String?
-    private let sessionDefaults: SessionDefaults
+    private var sessionDefaults: SessionDefaults
 
     init(courseID: String? = nil, sessionDefaults: SessionDefaults) {
         self.courseID = courseID
@@ -106,6 +106,8 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
         case let .file(courseIndex, fileIndex):
             entries[courseIndex].selectFile(index: fileIndex, selectionState: selectionState)
         }
+
+        sessionDefaults.offlineSyncSelections = CourseSyncItemSelection.make(from: entries)
 
         courseSyncEntries.send(entries)
     }

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -107,7 +107,16 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             entries[courseIndex].selectFile(index: fileIndex, selectionState: selectionState)
         }
 
-        sessionDefaults.offlineSyncSelections = CourseSyncItemSelection.make(from: entries)
+        if let courseID {
+            // If we only show one course then we should keep other course selections intact
+            var oldSelections = sessionDefaults.offlineSyncSelections
+            oldSelections.removeAll { $0.hasPrefix("courses/\(courseID)") }
+            let newSelections = CourseSyncItemSelection.make(from: entries)
+            sessionDefaults.offlineSyncSelections = oldSelections + newSelections
+        } else {
+            // If all courses are visible then it's safe to overwrite all course selections
+            sessionDefaults.offlineSyncSelections = CourseSyncItemSelection.make(from: entries)
+        }
 
         courseSyncEntries.send(entries)
     }

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -169,26 +169,6 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
         }.eraseToAnyPublisher()
     }
 
-    private func getTabs(courseId: String) -> AnyPublisher<[CourseSyncEntry.Tab], Error> {
-        ReactiveStore(
-            useCase: GetContextTabs(
-                context: Context.course(courseId)
-            )
-        )
-        .getEntities()
-        .map { $0.offlineSupportedTabs() }
-        .map {
-            $0.map {
-                CourseSyncEntry.Tab(
-                    id: "\(courseId)-\($0.id)",
-                    name: $0.label,
-                    type: $0.name
-                )
-            }
-        }
-        .eraseToAnyPublisher()
-    }
-
     private func getAllFilesIfFilesTabIsEnabled(
         course: CourseSyncSelectorCourse
     ) -> AnyPublisher<CourseSyncEntry, Error> {

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -150,7 +150,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
         return courseSyncEntries
             .first { !$0.isEmpty }
             .map { syncEntries in
-                syncEntries.first { $0.id == courseID }?.name
+                syncEntries.first { $0.id == "courses/\(courseID)" }?.name
             }
             .replaceNil(with: "")
             .replaceError(with: "")
@@ -175,7 +175,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
         let tabs = Array(course.tabs).offlineSupportedTabs()
         let mappedTabs = tabs.map {
             CourseSyncEntry.Tab(
-                id: "\(course.courseId)-\($0.id)",
+                id: "courses/\(course.courseId)/tabs/\($0.id)",
                 name: $0.label,
                 type: $0.name
             )
@@ -185,7 +185,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
                 .map { files in
                     CourseSyncEntry(
                         name: course.name,
-                        id: course.courseId,
+                        id: "courses/\(course.courseId)",
                         tabs: mappedTabs,
                         files: files
                     )
@@ -195,7 +195,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             return Just(
                 CourseSyncEntry(
                     name: course.name,
-                    id: course.courseId,
+                    id: "courses/\(course.courseId)",
                     tabs: mappedTabs,
                     files: []
                 )
@@ -226,7 +226,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
                 .filter { $0.url != nil && $0.mimeClass != nil }
                 .map {
                     CourseSyncEntry.File(
-                        id: $0.id ?? Foundation.UUID().uuidString,
+                        id: "courses/\(courseId)/files/\($0.id ?? Foundation.UUID().uuidString)",
                         displayName: $0.displayName ?? NSLocalizedString("Unknown file", comment: ""),
                         fileName: $0.filename,
                         url: $0.url!,

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
@@ -24,7 +24,7 @@ import CombineExt
 class CourseSyncSelectorInteractorPreview: CourseSyncSelectorInteractor {
     private let mockData: CurrentValueRelay<[CourseSyncEntry]>
 
-    required init(courseID: String? = nil) {
+    required init(courseID: String? = nil, sessionDefaults: SessionDefaults) {
         mockData = CurrentValueRelay<[CourseSyncEntry]>([
             .init(name: "Black Hole",
                   id: "0",

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
@@ -18,6 +18,9 @@
 
 import Foundation
 
+/**
+ This entity is saved to the user's defaults and represents a single item selection in the offline sync selection screen.
+ */
 public struct CourseSyncItemSelection: Equatable {
     public enum SelectionType: String, Equatable {
         case course
@@ -34,8 +37,8 @@ public struct CourseSyncItemSelection: Equatable {
         self.selectionType = selectionType
     }
 
-    public init?(_ string: String) {
-        let components = string.split(separator: "_").map { String($0) }
+    public init?(encodedValue: String) {
+        let components = encodedValue.split(separator: "_").map { String($0) }
 
         guard components.count == 2,
               let selectionType = SelectionType(rawValue: components[0])

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
@@ -27,10 +27,7 @@ public struct CourseSyncItemSelection: Equatable {
 
     public let id: String
     public let selectionType: SelectionType
-
-    public var toString: String {
-        "\(selectionType.rawValue)_\(id)"
-    }
+    public var encodedValue: String { "\(selectionType.rawValue)_\(id)" }
 
     public init(id: String, selectionType: SelectionType) {
         self.id = id

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
@@ -1,0 +1,53 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public struct CourseSyncItemSelection: Equatable {
+    public enum SelectionType: String, Equatable {
+        case course
+        case file
+        case tab
+    }
+
+    public let id: String
+    public let selectionType: SelectionType
+
+    public var toString: String {
+        "\(selectionType.rawValue)_\(id)"
+    }
+
+    public init(id: String, selectionType: SelectionType) {
+        self.id = id
+        self.selectionType = selectionType
+    }
+
+    public init?(_ string: String) {
+        let components = string.split(separator: "_").map { String($0) }
+
+        guard components.count == 2,
+              let selectionType = SelectionType(rawValue: components[0])
+        else {
+            return nil
+        }
+
+        let id = components[1]
+        self.id = id
+        self.selectionType = selectionType
+    }
+}

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelection.swift
@@ -50,4 +50,24 @@ public struct CourseSyncItemSelection: Equatable {
         self.id = id
         self.selectionType = selectionType
     }
+
+    func toCourseEntrySelection(from syncEntries: [CourseSyncEntry]) -> CourseEntrySelection? {
+        switch selectionType {
+        case .course:
+            guard let index = syncEntries.firstIndex(where: { $0.id == id }) else { return nil }
+            return .course(index)
+        case .file:
+            for (courseIndex, course) in syncEntries.enumerated() {
+                guard let fileIndex = course.files.firstIndex(where: { $0.id == id }) else { continue }
+                return .file(courseIndex, fileIndex)
+            }
+            return nil
+        case .tab:
+            for (courseIndex, course) in syncEntries.enumerated() {
+                guard let tabIndex = course.tabs.firstIndex(where: { $0.id == id }) else { continue }
+                return .tab(courseIndex, tabIndex)
+            }
+            return nil
+        }
+    }
 }

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
@@ -121,7 +121,7 @@ extension Array where Element == CourseSyncEntry {
 extension CourseSyncEntry {
 
     func makeViewModelItem() -> CourseSyncSelectorViewModel.Item {
-        .init(id: "course-\(id)",
+        .init(id: id,
               title: name,
               subtitle: nil,
               selectionState: selectionState,
@@ -133,7 +133,7 @@ extension CourseSyncEntry {
 extension CourseSyncEntry.Tab {
 
     func makeViewModelItem() -> CourseSyncSelectorViewModel.Item {
-        .init(id: "courseTab-\(id)",
+        .init(id: id,
               title: name,
               subtitle: nil,
               selectionState: selectionState,
@@ -145,7 +145,7 @@ extension CourseSyncEntry.Tab {
 extension CourseSyncEntry.File {
 
     func makeViewModelItem() -> CourseSyncSelectorViewModel.Item {
-        .init(id: "file-\(id)",
+        .init(id: id,
               title: displayName,
               subtitle: nil,
               selectionState: selectionState,

--- a/Core/Core/CourseSync/CourseSyncSettings/CourseSyncSettingsAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/CourseSyncSettingsAssembly.swift
@@ -29,8 +29,7 @@ public enum CourseSyncSettingsAssembly {
 #if DEBUG
 
     static func makePreview() -> some View {
-        let sessionDefaults = SessionDefaults(sessionID: "preview")
-        let interactor = CourseSyncSettingsInteractorLive(storage: sessionDefaults)
+        let interactor = CourseSyncSettingsInteractorLive(storage: .fallback)
         let viewModel = CourseSyncSettingsViewModel(interactor: interactor)
         return CourseSyncSettingsView(viewModel: viewModel)
     }

--- a/Core/Core/Dashboard/Settings/Model/DashboardSettingsInteractorLive.swift
+++ b/Core/Core/Dashboard/Settings/Model/DashboardSettingsInteractorLive.swift
@@ -35,7 +35,7 @@ public class DashboardSettingsInteractorLive: DashboardSettingsInteractor {
     private var userSettings: Store<GetUserSettings>!
 
     public init(environment: AppEnvironment, defaults: SessionDefaults?) {
-        let defaults = defaults ?? SessionDefaults(sessionID: "")
+        let defaults = defaults ?? .fallback
         let storedLayout: DashboardLayout = defaults.isDashboardLayoutGrid ? .grid : .list
         self.defaults = defaults
         self.layout = CurrentValueSubject<DashboardLayout, Never>(storedLayout)

--- a/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
+++ b/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
@@ -51,4 +51,15 @@ class SessionDefaultsTests: XCTestCase {
         defaults.reset()
         XCTAssertFalse(defaults.isDashboardLayoutGrid)
     }
+
+    func testCourseSyncItemPersistency() {
+        let item1 = CourseSyncItemSelection(id: "1", selectionType: .tab)
+        let item2 = CourseSyncItemSelection(id: "2", selectionType: .course)
+        let item3 = CourseSyncItemSelection(id: "3", selectionType: .file)
+        defaults.offlineSyncSelections = [item1, item2, item3]
+
+        let testee = defaults.offlineSyncSelections
+
+        XCTAssertEqual(testee, [item1, item2, item3])
+    }
 }

--- a/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
+++ b/Core/CoreTests/AppEnvironment/SessionDefaultsTests.swift
@@ -53,9 +53,9 @@ class SessionDefaultsTests: XCTestCase {
     }
 
     func testCourseSyncItemPersistency() {
-        let item1 = CourseSyncItemSelection(id: "1", selectionType: .tab)
-        let item2 = CourseSyncItemSelection(id: "2", selectionType: .course)
-        let item3 = CourseSyncItemSelection(id: "3", selectionType: .file)
+        let item1 = "courses/1/tabs/1"
+        let item2 = "courses/2"
+        let item3 = "courses/1/files/1"
         defaults.offlineSyncSelections = [item1, item2, item3]
 
         let testee = defaults.offlineSyncSelections

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -65,7 +65,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
 
         waitForExpectations(timeout: 0.1)
         XCTAssertEqual(entries.count, 1)
-        XCTAssertEqual(entries.first?.id, "2")
+        XCTAssertEqual(entries.first?.id, "courses/2")
         subscription.cancel()
     }
 
@@ -313,7 +313,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
     func testAppliesPreviousSelection() {
         // MARK: - GIVEN
         var session = SessionDefaults(sessionID: "oldSession")
-        session.offlineSyncSelections = [.init(id: "2", selectionType: .course)]
+        session.offlineSyncSelections = ["courses/2"]
 
         mockCourseList(courseList: [
             .make(id: "1", tabs: []),
@@ -332,7 +332,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
             .first()
 
         // MARK: - THEN
-        XCTAssertSingleOutputEquals(selectedItemID, "2")
+        XCTAssertSingleOutputEquals(selectedItemID, "courses/2")
         session.reset()
     }
 
@@ -353,7 +353,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         testee.setSelected(selection: .course(1), selectionState: .selected)
 
         // MARK: - THEN
-        XCTAssertEqual(session.offlineSyncSelections, [.init(id: "2", selectionType: .course)])
+        XCTAssertEqual(session.offlineSyncSelections, ["courses/2"])
         session.reset()
     }
 

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -308,6 +308,8 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         subscriptions.removeAll()
     }
 
+    // MARK: - Selection Persistency
+
     func testAppliesPreviousSelection() {
         // MARK: - GIVEN
         var session = SessionDefaults(sessionID: "oldSession")
@@ -331,6 +333,27 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
 
         // MARK: - THEN
         XCTAssertSingleOutputEquals(selectedItemID, "2")
+        session.reset()
+    }
+
+    func testSavesSelectionState() {
+        // MARK: - GIVEN
+        var session = SessionDefaults(sessionID: "emptySession")
+        XCTAssertTrue(session.offlineSyncSelections.isEmpty)
+
+        mockCourseList(courseList: [
+            .make(id: "1", tabs: []),
+            .make(id: "2", tabs: []),
+        ])
+
+        let testee = CourseSyncSelectorInteractorLive(sessionDefaults: session)
+        XCTAssertFinish(testee.getCourseSyncEntries().first())
+
+        // MARK: - WHEN
+        testee.setSelected(selection: .course(1), selectionState: .selected)
+
+        // MARK: - THEN
+        XCTAssertEqual(session.offlineSyncSelections, [.init(id: "2", selectionType: .course)])
         session.reset()
     }
 

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
@@ -1,0 +1,59 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class CourseSyncItemSelectionTests: XCTestCase {
+
+    func testMappingToCourseEntrySelection() {
+        let syncEntries = [
+            CourseSyncEntry(name: "",
+                            id: "1",
+                            tabs: [],
+                            files: [],
+                            isCollapsed: false,
+                            selectionState: .deselected,
+                            isEverythingSelected: false,
+                            state: .loading(nil)),
+            CourseSyncEntry(name: "",
+                            id: "2",
+                            tabs: [
+                                .init(id: "t1", name: "", type: .files),
+                                .init(id: "t2", name: "", type: .files),
+                            ],
+                            files: [
+                                .make(id: "f1", displayName: ""),
+                                .make(id: "f2", displayName: ""),
+                            ],
+                            isCollapsed: false,
+                            selectionState: .deselected,
+                            isEverythingSelected: false,
+                            state: .loading(nil)),
+        ]
+
+        let courseSelection = CourseSyncItemSelection(id: "2", selectionType: .course)
+        XCTAssertEqual(courseSelection.toCourseEntrySelection(from: syncEntries), .course(1))
+
+        let tabSelection = CourseSyncItemSelection(id: "t2", selectionType: .tab)
+        XCTAssertEqual(tabSelection.toCourseEntrySelection(from: syncEntries), .tab(1, 1))
+
+        let fileSelection = CourseSyncItemSelection(id: "f2", selectionType: .file)
+        XCTAssertEqual(fileSelection.toCourseEntrySelection(from: syncEntries), .file(1, 1))
+    }
+}

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
@@ -34,12 +34,12 @@ class CourseSyncItemSelectionTests: XCTestCase {
             CourseSyncEntry(name: "",
                             id: "2",
                             tabs: [
-                                .init(id: "t1", name: "", type: .files),
-                                .init(id: "t2", name: "", type: .files),
+                                .init(id: "3", name: "", type: .files),
+                                .init(id: "4", name: "", type: .files),
                             ],
                             files: [
-                                .make(id: "f1", displayName: ""),
-                                .make(id: "f2", displayName: ""),
+                                .make(id: "5", displayName: ""),
+                                .make(id: "6", displayName: ""),
                             ],
                             isCollapsed: false,
                             selectionState: .deselected,
@@ -47,70 +47,14 @@ class CourseSyncItemSelectionTests: XCTestCase {
                             state: .loading(nil)),
         ]
 
-        let courseSelection = CourseSyncItemSelection(id: "2", selectionType: .course)
+        let courseSelection = "2"
         XCTAssertEqual(courseSelection.toCourseEntrySelection(from: syncEntries), .course(1))
 
-        let tabSelection = CourseSyncItemSelection(id: "t2", selectionType: .tab)
+        let tabSelection = "4"
         XCTAssertEqual(tabSelection.toCourseEntrySelection(from: syncEntries), .tab(1, 1))
 
-        let fileSelection = CourseSyncItemSelection(id: "f2", selectionType: .file)
+        let fileSelection = "6"
         XCTAssertEqual(fileSelection.toCourseEntrySelection(from: syncEntries), .file(1, 1))
-    }
-
-    // MARK: - Mapping From Single Course Sync Entity
-
-    func testInitFromCourseSyncEntry() {
-        let deSelectedEntry = CourseSyncEntry(name: "", id: "1", tabs: [], files: [],
-                                              selectionState: .deselected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntry: deSelectedEntry))
-
-        let partiallySelectedEntry = CourseSyncEntry(name: "", id: "2", tabs: [], files: [],
-                                                     selectionState: .partiallySelected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntry: partiallySelectedEntry))
-
-        let selectedEntry = CourseSyncEntry(name: "", id: "3", tabs: [], files: [],
-                                            selectionState: .selected)
-        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntry: selectedEntry),
-                       .init(id: "3", selectionType: .course))
-    }
-
-    func testInitFromCourseSyncEntryTab() {
-        let deSelectedEntry = CourseSyncEntry.Tab(id: "1", name: "", type: .pages, selectionState: .deselected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryTab: deSelectedEntry))
-
-        let partiallySelectedEntry = CourseSyncEntry.Tab(id: "2", name: "", type: .pages, selectionState: .partiallySelected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryTab: partiallySelectedEntry))
-
-        let selectedEntry = CourseSyncEntry.Tab(id: "3", name: "", type: .pages, selectionState: .selected)
-        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntryTab: selectedEntry),
-                       .init(id: "3", selectionType: .tab))
-    }
-
-    func testInitFromCourseSyncEntryFile() {
-        let deSelectedEntry = CourseSyncEntry.File(id: "1",
-                                                   displayName: "",
-                                                   fileName: "",
-                                                   url: URL(string: "/")!,
-                                                   mimeClass: "",
-                                                   selectionState: .deselected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryFile: deSelectedEntry))
-
-        let partiallySelectedEntry = CourseSyncEntry.File(id: "2",
-                                                          displayName: "",
-                                                          fileName: "",
-                                                          url: URL(string: "/")!,
-                                                          mimeClass: "",
-                                                          selectionState: .partiallySelected)
-        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryFile: partiallySelectedEntry))
-
-        let selectedEntry = CourseSyncEntry.File(id: "3",
-                                                 displayName: "",
-                                                 fileName: "",
-                                                 url: URL(string: "/")!,
-                                                 mimeClass: "",
-                                                 selectionState: .selected)
-        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntryFile: selectedEntry),
-                       .init(id: "3", selectionType: .file))
     }
 
     // MARK: - Mapping From An Array Of Course Sync Entities
@@ -126,7 +70,7 @@ class CourseSyncItemSelectionTests: XCTestCase {
                                               url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
                                      ],
                                      selectionState: .selected)
-        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "1", selectionType: .course)])
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), ["1"])
     }
 
     func testMapsSelectedFilesTabButNotFiles() {
@@ -140,7 +84,7 @@ class CourseSyncItemSelectionTests: XCTestCase {
                                               url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
                                      ],
                                      selectionState: .partiallySelected)
-        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "2", selectionType: .tab)])
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), ["2"])
     }
 
     func testMapsSelectedTabs() {
@@ -152,7 +96,7 @@ class CourseSyncItemSelectionTests: XCTestCase {
                                      ],
                                      files: [],
                                      selectionState: .partiallySelected)
-        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "2", selectionType: .tab)])
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), ["2"])
     }
 
     func testMapsSelectedFiles() {
@@ -168,6 +112,6 @@ class CourseSyncItemSelectionTests: XCTestCase {
                                               url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
                                      ],
                                      selectionState: .partiallySelected)
-        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "4", selectionType: .file)])
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), ["4"])
     }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncItemSelectionTests.swift
@@ -56,4 +56,118 @@ class CourseSyncItemSelectionTests: XCTestCase {
         let fileSelection = CourseSyncItemSelection(id: "f2", selectionType: .file)
         XCTAssertEqual(fileSelection.toCourseEntrySelection(from: syncEntries), .file(1, 1))
     }
+
+    // MARK: - Mapping From Single Course Sync Entity
+
+    func testInitFromCourseSyncEntry() {
+        let deSelectedEntry = CourseSyncEntry(name: "", id: "1", tabs: [], files: [],
+                                              selectionState: .deselected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntry: deSelectedEntry))
+
+        let partiallySelectedEntry = CourseSyncEntry(name: "", id: "2", tabs: [], files: [],
+                                                     selectionState: .partiallySelected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntry: partiallySelectedEntry))
+
+        let selectedEntry = CourseSyncEntry(name: "", id: "3", tabs: [], files: [],
+                                            selectionState: .selected)
+        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntry: selectedEntry),
+                       .init(id: "3", selectionType: .course))
+    }
+
+    func testInitFromCourseSyncEntryTab() {
+        let deSelectedEntry = CourseSyncEntry.Tab(id: "1", name: "", type: .pages, selectionState: .deselected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryTab: deSelectedEntry))
+
+        let partiallySelectedEntry = CourseSyncEntry.Tab(id: "2", name: "", type: .pages, selectionState: .partiallySelected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryTab: partiallySelectedEntry))
+
+        let selectedEntry = CourseSyncEntry.Tab(id: "3", name: "", type: .pages, selectionState: .selected)
+        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntryTab: selectedEntry),
+                       .init(id: "3", selectionType: .tab))
+    }
+
+    func testInitFromCourseSyncEntryFile() {
+        let deSelectedEntry = CourseSyncEntry.File(id: "1",
+                                                   displayName: "",
+                                                   fileName: "",
+                                                   url: URL(string: "/")!,
+                                                   mimeClass: "",
+                                                   selectionState: .deselected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryFile: deSelectedEntry))
+
+        let partiallySelectedEntry = CourseSyncEntry.File(id: "2",
+                                                          displayName: "",
+                                                          fileName: "",
+                                                          url: URL(string: "/")!,
+                                                          mimeClass: "",
+                                                          selectionState: .partiallySelected)
+        XCTAssertNil(CourseSyncItemSelection(courseSyncEntryFile: partiallySelectedEntry))
+
+        let selectedEntry = CourseSyncEntry.File(id: "3",
+                                                 displayName: "",
+                                                 fileName: "",
+                                                 url: URL(string: "/")!,
+                                                 mimeClass: "",
+                                                 selectionState: .selected)
+        XCTAssertEqual(CourseSyncItemSelection(courseSyncEntryFile: selectedEntry),
+                       .init(id: "3", selectionType: .file))
+    }
+
+    // MARK: - Mapping From An Array Of Course Sync Entities
+
+    func testMapsSelectedCourseButNotTabsOrFiles() {
+        let course = CourseSyncEntry(name: "",
+                                     id: "1",
+                                     tabs: [
+                                        .init(id: "2", name: "", type: .pages, selectionState: .selected)
+                                     ],
+                                     files: [
+                                        .init(id: "3", displayName: "", fileName: "",
+                                              url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
+                                     ],
+                                     selectionState: .selected)
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "1", selectionType: .course)])
+    }
+
+    func testMapsSelectedFilesTabButNotFiles() {
+        let course = CourseSyncEntry(name: "",
+                                     id: "1",
+                                     tabs: [
+                                        .init(id: "2", name: "", type: .files, selectionState: .selected),
+                                     ],
+                                     files: [
+                                        .init(id: "3", displayName: "", fileName: "",
+                                              url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
+                                     ],
+                                     selectionState: .partiallySelected)
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "2", selectionType: .tab)])
+    }
+
+    func testMapsSelectedTabs() {
+        let course = CourseSyncEntry(name: "",
+                                     id: "1",
+                                     tabs: [
+                                        .init(id: "2", name: "", type: .files, selectionState: .selected),
+                                        .init(id: "3", name: "", type: .files, selectionState: .deselected),
+                                     ],
+                                     files: [],
+                                     selectionState: .partiallySelected)
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "2", selectionType: .tab)])
+    }
+
+    func testMapsSelectedFiles() {
+        let course = CourseSyncEntry(name: "",
+                                     id: "1",
+                                     tabs: [
+                                        .init(id: "2", name: "", type: .files, selectionState: .partiallySelected),
+                                     ],
+                                     files: [
+                                        .init(id: "3", displayName: "", fileName: "",
+                                              url: URL(string: "/")!, mimeClass: "", selectionState: .deselected),
+                                        .init(id: "4", displayName: "", fileName: "",
+                                              url: URL(string: "/")!, mimeClass: "", selectionState: .selected),
+                                     ],
+                                     selectionState: .partiallySelected)
+        XCTAssertEqual(CourseSyncItemSelection.make(from: [course]), [.init(id: "4", selectionType: .file)])
+    }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncSelectorEntryTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/Entities/CourseSyncSelectorEntryTests.swift
@@ -21,6 +21,23 @@ import XCTest
 
 class CourseSyncEntryTests: XCTestCase {
 
+    func testCourseId() {
+        let testee = CourseSyncEntry(name: "",
+                                     id: "courses/3",
+                                     tabs: [],
+                                     files: [])
+        XCTAssertEqual(testee.courseId, "3")
+    }
+
+    func testFileId() {
+        let testee = CourseSyncEntry.File(id: "courses/3/files/2",
+                                          displayName: "",
+                                          fileName: "",
+                                          url: URL(string: "/")!,
+                                          mimeClass: "")
+        XCTAssertEqual(testee.fileId, "2")
+    }
+
     func testCourseSelection() {
         var entry = CourseSyncEntry(
             name: "1",

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -25,7 +25,7 @@ class CourseSyncSelectorViewModelItemTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockInteractor = MockCourseSyncSelectorInteractor()
+        mockInteractor = MockCourseSyncSelectorInteractor(sessionDefaults: .fallback)
     }
 
     // MARK: - Properties
@@ -255,7 +255,7 @@ private class MockCourseSyncSelectorInteractor: CourseSyncSelectorInteractor {
     private(set) var lastSelected: (selection: Core.CourseEntrySelection, isSelected: Bool)?
     private(set) var lastCollapsed: (selection: Core.CourseEntrySelection, isCollapsed: Bool)?
 
-    required init(courseID: String? = nil) {
+    required init(courseID: String? = nil, sessionDefaults: SessionDefaults) {
     }
 
     func getCourseSyncEntries() -> AnyPublisher<[Core.CourseSyncEntry], Error> {

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -29,7 +29,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        mockSelectorInteractor = CourseSyncSelectorInteractorMock()
+        mockSelectorInteractor = CourseSyncSelectorInteractorMock(sessionDefaults: .fallback)
         mockSyncInteractor = CourseSyncInteractorMock()
         router = TestRouter()
         testee = CourseSyncSelectorViewModel(
@@ -130,7 +130,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
 
 class CourseSyncSelectorInteractorMock: CourseSyncSelectorInteractor {
 
-    required init(courseID: String? = nil) {
+    required init(courseID: String? = nil, sessionDefaults: SessionDefaults) {
     }
 
     let courseSyncEntriesSubject = PassthroughSubject<[CourseSyncEntry], Error>()

--- a/Core/CoreTests/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractorLiveTests.swift
@@ -21,7 +21,7 @@ import TestsFoundation
 import XCTest
 
 class CourseSyncSettingsInteractorLiveTests: XCTestCase {
-    private var defaults = SessionDefaults(sessionID: "test")
+    private var defaults = SessionDefaults.fallback
 
     override func setUp() {
         super.setUp()

--- a/Core/CoreTests/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModelTests.swift
@@ -104,7 +104,6 @@ class CourseSyncSettingsViewModelTests: XCTestCase {
     }
 
     private func makeInteractor() -> CourseSyncSettingsInteractor {
-        let session = SessionDefaults(sessionID: "test")
-        return CourseSyncSettingsInteractorLive(storage: session)
+        return CourseSyncSettingsInteractorLive(storage: .fallback)
     }
 }

--- a/Core/CoreTests/Dashboard/Model/Settings/DashboardSettingsInteractorLiveTests.swift
+++ b/Core/CoreTests/Dashboard/Model/Settings/DashboardSettingsInteractorLiveTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 
 class DashboardSettingsInteractorLiveTests: CoreTestCase {
-    private var defaults = SessionDefaults(sessionID: "")
+    private var defaults = SessionDefaults.fallback
 
     // MARK: - Initial Values
 

--- a/Core/CoreTests/Extensions/UIColorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UIColorExtensionsTests.swift
@@ -71,21 +71,21 @@ class UIColorExtensionsTests: XCTestCase {
     }
 
     func testCustomColorInUnspecifiedTheme() {
-        var sessionDefaults = SessionDefaults(sessionID: "testSession")
+        var sessionDefaults = SessionDefaults.fallback
         sessionDefaults.interfaceStyle = .unspecified
         AppEnvironment.shared.userDefaults = sessionDefaults
         XCTAssertEqual(UIColor.backgroundLightest.hexString, "#ffffff")
     }
 
     func testCustomColorInLightTheme() {
-        var sessionDefaults = SessionDefaults(sessionID: "testSession")
+        var sessionDefaults = SessionDefaults.fallback
         sessionDefaults.interfaceStyle = .light
         AppEnvironment.shared.userDefaults = sessionDefaults
         XCTAssertEqual(UIColor.backgroundLightest.hexString, "#ffffff")
     }
 
     func testCustomColorInDarkTheme() {
-        var sessionDefaults = SessionDefaults(sessionID: "testSession")
+        var sessionDefaults = SessionDefaults.fallback
         sessionDefaults.interfaceStyle = .dark
         AppEnvironment.shared.userDefaults = sessionDefaults
         XCTAssertEqual(UIColor.backgroundLightest.hexString, "#121212")

--- a/Core/CoreTests/Extensions/UIFontExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/UIFontExtensionsTests.swift
@@ -36,7 +36,7 @@ class UIFontExtensionsTests: XCTestCase {
     func testScaledK5Font() {
         ExperimentalFeature.K5Dashboard.isEnabled = true
         let environment = AppEnvironment.shared
-        environment.userDefaults = SessionDefaults(sessionID: "123")
+        environment.userDefaults = .fallback
         environment.userDefaults?.isElementaryViewEnabled = true
         environment.k5.userDidLogin(isK5Account: true)
 


### PR DESCRIPTION
refs: MBL-16759
affects: Student
release note: none

test plan:
- Open offline sync selection screen.
- Select a few items.
- Close the screen.
- Open it again.
- Selections should be restored.
- Play around with whole course and files tab selection.
- Selections should be restored after app restart.
- Opening the selection screen from the dashboard or from a course should display consistent selections.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet