### PR TITLE
Offline conferences

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 		40EC348B47380701DB1A7FBB /* balsamiq_regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = BF0AEE0D31834D46560E619C /* balsamiq_regular.ttf */; };
 		415E3F33B78F1626B43A9EAB /* SearchRecipientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BA0EAC31A3C5754AA13A5B /* SearchRecipientTests.swift */; };
 		41BFAF868D4FF58CC10BE8BF /* CourseSyncProgressInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */; };
+		41C823777554F5B25D4B2D79 /* CourseSyncConferencesInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F797E34D0EA8D55D68E0232 /* CourseSyncConferencesInteractor.swift */; };
 		4209958C9EC3BB65082075CD /* PageViewEventRequestManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA163983762B396B680B808 /* PageViewEventRequestManagerTests.swift */; };
 		421CC7BF210AAF12788CB31F /* Secret.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E7EA40D8FAD71D6F0DE3E39 /* Secret.swift */; };
 		421F584C346A7193E9D91081 /* FileSubmissionAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1B7F797D4E7AFA26302167D /* FileSubmissionAssembly.swift */; };
@@ -778,6 +779,7 @@
 		7D5AB2F79E82B93C4E0F9242 /* GetUserSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F28B37762A5E7403362A63 /* GetUserSettingsTests.swift */; };
 		7D86702098C4B249C5273B45 /* APICourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E6D0169A03E2B671E863A6 /* APICourse.swift */; };
 		7D9F7BB9BEC09E94CC490BDD /* AssignmentDueDateItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48B1B096B3006887A99C414B /* AssignmentDueDateItemView.swift */; };
+		7DC44D20B493714A52C1C92F /* CourseSyncConferencesInteractorLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0125E27F390B3D9F5370C9 /* CourseSyncConferencesInteractorLiveTests.swift */; };
 		7DDC34CD0AFD13BDEF3BC36A /* K5ResourcesHomeroomInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD483C88B9790DF9AC6824B /* K5ResourcesHomeroomInfoViewModel.swift */; };
 		7DFFFA267660CB7312DF556A /* DashboardOfflineSyncProgressCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F514A0908B751C8F0BF695BB /* DashboardOfflineSyncProgressCardViewModelTests.swift */; };
 		7E402A4AA18E72FA23351E31 /* LoginManualOAuthViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 509FD7FFF9CF519742DA8A75 /* LoginManualOAuthViewController.storyboard */; };
@@ -2517,6 +2519,7 @@
 		7F0DEE128B0CD12A4F61F61E /* GetCourseSingleUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetCourseSingleUserTests.swift; sourceTree = "<group>"; };
 		7F3C5228820111819B5BD53E /* GradeCircleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeCircleView.swift; sourceTree = "<group>"; };
 		7F3EA8A3F29C878986F6620E /* da-instk12 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "da-instk12"; path = "da-instk12.lproj/Localizable.strings"; sourceTree = "<group>"; };
+		7F797E34D0EA8D55D68E0232 /* CourseSyncConferencesInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncConferencesInteractor.swift; sourceTree = "<group>"; };
 		7F90593278C021782466F67D /* UIMenuExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIMenuExtensions.swift; sourceTree = "<group>"; };
 		7FE2E90722DA48FE7D706B2B /* IDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IDTests.swift; sourceTree = "<group>"; };
 		801F893D7D56B3225F8954C0 /* RichContentToolbarView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RichContentToolbarView.xib; sourceTree = "<group>"; };
@@ -2803,6 +2806,7 @@
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9B4C16E6E68A8586390D94C /* pt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pt; path = pt.lproj/Main.strings; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
+		AA0125E27F390B3D9F5370C9 /* CourseSyncConferencesInteractorLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncConferencesInteractorLiveTests.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
 		AA3E0A56A7A1280E8A16229E /* InboxMessageInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageInteractorLive.swift; sourceTree = "<group>"; };
 		AA6016367FF7B91B66FF7ACA /* FileAccessReportInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileAccessReportInteractor.swift; sourceTree = "<group>"; };
@@ -5809,6 +5813,7 @@
 			isa = PBXGroup;
 			children = (
 				715C723162E66FA3602CC753 /* CourseSyncAssignmentsInteractorLiveTests.swift */,
+				AA0125E27F390B3D9F5370C9 /* CourseSyncConferencesInteractorLiveTests.swift */,
 				1F997652C2C8991C02AAE13C /* CourseSyncEntryComposerInteractorLiveTests.swift */,
 				07001BE8FD914891BCBA70A0 /* CourseSyncFilesInteractorLiveTests.swift */,
 				2DC4A2E837F88DC752BECB81 /* CourseSyncGradesInteractorLiveTests.swift */,
@@ -6436,6 +6441,7 @@
 			isa = PBXGroup;
 			children = (
 				9A160A69DD667D66A1929CA2 /* CourseSyncAssignmentsInteractor.swift */,
+				7F797E34D0EA8D55D68E0232 /* CourseSyncConferencesInteractor.swift */,
 				A54CFDBD18BCE51A7498A22B /* CourseSyncFilesInteractor.swift */,
 				89C9CB84307B66A2922C91C0 /* CourseSyncGradesInteractor.swift */,
 				8AC257DD7E6E7B7812BBE5B8 /* CourseSyncInteractor.swift */,
@@ -8961,6 +8967,7 @@
 				DFD3AAD755B3F0286737535B /* CourseSettingsViewModelTests.swift in Sources */,
 				047A1B30D4E1BCEF0CC4F681 /* CourseSyncAssignmentsInteractorLiveTests.swift in Sources */,
 				606E7AEEA62C454FC625769A /* CourseSyncCleanupInteractorTests.swift in Sources */,
+				7DC44D20B493714A52C1C92F /* CourseSyncConferencesInteractorLiveTests.swift in Sources */,
 				2BF5D8C0F10225334CD0D2FD /* CourseSyncDiskSpaceInfoViewModelTests.swift in Sources */,
 				39F314281BA2DF651257F8A6 /* CourseSyncEntryComposerInteractorLiveTests.swift in Sources */,
 				B920C870F9C275F27788D292 /* CourseSyncEntryProgressTests.swift in Sources */,
@@ -9575,6 +9582,7 @@
 				A8A8A93DE637ABB16758B5E2 /* CourseSettingsViewModel.swift in Sources */,
 				4729ACB8904C4826F3D0166D /* CourseSyncAssignmentsInteractor.swift in Sources */,
 				B89E759D3489D7DDF8768050 /* CourseSyncCleanupInteractor.swift in Sources */,
+				41C823777554F5B25D4B2D79 /* CourseSyncConferencesInteractor.swift in Sources */,
 				8845403752E1C349262CEDC6 /* CourseSyncDiskSpaceInfoView.swift in Sources */,
 				09047E641010FD12632BFD87 /* CourseSyncDiskSpaceInfoViewModel.swift in Sources */,
 				9B080D9D1E88DB50861859D8 /* CourseSyncDownloadProgress.swift in Sources */,

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -110,13 +110,7 @@ open class AppEnvironment {
         if Thread.isMainThread {
             return locateTopViewController()
         } else {
-            var topController: UIViewController?
-
-            DispatchQueue.main.sync {
-                topController = locateTopViewController()
-            }
-
-            return topController
+            return DispatchQueue.main.sync { locateTopViewController() }
         }
     }
 

--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -99,11 +99,25 @@ open class AppEnvironment {
     }
 
     public var topViewController: UIViewController? {
-        var controller = window?.rootViewController
-        while controller?.presentedViewController != nil {
-            controller = controller?.presentedViewController
+        let locateTopViewController: () -> UIViewController? = {
+            var controller = self.window?.rootViewController
+            while controller?.presentedViewController != nil {
+                controller = controller?.presentedViewController
+            }
+            return controller
         }
-        return controller
+
+        if Thread.isMainThread {
+            return locateTopViewController()
+        } else {
+            var topController: UIViewController?
+
+            DispatchQueue.main.sync {
+                topController = locateTopViewController()
+            }
+
+            return topController
+        }
     }
 
     private var startupIsCompleted = false

--- a/Core/Core/Conferences/ConferenceDetailsViewController.swift
+++ b/Core/Core/Conferences/ConferenceDetailsViewController.swift
@@ -78,6 +78,7 @@ public class ConferenceDetailsViewController: ScreenViewTrackableViewController,
 
         joinButton.setTitle(NSLocalizedString("Join", bundle: .core, comment: ""), for: .normal)
         joinButton.isHidden = true
+        joinButton.makeUnavailableInOfflineMode()
 
         recordingsHeadingLabel.text = NSLocalizedString("Recordings", bundle: .core, comment: "")
         recordingsView.isHidden = true

--- a/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
@@ -26,6 +26,7 @@ public enum CourseSyncDownloaderAssembly {
             CourseSyncAssignmentsInteractorLive(),
             CourseSyncGradesInteractorLive(userId: AppEnvironment.shared.currentSession?.userID ?? "self"),
             CourseSyncSyllabusInteractorLive(),
+            CourseSyncConferencesInteractorLive(),
         ]
         let scheduler = DispatchQueue(
             label: "com.instructure.icanvas.core.course-sync-download"

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncConferencesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncConferencesInteractor.swift
@@ -1,0 +1,58 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Foundation
+
+public protocol CourseSyncConferencesInteractor: CourseSyncContentInteractor {}
+
+extension CourseSyncConferencesInteractor {
+    public var associatedTabType: TabName { .conferences }
+}
+
+public final class CourseSyncConferencesInteractorLive: CourseSyncConferencesInteractor {
+    public init() {}
+
+    public func getContent(courseId: String) -> AnyPublisher<Void, Error> {
+        Publishers
+            .Zip3(fetchColors(),
+                  fetchConferences(courseId: courseId),
+                  fetchCourse(courseId: courseId))
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    private func fetchColors() -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetCustomColors())
+    }
+
+    private func fetchConferences(courseId: String) -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetConferences(context: .course(courseId)))
+    }
+
+    private func fetchCourse(courseId: String) -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetCourse(courseID: courseId))
+    }
+
+    private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
+        ReactiveStore(useCase: useCase)
+            .getEntities()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+}

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -102,6 +102,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
             downloadTabContent(for: entry, tabName: .pages),
             downloadTabContent(for: entry, tabName: .grades),
             downloadTabContent(for: entry, tabName: .syllabus),
+            downloadTabContent(for: entry, tabName: .conferences),
             downloadFiles(for: entry),
         ]
         .zip()

--- a/Core/Core/Courses/CourseDetails/Model/TabFilter.swift
+++ b/Core/Core/Courses/CourseDetails/Model/TabFilter.swift
@@ -19,7 +19,7 @@
 extension Array where Element == Tab {
     private var mobileSupportedTabs: [TabName] { [.assignments, .quizzes, .discussions, .announcements, .people, .pages, .files, .modules, .syllabus] }
 
-    private var offlineSupportedTabs: [TabName] { [.assignments, .pages, .files, .grades, .syllabus] }
+    private var offlineSupportedTabs: [TabName] { [.assignments, .pages, .files, .grades, .syllabus, .conferences] }
 
     func filteredTabsForCourseHome(isStudent: Bool) -> [Tab] {
         var tabs = self

--- a/Core/Core/Offline/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/OfflineModeInteractor.swift
@@ -26,7 +26,8 @@ public protocol OfflineModeInteractor {
 
 public final class OfflineModeInteractorLive: OfflineModeInteractor {
     /// Use a shared instance in cases where you need immediate result from `NetworkAvailabilityService`. Otherwise initiate a unique instance.
-    public static let shared = OfflineModeInteractorLive()
+    /// The internal(set) is for mocking purposes.
+    public internal(set) static var shared: OfflineModeInteractor = OfflineModeInteractorLive()
 
     // MARK: - Dependencies
 

--- a/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
+++ b/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
@@ -20,7 +20,12 @@ import UIKit
 
 extension UIAlertController {
 
+    /// To be used with target:action pattern.
     @objc
+    public static func showItemNotAvailableInOfflineAlert(sender: Any?) {
+        showItemNotAvailableInOfflineAlert()
+    }
+
     public static func showItemNotAvailableInOfflineAlert(_ completion: (() -> Void)? = nil) {
         let title = NSLocalizedString("Offline mode", comment: "")
         let message = NSLocalizedString("This item is not available offline.", comment: "")

--- a/Core/Core/Offline/View/UIButtonOfflineSupport.swift
+++ b/Core/Core/Offline/View/UIButtonOfflineSupport.swift
@@ -23,13 +23,20 @@ extension UIButton {
     // MARK: - Public Interface
 
     public func makeUnavailableInOfflineMode(_ interactor: OfflineModeInteractor = OfflineModeInteractorLive.shared) {
+
+        // This method is usually called in some setup method and it looks better if the button is instantly disabled
+        // rather then animating to its disabled state while the view controller is animating in.
+        if interactor.isOfflineModeEnabled() {
+            setUnavailableState(isAnimated: false)
+        }
+
         unowned let uSelf = self
         let observation = interactor
             .observeIsOfflineMode()
             .removeDuplicates()
             .sink { offlineMode in
                 if offlineMode {
-                    uSelf.setUnavailableState()
+                    uSelf.setUnavailableState(isAnimated: true)
                 } else {
                     uSelf.setAvailableState()
                 }
@@ -44,8 +51,8 @@ extension UIButton {
         static var TapGestureRecognizer = "TapGestureRecognizer"
     }
 
-    private func setUnavailableState() {
-        UIView.animate(withDuration: 0.3) {
+    private func setUnavailableState(isAnimated: Bool) {
+        UIView.animate(withDuration: isAnimated ? 0.3 : 0.0) {
             self.alpha = 0.3
         }
 
@@ -55,7 +62,7 @@ extension UIButton {
         }
 
         let tapRecognizer = UITapGestureRecognizer(target: UIAlertController.self,
-                                                   action: #selector(UIAlertController.showItemNotAvailableInOfflineAlert))
+                                                   action: #selector(UIAlertController.showItemNotAvailableInOfflineAlert(sender:)))
         addGestureRecognizer(tapRecognizer)
         objc_setAssociatedObject(self, &AssociatedObjectKeys.TapGestureRecognizer, tapRecognizer, .OBJC_ASSOCIATION_RETAIN)
     }

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncConferencesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncConferencesInteractorLiveTests.swift
@@ -1,0 +1,102 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import Combine
+import XCTest
+
+class CourseSyncConferencesInteractorLiveTests: CoreTestCase {
+
+    override class func tearDown() {
+        OfflineModeInteractorLive.shared = OfflineModeInteractorLive()
+        super.tearDown()
+    }
+
+    func testAssociatedTab() {
+        XCTAssertEqual(CourseSyncConferencesInteractorLive().associatedTabType, .conferences)
+    }
+
+    func testSavedDataPopulatesViewController() {
+        // MARK: - GIVEN
+        api.mock(GetCustomColors(), value: .init(custom_colors: [:]))
+        api.mock(GetCourse(courseID: "testCourse"), value: .make(id: "testCourse"))
+        api.mock(GetConferences(context: .course("testCourse")), value: .init(conferences: [
+            .make(context_id: "course_testCourse",
+                  description: "this test conference ended",
+                  ended_at: .distantPast,
+                  id: "1",
+                  title: "ended conference"),
+            .make(context_id: "course_testCourse",
+                  description: "this is an ongoing test conference",
+                  id: "2",
+                  started_at: Date().addingTimeInterval(-1),
+                  title: "ongoing conference"),
+        ]))
+        XCTAssertFinish(CourseSyncConferencesInteractorLive().getContent(courseId: "testCourse"))
+        API.resetMocks()
+
+        // MARK: - WHEN
+        OfflineModeInteractorLive.shared = AlwaysOfflineModeInteractor()
+        let testee = ConferenceListViewController.create(context: .course("testCourse"))
+        testee.view.layoutIfNeeded()
+        testee.viewWillAppear(false)
+        drainMainQueue()
+
+        // MARK: - THEN
+        XCTAssertEqual(testee.tableView.numberOfSections, 2) // new and concluded conferences sections
+
+        guard let newConferencesHeader = testee.tableView.headerView(forSection: 0) as? SectionHeaderView else {
+            return XCTFail()
+        }
+        XCTAssertEqual(newConferencesHeader.titleLabel.text, "New Conferences")
+
+        guard let concludedSectionHeader = testee.tableView.headerView(forSection: 1) as? SectionHeaderView else {
+            return XCTFail()
+        }
+        XCTAssertEqual(concludedSectionHeader.titleLabel.text, "Concluded Conferences")
+
+        guard let ongoingConferenceCell = testee.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? ConferenceListCell else {
+            return XCTFail()
+        }
+        XCTAssertEqual(ongoingConferenceCell.titleLabel.text, "ongoing conference")
+        XCTAssertEqual(ongoingConferenceCell.detailsLabel.text, "this is an ongoing test conference")
+        XCTAssertEqual(ongoingConferenceCell.statusLabel.text, "In Progress")
+
+        guard let concludedConferenceCell = testee.tableView.cellForRow(at: IndexPath(row: 0, section: 1)) as? ConferenceListCell else {
+            return XCTFail()
+        }
+        XCTAssertEqual(concludedConferenceCell.titleLabel.text, "ended conference")
+        XCTAssertEqual(concludedConferenceCell.detailsLabel.text, "this test conference ended")
+        XCTAssertEqual(concludedConferenceCell.statusLabel.text?.hasPrefix("Concluded"), true)
+    }
+}
+
+class AlwaysOfflineModeInteractor: OfflineModeInteractor {
+
+    func isOfflineModeEnabled() -> Bool {
+        true
+    }
+
+    func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+
+    func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
+        Just(NetworkAvailabilityStatus.disconnected).eraseToAnyPublisher()
+    }
+}


### PR DESCRIPTION
- Added conference data downloader.
- Updated conference details for offline mode.
- Fixed a crash when presenting offline alert from tap gesture recognizer.
- Fixed a warning about UI being modified from background thread.

refs: MBL-16769
affects: Student
release note: none

test plan:
- Sync the BigBlueButton tab for offline usage.
- Turn off internet on the device.
- Go to BigBlueButton page.
- List should show both ongoing and concluded conferences.
- Conference details page should have the join button disabled when visiting an active conference.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet