### PR TITLE
Fix crash on app start

### DIFF
--- a/Core/Core/Dashboard/OfflineSync/DashboardOfflineSyncProgressCardAssembly.swift
+++ b/Core/Core/Dashboard/OfflineSync/DashboardOfflineSyncProgressCardAssembly.swift
@@ -24,15 +24,17 @@ public enum DashboardOfflineSyncProgressCardAssembly {
     static func makeViewModel(container: NSPersistentContainer = AppEnvironment.shared.database,
                               router: Router = AppEnvironment.shared.router)
     -> DashboardOfflineSyncProgressCardViewModel {
+        let offlineModeInteractor = OfflineModeAssembly.make()
         let interactor = CourseSyncProgressObserverInteractorLive(container: container)
-        return DashboardOfflineSyncProgressCardViewModel(interactor: interactor, router: router)
+        return DashboardOfflineSyncProgressCardViewModel(interactor: interactor, offlineModeInteractor: offlineModeInteractor, router: router)
     }
 
 #if DEBUG
 
     static func makePreview() -> some View {
+        let offlineModeInteractor = OfflineModeAssembly.make()
         let interactor = DashboardOfflineSyncInteractorPreview()
-        let viewModel = DashboardOfflineSyncProgressCardViewModel(interactor: interactor,
+        let viewModel = DashboardOfflineSyncProgressCardViewModel(interactor: interactor, offlineModeInteractor: offlineModeInteractor,
                                                                   router: AppEnvironment.shared.router)
         return DashboardOfflineSyncProgressCardView(viewModel: viewModel)
     }

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -33,20 +33,37 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
     private let scheduler: AnySchedulerOf<DispatchQueue>
     private var subscriptions = Set<AnyCancellable>()
 
+    /**
+     - parameters:
+        - offlineModeInteractor: This is used to determine if the feature flag is turned on. If it's off then
+     we don't subscribe to CoreData updates to save some CPU time.
+     */
     public init(interactor: CourseSyncProgressObserverInteractor,
+                offlineModeInteractor: OfflineModeInteractor,
                 router: Router,
                 scheduler: AnySchedulerOf<DispatchQueue> = .main) {
         self.interactor = interactor
         self.router = router
         self.scheduler = scheduler
 
-        setupProgressUpdates()
+        guard offlineModeInteractor.isFeatureFlagEnabled() else { return }
+
+        let downloadProgressPublisher = interactor
+            .observeDownloadProgress()
+            .share()
+            .makeConnectable()
+
+        setupProgressUpdates(downloadProgressPublisher)
         setupAutoAppearanceOnSyncStart()
         setupAutoHideOnSyncCancel()
-        setupAutoDismissUponCompletion()
+        setupAutoDismissUponCompletion(downloadProgressPublisher)
         setupSubtitleCounterUpdates()
         handleDismissTap()
         handleCardTap()
+
+        downloadProgressPublisher
+            .connect()
+            .store(in: &subscriptions)
     }
 
     private func setupSubtitleCounterUpdates() {
@@ -61,17 +78,15 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
             .assign(to: &$subtitle)
     }
 
-    private func setupProgressUpdates() {
-        interactor
-            .observeDownloadProgress()
+    private func setupProgressUpdates(_ downloadProgress: some Publisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>) {
+        downloadProgress
             .map { $0.firstItem?.progress ?? 0 }
             .receive(on: scheduler)
             .assign(to: &$progress)
     }
 
-    private func setupAutoDismissUponCompletion() {
-        interactor
-            .observeDownloadProgress()
+    private func setupAutoDismissUponCompletion(_ downloadProgress: some Publisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>) {
+        downloadProgress
             .map { $0.firstItem?.progress ?? 0 }
             .filter { $0 >= 1 }
             .mapToValue(false)

--- a/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
@@ -27,6 +27,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
     func testSubtitleItemCounterIgnoresContainerSelections() {
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
         XCTAssertEqual(testee.subtitle, "2 items are syncing.")
@@ -36,6 +37,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router)
         XCTAssertFalse(testee.isVisible)
 
@@ -53,6 +55,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient,
                                                                       progressToReport: 1)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: testScheduler.eraseToAnyScheduler())
         NotificationCenter.default.post(name: .OfflineSyncTriggered,
@@ -71,6 +74,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
     func testUpdatesProgress() {
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
 
@@ -81,6 +85,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router)
         NotificationCenter.default.post(name: .OfflineSyncTriggered,
                                         object: nil)
@@ -97,6 +102,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router)
         let source = UIViewController()
 
@@ -141,4 +147,24 @@ private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserv
 
         return Just(.data([course, fileTab, file1, file2])).eraseToAnyPublisher()
     }
+}
+
+private class MockOfflineModeInteractorEnabled: OfflineModeInteractor {
+    func isFeatureFlagEnabled() -> Bool {
+        true
+    }
+
+    func observeIsFeatureFlagEnabled() -> AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+
+    func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
+        Just(true).eraseToAnyPublisher()
+    }
+
+    func observeNetworkStatus() -> AnyPublisher<Core.NetworkAvailabilityStatus, Never> {
+        Just(.disconnected).eraseToAnyPublisher()
+    }
+
+    func isOfflineModeEnabled() -> Bool { true }
 }


### PR DESCRIPTION
- Skip offline sync progress listener setup in case the feature flag is off.
- Avoid using multiple observe calls on progress interactor.

refs: MBL-17021
affects: Student, Teacher
release note: Fixed a crash on app start.

test plan:
- Check if the dashboard banner for offline sync still appears during a sync.
- App shouldn't crash right after start.