### PR TITLE
Allow embedded Studio videos in RCE content

### DIFF
--- a/Core/Core/CoreWebView/CoreWebView.swift
+++ b/Core/Core/CoreWebView/CoreWebView.swift
@@ -135,6 +135,11 @@ open class CoreWebView: WKWebView {
         isOpaque = false
         backgroundColor = UIColor.clear
 
+#if DEBUG
+        if #available(iOS 16.4, *) {
+            isInspectable = true
+        }
+#endif
         addScript(js)
         handle("resize") { [weak self] message in
             guard let self = self,

--- a/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
@@ -87,6 +87,12 @@ extension CoreWebView {
         function fixLTITools() {
             // Replace all iframes with a button to launch in SFSafariViewController
             document.querySelectorAll('iframe').forEach(iframe => {
+
+                const allowedStudioDomains = ['instructuremedia.com', 'arc.inseng.net', 'arc.docker'];
+                if (allowedStudioDomains.some(domain => iframe.src.includes(domain))) {
+                    return;
+                }
+
                 const replace = iframe => {
                     const a = document.createElement('a')
                     a.textContent = \(CoreWebView.jsString(buttonText))


### PR DESCRIPTION
refs: MBL-16989
affects: Parent, Student, Teacher
release note: Studio media content now shows up on details and edit pages instead of launching as an external LTI tool.
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/25fe452e-273f-434b-be49-263082183c4c" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/79920680/9f19ac80-9f07-4c63-8e19-b61d0a7f54fa" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
