### PR TITLE
Add helper publisher to observe file and course entry progresses together in a single progress value

### DIFF
--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
@@ -23,6 +23,8 @@ import Foundation
 protocol CourseSyncProgressObserverInteractor {
     func observeFileProgress() -> AnyPublisher<ReactiveStore<LocalUseCase<CourseSyncFileProgress>>.State, Never>
     func observeEntryProgress() -> AnyPublisher<ReactiveStore<LocalUseCase<CourseSyncEntryProgress>>.State, Never>
+    /// Combines file + entry progresses. Range is `0...1`.
+    func observeCombinedProgress() -> AnyPublisher<Float, Never>
 }
 
 final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserverInteractor {
@@ -50,5 +52,79 @@ final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserver
         )
         .observeEntities()
         .eraseToAnyPublisher()
+    }
+
+    func observeCombinedProgress() -> AnyPublisher<Float, Never> {
+        let fileProgress = observeFileProgress()
+            .map {
+                if let progress = $0.firstItem {
+                    return (toDownload: progress.bytesToDownload,
+                            downloaded: progress.bytesDownloaded)
+                } else {
+                    return (toDownload: 0,
+                            downloaded: 0)
+                }
+            }
+        let entryProgress = observeEntryProgress()
+            .map { $0.allItems?.downloadSizes ?? (toDownload: 0, downloaded: 0) }
+
+        return Publishers
+            .CombineLatest(fileProgress, entryProgress)
+            .map { fileProgress, entryProgress in
+                let totalToDownload = fileProgress.toDownload + entryProgress.toDownload
+                let totalDownloaded = fileProgress.downloaded + entryProgress.downloaded
+                if totalToDownload > 0 {
+                    return Float(totalDownloaded) / Float(totalToDownload)
+                } else {
+                    return 0
+                }
+            }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+}
+
+extension Array where Element == CourseSyncEntryProgress {
+
+    var downloadSizes: (toDownload: Int, downloaded: Int) {
+        let estimatedEntrySize = 100_000
+        return self
+            .removeCourseEntries()
+            .removeFileEntries()
+            .reduce(into: (toDownload: 0, downloaded: 0)) { partialResult, entry in
+                partialResult.toDownload += estimatedEntrySize
+
+                switch entry.state {
+                case .downloaded, .error:
+                    partialResult.downloaded += estimatedEntrySize
+                default: break
+                }
+            }
+    }
+
+    /// Course entries on their own are not syncable entries (only their tabs) and can be ignored
+    private func removeCourseEntries() -> Self {
+        var result = self
+        result.removeAll { entry in
+            if case .course = entry.selection {
+                return true
+            } else {
+                return false
+            }
+        }
+        return result
+    }
+
+    /// File progresses are tracked separately so we don't need to calculate with them here.
+    private func removeFileEntries() -> Self {
+        var result = self
+        result.removeAll { entry in
+            if case .file = entry.selection {
+                return true
+            } else {
+                return false
+            }
+        }
+        return result
     }
 }

--- a/Core/Core/Store/ReactiveStore.swift
+++ b/Core/Core/Store/ReactiveStore.swift
@@ -37,6 +37,20 @@ public class ReactiveStore<U: UseCase> {
         }
 
         case loading, error(Error), data([U.Model])
+
+        /// If the enum's case is `.data` then extracts and returns all models.
+        public var allItems: [U.Model]? {
+            if case .data(let data) = self {
+                return data
+            } else {
+                return nil
+            }
+        }
+
+        /// If the enum's case is `.data` then extracts and returns the first item.
+        public var firstItem: U.Model? {
+            allItems?.first
+        }
     }
 
     private let env: AppEnvironment


### PR DESCRIPTION
The mechanism is that we convert each non-file sync item to an estimated size of 100 kB and add it to the file progress in bytes then report back the combined progress.

Test plan:
- In terminal, cd to project root.
- Copy the git diff below to your clipboard
- Run `pbpaste | git apply`.
- Open a course's sync screen.
- Select a few tabs, include a some files.
- Start sync.
- Check console for lines starting with `Progress: `.
- Progress should go from 0 to 1 during the sync progress.

```
diff --git a/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift b/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift
index f6ac6a9f0..5ad76346a 100644
--- a/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift
+++ b/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift
@@ -39,6 +39,18 @@ public class DashboardCourseCardListViewModel: ObservableObject {
     public init(_ interactor: DashboardCourseCardListInteractor) {
         self.interactor = interactor
 
+        let context = AppEnvironment.shared.database.viewContext
+        context.performAndWait {
+            let fileProgresses: [CourseSyncFileProgress] = context.fetch(scope: .all)
+            context.delete(fileProgresses)
+            let entryProgresses: [CourseSyncEntryProgress] = context.fetch(scope: .all)
+            context.delete(entryProgresses)
+        }
+        CourseSyncProgressObserverInteractorLive()
+            .observeCombinedProgress()
+            .sink { print("Progress: \($0)") }
+            .store(in: &subscriptions)
+
         NotificationCenter.default.publisher(for: .favoritesDidChange)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.refresh() }

```

[ignore-commit-lint]