### PR TITLE
Fix offline banner alignment

### DIFF
--- a/Core/Core/Offline/View/OfflineBannerView.swift
+++ b/Core/Core/Offline/View/OfflineBannerView.swift
@@ -41,8 +41,8 @@ class OfflineBannerView: UIView {
         leadingAnchor.constraint(equalTo: viewController.view.leadingAnchor).isActive = true
         trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor).isActive = true
         topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
-        heightAnchor.constraint(greaterThanOrEqualToConstant: 31.5).isActive = true
-        separatorHeight.constant = 0.5
+        heightAnchor.constraint(equalToConstant: 32).isActive = true
+        separatorHeight.constant = 1 / UIScreen.main.scale
     }
 
     private func setup() {

--- a/Core/Core/Offline/View/OfflineBannerView.swift
+++ b/Core/Core/Offline/View/OfflineBannerView.swift
@@ -22,6 +22,7 @@ class OfflineBannerView: UIView {
     @IBOutlet private unowned var onlineContainer: UIView!
     @IBOutlet private unowned var offlineContainer: UIView!
     @IBOutlet private unowned var separatorHeight: NSLayoutConstraint!
+    @IBOutlet private unowned var offlineIconCenter: NSLayoutConstraint!
     private var viewModel: OfflineBannerViewModel! {
         didSet {
             setup()
@@ -42,6 +43,7 @@ class OfflineBannerView: UIView {
         trailingAnchor.constraint(equalTo: viewController.view.trailingAnchor).isActive = true
         topAnchor.constraint(equalTo: viewController.view.safeAreaLayoutGuide.bottomAnchor).isActive = true
         heightAnchor.constraint(equalToConstant: 32).isActive = true
+        offlineIconCenter.constant = 1 / UIScreen.main.scale
         separatorHeight.constant = 1 / UIScreen.main.scale
     }
 

--- a/Core/Core/Offline/View/OfflineBannerView.xib
+++ b/Core/Core/Offline/View/OfflineBannerView.xib
@@ -28,7 +28,7 @@
                             <rect key="frame" x="166.66666666666666" y="0.0" width="60" height="30"/>
                             <subviews>
                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="offlineLine" translatesAutoresizingMaskIntoConstraints="NO" id="ohM-Lc-GPb">
-                                    <rect key="frame" x="0.0" y="7" width="18" height="18"/>
+                                    <rect key="frame" x="0.0" y="6" width="18" height="18"/>
                                     <color key="tintColor" name="textDarkest"/>
                                     <constraints>
                                         <constraint firstAttribute="width" constant="18" id="4RO-7N-BNJ"/>
@@ -51,7 +51,7 @@
                                 <constraint firstItem="ohM-Lc-GPb" firstAttribute="leading" secondItem="esq-fQ-yUr" secondAttribute="leading" id="Vft-Tx-sNb"/>
                                 <constraint firstItem="Bly-U5-Ddc" firstAttribute="centerY" secondItem="esq-fQ-yUr" secondAttribute="centerY" id="bKY-k7-IX8"/>
                                 <constraint firstItem="Bly-U5-Ddc" firstAttribute="leading" secondItem="ohM-Lc-GPb" secondAttribute="trailing" constant="4" id="mMc-cR-RDV"/>
-                                <constraint firstItem="ohM-Lc-GPb" firstAttribute="centerY" secondItem="esq-fQ-yUr" secondAttribute="centerY" constant="1" id="pzC-a9-96I"/>
+                                <constraint firstItem="ohM-Lc-GPb" firstAttribute="centerY" secondItem="esq-fQ-yUr" secondAttribute="centerY" id="pzC-a9-96I"/>
                             </constraints>
                         </view>
                     </subviews>
@@ -102,6 +102,7 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="offlineContainer" destination="BNN-0A-qts" id="zAB-rJ-xmE"/>
+                <outlet property="offlineIconCenter" destination="pzC-a9-96I" id="4IA-kW-7wr"/>
                 <outlet property="onlineContainer" destination="jRu-na-zJM" id="sOc-ze-RXS"/>
                 <outlet property="separatorHeight" destination="uUs-E1-c6G" id="fvr-8q-Bhm"/>
             </connections>

--- a/Core/Core/Offline/View/OfflineBannerView.xib
+++ b/Core/Core/Offline/View/OfflineBannerView.xib
@@ -83,7 +83,6 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" name="crimson"/>
             <accessibility key="accessibilityConfiguration">
                 <accessibilityTraits key="traits" notEnabled="YES"/>
             </accessibility>
@@ -124,9 +123,6 @@
         </namedColor>
         <namedColor name="borderMedium">
             <color red="0.7803921568627451" green="0.80392156862745101" blue="0.81960784313725488" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
-        <namedColor name="crimson">
-            <color red="0.93333333333333335" green="0.023529411764705882" blue="0.070588235294117646" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="shamrock">
             <color red="0.070588235294117646" green="0.47843137254901963" blue="0.10588235294117647" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
refs: MBL-16773
affects: Student
release note: none

test plan:
- Change app to dark mode to make the error stand out.
- Go offline.
- Scroll the dashboard up and down to see if there's a space between the tab bar and the offline banner.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/8d514b2d-a892-4d1c-aa02-98c14cb9ffa7" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/1ec841b5-cd9d-4782-b91e-16fa5e70d8f4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
