### PR TITLE
Disable not available assignment buttons in offline mode

### DIFF
--- a/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
+++ b/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 public struct AssignmentListView: View, ScreenViewTrackable {
     @Environment(\.viewController) private var controller
     @ObservedObject private var viewModel: AssignmentListViewModel
+    @StateObject private var offlineModeViewModel = OfflineModeViewModel(interactor: OfflineModeInteractorLive.shared)
     public let screenViewTrackingParameters: ScreenViewTrackingParameters
 
     @State private var isShowingGradingPeriodPicker = false
@@ -75,13 +76,13 @@ public struct AssignmentListView: View, ScreenViewTrackable {
     @ViewBuilder
     private var gradingPeriodButton: some View {
         if viewModel.selectedGradingPeriod == nil {
-            Button(action: {
+            PrimaryButton(isAvailable: !$offlineModeViewModel.isOffline) {
                 isShowingGradingPeriodPicker = true
-            }, label: {
+            } label: {
                 Text("Filter", bundle: .core)
                     .font(.semibold16)
                     .foregroundColor(Color(Brand.shared.linkColor))
-            }).actionSheet(isPresented: $isShowingGradingPeriodPicker) {
+            }.actionSheet(isPresented: $isShowingGradingPeriodPicker) {
                 ActionSheet(title: Text("Filter by", bundle: .core), buttons: gradingPeriodButtons)
             }
         } else {

--- a/Core/Core/Offline/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/OfflineModeInteractor.swift
@@ -43,11 +43,10 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
     }
 
     public func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
-        unowned let unownedSelf = self
         return availabilityService
             .startObservingStatus()
             .receive(on: DispatchQueue.main)
-            .map { _ in unownedSelf.isOfflineModeEnabled() }
+            .map { _ in self.isOfflineModeEnabled() }
             .eraseToAnyPublisher()
     }
 

--- a/Core/Core/Offline/View/UIButtonOfflineSupport.swift
+++ b/Core/Core/Offline/View/UIButtonOfflineSupport.swift
@@ -19,6 +19,8 @@
 import UIKit
 
 extension UIButton {
+    /// When a button is disabled in offline mode this is the alpha component we apply to it.
+    public static var DisabledInOfflineAlpha: CGFloat = 0.3
 
     // MARK: - Public Interface
 
@@ -53,7 +55,7 @@ extension UIButton {
 
     private func setUnavailableState(isAnimated: Bool) {
         UIView.animate(withDuration: isAnimated ? 0.3 : 0.0) {
-            self.alpha = 0.3
+            self.alpha = UIButton.DisabledInOfflineAlpha
         }
 
         // Extra safety not to add any more tap recognizers if one is already in place

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -682,6 +682,7 @@
                         <outlet property="quizTimeLimitValueLabel" destination="vY4-Ty-iuC" id="UBY-Az-JpA"/>
                         <outlet property="quizView" destination="RBf-wD-x1b" id="AoK-pJ-beV"/>
                         <outlet property="scrollView" destination="2qC-UP-t75" id="IxZ-Ml-aPC"/>
+                        <outlet property="scrollViewBottom" destination="JB1-8g-YCS" id="kKF-fu-C4c"/>
                         <outlet property="statusIconView" destination="Tdl-M0-B5e" id="11O-xE-tnq"/>
                         <outlet property="statusLabel" destination="co0-jJ-6sI" id="P3s-MG-6Xw"/>
                         <outlet property="submissionButton" destination="bN3-2w-CuG" id="uhR-2z-p6S"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -28,6 +28,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var descriptionHeadingLabel: UILabel?
     @IBOutlet weak var descriptionView: UIView?
     @IBOutlet weak var scrollView: UIScrollView?
+    @IBOutlet weak var scrollViewBottom: NSLayoutConstraint!
     @IBOutlet weak var loadingView: CircleProgressView!
     @IBOutlet weak var submissionButtonView: UIView?
     @IBOutlet weak var submissionButton: DynamicButton?
@@ -157,6 +158,10 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         let tapGradedView = UITapGestureRecognizer(target: self, action: #selector(didTapSubmission(_:)))
         gradedView?.addGestureRecognizer(tapGradedView)
+
+        submitAssignmentButton.makeUnavailableInOfflineMode()
+        fileSubmissionButton?.makeUnavailableInOfflineMode()
+        submissionButton?.makeUnavailableInOfflineMode()
 
         presenter?.viewIsReady()
     }
@@ -313,14 +318,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         submissionButtonSection?.isHidden = presenter.viewSubmissionButtonSectionIsHidden()
         showDescription(!presenter.descriptionIsHidden())
 
-        if assignment.submissionTypes.contains(where: { type in
-            type == .basic_lti_launch || type == .external_tool
-        }) {
-            submitAssignmentButton.makeUnavailableInOfflineMode()
-        } else {
-            submitAssignmentButton.isHidden = presenter.submitAssignmentButtonIsHidden()
-
-        }
+        submitAssignmentButton.isHidden = presenter.submitAssignmentButtonIsHidden()
 
         lockedSubheaderWebView.loadHTMLString(presenter.lockExplanation)
         centerLockedIconContainerView()
@@ -369,14 +367,11 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         submitAssignmentButton.setTitle(title, for: .normal)
 
         if title == nil {
-            scrollView?.scrollIndicatorInsets = .zero
-            scrollView?.contentInset = .zero
+            scrollViewBottom.constant = 0
             submitAssignmentButton.alpha = 0
         } else {
-            let inset = UIEdgeInsets(top: 0, left: 0, bottom: submitAssignmentButton.bounds.size.height, right: 0)
-            scrollView?.scrollIndicatorInsets = inset
-            scrollView?.contentInset = inset
-            submitAssignmentButton.alpha = 1.0
+            scrollViewBottom.constant = -submitAssignmentButton.bounds.size.height
+            submitAssignmentButton.alpha = OfflineModeInteractorLive.shared.isOfflineModeEnabled() ? UIButton.DisabledInOfflineAlpha : 1.0
         }
     }
 

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsViewControllerTests.swift
@@ -83,8 +83,7 @@ class AssignmentDetailsViewControllerTests: StudentTestCase {
         viewController.showSubmitAssignmentButton(title: "hello")
         XCTAssertEqual(viewController.submitAssignmentButton.title(for: .normal), "hello")
         XCTAssertEqual(viewController.submitAssignmentButton.alpha, 1.0)
-        XCTAssertNotEqual(viewController.scrollView?.contentInset, .zero)
-        XCTAssertNotEqual(viewController.scrollView?.verticalScrollIndicatorInsets, .zero)
+        XCTAssertNotEqual(viewController.scrollViewBottom.constant, 0)
 
         viewController.showSubmitAssignmentButton(title: nil)
         XCTAssertEqual(viewController.scrollView?.contentInset, .zero)


### PR DESCRIPTION
refs: MBL-16761
affects: Student
release note: none

test plan:
- Sync assignments for offline mode.
- Go offline.
- Enter assignments list view.
- Filter button should be disabled.
- Go to an assignment detail page.
- Submission and rubric, submit buttons should be disabled.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
