### PR TITLE
Offline announcements

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -645,6 +645,7 @@
 		6B0524E27D48BCD02734730E /* DashboardContainerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8393F724BDD07494D142FCE /* DashboardContainerViewModel.swift */; };
 		6B0939C84E309FAA683FC3D6 /* TestOperationQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE282BDD1EFE56BE1CF9E3B6 /* TestOperationQueue.swift */; };
 		6B0FF4414CB67D2EE406F905 /* GetSubmissionComments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BC607226FEFE22FBD92C14D /* GetSubmissionComments.swift */; };
+		6B66DEC9CD416C87EA09C461 /* CourseSyncAnnouncementsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4DC59CBE99E6D08FE7D348C /* CourseSyncAnnouncementsInteractor.swift */; };
 		6B82A590523E3940E67B80C1 /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4E5AEAED2D39CA04B540B4F /* StringExtensionTests.swift */; };
 		6B8A49BFF1CE18F3916E83EB /* QuizListViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF62474862BFE3BDB075424A /* QuizListViewControllerTests.swift */; };
 		6B8D12C73ECEC194A243E905 /* SessionDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D7F20136B99ADD6EAB7F8B /* SessionDefaults.swift */; };
@@ -1145,6 +1146,7 @@
 		BE5E0D6C957CFD38D0155952 /* APIUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B251A6BBCC60FFF431C150DB /* APIUserTests.swift */; };
 		BE775653CCB1EF925E263040 /* ConfirmationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FB1FDE58D78AC3EFFDB0B4 /* ConfirmationAlert.swift */; };
 		BE9A702335DF64FBAA00F4E9 /* CourseDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E16677AE71E7A605D60C693 /* CourseDetailsViewModel.swift */; };
+		BED66F3AD8DF7E27178ADF80 /* CourseSyncAnnouncementsInteractorLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A615DB67EEA3AA2FF53F6AF /* CourseSyncAnnouncementsInteractorLiveTests.swift */; };
 		BF0A0F8A10BFDD7A5C19A2F3 /* K5ScheduleViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D134AC5D975BF3D9C35BF2F /* K5ScheduleViewModelTests.swift */; };
 		BF40752F66B259254CDB927B /* GetEnvironmentFeatureFlagsRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 972FD90722B1C2E476D08896 /* GetEnvironmentFeatureFlagsRequest.swift */; };
 		BF75639BB9DC0F0F0F0A33D6 /* GetSSOLoginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3081BDA882D783461C3BB9C0 /* GetSSOLoginTests.swift */; };
@@ -1911,6 +1913,7 @@
 		29E1C39E7CF8B83FAB017461 /* CalendarDayIconView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = CalendarDayIconView.xib; sourceTree = "<group>"; };
 		2A0E3CAB62083B565F1EA29C /* AssignmentListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListView.swift; sourceTree = "<group>"; };
 		2A3899997AA91BF2FFF59F10 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		2A615DB67EEA3AA2FF53F6AF /* CourseSyncAnnouncementsInteractorLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncAnnouncementsInteractorLiveTests.swift; sourceTree = "<group>"; };
 		2A73489EEFA8A522E722E899 /* LoginFindSchoolViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewController.swift; sourceTree = "<group>"; };
 		2A88EB9BB2BFC2FE9B7E6875 /* FileSubmissionCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSubmissionCleanupTests.swift; sourceTree = "<group>"; };
 		2A9BF33E05607BE1B419DB09 /* ContextColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextColor.swift; sourceTree = "<group>"; };
@@ -3286,6 +3289,7 @@
 		F48DE98C91B4774F4C5E404D /* APIObserverAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIObserverAlert.swift; sourceTree = "<group>"; };
 		F4BB7031E1B4AF7482126585 /* ConversationDetailCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationDetailCell.swift; sourceTree = "<group>"; };
 		F4D17488D0C4506B625E207A /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		F4DC59CBE99E6D08FE7D348C /* CourseSyncAnnouncementsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncAnnouncementsInteractor.swift; sourceTree = "<group>"; };
 		F4DE68B70EF1C6409DDDCF7F /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		F4E5AEAED2D39CA04B540B4F /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		F514A0908B751C8F0BF695BB /* DashboardOfflineSyncProgressCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardOfflineSyncProgressCardViewModelTests.swift; sourceTree = "<group>"; };
@@ -5808,6 +5812,7 @@
 		765E84AB405FFA5DACD0D500 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				2A615DB67EEA3AA2FF53F6AF /* CourseSyncAnnouncementsInteractorLiveTests.swift */,
 				715C723162E66FA3602CC753 /* CourseSyncAssignmentsInteractorLiveTests.swift */,
 				1F997652C2C8991C02AAE13C /* CourseSyncEntryComposerInteractorLiveTests.swift */,
 				07001BE8FD914891BCBA70A0 /* CourseSyncFilesInteractorLiveTests.swift */,
@@ -6435,6 +6440,7 @@
 		9588C81A135C0FC83552D67F /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				F4DC59CBE99E6D08FE7D348C /* CourseSyncAnnouncementsInteractor.swift */,
 				9A160A69DD667D66A1929CA2 /* CourseSyncAssignmentsInteractor.swift */,
 				A54CFDBD18BCE51A7498A22B /* CourseSyncFilesInteractor.swift */,
 				89C9CB84307B66A2922C91C0 /* CourseSyncGradesInteractor.swift */,
@@ -8959,6 +8965,7 @@
 				8CCBC000ED57E3B30185A885 /* CoursePickerViewModelTests.swift in Sources */,
 				736AE1BECC79C6AF052D56A4 /* CourseSectionTests.swift in Sources */,
 				DFD3AAD755B3F0286737535B /* CourseSettingsViewModelTests.swift in Sources */,
+				BED66F3AD8DF7E27178ADF80 /* CourseSyncAnnouncementsInteractorLiveTests.swift in Sources */,
 				047A1B30D4E1BCEF0CC4F681 /* CourseSyncAssignmentsInteractorLiveTests.swift in Sources */,
 				606E7AEEA62C454FC625769A /* CourseSyncCleanupInteractorTests.swift in Sources */,
 				2BF5D8C0F10225334CD0D2FD /* CourseSyncDiskSpaceInfoViewModelTests.swift in Sources */,
@@ -9573,6 +9580,7 @@
 				DB25386E992CA6AE6249FA77 /* CourseSection.swift in Sources */,
 				C9139B41E63986BD683531F8 /* CourseSettingsView.swift in Sources */,
 				A8A8A93DE637ABB16758B5E2 /* CourseSettingsViewModel.swift in Sources */,
+				6B66DEC9CD416C87EA09C461 /* CourseSyncAnnouncementsInteractor.swift in Sources */,
 				4729ACB8904C4826F3D0166D /* CourseSyncAssignmentsInteractor.swift in Sources */,
 				B89E759D3489D7DDF8768050 /* CourseSyncCleanupInteractor.swift in Sources */,
 				8845403752E1C349262CEDC6 /* CourseSyncDiskSpaceInfoView.swift in Sources */,

--- a/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
@@ -26,6 +26,7 @@ public enum CourseSyncDownloaderAssembly {
             CourseSyncAssignmentsInteractorLive(),
             CourseSyncGradesInteractorLive(userId: AppEnvironment.shared.currentSession?.userID ?? "self"),
             CourseSyncSyllabusInteractorLive(),
+            CourseSyncAnnouncementsInteractorLive(),
         ]
         let scheduler = DispatchQueue(
             label: "com.instructure.icanvas.core.course-sync-download"

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractor.swift
@@ -1,0 +1,63 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Foundation
+
+public protocol CourseSyncAnnouncementsInteractor: CourseSyncContentInteractor {}
+
+extension CourseSyncAnnouncementsInteractor {
+    public var associatedTabType: TabName { .announcements }
+}
+
+public final class CourseSyncAnnouncementsInteractorLive: CourseSyncAnnouncementsInteractor {
+    public init() {}
+
+    public func getContent(courseId: String) -> AnyPublisher<Void, Error> {
+        Publishers
+            .Zip4(fetchColors(),
+                  fetchCourse(courseId: courseId),
+                  fetchAnnouncements(courseId: courseId),
+                  fetchFeatureFlags(courseId: courseId))
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    private func fetchColors() -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetCustomColors())
+    }
+
+    private func fetchCourse(courseId: String) -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetCourse(courseID: courseId))
+    }
+
+    private func fetchAnnouncements(courseId: String) -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetAnnouncements(context: .course(courseId)))
+    }
+
+    private func fetchFeatureFlags(courseId: String) -> AnyPublisher<Void, Error> {
+        fetchUseCase(GetEnabledFeatureFlags(context: .course(courseId)))
+    }
+
+    private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
+        ReactiveStore(useCase: useCase)
+            .getEntities()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+}

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -54,6 +54,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
     var topicID = ""
     private var newReplyIDFromCurrentUser: String?
     private var isContentLargerThanView: Bool { webView.scrollView.contentSize.height > view.frame.size.height }
+    private var offlineModeInteractor: OfflineModeInteractor?
 
     public lazy var screenViewTrackingParameters = ScreenViewTrackingParameters(
         eventName: "\(context.pathComponent)/\(isAnnouncement ? "announcements" : "discussion_topics")/\(topicID)"
@@ -98,7 +99,8 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         topicID: String,
         isAnnouncement: Bool = false,
         showEntryID: String? = nil,
-        showRepliesToEntryID: String? = nil
+        showRepliesToEntryID: String? = nil,
+        offlineModeInteractor: OfflineModeInteractor? = OfflineModeInteractorLive.shared
     ) -> DiscussionDetailsViewController {
         let controller = loadFromStoryboard()
         controller.context = context
@@ -106,6 +108,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         controller.showEntryID = showEntryID
         controller.showRepliesToEntryID = showRepliesToEntryID
         controller.topicID = topicID
+        controller.offlineModeInteractor = offlineModeInteractor
         // needs to be set early for helm to correctly place done button
         controller.navigationItem.rightBarButtonItem = controller.optionsButton
         return controller
@@ -502,12 +505,22 @@ extension DiscussionDetailsViewController: CoreWebViewLinkDelegate {
         let path = Array(url.pathComponents.dropFirst(5))
         // Reply to main discussion
         if path.count == 1, path[0] == "reply" {
+            if offlineModeInteractor?.isOfflineModeEnabled() == true {
+                UIAlertController.showItemNotAvailableInOfflineAlert()
+                return true
+            }
+
             Analytics.shared.logEvent(isAnnouncement ? "announcement_replied" : "discussion_topic_replied")
             env.router.route(to: url, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             return true
         }
         // Reply to thread
         if path.count == 3, path[0] == "entries", !path[1].isEmpty, path[2] == "replies" {
+            if offlineModeInteractor?.isOfflineModeEnabled() == true {
+                UIAlertController.showItemNotAvailableInOfflineAlert()
+                return true
+            }
+
             env.router.route(to: url, from: self, options: .modal(.formSheet, isDismissable: false, embedInNav: true))
             return true
         }
@@ -526,8 +539,16 @@ extension DiscussionDetailsViewController: CoreWebViewLinkDelegate {
     }
 }
 
+// MARK: - User Actions From Nav Bar
+
 extension DiscussionDetailsViewController {
-    @objc func showTopicOptions() {
+
+    @objc
+    func showTopicOptions() {
+        if offlineModeInteractor?.isOfflineModeEnabled() == true {
+            return UIAlertController.showItemNotAvailableInOfflineAlert()
+        }
+
         guard let topic = topic.first else { return }
 
         let sheet = BottomSheetPickerViewController.create()
@@ -618,8 +639,15 @@ extension DiscussionDetailsViewController {
     }
 }
 
+// MARK: - User Actions From HTML
+
 extension DiscussionDetailsViewController {
+
     private func handleLike(_ message: WKScriptMessage) {
+        if offlineModeInteractor?.isOfflineModeEnabled() == true {
+            return UIAlertController.showItemNotAvailableInOfflineAlert()
+        }
+
         guard
             let body = message.body as? [String: Any],
             let entryID = body["entryID"] as? String,
@@ -652,6 +680,10 @@ extension DiscussionDetailsViewController {
     }
 
     private func handleMoreOptions(_ message: WKScriptMessage) {
+        if offlineModeInteractor?.isOfflineModeEnabled() == true {
+            return UIAlertController.showItemNotAvailableInOfflineAlert()
+        }
+
         guard
             let body = message.body as? [String: Any],
             let entryID = body["entryID"] as? String

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractorLiveTests.swift
@@ -1,0 +1,110 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2023-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import Combine
+import TestsFoundation
+import XCTest
+
+class CourseSyncAnnouncementsInteractorLiveTests: CoreTestCase {
+
+    override class func tearDown() {
+        OfflineModeInteractorLive.shared = OfflineModeInteractorLive()
+        super.tearDown()
+    }
+
+    func testAssociatedTab() {
+        XCTAssertEqual(CourseSyncAnnouncementsInteractorLive().associatedTabType, .announcements)
+    }
+
+    func testSavedDataPopulatesViewController() {
+        // MARK: - GIVEN
+        setupMocks()
+        XCTAssertFinish(CourseSyncAnnouncementsInteractorLive().getContent(courseId: "testCourse"))
+        API.resetMocks()
+
+        // MARK: - WHEN
+        OfflineModeInteractorLive.shared = AlwaysOfflineModeInteractor()
+        let testee = AnnouncementListViewController.create(context: .course("testCourse"))
+        testee.view.layoutIfNeeded()
+        testee.viewWillAppear(false)
+
+        // MARK: - THEN
+        XCTAssertEqual((testee.navigationItem.titleView as? TitleSubtitleView)?.subtitle, "Course One")
+
+        guard let announcementCell = testee.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? AnnouncementListCell else {
+            return XCTFail()
+        }
+        XCTAssertEqual(announcementCell.dateLabel.text?.hasPrefix("Last post "), true)
+        XCTAssertEqual(announcementCell.titleLabel.text, "my discussion topic")
+    }
+
+    func testFailuresReported() {
+        let testee = CourseSyncAnnouncementsInteractorLive()
+
+        setupMocks()
+        api.mock(GetCustomColors(),
+                 error: NSError.instructureError(""))
+        XCTAssertFailure(testee.getContent(courseId: "testCourse"))
+
+        setupMocks()
+        api.mock(GetCourse(courseID: "testCourse"),
+                 error: NSError.instructureError(""))
+        XCTAssertFailure(testee.getContent(courseId: "testCourse"))
+
+        setupMocks()
+        api.mock(GetAnnouncements(context: .course("testCourse")),
+                 error: NSError.instructureError(""))
+        XCTAssertFailure(testee.getContent(courseId: "testCourse"))
+
+        setupMocks()
+        api.mock(GetEnabledFeatureFlags(context: .course("testCourse")),
+                 error: NSError.instructureError(""))
+        XCTAssertFailure(testee.getContent(courseId: "testCourse"))
+    }
+
+    private func setupMocks() {
+        api.mock(GetCustomColors(),
+                 value: .init(custom_colors: [:]))
+        api.mock(GetCourse(courseID: "testCourse"),
+                 value: .make(id: "testCourse"))
+        api.mock(GetAnnouncements(context: .course("testCourse")),
+                 value: [
+                    .make(html_url: URL(string: "/courses/testCourse")!,
+                          last_reply_at: Date(timeIntervalSince1970: 0),
+                          subscription_hold: "topic_is_announcement"),
+                 ])
+        api.mock(GetEnabledFeatureFlags(context: .course("testCourse")),
+                 value: [])
+    }
+}
+
+class AlwaysOfflineModeInteractor: OfflineModeInteractor {
+
+    func isOfflineModeEnabled() -> Bool {
+        true
+    }
+
+    func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+
+    func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
+        Just(NetworkAvailabilityStatus.disconnected).eraseToAnyPublisher()
+    }
+}

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncAnnouncementsInteractorLiveTests.swift
@@ -93,18 +93,3 @@ class CourseSyncAnnouncementsInteractorLiveTests: CoreTestCase {
                  value: [])
     }
 }
-
-class AlwaysOfflineModeInteractor: OfflineModeInteractor {
-
-    func isOfflineModeEnabled() -> Bool {
-        true
-    }
-
-    func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
-        Just(true).eraseToAnyPublisher()
-    }
-
-    func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
-        Just(NetworkAvailabilityStatus.disconnected).eraseToAnyPublisher()
-    }
-}


### PR DESCRIPTION
refs: MBL-16770
affects: Student
release note: none

test plan:
- Sync Announcements tab for offline usage.
- Turn off internet on the device.
- Go to Announcements list.
- Announcements should appear.
- Enter an announcement.
- Announcement and replies should render.
- Images/MathJax equations won't be available.
- User actions shouldn't be available beside the replies button that is show is there are too many replies in a thread.

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet