### PR TITLE
Improve course sync interactor setup

### DIFF
--- a/Core/Core/Contexts/TabName.swift
+++ b/Core/Core/Contexts/TabName.swift
@@ -34,4 +34,12 @@ public enum TabName: String, Codable {
     case outcomes
     case custom
     case grades
+
+    public static let OfflineSyncableTabs: [TabName] = [
+        .assignments,
+        .pages,
+        .files,
+        .grades,
+        .syllabus,
+    ]
 }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -97,63 +97,69 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
             state: .loading(nil)
         )
 
-        return [
-            downloadTabContent(for: entry, tabName: .assignments),
-            downloadTabContent(for: entry, tabName: .pages),
-            downloadTabContent(for: entry, tabName: .grades),
-            downloadTabContent(for: entry, tabName: .syllabus),
-            downloadFiles(for: entry),
-        ]
-        .zip()
-        .receive(on: scheduler)
-        .updateErrorState {
-            unownedSelf.setState(
-                selection: .course(entry.id),
-                state: .error
-            )
-        }
-        .updateDownloadedState {
-            unownedSelf.setState(
-                selection: .course(entry.id),
-                state: .downloaded
-            )
-        }
-        .map { _ in () }
-        .eraseToAnyPublisher()
+        var downloaders = TabName
+            .OfflineSyncableTabs
+            .filter { $0 != .files } // files are handled separately
+            .map { downloadTabContent(for: entry, tabName: $0) }
+        downloaders.append(downloadFiles(for: entry))
+
+        return downloaders
+            .zip()
+            .receive(on: scheduler)
+            .updateErrorState {
+                unownedSelf.setState(
+                    selection: .course(entry.id),
+                    state: .error
+                )
+            }
+            .updateDownloadedState {
+                unownedSelf.setState(
+                    selection: .course(entry.id),
+                    state: .downloaded
+                )
+            }
+            .map { _ in () }
+            .eraseToAnyPublisher()
     }
 
     private func downloadTabContent(for entry: CourseSyncEntry, tabName: TabName) -> AnyPublisher<Void, Error> {
         unowned let unownedSelf = self
 
-        if let tabIndex = entry.tabs.firstIndex(where: { $0.type == tabName }),
-           entry.tabs[tabIndex].selectionState == .selected,
-           let interactor = contentInteractors.first(where: { $0.associatedTabType == tabName }) {
-            return interactor.getContent(courseId: entry.courseId)
-                .receive(on: scheduler)
-                .updateLoadingState {
-                    unownedSelf.setState(
-                        selection: .tab(entry.id, entry.tabs[tabIndex].id),
-                        state: .loading(nil)
-                    )
-                }
-                .updateErrorState {
-                    unownedSelf.setState(
-                        selection: .tab(entry.id, entry.tabs[tabIndex].id),
-                        state: .error
-                    )
-                }
-                .updateDownloadedState {
-                    unownedSelf.setState(
-                        selection: .tab(entry.id, entry.tabs[tabIndex].id),
-                        state: .downloaded
-                    )
-                }
-                .eraseToAnyPublisher()
-        } else {
+        guard let tabIndex = entry.tabs.firstIndex(where: { $0.type == tabName }),
+              entry.tabs[tabIndex].selectionState == .selected else {
             return Just(())
                 .setFailureType(to: Error.self)
                 .eraseToAnyPublisher()
         }
+
+        guard let interactor = contentInteractors.first(where: { $0.associatedTabType == tabName }) else {
+            assertionFailure("No interactor found for selected tab: \(tabName)")
+            return Just(())
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+
+        return interactor.getContent(courseId: entry.courseId)
+            .receive(on: scheduler)
+            .updateLoadingState {
+                unownedSelf.setState(
+                    selection: .tab(entry.id, entry.tabs[tabIndex].id),
+                    state: .loading(nil)
+                )
+            }
+            .updateErrorState {
+                unownedSelf.setState(
+                    selection: .tab(entry.id, entry.tabs[tabIndex].id),
+                    state: .error
+                )
+            }
+            .updateDownloadedState {
+                unownedSelf.setState(
+                    selection: .tab(entry.id, entry.tabs[tabIndex].id),
+                    state: .downloaded
+                )
+            }
+            .eraseToAnyPublisher()
     }
 
     private func downloadFiles(for entry: CourseSyncEntry) -> AnyPublisher<Void, Error> {

--- a/Core/Core/Courses/CourseDetails/Model/TabFilter.swift
+++ b/Core/Core/Courses/CourseDetails/Model/TabFilter.swift
@@ -19,8 +19,6 @@
 extension Array where Element == Tab {
     private var mobileSupportedTabs: [TabName] { [.assignments, .quizzes, .discussions, .announcements, .people, .pages, .files, .modules, .syllabus] }
 
-    private var offlineSupportedTabs: [TabName] { [.assignments, .pages, .files, .grades, .syllabus] }
-
     func filteredTabsForCourseHome(isStudent: Bool) -> [Tab] {
         var tabs = self
 
@@ -42,7 +40,7 @@ extension Array where Element == Tab {
 
     func offlineSupportedTabs(isStudent: Bool = true) -> [Tab] {
         filteredTabsForCourseHome(isStudent: isStudent)
-            .filter { offlineSupportedTabs.contains($0.name) }
+            .filter { TabName.OfflineSyncableTabs.contains($0.name) }
     }
 
     func isFilesTabEnabled() -> Bool {

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -220,7 +220,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testFilesLoadingState() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -256,7 +256,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testFilesDownloadedBytes() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -293,7 +293,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testFilesPartialSelection() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -329,7 +329,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testAssignmentErrorState() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [assignmentsInteractor],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -358,7 +358,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testPagesErrorState() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [pagesInteractor],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -387,7 +387,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
 
     func testFilesErrorState() {
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            contentInteractors: [],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate
@@ -418,11 +418,7 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
         let syllbusDownloadStarted = expectation(description: "Syllabus download started")
         let mockSyllabusInteractor = CourseSyncSyllabusInteractorMock(expectation: syllbusDownloadStarted)
         let testee = CourseSyncInteractorLive(
-            contentInteractors: [
-                pagesInteractor,
-                assignmentsInteractor,
-                mockSyllabusInteractor,
-            ],
+            contentInteractors: [mockSyllabusInteractor],
             filesInteractor: filesInteractor,
             progressWriterInteractor: CourseSyncProgressWriterInteractorLive(),
             scheduler: .immediate


### PR DESCRIPTION
- Extract offline syncable tabs array to a public property.
- Update CourseSyncInteractor to automatically sync all offline syncable tabs.
- Added a safety check that triggers in debug builds when the CourseSyncInteractor received no CourseSyncContentInteractor from the assembly.

CI: I want a Student build so we can check if sync still works.

[ignore-commit-lint]