### PR TITLE
Update developer menu

### DIFF
--- a/Core/Core/DeveloperMenu/DeveloperMenuView.swift
+++ b/Core/Core/DeveloperMenu/DeveloperMenuView.swift
@@ -87,6 +87,13 @@ public struct DeveloperMenuView: View {
                 .deletingLastPathComponent()
                 .absoluteString
         }()
+        let sharedDirectory: String? = {
+            guard let appGroup = Bundle.main.appGroupID() else { return nil }
+            return URL
+                .Directories
+                .sharedContainers(appGroup)?
+                .absoluteString
+        }()
 
         items.append(contentsOf: [
             DeveloperMenuItem("View Experimental Features") {
@@ -116,6 +123,14 @@ public struct DeveloperMenuView: View {
                 snackBarViewModel.showSnack("App Directory copied to clipboard.")
             },
         ])
+
+        if let sharedDirectory {
+            items.append(DeveloperMenuItem("Shared Container Directory\n\(sharedDirectory)",
+                                           icon: .toClipboard) {
+                UIPasteboard.general.string = sharedDirectory
+                snackBarViewModel.showSnack("Shared Container Directory copied to clipboard.")
+            })
+        }
 
         #if DEBUG
         items.append(


### PR DESCRIPTION
refs: MBL-16706
affects: Student, Teacher
release note: none

test plan:
- Open developer menu.
- Design should be according to the latest app standards.
- Cells should register taps when touched on an empty area.
- Open a menu item and close it.
- Menu items shouldn't duplicate.
- Two new items should be available. One for the app directory and another for the shared container dir.