### PR TITLE
Parallelise test runs

### DIFF
--- a/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
+++ b/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
@@ -40,16 +40,16 @@ class DiscussionsTests: E2ETestCase {
         XCTAssertTrue(discussionButton.isVisible)
         XCTAssertTrue(discussionButton.label.contains(discussion.title))
 
-        let discussionLastPostLabel = Helper.discussionDataLabel(discussion: discussion, label: .lastPost)
+        let discussionLastPostLabel = Helper.discussionDataLabel(discussion: discussion, label: .lastPost)!
             .waitUntil(.visible)
         XCTAssertTrue(discussionLastPostLabel.isVisible)
 
-        let discussionRepliesLabel = Helper.discussionDataLabel(discussion: discussion, label: .replies)
+        let discussionRepliesLabel = Helper.discussionDataLabel(discussion: discussion, label: .replies)!
             .waitUntil(.visible)
         XCTAssertTrue(discussionRepliesLabel.isVisible)
         XCTAssertEqual(discussionRepliesLabel.label, "\(discussion.discussion_subentry_count) Replies")
 
-        let discussionUnreadLabel = Helper.discussionDataLabel(discussion: discussion, label: .unread)
+        let discussionUnreadLabel = Helper.discussionDataLabel(discussion: discussion, label: .unread)!
             .waitUntil(.visible)
         XCTAssertTrue(discussionUnreadLabel.isVisible)
         XCTAssertEqual(discussionUnreadLabel.label, "\(discussion.unread_count) Unread")
@@ -213,14 +213,11 @@ class DiscussionsTests: E2ETestCase {
 
         // On iPad: Discussion replies label is visible right after the reply is sent
         // On iPhone: Back button needs to be tapped for the label to get visible
-        let discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)
-            .waitUntil(.visible, timeout: 5)
-        if discussionDataLabelReplies.isVanished {
-            Helper.backButton.hit()
-            discussionDataLabelReplies.waitUntil(.visible)
-        }
+        var discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)
+        if discussionDataLabelReplies == nil { Helper.backButton.hit() }
+        discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)!.waitUntil(.visible)
 
-        XCTAssertEqual(discussionDataLabelReplies.label, "1 Reply")
+        XCTAssertEqual(discussionDataLabelReplies!.label, "1 Reply")
 
         Helper.backButton.hit()
         Helper.backButton.hit()

--- a/Student/StudentE2ETests/Files/FilesTests.swift
+++ b/Student/StudentE2ETests/Files/FilesTests.swift
@@ -51,7 +51,11 @@ class FilesTests: E2ETestCase {
         let titleOfFile = SafariAppHelper.Share.titleLabel(title: FilesHelper.TestPDF.title).waitUntil(.visible)
         XCTAssertTrue(titleOfFile.isVisible)
 
-        SafariAppHelper.Share.copyButton.swipeUp()
+        // On iPad: Title label is not visible, swipeUp only works with Copy button
+        // On iPhone: Title label is visible, swipeUp only works as "safariApp.swipeUp"
+        let copyButton = SafariAppHelper.Share.copyButton.waitUntil(.visible)
+        let titleLabel = SafariAppHelper.Share.titleLabel(title: FilesHelper.TestPDF.title).waitUntil(.visible, timeout: 5)
+        if titleLabel.isVisible { SafariAppHelper.safariApp.swipeUp() } else { copyButton.swipeUp() }
         let saveToFilesButton = SafariAppHelper.Share.saveToFiles.waitUntil(.visible)
         XCTAssertTrue(saveToFilesButton.isVisible)
 

--- a/Student/StudentE2ETests/Settings/SettingsTests.swift
+++ b/Student/StudentE2ETests/Settings/SettingsTests.swift
@@ -272,7 +272,7 @@ class SettingsTests: E2ETestCase {
         let continueButton = CalendarAppHelper.continueButton.waitUntil(.visible, timeout: 5)
         if continueButton.isVisible {
             continueButton.hit()
-            app.hit()
+            CalendarAppHelper.calendarApp.hit()
         }
 
         let calendarNavBar = CalendarAppHelper.navBar.waitUntil(.visible)

--- a/Student/StudentE2ETests/Settings/SettingsTests.swift
+++ b/Student/StudentE2ETests/Settings/SettingsTests.swift
@@ -265,6 +265,7 @@ class SettingsTests: E2ETestCase {
         XCTAssertTrue(subscribeToCalendarFeed.isVisible)
 
         subscribeToCalendarFeed.hit()
+        CalendarAppHelper.calendarApp.activate()
         let calendarAppRunning = CalendarAppHelper.calendarApp.wait(for: .runningForeground, timeout: 15)
         XCTAssertTrue(calendarAppRunning)
 

--- a/TestPlans/CalendarE2E.xctestplan
+++ b/TestPlans/CalendarE2E.xctestplan
@@ -23,6 +23,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "ActAsUserTests",
         "AnnouncementsTests",

--- a/TestPlans/CoreTests.xctestplan
+++ b/TestPlans/CoreTests.xctestplan
@@ -26,9 +26,10 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Core.xcodeproj",
-        "identifier" : "2C964836211E2F1A002C3255",
+        "identifier" : "73B1A2AD90A7970B7DB39CDC",
         "name" : "CoreTests"
       }
     }

--- a/TestPlans/IPadTests.xctestplan
+++ b/TestPlans/IPadTests.xctestplan
@@ -18,6 +18,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/Parent\/Parent.xcodeproj",
         "identifier" : "E80763C723E08DA10085DAFB",
@@ -25,6 +26,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "E8C6F4CF23D626220086B865",
@@ -33,6 +35,7 @@
     },
     {
       "enabled" : false,
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/rn\/Teacher\/ios\/Teacher.xcodeproj",
         "identifier" : "E841D8A223D6472F00685A63",

--- a/TestPlans/NightlyTests.xctestplan
+++ b/TestPlans/NightlyTests.xctestplan
@@ -59,6 +59,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/Core\/Core.xcodeproj",
         "identifier" : "73B1A2AD90A7970B7DB39CDC",
@@ -66,6 +67,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "7DE1160622F8AAB1005BFE98",
@@ -73,6 +75,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/rn\/Teacher\/ios\/Teacher.xcodeproj",
         "identifier" : "B15CA25C221DDB820014FB02",
@@ -80,6 +83,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/Parent\/Parent.xcodeproj",
         "identifier" : "3B36A2DE2322C26A00599A1E",
@@ -87,6 +91,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "E8C6F4CF23D626220086B865",
@@ -94,6 +99,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/rn\/Teacher\/ios\/Teacher.xcodeproj",
         "identifier" : "E841D8A223D6472F00685A63",
@@ -101,6 +107,7 @@
       }
     },
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "PlannerTests\/testSwipes()"
       ],

--- a/TestPlans/PRTests.xctestplan
+++ b/TestPlans/PRTests.xctestplan
@@ -56,6 +56,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:..\/Core\/Core.xcodeproj",
         "identifier" : "73B1A2AD90A7970B7DB39CDC",

--- a/TestPlans/ParentE2E.xctestplan
+++ b/TestPlans/ParentE2E.xctestplan
@@ -26,6 +26,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "PlannerTests\/testSwipes()"
       ],

--- a/TestPlans/StudentE2E.xctestplan
+++ b/TestPlans/StudentE2E.xctestplan
@@ -26,6 +26,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "E8C6F4CF23D626220086B865",

--- a/TestPlans/TeacherE2E.xctestplan
+++ b/TestPlans/TeacherE2E.xctestplan
@@ -26,6 +26,7 @@
   },
   "testTargets" : [
     {
+      "parallelizable" : true,
       "skippedTests" : [
         "ContextCardE2ETests",
         "DSPagesTests\/testDeletePage()",

--- a/TestsFoundation/TestsFoundation/Helpers/CourseDetailsHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/CourseDetailsHelper.swift
@@ -36,5 +36,6 @@ public class CourseDetailsHelper: BaseHelper {
 
     public static var titleLabel: XCUIElement { app.find(id: "course-details.title-lbl") }
     public static var subtitleLabel: XCUIElement { app.find(id: "course-details.subtitle-lbl") }
-    public static func cell(type: CellType) -> XCUIElement { app.find(id: "courses-details.\(type.rawValue)-cell") }
+
+    public static func cell(type: CellType) -> XCUIElement { return app.find(id: "courses-details.\(type.rawValue)-cell") }
 }

--- a/TestsFoundation/TestsFoundation/Helpers/DiscussionsHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/DiscussionsHelper.swift
@@ -27,15 +27,16 @@ public class DiscussionsHelper: BaseHelper {
     public static var noDiscussionsPandaImage: XCUIElement { app.find(id: "PandaNoDiscussions") }
 
     public static func discussionButton(discussion: DSDiscussionTopic? = nil, discussionId: String? = nil) -> XCUIElement {
-        app.find(id: "DiscussionListCell.\(discussion?.id ?? discussionId!)")
+        return app.find(id: "DiscussionListCell.\(discussion?.id ?? discussionId!)")
     }
 
-    public static func discussionDataLabel(discussion: DSDiscussionTopic, label: DiscussionLabelTypes) -> XCUIElement {
-        discussionButton(discussion: discussion).findAll(type: .staticText, minimumCount: 4)[label.rawValue]
+    public static func discussionDataLabel(discussion: DSDiscussionTopic, label: DiscussionLabelTypes) -> XCUIElement? {
+        let result = discussionButton(discussion: discussion).findAll(type: .staticText, minimumCount: 4)
+        return result.count >= label.rawValue ? result[label.rawValue] : nil
     }
 
     public static func discussionsNavBar(course: DSCourse) -> XCUIElement {
-        app.find(id: "Discussions, \(course.name)")
+        return app.find(id: "Discussions, \(course.name)")
     }
 
     public struct Details {


### PR DESCRIPTION
- All of the test plans were set to parallelable.
- Latest [Student E2E test run](https://app.bitrise.io/build/a3db16db-72da-48a8-a503-1b5458242725) resulted in 37 minutes duration. Previous runs had 78 minutes or larger duration.
- Some small minor fixes on some test cases.