### PR TITLE
Update page list API call to include page body

### DIFF
--- a/Core/Core/Pages/APIPage.swift
+++ b/Core/Core/Pages/APIPage.swift
@@ -59,6 +59,10 @@ extension APIPage {
 #endif
 
 public struct GetPagesRequest: APIRequestable {
+    public enum Include: String, CaseIterable {
+        case body
+    }
+
     public typealias Response = [APIPage]
 
     let context: Context
@@ -67,7 +71,10 @@ public struct GetPagesRequest: APIRequestable {
         return "\(context.pathComponent)/pages"
     }
     public var query: [APIQueryItem] {
-        return [.value("sort", "title")]
+        return [
+            .value("sort", "title"),
+            .include(Include.allCases.map { $0.rawValue }),
+        ]
     }
 }
 

--- a/Core/CoreTests/Pages/APIPageTests.swift
+++ b/Core/CoreTests/Pages/APIPageTests.swift
@@ -28,6 +28,7 @@ class APIPageTests: XCTestCase {
         XCTAssertEqual(GetPagesRequest(context: groupContext).path, "groups/42/pages")
         XCTAssertEqual(GetPagesRequest(context: courseContext).queryItems, [
             URLQueryItem(name: "sort", value: "title"),
+            URLQueryItem(name: "include[]", value: "body"),
         ])
     }
 


### PR DESCRIPTION
refs: MBL-16763
affects: Student
release note: none

test plan:
- Sync "Pages" for offline mode.
- Go offline, check page details page.
- Page body should display.
- Go online, pull to refresh the pages list screen.
- Go offline again check page details.
- Page body should still display.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet