### PR TITLE
Fix like counter not displaying the proper amount of likes in case someone disliked a post

### DIFF
--- a/Core/Core/Discussions/APIDiscussion.swift
+++ b/Core/Core/Discussions/APIDiscussion.swift
@@ -78,7 +78,6 @@ public struct APIDiscussionEntry: Codable, Equatable {
     let created_at: Date?
     let updated_at: Date?
     var message: String?
-    let rating_count: Int?
     let rating_sum: Int?
     let replies: [APIDiscussionEntry]?
     let attachment: APIFile?
@@ -241,14 +240,14 @@ extension APIDiscussionView {
         entry_ratings: [String: Int] = ["3": 1, "5": 1],
         forced_entries: [ID] = [1],
         view: [APIDiscussionEntry] = [
-            .make(id: 1, message: "m1", rating_count: 1, replies: [
-                .make(id: 2, user_id: 2, parent_id: 1, message: "m2", rating_count: 0, replies: [
-                    .make(id: 3, parent_id: 2, message: "m3", rating_count: 3, replies: [
+            .make(id: 1, message: "m1", rating_sum: 1, replies: [
+                .make(id: 2, user_id: 2, parent_id: 1, message: "m2", rating_sum: 0, replies: [
+                    .make(id: 3, parent_id: 2, message: "m3", rating_sum: 3, replies: [
                         .make(id: 4, parent_id: 3, message: "m4 (deep)"),
                     ]),
                 ]),
             ]),
-            .make(id: 5, message: "m5", rating_count: 1),
+            .make(id: 5, message: "m5", rating_sum: 1),
         ],
         new_entries: [APIDiscussionEntry]? = nil
     ) -> APIDiscussionView {
@@ -271,7 +270,6 @@ extension APIDiscussionEntry {
         created_at: Date? = nil,
         updated_at: Date = Date(timeIntervalSinceReferenceDate: 0),
         message: String = "message",
-        rating_count: Int? = nil,
         rating_sum: Int? = nil,
         replies: [APIDiscussionEntry]? = nil,
         attachment: APIFile? = nil,
@@ -285,8 +283,7 @@ extension APIDiscussionEntry {
             created_at: created_at,
             updated_at: updated_at,
             message: message,
-            rating_count: rating_count,
-            rating_sum: rating_sum ?? rating_count,
+            rating_sum: rating_sum,
             replies: replies,
             attachment: attachment,
             deleted: deleted

--- a/Core/Core/Discussions/DiscussionEntry.swift
+++ b/Core/Core/Discussions/DiscussionEntry.swift
@@ -71,7 +71,7 @@ public final class DiscussionEntry: NSManagedObject {
         model.isForcedRead = forcedIDs?.contains(model.id) ?? model.isForcedRead
         model.isRead = unreadIDs.map { !$0.contains(model.id) } ?? model.isRead
         model.isRemoved = item.deleted == true
-        model.likeCount = item.rating_count ?? 0
+        model.likeCount = item.rating_sum ?? 0
         model.message = item.message
         model.parent = parent ?? model.parent
         model.parentID = item.parent_id?.value

--- a/Core/CoreTests/Discussions/DiscussionEntryTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionEntryTests.swift
@@ -38,7 +38,7 @@ class DiscussionEntryTests: CoreTestCase {
     }
 
     func testLikeCount() {
-        let entry = DiscussionEntry.make(from: .make(rating_count: 5))
+        let entry = DiscussionEntry.make(from: .make(rating_sum: 5))
         XCTAssertEqual(entry.likeCountText, "5 likes")
     }
 }


### PR DESCRIPTION
refs: MBL-17023
affects: Student, Teacher
release note: Fixed like counter not displaying the proper amount of likes in case someone disliked a post.

test plan:
- Go to a doiscussion that can be liked.
- Like a post with no likes.
- Like counter should display 1
- Dislike it the post.
- Like counter should go to 0.
- Do a pull to refresh.
- Like counter should still show 0.
- It can happen that the like button shows that the post is liked but this will go away after the API refreshes the data and you do a pull to refresh.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/58e7ad5b-782e-448e-83cc-853553edc0a8" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/ed1cc519-8f5a-410c-9e06-703684898def" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [x] Tested on tablet