### PR TITLE
Homeroom updates

### DIFF
--- a/Core/Core/Courses/K5/View/Subject/K5SubjectHeaderView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectHeaderView.swift
@@ -19,32 +19,32 @@
 import SwiftUI
 
 struct K5SubjectHeaderView: View {
-
     let title: String?
     let imageUrl: URL?
     let backgroundColor: Color?
 
     var body: some View {
         ZStack(alignment: .bottom) {
-
-            if let imageUrl = imageUrl {
+            backgroundColor
+            if let imageUrl {
                 GeometryReader { geometry in
                     RemoteImage(imageUrl, width: geometry.size.width, height: 113)
                         .clipped()
                         .contentShape(Path(CGRect(x: 0, y: 0, width: geometry.size.width, height: geometry.size.height)))
                 }
             }
-            Rectangle().foregroundColor(backgroundColor).opacity(imageUrl == nil ? 1 : 0.75)
-            Rectangle().fill(
-                LinearGradient(gradient: Gradient(colors: [.black, .clear]), startPoint: .leading, endPoint: .trailing)
-            ).frame(height: 38).opacity(0.60)
             if let title = title {
-                HStack {
-                    Text(title.uppercased()).foregroundColor(.textLightest).font(.regular17).padding(.leading, 16)
-                    Spacer()
-                }.padding(.bottom, 8)
+                Text(title.uppercased())
+                    .foregroundColor(.textLightest)
+                    .font(.regular17)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 8)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.black.opacity(0.60))
             }
-        }.frame(height: 113).cornerRadius(4)
+        }
+        .frame(height: 113)
+        .cornerRadius(4)
     }
 }
 

--- a/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectView.swift
@@ -51,14 +51,13 @@ public struct K5SubjectView: View, ScreenViewTrackable {
                 Divider()
             }
         }
-        .navigationBarStyle(.color(self.viewModel.courseColor))
-        .navigationTitle(self.viewModel.courseTitle ?? "", subtitle: nil)
+        .navigationBarStyle(.color(viewModel.courseColor))
+        .navigationTitle(viewModel.courseTitle ?? "", subtitle: nil)
     }
 
     public init(context: Context, selectedTabId: String? = nil) {
         self.viewModel = K5SubjectViewModel(context: context, selectedTabId: selectedTabId)
         self.screenViewTrackingParameters = ScreenViewTrackingParameters(eventName: "\(context.pathComponent)")
-        self.controller.value.navigationController?.navigationBar.tintColor = self.viewModel.courseColor
     }
 }
 

--- a/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomSubjectCardView.swift
+++ b/Core/Core/Dashboard/K5/View/Homeroom/K5HomeroomSubjectCardView.swift
@@ -66,7 +66,6 @@ public struct K5HomeroomSubjectCardView: View {
         ZStack {
             viewModel.color.frame(width: imageSize.width, height: imageSize.height)
             viewModel.imageURL.map { RemoteImage($0, width: imageSize.width, height: imageSize.height) }?
-                .opacity(0.4)
                 .clipped()
                 // Fix big course image consuming tap events.
                 .contentShape(Path(CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.height)))

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
@@ -31,7 +31,13 @@ public struct K5HomeroomSubjectCardViewModel {
         self.courseRoute = "/courses/\(courseId)"
         self.imageURL = imageURL
         self.name = name.uppercased()
-        self.color = ((color != nil) ? Color(color!) : .oxford)
+        self.color = {
+            if let color {
+                return Color(color.ensureContrast(against: .backgroundLightest))
+            } else {
+                return .oxford
+            }
+        }()
         self.infoLines = infoLines
     }
 }

--- a/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModelTests.swift
@@ -109,7 +109,8 @@ class K5HomeroomViewModelTests: CoreTestCase {
         XCTAssertEqual(card.name, "COURSE 1")
         XCTAssertEqual(card.courseRoute, "/courses/1")
         XCTAssertEqual(card.imageURL, URL(string: "https://instructure.com"))
-        XCTAssertEqual(card.color, Color(hexString: "#DEAD00"))
+        XCTAssertEqual(UIColor(card.color).hexString,
+                       UIColor(hexString: "#DEAD00")!.ensureContrast(against: .backgroundLightest).hexString)
 
         guard card.infoLines.count == 2 else { XCTFail("Info line count mismatch"); return }
         XCTAssertEqual(card.infoLines[0], K5HomeroomSubjectCardViewModel.InfoLine(icon: .k5dueToday, route: "/courses/1#schedule", text: "1 due today | ", highlightedText: "2 missing"))


### PR DESCRIPTION
### What's in this PR?
- Removed color overlay from subject images.
- Ensured subject card text contrast ratio is high enough.
- Fixed long course names not having a background in homeroom details page.

refs: MBL-17039, MBL-17036, MBL-17037
affects: Student
release note: Fixed contrast issues in homeroom view.

test plan: See tickets

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/149e58f2-3405-40a7-8b65-83e706892b3d" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/e84278a8-1081-4eea-b0a6-a3a5ad17d861" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/a7e588f3-7a62-4410-9e48-39ace6762c4f" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/edd2ead5-5e7d-4d5e-9ae2-a4f4a6f72b3c" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/f3b823a4-2f37-45ba-92ba-3a9e38498aa3" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/ca6df18e-5891-410f-9269-0c613004ecfa" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product
