### PR TITLE
Fix duplicated modules list on screen.

### DIFF
--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -315,3 +315,12 @@ extension ModuleListViewController: MasteryPathDelegate {
         } }
     }
 }
+
+extension ModuleListViewController: DefaultViewProvider {
+
+    public var defaultViewRoute: String? {
+        get { "/empty" }
+        // swiftlint:disable:next unused_setter_value
+        set {}
+    }
+}


### PR DESCRIPTION
refs: MBL-17019
affects: Student
release note: none

test plan:
- Create a course with modules as home page.
- Log in to the student app with a split view capable device and go to the course's details.
- Modules should display in the detail view.
- Tap on modules on the master list.
- Modules list should appear on the master list and the detail view should show an empty state instead of displaying also the modules list.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/22d8b6f2-089f-4ba2-95e3-c9b5210b94e5" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/fbff7870-713c-4bc5-90e8-0f7a6f940491" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode