### PR TITLE
Make script continue updating issues when one update fails

### DIFF
--- a/scripts/update-jira-issues.js
+++ b/scripts/update-jira-issues.js
@@ -69,7 +69,7 @@ const fixVersionForAppVersion = async (app, version) => {
 exports.addFixVersion = async (tag, issueKeys) => {
   const fixVersionName = await fixVersionForAppVersion(...(tag.split('-')))
   console.log(`Adding fix version "${fixVersionName}"\n${issueKeys.join('\n')}`)
-  await Promise.all(issueKeys.map(issueKey => client.updateIssue(issueKey, {
+  await Promise.allSettled(issueKeys.map(issueKey => client.updateIssue(issueKey, {
     update: { fixVersions: [ { add: { name: fixVersionName } } ] },
   })))
 }


### PR DESCRIPTION
We have one invalid ticket number (MBL-169968) on master that makes the release script interrupt. With this change we ignore any jira update failures and just continue as it was successful.

[ignore-commit-lint]