### PR TITLE
Offline sync retry logic

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2183,7 +2183,7 @@
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF8139D888212DC95299155 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2781,7 +2781,7 @@
 		A39C7A23AEDFA7CAA2A6DDEB /* APIRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequestableTests.swift; sourceTree = "<group>"; };
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2183,7 +2183,7 @@
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF8139D888212DC95299155 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2781,7 +2781,7 @@
 		A39C7A23AEDFA7CAA2A6DDEB /* APIRequestableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIRequestableTests.swift; sourceTree = "<group>"; };
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };

--- a/Core/Core/CourseSync/Common/Models/Entities/CourseSyncDownloadProgress.swift
+++ b/Core/Core/CourseSync/Common/Models/Entities/CourseSyncDownloadProgress.swift
@@ -22,6 +22,7 @@ import CoreData
 public final class CourseSyncDownloadProgress: NSManagedObject {
     @NSManaged public var bytesToDownload: Int
     @NSManaged public var bytesDownloaded: Int
+    @NSManaged public var isFinished: Bool
     @NSManaged public var error: String?
 
     var progress: Float {
@@ -34,14 +35,15 @@ public extension CourseSyncDownloadProgress {
     static func save(
         bytesToDownload: Int,
         bytesDownloaded: Int,
+        isFinished: Bool,
         error: String?,
         in context: NSManagedObjectContext
     ) -> CourseSyncDownloadProgress {
         let model: CourseSyncDownloadProgress = context.first(scope: .all) ?? context.insert()
         model.bytesToDownload = bytesToDownload
         model.bytesDownloaded = bytesDownloaded
+        model.isFinished = isFinished
         model.error = error
-
         return model
     }
 }

--- a/Core/Core/CourseSync/Common/Models/Entities/CourseSyncEntry.swift
+++ b/Core/Core/CourseSync/Common/Models/Entities/CourseSyncEntry.swift
@@ -164,6 +164,10 @@ public struct CourseSyncEntry: Equatable {
         return state == .error || tabsError || filesError
     }
 
+    var hasFileError: Bool {
+        files.contains { $0.state == .error }
+    }
+
     mutating func selectCourse(selectionState: ListCellView.SelectionState) {
         tabs.indices.forEach { tabs[$0].selectionState = selectionState }
         files.indices.forEach { files[$0].selectionState = selectionState }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -67,13 +67,16 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
 
         unowned let unownedSelf = self
 
+        let entriesWithInitialLoadingState = resetEntryStates(entries: entries)
+
         backgroundQueue.sync(flags: .barrier) {
-            courseSyncEntries.send(entries)
+            courseSyncEntries.send(entriesWithInitialLoadingState)
         }
 
         progressWriterInteractor.cleanUpPreviousDownloadProgress()
+        progressWriterInteractor.setInitialLoadingState(entries: entriesWithInitialLoadingState)
 
-        subscription = Publishers.Sequence(sequence: entries)
+        subscription = Publishers.Sequence(sequence: entriesWithInitialLoadingState)
             .buffer(size: .max, prefetch: .byRequest, whenFull: .dropOldest)
             .receive(on: scheduler)
             .flatMap(maxPublishers: .max(3)) { unownedSelf.downloadCourseDetails($0) }
@@ -257,6 +260,27 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
         progressWriterInteractor.saveDownloadProgress(entries: entries)
         backgroundQueue.sync(flags: .barrier) {
             courseSyncEntries.send(entries)
+        }
+    }
+
+    private func resetEntryStates(entries: [CourseSyncEntry]) -> [CourseSyncEntry] {
+        entries.map { entry in
+            var cpy = entry
+            if cpy.state != .downloaded {
+                cpy.state = .loading(nil)
+            } else {
+                return cpy
+            }
+
+            for var tab in cpy.tabs where tab.state != .downloaded {
+                tab.state = .loading(nil)
+            }
+
+            for var file in cpy.files where file.state != .downloaded {
+                file.state = .loading(nil)
+            }
+
+            return cpy
         }
     }
 }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -220,7 +220,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
             .collect()
             .handleEvents(
                 receiveOutput: { _ in
-                    let hasError = unownedSelf.safeCourseSyncEntriesValue[id: entry.id]?.hasError ?? false
+                    let hasError = unownedSelf.safeCourseSyncEntriesValue[id: entry.id]?.hasFileError ?? false
                     let state: CourseSyncEntry.State = hasError ? .error : .downloaded
 
                     unownedSelf.setState(

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncProgressWriterInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncProgressWriterInteractor.swift
@@ -21,7 +21,8 @@ import CoreData
 import Foundation
 
 public protocol CourseSyncProgressWriterInteractor {
-    func saveDownloadProgress(entries: [CourseSyncEntry], error: String?)
+    func saveDownloadProgress(entries: [CourseSyncEntry])
+    func saveDownloadResult(isFinished: Bool, error: String?)
     func cleanUpPreviousDownloadProgress()
     func saveStateProgress(id: String, selection: CourseEntrySelection, state: CourseSyncEntry.State)
 }
@@ -34,7 +35,7 @@ public final class CourseSyncProgressWriterInteractorLive: CourseSyncProgressWri
         context.automaticallyMergesChangesFromParent = true
     }
 
-    public func saveDownloadProgress(entries: [CourseSyncEntry], error: String? = nil) {
+    public func saveDownloadProgress(entries: [CourseSyncEntry]) {
         let bytesDownloaded = entries.totalDownloadedSize
         let bytesToDownloaded = entries.totalSelectedSize
 
@@ -42,6 +43,14 @@ public final class CourseSyncProgressWriterInteractorLive: CourseSyncProgressWri
             let progress: CourseSyncDownloadProgress = context.fetch(scope: .all).first ?? context.insert()
             progress.bytesDownloaded = bytesDownloaded
             progress.bytesToDownload = bytesToDownloaded
+            try? context.save()
+        }
+    }
+
+    public func saveDownloadResult(isFinished: Bool, error: String?) {
+        context.performAndWait {
+            let progress: CourseSyncDownloadProgress = context.fetch(scope: .all).first ?? context.insert()
+            progress.isFinished = isFinished
             progress.error = error
             try? context.save()
         }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncProgressWriterInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncProgressWriterInteractor.swift
@@ -24,6 +24,7 @@ public protocol CourseSyncProgressWriterInteractor {
     func saveDownloadProgress(entries: [CourseSyncEntry])
     func saveDownloadResult(isFinished: Bool, error: String?)
     func cleanUpPreviousDownloadProgress()
+    func setInitialLoadingState(entries: [CourseSyncEntry])
     func saveStateProgress(id: String, selection: CourseEntrySelection, state: CourseSyncEntry.State)
 }
 
@@ -61,6 +62,20 @@ public final class CourseSyncProgressWriterInteractorLive: CourseSyncProgressWri
             context.delete(context.fetch(scope: .all) as [CourseSyncStateProgress])
             context.delete(context.fetch(scope: .all) as [CourseSyncDownloadProgress])
             try? context.save()
+        }
+    }
+
+    public func setInitialLoadingState(entries: [CourseSyncEntry]) {
+        for entry in entries {
+            saveStateProgress(id: entry.id, selection: .course(entry.id), state: .loading(nil))
+
+            for tab in entry.tabs {
+                saveStateProgress(id: tab.id, selection: .tab(entry.id, tab.id), state: .loading(nil))
+            }
+
+            for file in entry.files {
+                saveStateProgress(id: file.id, selection: .file(entry.id, file.id), state: .loading(nil))
+            }
         }
     }
 

--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractor.swift
@@ -236,5 +236,14 @@ final class CourseSyncProgressInteractorLive: CourseSyncProgressInteractor {
 
     func cancelSync() {}
 
-    func retrySync() {}
+    func retrySync() {
+        let failedEntries = safeCourseSyncEntriesValue.map { entry in
+            var cpy = entry
+            cpy.tabs.removeAll { $0.state == .downloaded }
+            cpy.files.removeAll { $0.state == .downloaded }
+            return cpy
+        }
+
+        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: failedEntries)
+    }
 }

--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractor.swift
@@ -237,13 +237,6 @@ final class CourseSyncProgressInteractorLive: CourseSyncProgressInteractor {
     func cancelSync() {}
 
     func retrySync() {
-        let failedEntries = safeCourseSyncEntriesValue.map { entry in
-            var cpy = entry
-            cpy.tabs.removeAll { $0.state == .downloaded }
-            cpy.files.removeAll { $0.state == .downloaded }
-            return cpy
-        }
-
-        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: failedEntries)
+        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: safeCourseSyncEntriesValue)
     }
 }

--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
@@ -34,7 +34,7 @@ struct CourseSyncProgressView: View {
     @ViewBuilder
     private var trailingBarItem: some View {
         switch viewModel.state {
-        case .error:
+        case .dataWithError:
             retryButton
         default:
             dismissButton
@@ -44,14 +44,14 @@ struct CourseSyncProgressView: View {
     @ViewBuilder
     private var content: some View {
         switch viewModel.state {
-        case .error:
+        case .initialError:
             InteractivePanda(scene: NoResultsPanda(),
                              title: Text("Something went wrong", bundle: .core),
                              subtitle: Text("There was an unexpected error.", bundle: .core))
         case .loading:
             ProgressView()
                 .progressViewStyle(.indeterminateCircle())
-        case .data:
+        case .data, .dataWithError:
             VStack(spacing: 0) {
                 CourseSyncProgressInfoView(viewModel: courseSyncProgressInfoViewModel)
                     .padding(16)
@@ -116,7 +116,7 @@ struct CourseSyncProgressView: View {
 
     private var retryButton: some View {
         Button {
-            viewModel.retryButtonDidTap.accept(viewController)
+            viewModel.retryButtonDidTap.accept(())
         } label: {
             Text("Retry", bundle: .core)
                 .font(.regular16)

--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
@@ -44,7 +44,7 @@ struct CourseSyncProgressView: View {
     @ViewBuilder
     private var content: some View {
         switch viewModel.state {
-        case .initialError:
+        case .error:
             InteractivePanda(scene: NoResultsPanda(),
                              title: Text("Something went wrong", bundle: .core),
                              subtitle: Text("There was an unexpected error.", bundle: .core))

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
@@ -48,6 +48,7 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
 
         interactor.observeDownloadProgress()
             .receive(on: scheduler)
+            .throttle(for: .milliseconds(300), scheduler: scheduler, latest: true)
             .sink { state in
                 switch state {
                 case .data(let progressList):
@@ -59,6 +60,8 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
                         unownedSelf.syncFailure = true
                         return
                     }
+
+                    unownedSelf.syncFailure = false
 
                     let format = NSLocalizedString("Downloading %@ of %@", bundle: .core, comment: "Downloading 42 GB of 64 GB")
                     unownedSelf.progress = String.localizedStringWithFormat(

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
@@ -48,7 +48,6 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
 
         interactor.observeDownloadProgress()
             .receive(on: scheduler)
-            .throttle(for: .milliseconds(300), scheduler: scheduler, latest: true)
             .sink { state in
                 switch state {
                 case .data(let progressList):

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
@@ -56,13 +56,6 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
                         return
                     }
 
-                    guard progressList[0].error == nil else {
-                        unownedSelf.syncFailure = true
-                        return
-                    }
-
-                    unownedSelf.syncFailure = false
-
                     let format = NSLocalizedString("Downloading %@ of %@", bundle: .core, comment: "Downloading 42 GB of 64 GB")
                     unownedSelf.progress = String.localizedStringWithFormat(
                         format,
@@ -70,6 +63,12 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
                         progressList[0].bytesToDownload.humanReadableFileSize
                     )
                     unownedSelf.progressPercentage = progressList[0].progress
+
+                    if progressList[0].isFinished, progressList[0].error != nil {
+                        unownedSelf.syncFailure = true
+                    } else {
+                        unownedSelf.syncFailure = false
+                    }
                 default:
                     break
                 }

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -23,7 +23,7 @@ import SwiftUI
 class CourseSyncProgressViewModel: ObservableObject {
     enum State {
         case loading
-        case initialError
+        case error
         case data
         case dataWithError
     }
@@ -113,7 +113,7 @@ class CourseSyncProgressViewModel: ObservableObject {
             }
         }, receiveCompletion: { [unowned self] result in
             if case .failure = result {
-                state = .initialError
+                state = .error
             }
         })
         .map { $0.1 }

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -23,14 +23,16 @@ import SwiftUI
 class CourseSyncProgressViewModel: ObservableObject {
     enum State {
         case loading
+        case initialError
         case data
-        case error
+        case dataWithError
     }
 
     // MARK: - Output
 
     @Published public private(set) var state = State.loading
     @Published public private(set) var cells: [Cell] = []
+    @Published public private(set) var showRetryButton = false
 
     public let labels = (
         noCourses: (
@@ -51,7 +53,7 @@ class CourseSyncProgressViewModel: ObservableObject {
 
     public let cancelButtonDidTap = PassthroughRelay<WeakViewController>()
     public let dismissButtonDidTap = PassthroughRelay<WeakViewController>()
-    public let retryButtonDidTap = PassthroughRelay<WeakViewController>()
+    public let retryButtonDidTap = PassthroughRelay<Void>()
 
     // MARK: - Private
 
@@ -77,7 +79,7 @@ class CourseSyncProgressViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
-    private func handleDismissButtonTap(_ interactor: CourseSyncProgressInteractor) {
+    private func handleDismissButtonTap(_: CourseSyncProgressInteractor) {
         dismissButtonDidTap
             .sink { [unowned router] viewController in
                 router.dismiss(viewController)
@@ -87,28 +89,35 @@ class CourseSyncProgressViewModel: ObservableObject {
 
     private func handleRetryButtonTap(_ interactor: CourseSyncProgressInteractor, router: Router) {
         retryButtonDidTap
-            .sink { viewController in
+            .sink { _ in
                 interactor.retrySync()
-                router.dismiss(viewController)
             }
             .store(in: &subscriptions)
     }
 
     private func updateState(_ interactor: CourseSyncProgressInteractor) {
-        interactor
-            .observeEntries()
-            .map { $0.makeSyncProgressViewModelItems(interactor: interactor) }
-            .receive(on: DispatchQueue.main)
-            .handleEvents(receiveOutput: { [unowned self] progressList in
-                if progressList.count > 0 {
-                    state = .data
+        Publishers.CombineLatest(
+            interactor.observeDownloadProgress().setFailureType(to: Error.self),
+            interactor.observeEntries()
+        )
+        .throttle(for: .milliseconds(300), scheduler: DispatchQueue.main, latest: true)
+        .map { ($0.0, $0.1.makeSyncProgressViewModelItems(interactor: interactor)) }
+        .receive(on: DispatchQueue.main)
+        .handleEvents(receiveOutput: { [unowned self] downloadProgress, entryProgressList in
+            if entryProgressList.count > 0 {
+                state = .data
+
+                if downloadProgress.firstItem?.error != nil {
+                    state = .dataWithError
                 }
-            }, receiveCompletion: { [unowned self] result in
-                if case .failure = result {
-                    state = .error
-                }
-            })
-            .replaceError(with: [])
-            .assign(to: &$cells)
+            }
+        }, receiveCompletion: { [unowned self] result in
+            if case .failure = result {
+                state = .initialError
+            }
+        })
+        .map { $0.1 }
+        .replaceError(with: [])
+        .assign(to: &$cells)
     }
 }

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -107,7 +107,7 @@ class CourseSyncProgressViewModel: ObservableObject {
             if entryProgressList.count > 0 {
                 state = .data
 
-                if downloadProgress.firstItem?.error != nil {
+                if downloadProgress.firstItem?.isFinished ?? false, downloadProgress.firstItem?.error != nil {
                     state = .dataWithError
                 }
             }

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -100,7 +100,6 @@ class CourseSyncProgressViewModel: ObservableObject {
             interactor.observeDownloadProgress().setFailureType(to: Error.self),
             interactor.observeEntries()
         )
-        .throttle(for: .milliseconds(300), scheduler: DispatchQueue.main, latest: true)
         .map { ($0.0, $0.1.makeSyncProgressViewModelItems(interactor: interactor)) }
         .receive(on: DispatchQueue.main)
         .handleEvents(receiveOutput: { [unowned self] downloadProgress, entryProgressList in

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22F82" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22E261" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -275,6 +275,7 @@
         <attribute name="bytesDownloaded" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="bytesToDownload" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="error" optional="YES" attributeType="String"/>
+        <attribute name="isFinished" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
     </entity>
     <entity name="CourseSyncSelectorCourse" representedClassName="Core.CourseSyncSelectorCourse" syncable="YES">
         <attribute name="courseCode" attributeType="String"/>

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -387,6 +387,49 @@ class CourseSyncInteractorLiveTests: CoreTestCase {
         wait(for: [expectation], timeout: 1)
         subscription.cancel()
     }
+
+    func testInitialLoadingState() {
+        let testee = CourseSyncInteractorLive(
+            contentInteractors: [pagesInteractor, assignmentsInteractor],
+            filesInteractor: filesInteractor,
+            progressWriterInteractor: CourseSyncProgressWriterInteractorLive(container: database),
+            scheduler: .immediate
+        )
+        entries[0].tabs[0].selectionState = .selected
+        entries[0].tabs[1].selectionState = .selected
+        entries[0].tabs[2].selectionState = .selected
+        entries[0].files[0].selectionState = .selected
+        entries[0].files[1].selectionState = .selected
+
+        let subscription = testee.downloadContent(for: entries).sink()
+
+        let courseProgress: CourseSyncStateProgress = databaseClient.fetch(
+            scope: .where(#keyPath(CourseSyncStateProgress.id), equals: "entry-1")
+        ).first!
+        XCTAssertEqual(courseProgress.state, .loading(nil))
+
+        let assignmentsProgress: CourseSyncStateProgress = databaseClient.fetch(
+            scope: .where(#keyPath(CourseSyncStateProgress.id), equals: "tab-assignments")
+        ).first!
+        XCTAssertEqual(assignmentsProgress.state, .loading(nil))
+
+        let pagesProgress: CourseSyncStateProgress = databaseClient.fetch(
+            scope: .where(#keyPath(CourseSyncStateProgress.id), equals: "tab-pages")
+        ).first!
+        XCTAssertEqual(pagesProgress.state, .loading(nil))
+
+        let file1Progress: CourseSyncStateProgress = databaseClient.fetch(
+            scope: .where(#keyPath(CourseSyncStateProgress.id), equals: "file-1")
+        ).first!
+        XCTAssertEqual(file1Progress.state, .loading(nil))
+
+        let file2Progress: CourseSyncStateProgress = databaseClient.fetch(
+            scope: .where(#keyPath(CourseSyncStateProgress.id), equals: "file-1")
+        ).first!
+        XCTAssertEqual(file2Progress.state, .loading(nil))
+
+        subscription.cancel()
+    }
 }
 
 // MARK: - Mocks

--- a/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractorLiveTests.swift
@@ -302,7 +302,7 @@ class CourseSyncProgressInteractorLiveTests: CoreTestCase {
                         mimeClass: "image",
                         updatedAt: nil,
                         state: .error,
-                        bytesToDownload: 1000,
+                        bytesToDownload: 1000
                     ),
                     .init(
                         id: "courses/course-id-1/files/file-2",

--- a/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressInteractorLiveTests.swift
@@ -326,10 +326,10 @@ class CourseSyncProgressInteractorLiveTests: CoreTestCase {
         // THEN
         XCTAssertEqual(entries.count, 1)
         XCTAssertEqual(entries[0].state, .loading(nil))
-        XCTAssertEqual(entries[0].tabs.count, 1)
+        XCTAssertEqual(entries[0].tabs.count, 2)
         XCTAssertEqual(entries[0].tabs[0].id, "courses/course-id-1/tabs/files")
         XCTAssertEqual(entries[0].tabs[0].state, .error)
-        XCTAssertEqual(entries[0].files.count, 1)
+        XCTAssertEqual(entries[0].files.count, 2)
         XCTAssertEqual(entries[0].files[0].id, "courses/course-id-1/files/file-1")
 
         subscription1.cancel()

--- a/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractorLiveTests.swift
@@ -53,7 +53,7 @@ class CourseSyncProgressObserverInteractorLiveTests: CoreTestCase {
         entries[0].files[1].selectionState = .selected
         entries[0].files[0].state = .downloaded
         entries[0].files[1].state = .downloaded
-        helper.saveDownloadProgress(entries: entries, error: nil)
+        helper.saveDownloadProgress(entries: entries)
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee.observeDownloadProgress()

--- a/Core/CoreTests/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModelTests.swift
@@ -43,6 +43,7 @@ class CourseSyncProgressInfoViewModelTests: CoreTestCase {
         let fileProgress = CourseSyncDownloadProgress.save(
             bytesToDownload: 1000,
             bytesDownloaded: 500,
+            isFinished: false,
             error: nil,
             in: databaseClient
         )
@@ -61,7 +62,7 @@ class CourseSyncProgressInfoViewModelTests: CoreTestCase {
         )
     }
 
-    func testErrorDetails() {
+    func testErrorIsShownWhenFinished() {
         // GIVEN
         let testee = CourseSyncProgressInfoViewModel(
             interactor: courseSyncProgressInteractorMock,
@@ -70,6 +71,7 @@ class CourseSyncProgressInfoViewModelTests: CoreTestCase {
         let fileProgress = CourseSyncDownloadProgress.save(
             bytesToDownload: 1000,
             bytesDownloaded: 0,
+            isFinished: true,
             error: "Download failed.",
             in: databaseClient
         )
@@ -89,6 +91,30 @@ class CourseSyncProgressInfoViewModelTests: CoreTestCase {
         XCTAssertSingleOutputEquals(
             testee.$syncFailureSubtitle,
             "One or more files failed to sync. Check your internet connection and retry to submit."
+        )
+    }
+
+    func testErrorIsNotShownUntilFinished() {
+        // GIVEN
+        let testee = CourseSyncProgressInfoViewModel(
+            interactor: courseSyncProgressInteractorMock,
+            scheduler: .immediate
+        )
+        let fileProgress = CourseSyncDownloadProgress.save(
+            bytesToDownload: 1000,
+            bytesDownloaded: 0,
+            isFinished: false,
+            error: "Download failed.",
+            in: databaseClient
+        )
+
+        // WHEN
+        courseSyncProgressInteractorMock.courseSyncFileProgressSubject.send(.data([fileProgress]))
+
+        // THEN
+        XCTAssertSingleOutputEquals(
+            testee.$syncFailure,
+            false
         )
     }
 }

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -191,6 +191,20 @@
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
 		};
+		B46AC4F82A93474900972C67 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
+			remoteInfo = CoreTester;
+		};
+		B46AC4FA2A93474900972C67 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
+			remoteInfo = CoreTests;
+		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
@@ -704,6 +718,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
+				B46AC4F92A93474900972C67 /* CoreTester.app */,
+				B46AC4FB2A93474900972C67 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -993,6 +1009,20 @@
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		B46AC4F92A93474900972C67 /* CoreTester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CoreTester.app;
+			remoteRef = B46AC4F82A93474900972C67 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B46AC4FB2A93474900972C67 /* CoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CoreTests.xctest;
+			remoteRef = B46AC4FA2A93474900972C67 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -1124,7 +1154,6 @@
 				61BD60E72184E0F4FD7370F3 /* HelpHelper.swift in Sources */,
 				725E9BF8E41C6A616B1AA541 /* HttpResponseExtensions.swift in Sources */,
 				29106714316FC6E492695718 /* InboxHelper.swift in Sources */,
-				9C586F6B9CBC116CEC1C2060 /* K5E2ETestCase.swift in Sources */,
 				7B4C6D235E858C6C17C29830 /* K5Helper.swift in Sources */,
 				DC911A2167CFB16C6A61670F /* K5UITestCase.swift in Sources */,
 				80B8FDF8E9845B91049CFE77 /* KeychainEntryFixture.swift in Sources */,

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -191,20 +191,6 @@
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
 		};
-		B46AC4F82A93474900972C67 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		B46AC4FA2A93474900972C67 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
-		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
@@ -718,8 +704,6 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				B46AC4F92A93474900972C67 /* CoreTester.app */,
-				B46AC4FB2A93474900972C67 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1009,20 +993,6 @@
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B46AC4F92A93474900972C67 /* CoreTester.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CoreTester.app;
-			remoteRef = B46AC4F82A93474900972C67 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B46AC4FB2A93474900972C67 /* CoreTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CoreTests.xctest;
-			remoteRef = B46AC4FA2A93474900972C67 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 /* End PBXReferenceProxy section */
 
 /* Begin PBXShellScriptBuildPhase section */
@@ -1154,6 +1124,7 @@
 				61BD60E72184E0F4FD7370F3 /* HelpHelper.swift in Sources */,
 				725E9BF8E41C6A616B1AA541 /* HttpResponseExtensions.swift in Sources */,
 				29106714316FC6E492695718 /* InboxHelper.swift in Sources */,
+				9C586F6B9CBC116CEC1C2060 /* K5E2ETestCase.swift in Sources */,
 				7B4C6D235E858C6C17C29830 /* K5Helper.swift in Sources */,
 				DC911A2167CFB16C6A61670F /* K5UITestCase.swift in Sources */,
 				80B8FDF8E9845B91049CFE77 /* KeychainEntryFixture.swift in Sources */,


### PR DESCRIPTION
refs: MBL-16885
affects: Student
release note: none
test: 
1. I suggest to use my account because "Test" course has 100+ MB of files so you can play around with the retry logic. 
2. Start a course sync 
3. Open the progress screen
4. Turn off Wi-Fi
5. Turn back the Wi-Fi (To have an established connection you might need to wait an additional second after the Wi-Fi icon appears) 
6. Tap Retry 
7. You should see the previously failed Course/Tab/File row switches state from Error to Loading
8. If you previously successfully downloaded a couple of files, the total number of bytes should decrease because we are only downloading the ones that failed.
 
https://github.com/instructure/canvas-ios/assets/110813321/71f9f931-87a0-45a4-b250-a8ee06ceaa01

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [x] Tested on tablet