### PR TITLE
Fix navigation items being added multiple times

### DIFF
--- a/Core/Core/Extensions/ArrayExtensions.swift
+++ b/Core/Core/Extensions/ArrayExtensions.swift
@@ -27,3 +27,11 @@ public extension Array {
         append(element)
     }
 }
+
+extension Array where Element: UIBarButtonItem {
+    func removeDuplicates() -> [Element] {
+        return reduce([]) { result, element in
+            result.contains { $0.action == element.action } ? result : result + [element]
+        }
+    }
+}

--- a/Core/Core/Extensions/UIViewControllerExtensions.swift
+++ b/Core/Core/Extensions/UIViewControllerExtensions.swift
@@ -139,7 +139,7 @@ extension UIViewController {
         let right = navigationItem.rightBarButtonItems ?? []
         let left = navigationItem.leftBarButtonItems ?? []
         let leftItemsSupplementBackButton = navigationItem.leftItemsSupplementBackButton
-        navigationItem.rightBarButtonItems = (viewController.navigationItem.rightBarButtonItems ?? []) + right
+        navigationItem.rightBarButtonItems = (right + (viewController.navigationItem.rightBarButtonItems ?? [])).removeDuplicates()
         navigationItem.leftBarButtonItems = (viewController.navigationItem.leftBarButtonItems ?? []) + left
         navigationItem.leftItemsSupplementBackButton = viewController.navigationItem.leftItemsSupplementBackButton || leftItemsSupplementBackButton
 

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -77,6 +77,11 @@ public class ModuleItemSequenceViewController: UIViewController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
+        guard let previousTraitCollection = previousTraitCollection,
+              (traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass ||
+              traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass) else {
+            return
+        }
         if let viewController = currentViewController() {
             observations = syncNavigationBar(with: viewController)
         }

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -77,9 +77,6 @@ public class ModuleItemSequenceViewController: UIViewController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard UIDevice.current.userInterfaceIdiom == .pad else {
-            return
-        }
         if let viewController = currentViewController() {
             observations = syncNavigationBar(with: viewController)
         }

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -77,9 +77,7 @@ public class ModuleItemSequenceViewController: UIViewController {
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        guard let previousTraitCollection = previousTraitCollection,
-              (traitCollection.horizontalSizeClass != previousTraitCollection.horizontalSizeClass ||
-              traitCollection.verticalSizeClass != previousTraitCollection.verticalSizeClass) else {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
             return
         }
         if let viewController = currentViewController() {


### PR DESCRIPTION
Test the following things: 
- The fix for this [PR](https://github.com/instructure/canvas-ios/pull/2457) fix still works
- Open a Student/Teacher, open a Course, Discussion, rotate the device back and forth. You shouldn't see items appearing multiple times

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

