### PR TITLE
Offline dashboard notification error state

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -69,7 +69,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
                     fileUploadNotificationCards()
                     list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                 }
-                .animation(.default, value: offlineSyncCardViewModel.state.isHidden)
+                .animation(.default, value: offlineSyncCardViewModel.state)
                 .padding(.horizontal, verticalSpacing)
             }
             refreshAction: { onComplete in

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -69,7 +69,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
                     fileUploadNotificationCards()
                     list(CGSize(width: geometry.size.width - 32, height: geometry.size.height))
                 }
-                .animation(.default, value: offlineSyncCardViewModel.isVisible)
+                .animation(.default, value: offlineSyncCardViewModel.state.isHidden)
                 .padding(.horizontal, verticalSpacing)
             }
             refreshAction: { onComplete in

--- a/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
+++ b/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
@@ -41,7 +41,7 @@ struct DashboardOfflineSyncProgressCardView: View {
                 SwiftUI.EmptyView()
             }
         }
-        .animation(.default, value: viewModel.state.isHidden)
+        .animation(.default, value: viewModel.state)
     }
 
     private func containerCard(backgroundColor: Color, innerView: () -> some View) -> some View {
@@ -67,9 +67,15 @@ struct DashboardOfflineSyncProgressCardView: View {
                     .padding(.leading, 5)
                     .padding(.bottom, 5)
             }
-            .accessibilityLabel(Text("Dismiss notification", bundle: .core))
+            .accessibilityHidden(true)
         }
         .padding(.top, 16) // This is to add spacing between the dashboard's nav bar and this card
+        .accessibilityAction(named: Text("Show sync details", bundle: .core)) {
+            viewModel.cardDidTap.accept(viewController)
+        }
+        .accessibilityAction(named: Text("Dismiss", bundle: .core)) {
+            viewModel.dismissDidTap.accept()
+        }
     }
 
     private func progressView(_ progress: Float, _ progressText: String) -> some View {

--- a/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
+++ b/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
@@ -67,12 +67,9 @@ struct DashboardOfflineSyncProgressCardView: View {
                     .padding(.leading, 5)
                     .padding(.bottom, 5)
             }
-            .accessibilityHidden(true)
+            .accessibilityLabel(Text("Dismiss notification", bundle: .core))
         }
         .padding(.top, 16) // This is to add spacing between the dashboard's nav bar and this card
-        .accessibilityAction(named: Text("Dismiss notification", bundle: .core)) {
-            viewModel.dismissDidTap.accept()
-        }
     }
 
     private func progressView(_ progress: Float, _ progressText: String) -> some View {

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -21,9 +21,23 @@ import CombineExt
 import CombineSchedulers
 
 class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
-    @Published public private(set) var progress: Float = 0
-    @Published public private(set) var isVisible = false
-    @Published public private(set) var subtitle = ""
+    enum ViewState {
+        typealias Progress = Float // Ranging from 0 to 1
+        typealias ProgressText = String // Text
+
+        case progress(Progress, ProgressText)
+        case error
+        case hidden
+
+        var isHidden: Bool {
+            switch self {
+            case .hidden: return true
+            default: return false
+            }
+        }
+    }
+
+    @Published public private(set) var state: ViewState = .hidden
 
     public let dismissDidTap = PassthroughRelay<Void>()
     public let cardDidTap = PassthroughRelay<WeakViewController>()
@@ -35,7 +49,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
     /**
      - parameters:
-        - offlineModeInteractor: This is used to determine if the feature flag is turned on. If it's off then
+     - offlineModeInteractor: This is used to determine if the feature flag is turned on. If it's off then
      we don't subscribe to CoreData updates to save some CPU time.
      */
     public init(interactor: CourseSyncProgressObserverInteractor,
@@ -53,11 +67,9 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
             .share()
             .makeConnectable()
 
-        setupProgressUpdates(downloadProgressPublisher)
-        setupAutoAppearanceOnSyncStart()
+        setupAutoAppearanceOnSyncStart(downloadProgressPublisher)
         setupAutoHideOnSyncCancel()
         setupAutoDismissUponCompletion(downloadProgressPublisher)
-        setupSubtitleCounterUpdates()
         handleDismissTap()
         handleCardTap()
 
@@ -66,54 +78,60 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
-    private func setupSubtitleCounterUpdates() {
-        interactor
-            .observeStateProgress()
-            .compactMap { $0.allItems }
-            .map { $0.ignoreContainerSelections() }
-            .map {
-                let format = NSLocalizedString("d_items_syncing", comment: "")
-                return String.localizedStringWithFormat(format, $0.count) }
-            .receive(on: scheduler)
-            .assign(to: &$subtitle)
-    }
+    private typealias DownloadProgressPublisher = Publisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>
 
-    private func setupProgressUpdates(_ downloadProgress: some Publisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>) {
-        downloadProgress
-            .map { $0.firstItem?.progress ?? 0 }
-            .receive(on: scheduler)
-            .assign(to: &$progress)
-    }
-
-    private func setupAutoDismissUponCompletion(_ downloadProgress: some Publisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>) {
-        downloadProgress
-            .map { $0.firstItem?.progress ?? 0 }
-            .filter { $0 >= 1 }
-            .mapToValue(false)
-            .delay(for: .seconds(1), scheduler: scheduler)
-            .assign(to: &$isVisible)
-    }
-
-    private func setupAutoAppearanceOnSyncStart() {
+    private func setupAutoAppearanceOnSyncStart(_ downloadProgressPublisher: some DownloadProgressPublisher) {
         NotificationCenter
             .default
             .publisher(for: .OfflineSyncTriggered)
-            .mapToValue(true)
-            .assign(to: &$isVisible)
+            .flatMapLatest { [unowned self] _ in setupProgressUpdates(downloadProgressPublisher) }
+            .receive(on: scheduler)
+            .assign(to: &$state)
+    }
+
+    private func setupProgressUpdates(
+        _ downloadProgressPublisher: some DownloadProgressPublisher
+    ) -> AnyPublisher<DashboardOfflineSyncProgressCardViewModel.ViewState, Never> {
+        Publishers.CombineLatest(
+            interactor.observeStateProgress().compactMap { $0.allItems }.map { $0.ignoreContainerSelections() },
+            downloadProgressPublisher.compactMap { $0.firstItem }
+        )
+        .receive(on: scheduler)
+        .map { stateProgress, downloadProgress in
+            if downloadProgress.isFinished, downloadProgress.error != nil {
+                return .error
+            } else {
+                let format = NSLocalizedString("d_items_syncing", comment: "")
+                let formattedText = String.localizedStringWithFormat(format, stateProgress.count)
+                return .progress(downloadProgress.progress, formattedText)
+            }
+        }
+        .eraseToAnyPublisher()
     }
 
     private func setupAutoHideOnSyncCancel() {
         NotificationCenter
             .default
             .publisher(for: .OfflineSyncCancelled)
-            .mapToValue(false)
-            .assign(to: &$isVisible)
+            .mapToValue(.hidden)
+            .receive(on: scheduler)
+            .assign(to: &$state)
+    }
+
+    private func setupAutoDismissUponCompletion(_ downloadProgressPublisher: some DownloadProgressPublisher) {
+        downloadProgressPublisher
+            .compactMap { $0.firstItem }
+            .filter { $0.isFinished && $0.error == nil }
+            .mapToValue(.hidden)
+            .delay(for: .seconds(1), scheduler: scheduler)
+            .receive(on: scheduler)
+            .assign(to: &$state)
     }
 
     private func handleDismissTap() {
         dismissDidTap
-            .map { false }
-            .assign(to: &$isVisible)
+            .map { .hidden }
+            .assign(to: &$state)
     }
 
     private func handleCardTap() {
@@ -128,13 +146,12 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 }
 
 private extension Array where Element == CourseSyncStateProgress {
-
     /// Courses and file tabs are not syncable items so we should'n count them.
     func ignoreContainerSelections() -> Self {
         filter { entry in
             switch entry.selection {
             case .course: return false
-            case .tab(_, let tabID) where tabID.contains("/tabs/files"): return false
+            case let .tab(_, tabID) where tabID.contains("/tabs/files"): return false
             default: return true
             }
         }

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -21,7 +21,7 @@ import CombineExt
 import CombineSchedulers
 
 class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
-    enum ViewState {
+    enum ViewState: Equatable {
         typealias Progress = Float // Ranging from 0 to 1
         typealias ProgressText = String // Text
 
@@ -64,6 +64,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
         let downloadProgressPublisher = interactor
             .observeDownloadProgress()
+            .print("🍏 ")
             .share()
             .makeConnectable()
 
@@ -93,8 +94,8 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
         _ downloadProgressPublisher: some DownloadProgressPublisher
     ) -> AnyPublisher<DashboardOfflineSyncProgressCardViewModel.ViewState, Never> {
         Publishers.CombineLatest(
-            interactor.observeStateProgress().compactMap { $0.allItems }.map { $0.ignoreContainerSelections() },
-            downloadProgressPublisher.compactMap { $0.firstItem }
+            interactor.observeStateProgress().compactMap { $0.allItems }.map { $0.ignoreContainerSelections() }.print("🍔 "),
+            downloadProgressPublisher.compactMap { $0.firstItem }.print("🍎 ")
         )
         .receive(on: scheduler)
         .map { stateProgress, downloadProgress in

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -49,7 +49,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
     /**
      - parameters:
-     - offlineModeInteractor: This is used to determine if the feature flag is turned on. If it's off then
+        - offlineModeInteractor: This is used to determine if the feature flag is turned on. If it's off then
      we don't subscribe to CoreData updates to save some CPU time.
      */
     public init(interactor: CourseSyncProgressObserverInteractor,

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -116,7 +116,6 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
     private func restorePreviousFailedState(_ downloadProgressPublisher: some DownloadProgressPublisher) {
         downloadProgressPublisher
-            .first()
             .compactMap { $0.firstItem }
             .flatMap { downloadProgress -> AnyPublisher<DashboardOfflineSyncProgressCardViewModel.ViewState, Never> in
                 if downloadProgress.isFinished, downloadProgress.error != nil {
@@ -125,6 +124,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
                     return Empty(completeImmediately: true).eraseToAnyPublisher()
                 }
             }
+            .first()
             .receive(on: scheduler)
             .assign(to: &$state)
     }

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -64,7 +64,6 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
         let downloadProgressPublisher = interactor
             .observeDownloadProgress()
-            .print("🍏 ")
             .share()
             .makeConnectable()
 
@@ -94,8 +93,8 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
         _ downloadProgressPublisher: some DownloadProgressPublisher
     ) -> AnyPublisher<DashboardOfflineSyncProgressCardViewModel.ViewState, Never> {
         Publishers.CombineLatest(
-            interactor.observeStateProgress().compactMap { $0.allItems }.map { $0.ignoreContainerSelections() }.print("🍔 "),
-            downloadProgressPublisher.compactMap { $0.firstItem }.print("🍎 ")
+            interactor.observeStateProgress().compactMap { $0.allItems }.map { $0.ignoreContainerSelections() },
+            downloadProgressPublisher.compactMap { $0.firstItem }
         )
         .receive(on: scheduler)
         .map { stateProgress, downloadProgress in

--- a/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
@@ -16,45 +16,94 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-@testable import Core
-import CoreData
 import Combine
 import CombineSchedulers
+@testable import Core
+import CoreData
 import XCTest
 
 class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
-
     func testSubtitleItemCounterIgnoresContainerSelections() {
+        // MARK: - GIVEN
+
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
 
+        // MARK: - WHEN
+
         NotificationCenter.default.post(name: .OfflineSyncTriggered, object: nil)
+        mockInteractor.mockDownloadProgress()
+        mockInteractor.mockStateProgress()
+
+        // MARK: - THEN
 
         XCTAssertEqual(testee.state, .progress(0.5, "2 items are syncing."))
     }
 
-    /*
-    func testAppearsWhenReceivingSyncStartNotification() {
+    func testProgressUpdates() {
         // MARK: - GIVEN
+
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
-                                                               router: router)
-        XCTAssertFalse(testee.isVisible)
+                                                               router: router,
+                                                               scheduler: .immediate)
+
+        let progress: CourseSyncDownloadProgress = databaseClient.insert()
+        progress.bytesToDownload = 1000
+        progress.bytesDownloaded = 100
+        progress.isFinished = false
+        progress.error = nil
 
         // MARK: - WHEN
-        NotificationCenter.default.post(name: .OfflineSyncTriggered,
-                                        object: nil)
+
+        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: nil)
+        mockInteractor.mockStateProgress()
 
         // MARK: - THEN
-        XCTAssertTrue(testee.isVisible)
+
+        mockInteractor.mockDownloadProgress(progress)
+        XCTAssertEqual(testee.state, .progress(0.1, "2 items are syncing."))
+
+        progress.bytesDownloaded = 500
+        mockInteractor.mockDownloadProgress(progress)
+        XCTAssertEqual(testee.state, .progress(0.5, "2 items are syncing."))
+
+        progress.bytesDownloaded = 750
+        mockInteractor.mockDownloadProgress(progress)
+        XCTAssertEqual(testee.state, .progress(0.75, "2 items are syncing."))
+
+        progress.bytesDownloaded = 1000
+        mockInteractor.mockDownloadProgress(progress)
+        XCTAssertEqual(testee.state, .progress(1, "2 items are syncing."))
     }
 
-    func testDismissesItselfDelayedWhenProgressReaches1() {
+    func testErrorState() {
         // MARK: - GIVEN
+
+        let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
+        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+                                                               offlineModeInteractor: MockOfflineModeInteractorEnabled(),
+                                                               router: router,
+                                                               scheduler: .immediate)
+
+        // MARK: - WHEN
+
+        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: nil)
+        mockInteractor.mockFailedDownloadProgress()
+        mockInteractor.mockStateProgress()
+
+        // MARK: - THEN
+
+        XCTAssertEqual(testee.state, .error)
+    }
+
+    func testAutoDismissOnComplete() {
+        // MARK: - GIVEN
+
         let testScheduler: TestSchedulerOf<DispatchQueue> = DispatchQueue.test
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient,
                                                                       progressToReport: 1)
@@ -62,48 +111,81 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: testScheduler.eraseToAnyScheduler())
-        NotificationCenter.default.post(name: .OfflineSyncTriggered,
-                                        object: nil)
-        XCTAssertTrue(testee.isVisible)
 
         // MARK: - WHEN
-        testScheduler.advance(by: .seconds(0.9))
-        XCTAssertTrue(testee.isVisible)
+
+        NotificationCenter.default.post(
+            name: .OfflineSyncTriggered,
+            object: nil
+        )
+        mockInteractor.mockFinishedDownloadProgress()
+        mockInteractor.mockStateProgress()
+
         testScheduler.advance(by: .seconds(0.1))
+        XCTAssertFalse(testee.state.isHidden)
 
         // MARK: - THEN
-        XCTAssertFalse(testee.isVisible)
+
+        testScheduler.advance(by: .seconds(0.9))
+        XCTAssertTrue(testee.state.isHidden)
     }
 
-    func testUpdatesProgress() {
-        let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
+    func testAutoDismissOnCancellation() {
+        // MARK: - GIVEN
+
+        let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient,
+                                                                      progressToReport: 1)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
 
-        XCTAssertEqual(testee.progress, 0.5)
+        // MARK: - WHEN
+
+        NotificationCenter.default.post(
+            name: .OfflineSyncTriggered,
+            object: nil
+        )
+        mockInteractor.mockDownloadProgress()
+        mockInteractor.mockStateProgress()
+
+        XCTAssertFalse(testee.state.isHidden)
+
+        // MARK: - THEN
+
+        NotificationCenter.default.post(
+            name: .OfflineSyncCancelled,
+            object: nil
+        )
+        XCTAssertTrue(testee.state.isHidden)
     }
 
     func testDismissHidesCard() {
         // MARK: - GIVEN
+
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
-                                                               router: router)
+                                                               router: router,
+                                                               scheduler: .immediate)
         NotificationCenter.default.post(name: .OfflineSyncTriggered,
                                         object: nil)
-        XCTAssertTrue(testee.isVisible)
+        mockInteractor.mockDownloadProgress()
+        mockInteractor.mockStateProgress()
+        XCTAssertFalse(testee.state.isHidden)
 
         // MARK: - WHEN
+
         testee.dismissDidTap.accept()
 
         // MARK: - THEN
-        XCTAssertFalse(testee.isVisible)
+
+        XCTAssertTrue(testee.state.isHidden)
     }
 
     func testCardTapRoutesToProgressView() {
         // MARK: - GIVEN
+
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
         let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
@@ -111,14 +193,15 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         let source = UIViewController()
 
         // MARK: - WHEN
+
         testee.cardDidTap.accept(.init(source))
 
         // MARK: - THEN
+
         XCTAssertTrue(router.lastRoutedTo("/offline/progress",
                                           withOptions: .modal(isDismissable: false,
                                                               embedInNav: true)))
     }
-     */
 }
 
 private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserverInteractor {
@@ -126,21 +209,37 @@ private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserv
     private let progressToReport: Float
     private let bytesToDownload: Float = 10
 
-    init(context: NSManagedObjectContext, progressToReport: Float = 0.5) {
-        self.context = context
-        self.progressToReport = progressToReport
-    }
+    private let downloadProgressPublisher = PassthroughSubject<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never>()
+    private let stateProgressPublisher = PassthroughSubject<ReactiveStore<GetCourseSyncStateProgressUseCase>.State, Never>()
 
-    func observeDownloadProgress()
-    -> AnyPublisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never> {
+    private lazy var downloadProgressMock: CourseSyncDownloadProgress = {
         let item: CourseSyncDownloadProgress = context.insert()
         item.bytesToDownload = Int(bytesToDownload)
         item.bytesDownloaded = Int(progressToReport * bytesToDownload)
-        return Just(.data([item])).eraseToAnyPublisher()
-    }
+        item.isFinished = false
+        item.error = nil
+        return item
+    }()
 
-    func observeStateProgress()
-    -> AnyPublisher<ReactiveStore<GetCourseSyncStateProgressUseCase>.State, Never> {
+    private lazy var downloadProgressFinishedMock: CourseSyncDownloadProgress = {
+        let item: CourseSyncDownloadProgress = context.insert()
+        item.bytesToDownload = Int(bytesToDownload)
+        item.bytesDownloaded = Int(progressToReport * bytesToDownload)
+        item.isFinished = true
+        item.error = nil
+        return item
+    }()
+
+    private lazy var downloadProgressErrorMock: CourseSyncDownloadProgress = {
+        let item: CourseSyncDownloadProgress = context.insert()
+        item.bytesToDownload = Int(bytesToDownload)
+        item.bytesDownloaded = Int(progressToReport * bytesToDownload)
+        item.isFinished = true
+        item.error = "Failed."
+        return item
+    }()
+
+    private lazy var stateProgressMock: [CourseSyncStateProgress] = {
         let course: CourseSyncStateProgress = context.insert()
         course.selection = .course("")
         let fileTab: CourseSyncStateProgress = context.insert()
@@ -149,8 +248,42 @@ private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserv
         file1.selection = .file("", "")
         let file2: CourseSyncStateProgress = context.insert()
         file2.selection = .file("", "")
+        return [course, fileTab, file1, file2]
+    }()
 
-        return Just(.data([course, fileTab, file1, file2])).eraseToAnyPublisher()
+    init(context: NSManagedObjectContext, progressToReport: Float = 0.5) {
+        self.context = context
+        self.progressToReport = progressToReport
+    }
+
+    func observeDownloadProgress()
+        -> AnyPublisher<ReactiveStore<GetCourseSyncDownloadProgressUseCase>.State, Never> {
+        downloadProgressPublisher.eraseToAnyPublisher()
+    }
+
+    func observeStateProgress()
+        -> AnyPublisher<ReactiveStore<GetCourseSyncStateProgressUseCase>.State, Never> {
+        stateProgressPublisher.eraseToAnyPublisher()
+    }
+
+    func mockDownloadProgress() {
+        downloadProgressPublisher.send(.data([downloadProgressMock]))
+    }
+
+    func mockDownloadProgress(_ progress: CourseSyncDownloadProgress) {
+        downloadProgressPublisher.send(.data([progress]))
+    }
+
+    func mockFinishedDownloadProgress() {
+        downloadProgressPublisher.send(.data([downloadProgressFinishedMock]))
+    }
+
+    func mockFailedDownloadProgress() {
+        downloadProgressPublisher.send(.data([downloadProgressErrorMock]))
+    }
+
+    func mockStateProgress() {
+        stateProgressPublisher.send(.data(stateProgressMock))
     }
 }
 

--- a/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
@@ -30,9 +30,13 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
-        XCTAssertEqual(testee.subtitle, "2 items are syncing.")
+
+        NotificationCenter.default.post(name: .OfflineSyncTriggered, object: nil)
+
+        XCTAssertEqual(testee.state, .progress(0.5, "2 items are syncing."))
     }
 
+    /*
     func testAppearsWhenReceivingSyncStartNotification() {
         // MARK: - GIVEN
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
@@ -114,6 +118,7 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
                                           withOptions: .modal(isDismissable: false,
                                                               embedInNav: true)))
     }
+     */
 }
 
 private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserverInteractor {

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -193,6 +193,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
+		};
+		B41ADD392AA8C2D600AB2043 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
+			remoteInfo = CoreTester;
+		};
+		B41ADD3B2AA8C2D600AB2043 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
+			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -712,6 +726,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
+				B41ADD3A2AA8C2D600AB2043 /* CoreTester.app */,
+				B41ADD3C2AA8C2D600AB2043 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1000,6 +1016,20 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B41ADD3A2AA8C2D600AB2043 /* CoreTester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CoreTester.app;
+			remoteRef = B41ADD392AA8C2D600AB2043 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B41ADD3C2AA8C2D600AB2043 /* CoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CoreTests.xctest;
+			remoteRef = B41ADD3B2AA8C2D600AB2043 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */


### PR DESCRIPTION
refs: MBL-16998
affects: Student
release note: none 
test plan: Start download, turn off Wi-Fi, check notification. 

Notes: 
1. The actual retry logic needs some polish, please focus on the dashboard notification handling for now. 
2. As discussed earlier, the error messages are not yet finalized. 

## Screenshots

https://github.com/instructure/canvas-ios/assets/110813321/5d05da7c-23b3-4323-9fd7-4f8be096a02e

## Checklist

- [x] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
