### PR TITLE
"Canvas" text on the login page does not meet contrast requirements

### DIFF
--- a/Core/Core/Login/LoginStartViewController.storyboard
+++ b/Core/Core/Login/LoginStartViewController.storyboard
@@ -492,6 +492,7 @@
                         <outlet property="whatsNewContainer" destination="3Ua-og-syp" id="X4Y-L1-IsS"/>
                         <outlet property="whatsNewLabel" destination="qRY-FA-Dia" id="P1N-zF-7St"/>
                         <outlet property="whatsNewLink" destination="va0-Ci-EPu" id="tKP-Ct-BDQ"/>
+                        <outlet property="wordmark" destination="shp-bR-v4y" id="udQ-J9-gKP"/>
                         <outlet property="wordmarkLabel" destination="1qr-uo-RMu" id="1PZ-ER-KtI"/>
                     </connections>
                 </viewController>

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -24,6 +24,7 @@ class LoginStartViewController: UIViewController {
     @IBOutlet weak var findSchoolButton: DynamicButton!
     @IBOutlet weak var lastLoginButton: UIButton!
     @IBOutlet weak var logoView: UIImageView!
+    @IBOutlet weak var wordmark: UIImageView!
     @IBOutlet weak var previousLoginsLabel: UILabel!
     @IBOutlet weak var previousLoginsTableView: UITableView!
     @IBOutlet weak var previousLoginsView: UIView!
@@ -78,6 +79,7 @@ class LoginStartViewController: UIViewController {
         }
         authenticationMethodLabel.isHidden = true
         logoView.tintColor = .currentLogoColor()
+        wordmark.tintColor = .currentLogoColor()
         animatableLogo.tintColor = logoView.tintColor
         previousLoginsView.isHidden = true
         self.lastLoginAccount = nil
@@ -90,7 +92,7 @@ class LoginStartViewController: UIViewController {
             : Bundle.main.isTeacherApp ? "TEACHER"
             : "STUDENT"
         ), attributes: [.kern: 2])
-        wordmarkLabel.textColor = .currentLogoColor()
+        wordmarkLabel.textColor = .textDarkest
         let loginText = NSLocalizedString("Log In", bundle: .core, comment: "")
         if MDMManager.shared.host != nil {
             findSchoolButton.isHidden = true


### PR DESCRIPTION
refs: MBL-169968
affects: Parent, Student, Teacher
release note: Fixed color contrast accessibility requirements on the login page.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/35f375ae-7ee1-4cfb-be70-8a29af97aaa1" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/e7470106-6e6b-4e88-a614-24335582d6ed" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/a1c0fc3d-a923-48ae-86ce-78aeb2fb9259" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/69fb4305-7c0a-429c-9a59-c2642b38a02e" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/a94edaaf-9121-4924-af82-3f4e3b3f6bc0" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/f554b6f9-708a-4a6f-9dea-b230907dd8ce" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
