### PR TITLE
Fix attached file getting deleted by iOS

### DIFF
--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -125,6 +125,12 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
         return controller
     }
 
+    deinit {
+        if let attachmentURL {
+            try? FileManager.default.removeItem(at: attachmentURL)
+        }
+    }
+
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest


### PR DESCRIPTION
Move picked file from app inbox to temp folder.

refs: MBL-16906
affects: Student, Teacher
release note: Fixed multiple issues with file attachment while replying to a discussion.

test plan:
- Go to a discussion, tap on reply.
- Use the paperclip icon to attach a file using the "Upload File" option.
- Send the app to the background for 1 minute.
- Go back to the app.
- Tap the paperclip icon, tap "View".
- File should be displayed instead of a gray screen with its filename on it.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/5f31a579-bc8a-4831-b1cb-cf2138c44b33" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/a89f6652-e49c-4923-905b-4b17877441ac" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
