### PR TITLE
Override user interface style unconditionally when switch to light mode button is pressed.

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -552,13 +552,15 @@ extension CoreWebView {
     private var themeSwitchButtonTopPadding: CGFloat { 16 }
 
     public func updateHtmlContentView() {
+        super.overrideUserInterfaceStyle = isInverted ? .light : .unspecified
         themeSwitcherButton.setNeedsUpdateConfiguration()
-        guard let htmlString = htmlString, let baseURL = baseURL else { return }
-        if htmlString.contains("prefers-color-scheme:dark") {
-            super.overrideUserInterfaceStyle = isInverted ? .light : .unspecified
-        } else {
-            super.loadHTMLString(self.html(for: htmlString), baseURL: baseURL)
-        }
+
+        guard let htmlString = htmlString,
+              let baseURL = baseURL,
+              !htmlString.contains("prefers-color-scheme:dark")
+        else { return }
+
+        super.loadHTMLString(self.html(for: htmlString), baseURL: baseURL)
     }
 
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -592,8 +594,8 @@ extension CoreWebView {
         }
 
         themeSwitcherButton.isHidden = !isThemeDark
-        let buttonHeightConstraint = self.themeSwitcherButton.heightAnchor.constraint(equalToConstant: buttonHeight)
-        let buttonTopConstraint = self.themeSwitcherButton.topAnchor.constraint(equalTo: parent.topAnchor, constant: buttonTopPadding)
+        let buttonHeightConstraint = themeSwitcherButton.heightAnchor.constraint(equalToConstant: buttonHeight)
+        let buttonTopConstraint = themeSwitcherButton.topAnchor.constraint(equalTo: parent.topAnchor, constant: buttonTopPadding)
 
         isThemeDark = parent.viewController?.traitCollection.userInterfaceStyle == .dark
         let buttonTitle = NSLocalizedString("Switch To Light Mode", bundle: .core, comment: "")


### PR DESCRIPTION
refs: MBL-17016
affects: Student, Teacher
release note: Improved "Switch To Light Mode" feature for documents.

test plan: See ticket for test files. Also check other places where "Switch To Light Mode" appears if it's still works correctly.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/141ea763-f2cc-4d79-b5eb-f671e879a61c" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/b4afb1ca-f2d5-4b7d-b717-60f407b2768b" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/d1ed2f05-db56-4ee6-9ea6-05666e8f5dbc" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/9ddc4007-3d1b-473a-bb47-4190d2330e33" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode