### PR TITLE
Offline sync delete unavailable files

### DIFF
--- a/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleDataTransport.git",
       "state" : {
-        "revision" : "98a00258d4518b7521253a70b7f70bb76d2120fe",
-        "version" : "9.2.4"
+        "revision" : "aae45a320fd0d11811820335b1eabc8753902a40",
+        "version" : "9.2.5"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "58d03d22beae762eaddbd30cb5a61af90d4b309f",
-        "version" : "7.11.3"
+        "revision" : "c38ce365d77b04a9a300c31061c5227589e5597b",
+        "version" : "7.11.5"
       }
     },
     {
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/promises.git",
       "state" : {
-        "revision" : "ec957ccddbcc710ccc64c9dcbd4c7006fcf8b73a",
-        "version" : "2.2.0"
+        "revision" : "e70e889c0196c76d22759eb50d6a0270ca9f1d9e",
+        "version" : "2.3.1"
       }
     },
     {
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "f25867a208f459d3c5a06935dceb9083b11cd539",
-        "version" : "1.22.0"
+        "revision" : "cf62cdaea48b77f1a631e5cb3aeda6047c2cba1d",
+        "version" : "1.23.0"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4af50b38daf0037cfbab15514a241224c3f62f98",
-        "version" : "0.8.5"
+        "revision" : "50843cbb8551db836adec2290bb4bc6bac5c1865",
+        "version" : "0.9.0"
       }
     }
   ],

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -2235,7 +2235,7 @@
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF8139D888212DC95299155 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2847,7 +2847,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2235,7 +2235,7 @@
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF8139D888212DC95299155 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2847,7 +2847,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -8886,8 +8886,7 @@
 		83ADD9484DDC11E75E9F182F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1200;
 				TargetAttributes = {
 					3C9856EABA187C2715A3B3E4 = {
 						DevelopmentTeam = B6333T4PXQ;
@@ -8904,7 +8903,7 @@
 				};
 			};
 			buildConfigurationList = 4EBE82DE9849E8F47BAECD7B /* Build configuration list for PBXProject "Core" */;
-			compatibilityVersion = "Xcode 14.0";
+			compatibilityVersion = "Xcode 11.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (

--- a/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
@@ -28,6 +28,12 @@ public protocol CourseSyncEntryComposerInteractor {
 }
 
 public final class CourseSyncEntryComposerInteractorLive: CourseSyncEntryComposerInteractor {
+    private let filesInteractor: CourseSyncFilesInteractor
+
+    init(filesInteractor: CourseSyncFilesInteractor = CourseSyncFilesInteractorLive()) {
+        self.filesInteractor = filesInteractor
+    }
+
     public func composeEntry(
         from course: CourseSyncSelectorCourse,
         useCache: Bool
@@ -41,7 +47,20 @@ public final class CourseSyncEntryComposerInteractorLive: CourseSyncEntryCompose
             )
         }
         if tabs.isFilesTabEnabled() {
-            return getFoldersAndFiles(courseId: course.courseId, useCache: useCache)
+            return filesInteractor.getFiles(courseId: course.courseId, useCache: useCache)
+                .map { files in
+                    files.map {
+                        CourseSyncEntry.File(
+                            id: "courses/\(course.courseId)/files/\($0.id ?? Foundation.UUID().uuidString)",
+                            displayName: $0.displayName ?? NSLocalizedString("Unknown file", comment: ""),
+                            fileName: $0.filename,
+                            url: $0.url!,
+                            mimeClass: $0.mimeClass!,
+                            updatedAt: $0.updatedAt,
+                            bytesToDownload: $0.size
+                        )
+                    }
+                }
                 .map { files in
                     CourseSyncEntry(
                         name: course.name,
@@ -63,120 +82,5 @@ public final class CourseSyncEntryComposerInteractorLive: CourseSyncEntryCompose
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
         }
-    }
-
-    /// Recursively looks up every file and folder under the specified `courseId` and returns a list of `CourseSyncEntry.File`.
-    private func getFoldersAndFiles(
-        courseId: String,
-        useCache: Bool
-    ) -> AnyPublisher<[CourseSyncEntry.File], Error> {
-        unowned let unownedSelf = self
-
-        let store = ReactiveStore(
-            useCase: GetFolderByPath(
-                context: .course(courseId)
-            )
-        )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities()
-
-        return publisher
-            .flatMap {
-                Publishers.Sequence(sequence: $0)
-                    .filter { !$0.lockedForUser && !$0.hiddenForUser }
-                    .setFailureType(to: Error.self)
-                    .flatMap { unownedSelf.getFiles(folderID: $0.id, initialArray: [], useCache: useCache) }
-            }
-            .map {
-                $0
-                    .compactMap { $0.file }
-                    .filter { $0.url != nil && $0.mimeClass != nil }
-                    .map {
-                        CourseSyncEntry.File(
-                            id: "courses/\(courseId)/files/\($0.id ?? Foundation.UUID().uuidString)",
-                            displayName: $0.displayName ?? NSLocalizedString("Unknown file", comment: ""),
-                            fileName: $0.filename,
-                            url: $0.url!,
-                            mimeClass: $0.mimeClass!,
-                            updatedAt: $0.updatedAt,
-                            bytesToDownload: $0.size
-                        )
-                    }
-            }
-            .replaceEmpty(with: [])
-            .eraseToAnyPublisher()
-    }
-
-    private func getFiles(
-        folderID: String,
-        initialArray: [FolderItem],
-        useCache: Bool
-    ) -> AnyPublisher<[FolderItem], Error> {
-        unowned let unownedSelf = self
-
-        var result = initialArray
-
-        return getFolderItems(folderID: folderID, useCache: useCache)
-            .flatMap { files, folderIDs in
-                result.append(contentsOf: files)
-
-                guard folderIDs.count > 0 else {
-                    return Just([result])
-                        .setFailureType(to: Error.self)
-                        .eraseToAnyPublisher()
-                }
-                return Publishers.Sequence(sequence: folderIDs)
-                    .setFailureType(to: Error.self)
-                    .flatMap(maxPublishers: .max(1)) {
-                        unownedSelf.getFiles(
-                            folderID: $0,
-                            initialArray: result,
-                            useCache: useCache
-                        )
-                        .handleEvents(receiveOutput: { result = $0 })
-                    }
-                    .collect()
-                    .eraseToAnyPublisher()
-            }
-            .first()
-            .map { _ in result }
-            .eraseToAnyPublisher()
-    }
-
-    private func getFolderItems(folderID: String, useCache: Bool) -> AnyPublisher<([FolderItem], [String]), Error> {
-        let store = ReactiveStore(
-            useCase: GetFolderItems(
-                folderID: folderID
-            )
-        )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities()
-
-        return publisher
-        .tryCatch { error -> AnyPublisher<[FolderItem], Error> in
-            if case .unauthorized = error as? Core.APIError {
-                return Just([])
-                    .setFailureType(to: Error.self)
-                    .eraseToAnyPublisher()
-            } else {
-                throw error
-            }
-        }
-        .map {
-            let files = $0
-                .filter {
-                    if let file = $0.file {
-                        return !file.lockedForUser && !file.hiddenForUser
-                    } else {
-                        return false
-                    }
-                }
-            let folderIDs = $0
-                .filter { $0.folder != nil }
-                .compactMap { $0.folder }
-                .filter { !$0.lockedForUser && !$0.hiddenForUser }
-                .map { $0.id }
-
-            return (files, folderIDs)
-        }
-        .eraseToAnyPublisher()
     }
 }

--- a/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
@@ -94,7 +94,6 @@ private extension Array where Element == CourseSyncEntry {
         filter: CourseSyncListFilter,
         sessionDefaults: SessionDefaults
     ) -> [CourseSyncEntry] {
-        var sessionDefaults = sessionDefaults
         var entriesCpy = self
 
         switch selection {

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractor.swift
@@ -231,12 +231,13 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
             .eraseToAnyPublisher()
         }
 
-        let courseFolderURL = URL.Directories.documents.appendingPathComponent("\(sessionID)/Offline/Files/\(courseId)")
+        let courseFolderURL = URL.Directories.documents.appendingPathComponent("\(sessionID)/Offline/Files/course-\(courseId)")
         let courseFileIDsArr: [String] = (try? fileManager.contentsOfDirectory(atPath: courseFolderURL.path)) ?? []
         let courseFileIDs = Set(courseFileIDsArr)
+        let mappedNewFileIDs = newFileIDs.map { "file-\($0)" }
 
         let unavailableFileFolderURLs = courseFileIDs
-            .subtracting(Set(newFileIDs))
+            .subtracting(Set(mappedNewFileIDs))
             .map { courseFolderURL.appendingPathComponent($0) }
 
         unowned let unownedSelf = self

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractor.swift
@@ -231,7 +231,9 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
             .eraseToAnyPublisher()
         }
 
-        let courseFolderURL = URL.Directories.documents.appendingPathComponent("\(sessionID)/Offline/Files/course-\(courseId)")
+        let courseFolderURL = URL.Directories.documents.appendingPathComponent(
+            URL.Paths.Offline.courseFolder(sessionID: sessionID, courseId: courseId)
+        )
         let courseFileIDsArr: [String] = (try? fileManager.contentsOfDirectory(atPath: courseFolderURL.path)) ?? []
         let courseFileIDs = Set(courseFileIDsArr)
         let mappedNewFileIDs = newFileIDs.map { "file-\($0)" }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -210,7 +210,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
                     selection: .file(entry.id, files[fileIndex].id), state: .loading(nil)
                 )
 
-                return unownedSelf.filesInteractor.getFile(
+                return unownedSelf.filesInteractor.downloadFile(
                     url: element.url,
                     fileID: element.fileId,
                     fileName: element.fileName,

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -83,6 +83,14 @@ public extension URL {
         }
     }
 
+    enum Paths {
+        public enum Offline {
+            public static func courseFolder(sessionID: String, courseId: String) -> String {
+                "\(sessionID)/Offline/Files/course-\(courseId)"
+            }
+        }
+    }
+
     func lookupFileSize() -> Int {
         guard self.isFileURL else { return 0 }
         let attributes = try? FileManager.default.attributesOfItem(atPath: path)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -267,11 +267,16 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
     }
 
     var filePathComponent: String? {
-        guard let sessionID = env.currentSession?.uniqueID, let name = files.first?.filename else { return nil }
-        if offlineFileInteractor?.isOffline == true {
+        guard
+            let sessionID = env.currentSession?.uniqueID,
+            let name = files.first?.filename
+        else {
+            return nil
+        }
+        if offlineFileInteractor?.isOffline == true, let contextId = context?.id {
             return offlineFileInteractor?.filePath(
                 sessionID: sessionID,
-                courseId: context?.id,
+                courseId: contextId,
                 fileID: fileID,
                 fileName: name
             )

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -269,7 +269,12 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
     var filePathComponent: String? {
         guard let sessionID = env.currentSession?.uniqueID, let name = files.first?.filename else { return nil }
         if offlineFileInteractor?.isOffline == true {
-            return offlineFileInteractor?.filePath(sessionID: sessionID, fileID: fileID, fileName: name)
+            return offlineFileInteractor?.filePath(
+                sessionID: sessionID,
+                courseId: context?.id,
+                fileID: fileID,
+                fileName: name
+            )
         }
         return "\(sessionID)/\(fileID)/\(name)"
     }

--- a/Core/Core/Offline/Model/OfflineFileInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineFileInteractor.swift
@@ -19,7 +19,7 @@
 import Combine
 
 public protocol OfflineFileInteractor {
-    func filePath(sessionID: String, courseId: String?, fileID: String, fileName: String) -> String
+    func filePath(sessionID: String, courseId: String, fileID: String, fileName: String) -> String
     func isItemAvailableOffline(courseID: String?, fileID: String?) -> Bool
     var isOffline: Bool { get }
 }
@@ -34,13 +34,9 @@ public final class OfflineFileInteractorLive: OfflineFileInteractor {
         self.offlineModeInteractor = offlineModeInteractor
     }
 
-    public func filePath(sessionID: String, courseId: String?, fileID: String, fileName: String) -> String {
+    public func filePath(sessionID: String, courseId: String, fileID: String, fileName: String) -> String {
         // Offline synced files are organized by the courseId in a folder.
-        if let courseId {
-            return "\(sessionID)/Offline/Files/\(courseId)/\(fileID)/\(fileName)"
-        } else {
-            return ""
-        }
+        "\(sessionID)/Offline/Files/course-\(courseId)/file-\(fileID)/\(fileName)"
     }
 
     public func isItemAvailableOffline(courseID: String?, fileID: String?) -> Bool {

--- a/Core/Core/Offline/Model/OfflineFileInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineFileInteractor.swift
@@ -19,7 +19,7 @@
 import Combine
 
 public protocol OfflineFileInteractor {
-    func filePath(sessionID: String, fileID: String, fileName: String) -> String
+    func filePath(sessionID: String, courseId: String?, fileID: String, fileName: String) -> String
     func isItemAvailableOffline(courseID: String?, fileID: String?) -> Bool
     var isOffline: Bool { get }
 }
@@ -34,8 +34,12 @@ public final class OfflineFileInteractorLive: OfflineFileInteractor {
         self.offlineModeInteractor = offlineModeInteractor
     }
 
-    public func filePath(sessionID: String, fileID: String, fileName: String) -> String {
-        "\(sessionID)/Offline/Files/\(fileID)/\(fileName)"
+    public func filePath(sessionID: String, courseId: String?, fileID: String, fileName: String) -> String {
+        if let courseId {
+            return "\(sessionID)/Offline/Files/\(courseId)/\(fileID)/\(fileName)"
+        } else {
+            return "\(sessionID)/Offline/Files/\(fileID)/\(fileName)"
+        }
     }
 
     public func isItemAvailableOffline(courseID: String?, fileID: String?) -> Bool {

--- a/Core/Core/Offline/Model/OfflineFileInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineFileInteractor.swift
@@ -36,7 +36,10 @@ public final class OfflineFileInteractorLive: OfflineFileInteractor {
 
     public func filePath(sessionID: String, courseId: String, fileID: String, fileName: String) -> String {
         // Offline synced files are organized by the courseId in a folder.
-        "\(sessionID)/Offline/Files/course-\(courseId)/file-\(fileID)/\(fileName)"
+        URL.Paths.Offline.courseFolder(
+            sessionID: sessionID,
+            courseId: courseId
+        ) + "/file-\(fileID)/\(fileName)"
     }
 
     public func isItemAvailableOffline(courseID: String?, fileID: String?) -> Bool {

--- a/Core/Core/Offline/Model/OfflineFileInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineFileInteractor.swift
@@ -35,10 +35,11 @@ public final class OfflineFileInteractorLive: OfflineFileInteractor {
     }
 
     public func filePath(sessionID: String, courseId: String?, fileID: String, fileName: String) -> String {
+        // Offline synced files are organized by the courseId in a folder.
         if let courseId {
             return "\(sessionID)/Offline/Files/\(courseId)/\(fileID)/\(fileName)"
         } else {
-            return "\(sessionID)/Offline/Files/\(fileID)/\(fileName)"
+            return ""
         }
     }
 

--- a/Core/CoreTests/CourseSync/Common/CourseSyncCleanupInteractorTests.swift
+++ b/Core/CoreTests/CourseSync/Common/CourseSyncCleanupInteractorTests.swift
@@ -48,13 +48,13 @@ class CourseSyncCleanupInteractorTests: XCTestCase {
         // MARK: - GIVEN
         // MARK: This should be deleted
         let mockSession = LoginSession.make(baseURL: URL(string: "https://test.instructure.com")!, userID: "testUserID")
-        let dbURL = URL.Directories.documents.appendingPathComponent("\(mockSession.uniqueID)/Offline/Files/fileFolder/image.jpg")
+        let dbURL = URL.Directories.documents.appendingPathComponent("\(mockSession.uniqueID)/Offline/Files/courseFolder/fileFolder/image.jpg")
         try write("test", to: dbURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: dbURL.path))
 
         // MARK: This user's files should be left intact
         let anotherMockSession = LoginSession.make(baseURL: URL(string: "https://test.instructure.com")!, userID: "testUserID2")
-        let anotherDbURL = URL.Directories.documents.appendingPathComponent("\(anotherMockSession.uniqueID)/Offline/Files/fileFolder/image.jpg")
+        let anotherDbURL = URL.Directories.documents.appendingPathComponent("\(anotherMockSession.uniqueID)/Offline/Files/courseFolder/fileFolder/image.jpg")
         try write("test", to: anotherDbURL)
         XCTAssertTrue(FileManager.default.fileExists(atPath: anotherDbURL.path))
 

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
@@ -82,7 +82,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         let testee = CourseSyncFilesInteractorLive()
         let expectation = expectation(description: "Publisher sends value")
         let url = URL(string: "1.jpg")!
-        let folderName = "canvas.instructure.com-1/Offline/Files/course-1/fileID"
+        let folderName = "canvas.instructure.com-1/Offline/Files/course-courseID/file-fileID"
 
         try? FileManager.default.createDirectory(
             at: URL.Directories.documents.appendingPathComponent(folderName),
@@ -95,16 +95,16 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
 
         let existingFile: File = databaseClient.insert()
         existingFile.url = url
-        existingFile.id = "file-fileID"
+        existingFile.id = "fileID"
         existingFile.filename = "fileName"
         existingFile.mimeClass = "mimeClass"
         existingFile.updatedAt = Date(timeIntervalSince1970: 1000)
         let folderItem: FolderItem = databaseClient.insert()
-        folderItem.id = "file-fileID"
+        folderItem.id = "fileID"
         folderItem.file = existingFile
 
         let subscription = testee.downloadFile(
-            courseId: "course-1",
+            courseId: "courseID",
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -247,7 +247,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
     func testUnavailableFiles() {
         let testee = CourseSyncFilesInteractorLive()
 
-        let folderName = "canvas.instructure.com-1/Offline/Files/course-1"
+        let folderName = "canvas.instructure.com-1/Offline/Files/course-courseID"
 
         try? FileManager.default.createDirectory(
             at: URL.Directories.documents.appendingPathComponent(folderName),
@@ -263,7 +263,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         )
 
         let subscription = testee.removeUnavailableFiles(
-            courseId: "course-1",
+            courseId: "courseID",
             newFileIDs: ["file-1"]
         )
         .sink()

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
@@ -41,6 +41,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
 
         var progressList: [Float] = []
         let subscription = testee.downloadFile(
+            courseId: "course-1",
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -81,7 +82,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         let testee = CourseSyncFilesInteractorLive()
         let expectation = expectation(description: "Publisher sends value")
         let url = URL(string: "1.jpg")!
-        let folderName = "canvas.instructure.com-1/Offline/Files/fileID"
+        let folderName = "canvas.instructure.com-1/Offline/Files/course-1/fileID"
 
         try? FileManager.default.createDirectory(
             at: URL.Directories.documents.appendingPathComponent(folderName),
@@ -103,6 +104,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         folderItem.file = existingFile
 
         let subscription = testee.downloadFile(
+            courseId: "course-1",
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -150,6 +152,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         folderItem.file = existingFile
 
         let subscription = testee.downloadFile(
+            courseId: "course-1",
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -178,6 +181,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
 
         var progressList: [Float] = []
         let subscription = testee.downloadFile(
+            courseId: "course-1",
             url: url,
             fileID: "1",
             fileName: "fileName",
@@ -217,19 +221,98 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
 
         environment.currentSession = nil
 
-        let subscription = testee.downloadFile(url: URL(string: "1")!, fileID: "1", fileName: "1", mimeClass: "1", updatedAt: nil)
-            .sink(receiveCompletion: { completion in
-                switch completion {
-                case let .failure(error):
-                    if error.localizedDescription == "There was an unexpected error. Please try again." {
-                        expectation.fulfill()
-                    }
-                default:
-                    break
+        let subscription = testee.downloadFile(
+            courseId: "course-1",
+            url: URL(string: "1")!,
+            fileID: "1",
+            fileName: "1",
+            mimeClass: "1",
+            updatedAt: nil
+        )
+        .sink(receiveCompletion: { completion in
+            switch completion {
+            case let .failure(error):
+                if error.localizedDescription == "There was an unexpected error. Please try again." {
+                    expectation.fulfill()
                 }
-            }, receiveValue: { _ in })
+            default:
+                break
+            }
+        }, receiveValue: { _ in })
 
         waitForExpectations(timeout: 0.1)
         subscription.cancel()
+    }
+
+    func testUnavailableFiles() {
+        let testee = CourseSyncFilesInteractorLive()
+
+        let folderName = "canvas.instructure.com-1/Offline/Files/course-1"
+
+        try? FileManager.default.createDirectory(
+            at: URL.Directories.documents.appendingPathComponent(folderName),
+            withIntermediateDirectories: true
+        )
+        FileManager.default.createFile(
+            atPath: URL.Directories.documents.appendingPathComponent(folderName + "/file-1").path,
+            contents: "test".data(using: .utf8)
+        )
+        FileManager.default.createFile(
+            atPath: URL.Directories.documents.appendingPathComponent(folderName + "/file-2").path,
+            contents: "test".data(using: .utf8)
+        )
+
+        let subscription = testee.removeUnavailableFiles(
+            courseId: "course-1",
+            newFileIDs: ["file-1"]
+        )
+        .sink()
+
+        let fileExists = FileManager.default.fileExists(
+            atPath: URL.Directories.documents.appendingPathComponent(folderName + "/file-2").path
+        )
+
+        XCTAssertFalse(fileExists)
+
+        subscription.cancel()
+    }
+
+    func testGetFiles() {
+        let testee = CourseSyncFilesInteractorLive()
+
+        let rootFolder = APIFolder.make(
+            context_type: "Course",
+            context_id: "course-id-1",
+            files_count: 1,
+            id: 0
+        )
+
+        let rootFolderFile = APIFile.make(
+            id: "file-1",
+            folder_id: 0,
+            display_name: "file-displayname-1",
+            filename: "file-name-1",
+            size: 1000
+        )
+
+        api.mock(
+            GetFolderByPath(context: .course("course-id-1")),
+            value: [rootFolder]
+        )
+
+        api.mock(
+            GetFoldersRequest(context: Context(.folder, id: "0")),
+            value: []
+        )
+
+        api.mock(
+            GetFilesRequest(context: Context(.folder, id: "0")),
+            value: [rootFolderFile]
+        )
+
+        XCTAssertSingleOutputEquals(
+            testee.getFiles(courseId: "course-id-1", useCache: false),
+            [File.make(from: rootFolderFile)]
+        )
     }
 }

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
@@ -40,7 +40,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         mock.suspend()
 
         var progressList: [Float] = []
-        let subscription = testee.getFile(
+        let subscription = testee.downloadFile(
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -102,7 +102,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         folderItem.id = "file-fileID"
         folderItem.file = existingFile
 
-        let subscription = testee.getFile(
+        let subscription = testee.downloadFile(
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -149,7 +149,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         folderItem.id = "file-fileID"
         folderItem.file = existingFile
 
-        let subscription = testee.getFile(
+        let subscription = testee.downloadFile(
             url: url,
             fileID: "fileID",
             fileName: "fileName",
@@ -177,7 +177,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         mock.suspend()
 
         var progressList: [Float] = []
-        let subscription = testee.getFile(
+        let subscription = testee.downloadFile(
             url: url,
             fileID: "1",
             fileName: "fileName",
@@ -217,7 +217,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
 
         environment.currentSession = nil
 
-        let subscription = testee.getFile(url: URL(string: "1")!, fileID: "1", fileName: "1", mimeClass: "1", updatedAt: nil)
+        let subscription = testee.downloadFile(url: URL(string: "1")!, fileID: "1", fileName: "1", mimeClass: "1", updatedAt: nil)
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case let .failure(error):

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncFilesInteractorLiveTests.swift
@@ -129,7 +129,7 @@ class CourseSyncFilesInteractorLiveTests: CoreTestCase {
         shouldntInvokeExpectation.isInverted = true
 
         let url = URL(string: "1.jpg")!
-        let folderName = "canvas.instructure.com-1/Offline/Files/fileID"
+        let folderName = "canvas.instructure.com-1/Offline/Files/course-1/file-fileID"
 
         try? FileManager.default.createDirectory(
             at: URL.Directories.documents.appendingPathComponent(folderName),

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -596,9 +596,18 @@ private class CourseSyncAssignmentsInteractorMock: CourseSyncAssignmentsInteract
 
 private class CourseSyncFilesInteractorMock: CourseSyncFilesInteractor {
     let publisher = PassthroughSubject<Float, Error>()
+    let filePublisher = PassthroughSubject<[Core.File], Error>()
 
-    func downloadFile(url _: URL, fileID _: String, fileName _: String, mimeClass _: String, updatedAt _: Date?) -> AnyPublisher<Float, Error> {
+    func downloadFile(courseId _: String, url _: URL, fileID _: String, fileName _: String, mimeClass _: String, updatedAt _: Date?) -> AnyPublisher<Float, Error> {
         publisher.eraseToAnyPublisher()
+    }
+
+    func getFiles(courseId: String, useCache: Bool) -> AnyPublisher<[Core.File], Error> {
+        filePublisher.eraseToAnyPublisher()
+    }
+
+    func removeUnavailableFiles(courseId: String, newFileIDs: [String]) -> AnyPublisher<Void, Error> {
+        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
 

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -597,7 +597,7 @@ private class CourseSyncAssignmentsInteractorMock: CourseSyncAssignmentsInteract
 private class CourseSyncFilesInteractorMock: CourseSyncFilesInteractor {
     let publisher = PassthroughSubject<Float, Error>()
 
-    func getFile(url _: URL, fileID _: String, fileName _: String, mimeClass _: String, updatedAt _: Date?) -> AnyPublisher<Float, Error> {
+    func downloadFile(url _: URL, fileID _: String, fileName _: String, mimeClass _: String, updatedAt _: Date?) -> AnyPublisher<Float, Error> {
         publisher.eraseToAnyPublisher()
     }
 }

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -208,6 +208,20 @@
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
 		};
+		B4AE73E52AB9887E00D61CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
+			remoteInfo = CoreTester;
+		};
+		B4AE73E72AB9887E00D61CFD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
+			remoteInfo = CoreTests;
+		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
@@ -726,8 +740,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				5BB3D7A52AB82EA4006BB339 /* CoreTester.app */,
-				5BB3D7A72AB82EA4006BB339 /* CoreTests.xctest */,
+				B4AE73E62AB9887E00D61CFD /* CoreTester.app */,
+				B4AE73E82AB9887E00D61CFD /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1018,18 +1032,18 @@
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		5BB3D7A52AB82EA4006BB339 /* CoreTester.app */ = {
+		B4AE73E62AB9887E00D61CFD /* CoreTester.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = CoreTester.app;
-			remoteRef = 5BB3D7A42AB82EA4006BB339 /* PBXContainerItemProxy */;
+			remoteRef = B4AE73E52AB9887E00D61CFD /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		5BB3D7A72AB82EA4006BB339 /* CoreTests.xctest */ = {
+		B4AE73E82AB9887E00D61CFD /* CoreTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = CoreTests.xctest;
-			remoteRef = 5BB3D7A62AB82EA4006BB339 /* PBXContainerItemProxy */;
+			remoteRef = B4AE73E72AB9887E00D61CFD /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -187,40 +187,12 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		5BB3D7A42AB82EA4006BB339 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		5BB3D7A62AB82EA4006BB339 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
-		};
 		ADD0BD039DBE20C141DFDF5E /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
-		};
-		B4AE73E52AB9887E00D61CFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		B4AE73E72AB9887E00D61CFD /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -740,8 +712,6 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				B4AE73E62AB9887E00D61CFD /* CoreTester.app */,
-				B4AE73E82AB9887E00D61CFD /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1030,20 +1000,6 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4AE73E62AB9887E00D61CFD /* CoreTester.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CoreTester.app;
-			remoteRef = B4AE73E52AB9887E00D61CFD /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4AE73E82AB9887E00D61CFD /* CoreTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CoreTests.xctest;
-			remoteRef = B4AE73E72AB9887E00D61CFD /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */


### PR DESCRIPTION
This PR includes the following changes: 
- Whenever we sync a course, files that are persisted on the disk but not present on the server, will be deleted. 
- In order to be able to identify which file belongs to which course, files are now organized as `/Documents/Offline/Files/courseId/fileId/fileName`. 
- Moved file related logic from `CourseSyncEntryComposerInteractor` to `CourseSyncFilesInteractor`.  

refs: MBL-16813
affects: Student
release note: none
test plan: See ticket

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

