### PR TITLE
Fix 'none' release note handling

### DIFF
--- a/scripts/generate-release-notes.js
+++ b/scripts/generate-release-notes.js
@@ -163,7 +163,7 @@ function getReleaseNote (commit) {
   }
 
   let note = releaseNotes[1].trim()
-  if (note === 'none') return null
+  if (note.toLowerCase().startsWith('none') && note.length <= 5) return null
   return note
 }
 


### PR DESCRIPTION
The generate-release-notes script should ignore any case of none (None, NoNe, nONE, etc.) 
with up to one punctuation (eg. nonE?) added.
Longer release notes starting with none should be retained (eg. None of this makes any sense.)

[ignore-commit-lint]