### PR TITLE
Update PSPDFKit

### DIFF
--- a/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -140,8 +140,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PSPDFKit/PSPDFKit-SP",
       "state" : {
-        "revision" : "cb2120a42781b17de1e17b7923dcfa8852dbdb8a",
-        "version" : "12.0.2"
+        "revision" : "612f0c3e86a8a6c5a9fac87da9b990ce836c3214",
+        "version" : "12.3.0"
       }
     },
     {

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -10630,7 +10630,7 @@
 			repositoryURL = "https://github.com/PSPDFKit/PSPDFKit-SP";
 			requirement = {
 				kind = exactVersion;
-				version = 12.0.2;
+				version = 12.3.0;
 			};
 		};
 		FCD1D04FD946BB6C6C264E50 /* XCRemoteSwiftPackageReference "CombineExt" */ = {

--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
@@ -26,7 +26,7 @@ struct CourseSyncProgressView: View {
 
     var body: some View {
         content
-        .navigationBarTitleView(navBarTitleView)
+        .navigationTitle(navBarTitleView)
         .navigationBarItems(leading: cancelButton, trailing: trailingBarItem)
         .navigationBarStyle(.modal)
     }

--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
@@ -26,7 +26,7 @@ struct CourseSyncProgressView: View {
 
     var body: some View {
         content
-        .navigationTitle(navBarTitleView)
+        .navigationTitleStyled(navBarTitleView)
         .navigationBarItems(leading: cancelButton, trailing: trailingBarItem)
         .navigationBarStyle(.modal)
     }

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -26,7 +26,7 @@ struct CourseSyncSelectorView: View {
     var body: some View {
         content
         .background(Color.backgroundLightest)
-        .navigationTitle(navBarTitleView)
+        .navigationTitleStyled(navBarTitleView)
         .navigationBarItems(leading: leftNavBarButton, trailing: cancelButton)
         .navigationBarStyle(.modal)
     }

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -26,7 +26,7 @@ struct CourseSyncSelectorView: View {
     var body: some View {
         content
         .background(Color.backgroundLightest)
-        .navigationBarTitleView(navBarTitleView)
+        .navigationTitle(navBarTitleView)
         .navigationBarItems(leading: leftNavBarButton, trailing: cancelButton)
         .navigationBarStyle(.modal)
     }

--- a/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
@@ -28,7 +28,7 @@ public struct AssignmentPickerView: View {
 
     public var body: some View {
         content
-            .navigationTitle(Text("Select Assignment", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
+            .navigationTitleStyled(Text("Select Assignment", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
             .navigationBarTitleDisplayMode(.inline)
             .onReceive(viewModel.dismissViewDidTrigger) {
                 presentationMode.wrappedValue.dismiss()

--- a/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
@@ -28,7 +28,8 @@ public struct AssignmentPickerView: View {
 
     public var body: some View {
         content
-            .navigationBarTitleView(Text("Select Assignment", bundle: .core).font(.semibold17).foregroundColor(.textDarkest), displayMode: .inline)
+            .navigationTitle(Text("Select Assignment", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
+            .navigationBarTitleDisplayMode(.inline)
             .onReceive(viewModel.dismissViewDidTrigger) {
                 presentationMode.wrappedValue.dismiss()
             }

--- a/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
@@ -28,7 +28,8 @@ public struct CoursePickerView: View {
 
     public var body: some View {
         content
-            .navigationBarTitleView(Text("Select Course", bundle: .core).font(.semibold17).foregroundColor(.textDarkest), displayMode: .inline)
+            .navigationTitle(Text("Select Course", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
+            .navigationBarTitleDisplayMode(.inline)
     }
 
     @ViewBuilder

--- a/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/CoursePickerView.swift
@@ -28,7 +28,7 @@ public struct CoursePickerView: View {
 
     public var body: some View {
         content
-            .navigationTitle(Text("Select Course", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
+            .navigationTitleStyled(Text("Select Course", bundle: .core).font(.semibold17).foregroundColor(.textDarkest))
             .navigationBarTitleDisplayMode(.inline)
     }
 

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -51,7 +51,7 @@ public struct SubmitAssignmentExtensionView: View {
             .foregroundColor(.textDarkest)
             .font(.regular16)
             .navigationBarGlobal()
-            .navigationTitle(title)
+            .navigationTitleStyled(title)
             .navigationBarTitleDisplayMode(.inline)
             .navBarItems(trailing: cancelButton)
     }
@@ -70,7 +70,7 @@ public struct SubmitAssignmentExtensionView: View {
             .padding(.horizontal, 20)
         }
         .navigationBarGlobal()
-        .navigationTitle(title)
+        .navigationTitleStyled(title)
         .navigationBarTitleDisplayMode(.inline)
         .navBarItems(leading: cancelButton, trailing: submitButton)
         .onDisappear {

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -51,7 +51,8 @@ public struct SubmitAssignmentExtensionView: View {
             .foregroundColor(.textDarkest)
             .font(.regular16)
             .navigationBarGlobal()
-            .navigationBarTitleView(titleView, displayMode: .inline)
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
             .navBarItems(trailing: cancelButton)
     }
 
@@ -69,14 +70,15 @@ public struct SubmitAssignmentExtensionView: View {
             .padding(.horizontal, 20)
         }
         .navigationBarGlobal()
-        .navigationBarTitleView(titleView, displayMode: .inline)
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
         .navBarItems(leading: cancelButton, trailing: submitButton)
         .onDisappear {
             accessibilityFocus = nil
         }
     }
 
-    private var titleView: some View {
+    private var title: Text {
         Text("Canvas Student", bundle: .core).font(.semibold17).foregroundColor(.textDarkest)
     }
 

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
@@ -86,25 +86,6 @@ struct NavBarBackButtonModifier: ViewModifier {
     }
 }
 
-struct NavigationBarTitleViewModifier<Title: View>: ViewModifier {
-    @Environment(\.viewController) var controller
-    let titleHost: UIViewController
-
-    init(titleView: Title) {
-        self.titleHost = CoreHostingController(titleView)
-    }
-
-    func body(content: Content) -> some View {
-        if let navController = controller.value.navigationController {
-            if titleHost.parent == nil {
-                navController.addChild(titleHost)
-            }
-            controller.value.navigationItem.titleView = titleHost.view
-        }
-        return content.overlay(Color?.none) // needs something modified to actually run
-    }
-}
-
 extension View {
     public func navigationBarStyle(_ style: UINavigationBar.Style) -> some View {
         modifier(NavigationBarStyleModifier(style: style))
@@ -112,11 +93,6 @@ extension View {
 
     public func navigationTitle(_ title: String, subtitle: String?) -> some View {
         modifier(TitleSubtitleModifier(title: title, subtitle: subtitle))
-    }
-
-    /// Only applicable to UIViewController based navigations.
-    public func navigationTitle<Title: View>(_ view: Title) -> some View {
-        modifier(NavigationBarTitleViewModifier(titleView: view))
     }
 
     public func navigationBarGlobal() -> some View {

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
@@ -86,6 +86,25 @@ struct NavBarBackButtonModifier: ViewModifier {
     }
 }
 
+struct NavigationBarTitleViewModifier<Title: View>: ViewModifier {
+    @Environment(\.viewController) var controller
+    let titleHost: UIViewController
+
+    init(titleView: Title) {
+        self.titleHost = CoreHostingController(titleView)
+    }
+
+    func body(content: Content) -> some View {
+        if let navController = controller.value.navigationController {
+            if titleHost.parent == nil {
+                navController.addChild(titleHost)
+            }
+            controller.value.navigationItem.titleView = titleHost.view
+        }
+        return content.overlay(Color?.none) // needs something modified to actually run
+    }
+}
+
 extension View {
     public func navigationBarStyle(_ style: UINavigationBar.Style) -> some View {
         modifier(NavigationBarStyleModifier(style: style))
@@ -93,6 +112,11 @@ extension View {
 
     public func navigationTitle(_ title: String, subtitle: String?) -> some View {
         modifier(TitleSubtitleModifier(title: title, subtitle: subtitle))
+    }
+
+    /// Only applicable to UIViewController based navigations.
+    public func navigationTitle<Title: View>(_ view: Title) -> some View {
+        modifier(NavigationBarTitleViewModifier(titleView: view))
     }
 
     public func navigationBarGlobal() -> some View {

--- a/Core/Core/ViewModifiers/NavBarItems.swift
+++ b/Core/Core/ViewModifiers/NavBarItems.swift
@@ -25,7 +25,7 @@ extension View {
     }
 
     public func navBarItems<T>(trailing: () -> T) -> some View where T: View {
-        self.toolbar {
+        toolbar {
             ToolbarItem(placement: .navigationBarTrailing, content: trailing)
         }
     }
@@ -35,9 +35,19 @@ extension View {
     }
 
     public func navBarItems<L, T>(leading: () -> L, trailing: () -> T) -> some View where L: View, T: View {
-        self.toolbar {
+        toolbar {
             ToolbarItem(placement: .navigationBarLeading, content: leading)
             ToolbarItem(placement: .navigationBarTrailing, content: trailing)
+        }
+    }
+
+    /**
+     The built-in `.navigationTitle(Text)` modifier ignores all font and color modifiers on the text
+     so we use this `toolbar` based solution to have the title styled.
+     */
+    public func navigationTitleStyled<T>(_ title: T) -> some View where T: View {
+        toolbar {
+            ToolbarItem(placement: .principal, content: { title })
         }
     }
 }

--- a/Core/project.yml
+++ b/Core/project.yml
@@ -24,7 +24,7 @@ packages:
     exactVersion: 3.5.0
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 12.0.2
+    exactVersion: 12.3.0
 projectReferences:
   TestsFoundation:
     path: ../TestsFoundation/TestsFoundation.xcodeproj

--- a/Podfile
+++ b/Podfile
@@ -18,7 +18,7 @@ def canvas_crashlytics_rn_firebase_pods
 end
 
 def pspdfkit
-  pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/12.0.3.podspec'
+  pod 'PSPDFKit', podspec: 'https://customers.pspdfkit.com/pspdfkit-ios/12.3.0.podspec'
 end
 
 def react_native_pods

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -103,9 +103,9 @@ PODS:
   - nanopb/decode (2.30908.0)
   - nanopb/encode (2.30908.0)
   - PromisesObjC (2.1.1)
-  - PSPDFKit (12.0.3):
-    - PSPDFKit/Core (= 12.0.3)
-  - PSPDFKit/Core (12.0.3)
+  - PSPDFKit (12.3.0):
+    - PSPDFKit/Core (= 12.3.0)
+  - PSPDFKit/Core (12.3.0)
   - RCTRequired (0.63.2)
   - RCTTypeSafety (0.63.2):
     - FBLazyVector (= 0.63.2)
@@ -378,7 +378,7 @@ DEPENDENCIES:
   - glog (from `./rn/Teacher/node_modules/react-native/third-party-podspecs/glog.podspec`)
   - GoogleUtilities (~> 7.6)
   - Interactable (from `./rn/Teacher/node_modules/react-native-interactable`)
-  - PSPDFKit (from `https://customers.pspdfkit.com/pspdfkit-ios/12.0.3.podspec`)
+  - PSPDFKit (from `https://customers.pspdfkit.com/pspdfkit-ios/12.3.0.podspec`)
   - RCTRequired (from `./rn/Teacher/node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `./rn/Teacher/node_modules/react-native/Libraries/TypeSafety`)
   - React (from `./rn/Teacher/node_modules/react-native/`)
@@ -446,7 +446,7 @@ EXTERNAL SOURCES:
   Interactable:
     :path: "./rn/Teacher/node_modules/react-native-interactable"
   PSPDFKit:
-    :podspec: https://customers.pspdfkit.com/pspdfkit-ios/12.0.3.podspec
+    :podspec: https://customers.pspdfkit.com/pspdfkit-ios/12.3.0.podspec
   RCTRequired:
     :path: "./rn/Teacher/node_modules/react-native/Libraries/RCTRequired"
   RCTTypeSafety:
@@ -534,7 +534,7 @@ SPEC CHECKSUMS:
   Interactable: 0a9f2a42b02ea03114d7e03e714d946a65cd8d0b
   nanopb: a0ba3315591a9ae0a16a309ee504766e90db0c96
   PromisesObjC: ab77feca74fa2823e7af4249b8326368e61014cb
-  PSPDFKit: eef820b631663ce121f9ec5f3cd7581164d57194
+  PSPDFKit: 39123c1bff6051a2a11d6b50cfe7ffab221fcfe0
   RCTRequired: f13f25e7b12f925f1f6a6a8c69d929a03c0129fe
   RCTTypeSafety: 44982c5c8e43ff4141eb519a8ddc88059acd1f3a
   React: e1c65dd41cb9db13b99f24608e47dd595f28ca9a
@@ -569,6 +569,6 @@ SPEC CHECKSUMS:
   RNSound: da030221e6ac7e8290c6b43f2b5f2133a8e225b0
   Yoga: 7740b94929bbacbddda59bf115b5317e9a161598
 
-PODFILE CHECKSUM: 2a476985ddbaab614cee2e57c53fa5eb04067cc7
+PODFILE CHECKSUM: fe9d8e31c4cf1039e29a88f96947723373d6ca77
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
- Updated PSPDFKit to 12.3.0.
- It turned out that we used a helper method from this SDK for navigation bars that is no longer available.
- I added a new helper method that can be used to set a navigation bar title view with a SwiftUI view.

refs: MBL-16828
affects: Student, Teacher
release note: none

test plan:
- Check if SpeedGrader annotations work.
- Check if student annotation works.
- Check if file submit extension screen titles and offline sync selector title appear.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
