### PR TITLE
Add screen view logging to ModuleItemDetailsViewController

### DIFF
--- a/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -147,7 +147,14 @@ public class ModuleItemDetailsViewController: UIViewController, ColoredNavViewPr
             return LTIViewController.create(tools: tools, name: item.title)
         default:
             guard let url = item.url else { return nil }
-            return env.router.match(url.appendingOrigin("module_item_details"))
+            let preparedURL = url.appendingOrigin("module_item_details")
+            let itemViewController = env.router.match(preparedURL)
+
+            if let itemViewController, let routeTemplate = env.router.template(for: preparedURL) {
+                Analytics.shared.logScreenView(route: routeTemplate, viewController: itemViewController)
+            }
+
+            return itemViewController
         }
     }
 

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -128,7 +128,7 @@ open class Router {
         return nil
     }
 
-    public func template(for url: URL) -> String? {
+    open func template(for url: URL) -> String? {
         template(for: .parse(url))
     }
     public func template(for url: String) -> String? {

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
@@ -237,4 +237,26 @@ class ModuleItemDetailsViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         wait(for: [expectation], timeout: 0.1)
     }
+
+    func testReportsScreenViewForLoadedChildViewController() {
+        let mockAnalyticsHandler = MockAnalyticsHandler()
+        Analytics.shared.handler = mockAnalyticsHandler
+        router.mock("/courses/1/assignments/2?origin=module_item_details") {
+            DetailViewController()
+        }
+        router.mockTemplate(for: URL(string: "/courses/1/assignments/2?origin=module_item_details")!, template: "/courses/:courseId")
+        api.mock(controller.store,
+                 value: .make(
+                    id: "3",
+                    title: "Submit this thing!",
+                    content: .assignment("2"),
+                    url: URL(string: "/courses/1/assignments/2")!,
+                    content_details: .make())
+        )
+        controller.view.layoutIfNeeded()
+
+        XCTAssertEqual(mockAnalyticsHandler.lastEventName, "screen_view")
+        XCTAssertEqual(mockAnalyticsHandler.lastEventParameters?["screen_name"] as? String, "/courses/:courseId")
+        XCTAssertEqual(mockAnalyticsHandler.lastEventParameters?["screen_class"] as? String, "DetailViewController")
+    }
 }

--- a/TestsFoundation/TestsFoundation/Router/TestRouter.swift
+++ b/TestsFoundation/TestsFoundation/Router/TestRouter.swift
@@ -116,4 +116,16 @@ public class TestRouter: Router {
         showExpectation = XCTestExpectation(description: "show")
         popExpectation = XCTestExpectation(description: "pop")
     }
+
+    // MARK: Template Method Mocks
+
+    public private(set) var mockedURLTemplates: [URL: String] = [:]
+
+    public func mockTemplate(for url: URL, template: String) {
+        mockedURLTemplates[url] = template
+    }
+
+    public override func template(for url: URL) -> String? {
+        mockedURLTemplates[url]
+    }
 }


### PR DESCRIPTION
Add screen view event when ModuleItemDetailsViewController loads a child view controller without using the router's route method.

refs: MBL-16906
affects: Student, Teacher
release note: none

test plan:
- Module sequence still works.
- Upcoming crashes should include screen view events visited via the module sequence view controller.