### PR TITLE
Disable offline mode selection screens in offline mode

### DIFF
--- a/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/CourseSyncSelectorAssembly.swift
@@ -31,10 +31,8 @@ public enum CourseSyncSelectorAssembly {
             router: env.router
         )
         let diskSpaceViewModel = CourseSyncDiskSpaceInfoViewModel(interactor: diskSpaceInteractor, app: env.app ?? .student)
-        let offlineModeViewModel = OfflineModeViewModel(interactor: OfflineModeAssembly.make())
         let view = CourseSyncSelectorView(viewModel: viewModel,
-                                          diskSpaceViewModel: diskSpaceViewModel,
-                                          offlineModeViewModel: offlineModeViewModel)
+                                          diskSpaceViewModel: diskSpaceViewModel)
         return CoreHostingController(view)
     }
 
@@ -55,10 +53,8 @@ public enum CourseSyncSelectorAssembly {
             router: env.router
         )
         let diskSpaceViewModel = CourseSyncDiskSpaceInfoViewModel(interactor: diskSpaceInteractor, app: env.app ?? .student)
-        let offlineModeViewModel = OfflineModeViewModel(interactor: OfflineModeInteractorMock())
         return CourseSyncSelectorView(viewModel: viewModel,
-                                      diskSpaceViewModel: diskSpaceViewModel,
-                                      offlineModeViewModel: offlineModeViewModel)
+                                      diskSpaceViewModel: diskSpaceViewModel)
     }
 
 #endif

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -22,7 +22,6 @@ struct CourseSyncSelectorView: View {
     @Environment(\.viewController) var viewController
     @StateObject var viewModel: CourseSyncSelectorViewModel
     @StateObject var diskSpaceViewModel: CourseSyncDiskSpaceInfoViewModel
-    @StateObject var offlineModeViewModel: OfflineModeViewModel
 
     var body: some View {
         content
@@ -137,7 +136,7 @@ struct CourseSyncSelectorView: View {
     }
 
     private var syncButton: some View {
-        PrimaryButton(isUnavailable: $offlineModeViewModel.isOffline) {
+        Button {
             viewModel.syncButtonDidTap.accept(viewController)
         } label: {
             Text("Sync", bundle: .core)
@@ -149,7 +148,6 @@ struct CourseSyncSelectorView: View {
                 .opacity(viewModel.syncButtonDisabled ? 0.42 : 1)
         }
         .disabled(viewModel.syncButtonDisabled)
-        .animation(.default, value: offlineModeViewModel.isOffline)
     }
 
     @ViewBuilder

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -170,7 +170,11 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         .accessibilityLabel(Text("Dashboard Options", bundle: .core))
         .confirmationDialog("", isPresented: $isShowingKebabDialog) {
             Button {
-                env.router.route(to: "/offline/sync_picker", from: controller, options: .modal(isDismissable: false, embedInNav: true))
+                if offlineModeViewModel.isOffline {
+                    UIAlertController.showItemNotAvailableInOfflineAlert()
+                } else {
+                    env.router.route(to: "/offline/sync_picker", from: controller, options: .modal(isDismissable: false, embedInNav: true))
+                }
             } label: {
                 Text("Manage Offline Content", bundle: .core)
             }

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -128,6 +128,10 @@ struct DashboardCourseCardView: View {
         .identifier("DashboardCourseCell.\(courseCard.id).optionsButton")
         .confirmationDialog("", isPresented: $isShowingKebabDialog) {
             Button {
+                if offlineModeViewModel.isOffline {
+                    return UIAlertController.showItemNotAvailableInOfflineAlert()
+                }
+
                 var route = "/offline/sync_picker"
 
                 if let courseID = courseCard.course?.id {


### PR DESCRIPTION
refs: MBL-17087
affects: Student
release note: none

test plan:
- Turn the student app to offline mode.
- On the dashboard, tap the kebab menu on the top right corner and select "Manage Offline Content".
- Offline mode dialog should show.
- Tap on the kebab menu on a course and select "Manage Offline Content".
- Offline mode dialog should show.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet