### PR TITLE
Fix discussions not being rendered in some cases

### DIFF
--- a/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
@@ -24,12 +24,14 @@ import Foundation
 extension CoreWebView {
 
     public static func jsString(_ string: String?) -> String {
-        guard let string,
-              // These will cause JS syntax errors, removing them will alter character rendering however
-              let stripped = string.applyingTransform(.stripCombiningMarks, reverse: false)
-        else { return "null" }
+        guard var string else { return "null" }
 
-        let escaped = stripped
+        // These will cause JS syntax errors, removing them will alter character rendering however
+        if let stripped = string.applyingTransform(.stripCombiningMarks, reverse: false) {
+            string = stripped
+        }
+
+        let escaped = string
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "'", with: "\\'")
             .replacingOccurrences(of: "\r", with: "\\r")

--- a/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/CoreWebViewJSInjections.swift
@@ -24,8 +24,12 @@ import Foundation
 extension CoreWebView {
 
     public static func jsString(_ string: String?) -> String {
-        guard let string = string else { return "null" }
-        let escaped = string
+        guard let string,
+              // These will cause JS syntax errors, removing them will alter character rendering however
+              let stripped = string.applyingTransform(.stripCombiningMarks, reverse: false)
+        else { return "null" }
+
+        let escaped = stripped
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "'", with: "\\'")
             .replacingOccurrences(of: "\r", with: "\\r")


### PR DESCRIPTION
### What changed?
- Removed unicode combining marks from strings passed to JS to avoid illegal character exception.
- Modified discussion render error handler to load the discussion website instead of showing an alert dialog.

refs: MBL-17012
affects: Student, Teacher
release note: Fixed discussions not being rendered in some cases.

test plan:
- Log into my account either as a teacher or a student.
- Go to Primary Course > Discussions > Javascript Error
- Discussion should load.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/a58e9b02-0a9e-4d5e-ae0c-d3375fe5f5b4" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/be254769-4214-4b5e-9790-976348cc57e0" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet