### PR TITLE
Fix annotations in pdf files not styled to correctly

### DIFF
--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -125,7 +125,7 @@ public class DocViewerViewController: UIViewController {
                 let provider = DocViewerAnnotationProvider(documentProvider: documentProvider,
                                                            fileAnnotationProvider: fileAnnotationProvider,
                                                            metadata: metadata,
-                                                           annotations: annotations,
+                                                           apiAnnotations: annotations,
                                                            api: self.session.api,
                                                            sessionID: sessionID,
                                                            isAnnotationEditingDisabled: !self.isAnnotatable || metadata.annotations?.enabled == false)

--- a/Core/Core/DocViewer/ViewModel/AnnotationDrag/Gesture/Helpers/DocumentExtensions.swift
+++ b/Core/Core/DocViewer/ViewModel/AnnotationDrag/Gesture/Helpers/DocumentExtensions.swift
@@ -24,6 +24,6 @@ extension Optional where Wrapped == Document {
     func movableAnnotations(on pageIndex: PageIndex) -> [Annotation] {
         guard let document = self else { return [] }
         let annotationsOnPage = document.annotations(at: pageIndex)
-        return annotationsOnPage.filter { !$0.isReadOnly && $0.isMovable }
+        return annotationsOnPage.filter { $0.isEditable && $0.isMovable }
     }
 }

--- a/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerAnnotationProviderTests.swift
@@ -73,7 +73,7 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
                 rotations: nil,
                 urls: APIDocViewerURLsMetadata(pdf_download: APIURL.make().rawValue)
             ),
-            annotations: annotations,
+            apiAnnotations: annotations,
             api: environment.api,
             sessionID: "a",
             isAnnotationEditingDisabled: isAnnotationEditingDisabled
@@ -219,7 +219,7 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
 
         guard let annotation = providers.annotationProvider.annotationsForPage(at: 0)?.first else { XCTFail("No annotations to test"); return }
 
-        XCTAssertTrue(annotation.flags.contains(.readOnly))
+        XCTAssertFalse(annotation.isEditable)
     }
 
     func testAnnotationFromPDFIsReadOnlyWhenAnnotatingIsDisabled() {
@@ -227,7 +227,7 @@ class DocViewerAnnotationProviderTests: CoreTestCase {
 
         guard let annotation = providers.annotationProvider.annotationsForPage(at: 0)?.first else { XCTFail("No annotations to test"); return }
 
-        XCTAssertTrue(annotation.flags.contains(.readOnly))
+        XCTAssertFalse(annotation.isEditable)
     }
 
     func testAnnotationFromPDFIsFlagged() {

--- a/Core/CoreTests/DocViewer/Mocks/MockDocViewerAnnotationProvider.swift
+++ b/Core/CoreTests/DocViewer/Mocks/MockDocViewerAnnotationProvider.swift
@@ -31,7 +31,7 @@ class MockDocViewerAnnotationProvider: DocViewerAnnotationProvider {
         super.init(documentProvider: documentProvider,
                    fileAnnotationProvider: PDFFileAnnotationProvider(documentProvider: documentProvider),
                    metadata: .make(annotations: .make(enabled: isAPIEnabledAnnotations)),
-                   annotations: [],
+                   apiAnnotations: [],
                    api: API(),
                    sessionID: "",
                    isAnnotationEditingDisabled: isAnnotatingDisabledInApp)


### PR DESCRIPTION
- Use `isEditable` property instead of `readOnly` flag to disable editing on annotations inside the pdf file.
- Amend move tool to check for this new property.
- Embed annotation fetch calls in thread safe blocks according to the guidelines.

refs: MBL-16848
affects: Student, Teacher
release note: Fixed annotations in pdf files not styled to correctly.

test plan:
- See ticket if the correct style is applied to pdf annotations.
- Annotations from a pdf file shouldn't be editable.
- Move tool should work on canvas annotations.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/9c2a7156-766a-4f2a-974d-2c0eeabe69fb" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/18e4edc4-04e2-458e-8619-304eb4627268" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet