### PR TITLE
Add error logging to crashlytics

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -95,7 +95,6 @@
 		0EA924DCE1C57E35FB7DFDA6 /* LoginStartViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67AD61608F7BA35C41B3D85 /* LoginStartViewController.swift */; };
 		0EC6263BFC83A9648A51D045 /* RichContentToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFA486C4876FCB7C243AAC95 /* RichContentToolbarView.swift */; };
 		0EE25BF09581E5E4AC1669F5 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BC623C0CD68A8AB70145B80 /* AppEnvironment.swift */; };
-		0F135BC82678085E16914FAC /* MockAnalyticsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15154DB2F9F5F7C5F78DF5EB /* MockAnalyticsHandler.swift */; };
 		0F1A5F57D5D63FB688D9CD9F /* GetContextPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8290AAED7BA52A7C4D099C74 /* GetContextPermissions.swift */; };
 		0F1EB64D08AA16B83FC72ABC /* MotionModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9160E6FF32D199E6BF4310F /* MotionModifier.swift */; };
 		0F2793DCC1F46D1064D32110 /* MessageDetailsInteratorLive.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11FCB88AFB1B140BF0FB8EC /* MessageDetailsInteratorLive.swift */; };
@@ -233,6 +232,7 @@
 		245C9DB44886418467A2A5AE /* FileUploadTargetRequesterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AEB50CAF7EBB10B51D6062D /* FileUploadTargetRequesterTests.swift */; };
 		246B4B0D8AE27AA8BA4EFC0A /* FileProgressItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5FF688B43191518E8C02434 /* FileProgressItemView.swift */; };
 		248B95D3107374D23924B067 /* DocumentExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35BFFAB9ADA0ED5BB3AD4C67 /* DocumentExtensions.swift */; };
+		249B7B296D54E66F4BDCEEBF /* MockAnalyticsHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C74AB56326B9303CD57F83F4 /* MockAnalyticsHandler.swift */; };
 		24AA3689F8728BE8850B8458 /* UsageRights.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC6A40B05A66159F069CA28F /* UsageRights.swift */; };
 		24C6F4267B962AA856EB4A37 /* K5ResourcesHomeroomInfoViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27CBFCE1A8422B3EA36F10F5 /* K5ResourcesHomeroomInfoViewModelTests.swift */; };
 		24F706D72564DAF087039280 /* FileProgressListViewModelProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5084A9AE3290EDF87E9643B /* FileProgressListViewModelProtocolTests.swift */; };
@@ -1832,7 +1832,6 @@
 		14CD0262DAB15588F58F27D0 /* Plannable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Plannable.swift; sourceTree = "<group>"; };
 		14D574E5B2EB2CB4D19C4F92 /* CourseListItemSearchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListItemSearchTests.swift; sourceTree = "<group>"; };
 		15095DAA95E4095036F53C1F /* PublisherExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PublisherExtensionsTests.swift; sourceTree = "<group>"; };
-		15154DB2F9F5F7C5F78DF5EB /* MockAnalyticsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsHandler.swift; sourceTree = "<group>"; };
 		154AFFC414CC0A0C52B7A557 /* confetti.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = confetti.json; sourceTree = "<group>"; };
 		15E13D146F040A7DB7964CB8 /* ModuleItemDetailsViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ModuleItemDetailsViewController.storyboard; sourceTree = "<group>"; };
 		15E57158A8C15D99A7CF15F3 /* API.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = API.swift; sourceTree = "<group>"; };
@@ -3109,6 +3108,7 @@
 		C72CA7693A90E9118256E989 /* UploadAvatarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadAvatarTests.swift; sourceTree = "<group>"; };
 		C73B072DD0FA0F9DC78BC7AE /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.stringsdict; name = da; path = da.lproj/Localizable.stringsdict; sourceTree = "<group>"; };
 		C74853D7E3A4FAF817AD060D /* RichContentEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RichContentEditor.swift; sourceTree = "<group>"; };
+		C74AB56326B9303CD57F83F4 /* MockAnalyticsHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsHandler.swift; sourceTree = "<group>"; };
 		C752AA67F76F20E878F36C18 /* VideoPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayer.swift; sourceTree = "<group>"; };
 		C7F6E9917DB4EF3D8EDA4A59 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C7F958F95B1993A5CB69F6AE /* ContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextTests.swift; sourceTree = "<group>"; };
@@ -5658,6 +5658,7 @@
 			isa = PBXGroup;
 			children = (
 				1CE185592F73E6B146559A86 /* AnalyticsTests.swift */,
+				C74AB56326B9303CD57F83F4 /* MockAnalyticsHandler.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -5665,7 +5666,6 @@
 		62703D070FFE3DFF7152CC6A /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				15154DB2F9F5F7C5F78DF5EB /* MockAnalyticsHandler.swift */,
 				CE282BDD1EFE56BE1CF9E3B6 /* TestOperationQueue.swift */,
 			);
 			path = Utils;
@@ -9648,7 +9648,7 @@
 				F1DF39627B5C9F790B8B5AFA /* MessageDetailsInteractorLiveTests.swift in Sources */,
 				A352A8DCE7424D749356BE6B /* MessageDetailsViewModelTests.swift in Sources */,
 				CA5D1B4FF43103705D699684 /* MessageListStateUpdaterTests.swift in Sources */,
-				0F135BC82678085E16914FAC /* MockAnalyticsHandler.swift in Sources */,
+				249B7B296D54E66F4BDCEEBF /* MockAnalyticsHandler.swift in Sources */,
 				62CD9A6D62A254F9AE845FA1 /* MockCoreWebViewLinkDelegate.swift in Sources */,
 				EBDA7E91903AA086D89A0DB5 /* MockDocViewerAnnotationProvider.swift in Sources */,
 				15A59E9BFA318AE396DD9700 /* MockDocViewerAnnotationProviderDelegate.swift in Sources */,

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -377,7 +377,7 @@ extension CoreWebView: WKNavigationDelegate {
     }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        // TODO: Report Error
+        Analytics.shared.logError(name: "WebKit process terminated", reason: nil)
         CoreWebViewContentErrorViewEmbed.embed(errorDelegate: errorDelegate)
     }
 }

--- a/Core/Core/CourseSync/BackgroundUpdates/Model/OfflineSyncBackgroundTask.swift
+++ b/Core/Core/CourseSync/BackgroundUpdates/Model/OfflineSyncBackgroundTask.swift
@@ -119,6 +119,7 @@ public class OfflineSyncBackgroundTask: BackgroundTask {
                     self?.syncScheduler.updateNextSyncDate(sessionUniqueID: session.uniqueID)
                     Logger.shared.log("Offline: Sync finished")
                 case .failure(let error):
+                    Analytics.shared.logError(name: "Background offline sync failed", reason: error.localizedDescription)
                     Logger.shared.log("Offline: Sync failed with error: \(error.localizedDescription)")
                 }
 

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -396,7 +396,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
 
             if error != nil {
                 self.showFallbackWebView()
-                // TODO: Report render error
+                Analytics.shared.logError(name: "Javascript evaluation failed", reason: error?.localizedDescription)
                 return
             }
 

--- a/Core/Core/Files/Model/UploadManager.swift
+++ b/Core/Core/Files/Model/UploadManager.swift
@@ -352,6 +352,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
                         Analytics.shared.logEvent("submit_fileupload_failed", parameters: [
                             "error": error?.localizedDescription ?? "unknown",
                         ])
+                        Analytics.shared.logError(name: "File upload failed during submission", reason: error?.localizedDescription)
                         self.complete(file: file, error: error)
                         return
                     }
@@ -401,6 +402,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
             Analytics.shared.logEvent("fileupload_failed", parameters: [
                 "error": error.localizedDescription,
             ])
+            Analytics.shared.logError(name: "File upload failed", reason: error.localizedDescription)
         }
         context.performAndWait {
             file.uploadError = error?.localizedDescription

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -363,6 +363,7 @@ class LoginStartViewController: UIViewController {
                 guard let session = session, error == nil else {
                     loading?.dismiss(animated: true) {
                         self?.showQRCodeError()
+                        Analytics.shared.logError(name: "QR code login failed", reason: error?.localizedDescription)
                     }
                     return
                 }

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
@@ -63,6 +63,7 @@ public class AssignmentPickerListService: AssignmentPickerListServiceProtocol {
         } else {
             let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
             Analytics.shared.logEvent("error_loading_assignments", parameters: ["error": errorMessage])
+            Analytics.shared.logError(name: "Assignment list load failed", reason: error?.localizedDescription)
             result = .failure(errorMessage)
         }
 

--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
@@ -73,7 +73,7 @@ public class AttachmentCopyService {
         }
         attachment.loadItem(forTypeIdentifier: uti.rawValue, options: nil) { data, error in
             guard let coding = data, error == nil else {
-                Analytics.shared.logError("error_getting_encoded_attachment_data", description: error?.localizedDescription)
+                Analytics.shared.logError(name: "Failed to get encoded attachment data", reason: error?.localizedDescription)
                 callback(.failure(error ?? NSError.internalError()))
                 return
             }
@@ -104,7 +104,7 @@ public class AttachmentCopyService {
                 }
                 callback(.success(newURL))
             } catch {
-                Analytics.shared.logError("error_getting_file_data", description: error.localizedDescription)
+                Analytics.shared.logError(name: "Failed to get file data", reason: error.localizedDescription)
                 callback(.failure(error))
             }
         }

--- a/Core/Core/SubmitAssignmentExtension/Model/UTIFromNSItemProvider.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/UTIFromNSItemProvider.swift
@@ -23,7 +23,7 @@ extension NSItemProvider {
         let uti = Self.SupportedUTIs.first { hasItemConformingToTypeIdentifier($0.rawValue) }
 
         if uti == nil {
-            Analytics.shared.logError("error_unsupported_file_type", description: suggestedName)
+            Analytics.shared.logError(name: "Unsupported file type", reason: suggestedName)
         }
 
         return uti

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
@@ -54,6 +54,7 @@ public class CoursePickerViewModel: ObservableObject {
             } else {
                 let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
                 Analytics.shared.logEvent("error_loading_courses", parameters: ["error": errorMessage])
+                Analytics.shared.logError(name: "Course list loading failed", reason: error?.localizedDescription)
                 newState = .error(errorMessage)
             }
 

--- a/Core/CoreTests/Analytics/MockAnalyticsHandler.swift
+++ b/Core/CoreTests/Analytics/MockAnalyticsHandler.swift
@@ -1,6 +1,6 @@
 //
 // This file is part of Canvas.
-// Copyright (C) 2022-present  Instructure, Inc.
+// Copyright (C) 2023-present  Instructure, Inc.
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as
@@ -19,13 +19,35 @@
 import Core
 
 class MockAnalyticsHandler: AnalyticsHandler {
-    var loggedEventCount = 0
-    var lastEventName: String?
+    var lastEvent: String?
     var lastEventParameters: [String: Any]?
+    var totalEventCount = 0
+
+    var lastErrorName: String?
+    var lastErrorReason: String?
+    var totalErrorCount = 0
+
+    var lastScreenName: String?
+    var lastScreenClass: String?
+    var lastScreenViewApp: String?
+    var totalScreenViewCount = 0
+
+    func handleScreenView(screenName: String, screenClass: String, application: String) {
+        lastScreenName = screenName
+        lastScreenClass = screenClass
+        lastScreenViewApp = application
+        totalScreenViewCount += 1
+    }
+
+    func handleError(_ name: String, reason: String) {
+        lastErrorName = name
+        lastErrorReason = reason
+        totalErrorCount += 1
+    }
 
     func handleEvent(_ name: String, parameters: [String: Any]?) {
-        lastEventName = name
+        lastEvent = name
         lastEventParameters = parameters
-        loggedEventCount += 1
+        totalEventCount += 1
     }
 }

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -33,7 +33,7 @@ class CoreTestCase: XCTestCase {
     var api: API { environment.api }
     var router: TestRouter!
     var logger: TestLogger!
-    var analytics = TestAnalyticsHandler()
+    var analytics = MockAnalyticsHandler()
 
     lazy var environment = TestEnvironment()
     var currentSession: LoginSession!
@@ -85,18 +85,6 @@ class CoreTestCase: XCTestCase {
         let main = expectation(description: "main.async")
         DispatchQueue.main.async { main.fulfill() }
         wait(for: [main], timeout: 1)
-    }
-}
-
-class TestAnalyticsHandler: AnalyticsHandler {
-    struct Event {
-        let name: String
-        let parameters: [String: Any]?
-    }
-    var events = [Event]()
-
-    func handleEvent(_ name: String, parameters: [String: Any]?) {
-        events.append(.init(name: name, parameters: parameters))
     }
 }
 

--- a/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
@@ -317,7 +317,7 @@ class FileDetailsViewControllerTests: CoreTestCase {
 }
 
 extension FileDetailsViewControllerTests: PSPDFKit.PDFDocumentDelegate {
-    func  pdfDocumentDidSave(_ document: Document) {
+    func pdfDocumentDidSave(_ document: Document) {
         saveWasCalled = true
     }
 

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
@@ -255,8 +255,7 @@ class ModuleItemDetailsViewControllerTests: CoreTestCase {
         )
         controller.view.layoutIfNeeded()
 
-        XCTAssertEqual(mockAnalyticsHandler.lastEventName, "screen_view")
-        XCTAssertEqual(mockAnalyticsHandler.lastEventParameters?["screen_name"] as? String, "/courses/:courseId")
-        XCTAssertEqual(mockAnalyticsHandler.lastEventParameters?["screen_class"] as? String, "DetailViewController")
+        XCTAssertEqual(mockAnalyticsHandler.lastScreenName, "/courses/:courseId")
+        XCTAssertEqual(mockAnalyticsHandler.lastScreenClass, "DetailViewController")
     }
 }

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -422,12 +422,9 @@ class RouterTests: CoreTestCase {
 
         router.route(to: URLComponents(string: "/courses/1234/assignments")!, from: mockView, options: .modal())
 
-        XCTAssertEqual(analyticsHandler.lastEventName, "screen_view")
-        XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], [
-            "application": "teacher",
-            "screen_name": "/courses/:courseId/assignments",
-            "screen_class": "UIViewController",
-        ])
+        XCTAssertEqual(analyticsHandler.lastScreenName, "/courses/:courseId/assignments")
+        XCTAssertEqual(analyticsHandler.lastScreenClass, "UIViewController")
+        XCTAssertEqual(analyticsHandler.lastScreenViewApp, "teacher")
     }
 
     func testAnalyticsReportOnShow() {
@@ -439,13 +436,10 @@ class RouterTests: CoreTestCase {
 
         router.show(mockView, from: UIViewController(), analyticsRoute: "/courses/:courseId/assignments")
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "screen_view")
-        XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], [
-            "application": "parent",
-            "screen_name": "/courses/:courseId/assignments",
-            "screen_class": "MockViewController",
-        ])
+        XCTAssertEqual(analyticsHandler.totalScreenViewCount, 1)
+        XCTAssertEqual(analyticsHandler.lastScreenName, "/courses/:courseId/assignments")
+        XCTAssertEqual(analyticsHandler.lastScreenClass, "MockViewController")
+        XCTAssertEqual(analyticsHandler.lastScreenViewApp, "parent")
     }
 
     func testRouteTemplate() {
@@ -514,12 +508,9 @@ class RouterTests: CoreTestCase {
 
         testee.route(to: externalURL, from: mockViewController)
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "screen_view")
-        XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], [
-            "application": "student",
-            "screen_name": "/external_url",
-            "screen_class": "unknown",
-        ])
+        XCTAssertEqual(analyticsHandler.totalScreenViewCount, 1)
+        XCTAssertEqual(analyticsHandler.lastScreenName, "/external_url")
+        XCTAssertEqual(analyticsHandler.lastScreenClass, "unknown")
+        XCTAssertEqual(analyticsHandler.lastScreenViewApp, "student")
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/API/AssignmentPickerListServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/API/AssignmentPickerListServiceTests.swift
@@ -79,8 +79,8 @@ class AssignmentPickerListServiceTests: CoreTestCase {
         testee.courseID = "successID"
         waitForExpectations(timeout: 0.1)
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "assignments_loaded")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "assignments_loaded")
         XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: Int], ["count": 2])
     }
 
@@ -92,8 +92,8 @@ class AssignmentPickerListServiceTests: CoreTestCase {
         testee.courseID = "failureID"
         waitForExpectations(timeout: 0.1)
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "error_loading_assignments")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "error_loading_assignments")
         XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], ["error": "custom error"])
     }
 

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/UTIFromNSItemProviderTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/UTIFromNSItemProviderTests.swift
@@ -31,9 +31,9 @@ class UTIFromNSItemProviderTests: XCTestCase {
 
         _ = MockNSItemProvider(isSupported: true).uti
 
-        XCTAssertEqual(mockAnalyticsHandler.loggedEventCount, 0)
-        XCTAssertNil(mockAnalyticsHandler.lastEventName)
-        XCTAssertNil(mockAnalyticsHandler.lastEventParameters)
+        XCTAssertEqual(mockAnalyticsHandler.totalErrorCount, 0)
+        XCTAssertNil(mockAnalyticsHandler.lastErrorName)
+        XCTAssertNil(mockAnalyticsHandler.lastErrorReason)
     }
 
     func testInvalidUTI() {
@@ -46,9 +46,9 @@ class UTIFromNSItemProviderTests: XCTestCase {
 
         _ = MockNSItemProvider(isSupported: false).uti
 
-        XCTAssertEqual(mockAnalyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(mockAnalyticsHandler.lastEventName, "error_unsupported_file_type")
-        XCTAssertEqual(mockAnalyticsHandler.lastEventParameters as? [String: String], ["error": "test.pcx"])
+        XCTAssertEqual(mockAnalyticsHandler.totalErrorCount, 1)
+        XCTAssertEqual(mockAnalyticsHandler.lastErrorName, "Unsupported file type")
+        XCTAssertEqual(mockAnalyticsHandler.lastErrorReason, "test.pcx")
     }
 }
 

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
@@ -148,12 +148,12 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     func testReportsAssignmentSelectionToAnalytics() {
         let analyticsHandler = MockAnalyticsHandler()
         Analytics.shared.handler = analyticsHandler
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 0)
+        XCTAssertEqual(analyticsHandler.totalEventCount, 0)
 
         testee.assignmentSelected(.init(id: "", name: ""))
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "assignment_selected")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "assignment_selected")
         XCTAssertNil(analyticsHandler.lastEventParameters)
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/CoursePickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/CoursePickerViewModelTests.swift
@@ -79,12 +79,12 @@ class CoursePickerViewModelTests: CoreTestCase {
         let analyticsHandler = MockAnalyticsHandler()
         Analytics.shared.handler = analyticsHandler
         let testee = CoursePickerViewModel()
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1) // courses loaded event
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1) // courses loaded event
 
         testee.courseSelected(.init(id: "", name: ""))
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 2)
-        XCTAssertEqual(analyticsHandler.lastEventName, "course_selected")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 2)
+        XCTAssertEqual(analyticsHandler.lastEvent, "course_selected")
         XCTAssertNil(analyticsHandler.lastEventParameters)
     }
 
@@ -98,8 +98,8 @@ class CoursePickerViewModelTests: CoreTestCase {
 
         _ = CoursePickerViewModel()
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "courses_loaded")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "courses_loaded")
         XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: Int], ["count": 2])
     }
 
@@ -111,8 +111,8 @@ class CoursePickerViewModelTests: CoreTestCase {
 
         _ = CoursePickerViewModel()
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "error_loading_courses")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "error_loading_courses")
         XCTAssertEqual(analyticsHandler.lastEventParameters as? [String: String], ["error": "custom error"])
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModelTests.swift
@@ -94,12 +94,12 @@ class SubmitAssignmentExtensionViewModelTests: CoreTestCase {
     func testReportsCancelToAnalytics() {
         let analyticsHandler = MockAnalyticsHandler()
         Analytics.shared.handler = analyticsHandler
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 0)
+        XCTAssertEqual(analyticsHandler.totalEventCount, 0)
 
         testee.cancelTapped()
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "share_cancelled")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "share_cancelled")
         XCTAssertNil(analyticsHandler.lastEventParameters)
     }
 
@@ -108,12 +108,12 @@ class SubmitAssignmentExtensionViewModelTests: CoreTestCase {
         testee.assignmentPickerViewModel.assignmentSelected(.init(id: "", name: ""))
         let analyticsHandler = MockAnalyticsHandler()
         Analytics.shared.handler = analyticsHandler
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 0)
+        XCTAssertEqual(analyticsHandler.totalEventCount, 0)
 
         testee.submitTapped()
 
-        XCTAssertEqual(analyticsHandler.loggedEventCount, 1)
-        XCTAssertEqual(analyticsHandler.lastEventName, "submit_tapped")
+        XCTAssertEqual(analyticsHandler.totalEventCount, 1)
+        XCTAssertEqual(analyticsHandler.lastEvent, "submit_tapped")
         XCTAssertNil(analyticsHandler.lastEventParameters)
     }
 

--- a/Student/SubmitAssignment/SubmitAssignmentViewController.swift
+++ b/Student/SubmitAssignment/SubmitAssignmentViewController.swift
@@ -78,6 +78,16 @@ class SubmitAssignmentViewController: UIViewController {
 }
 
 extension SubmitAssignmentViewController: Core.AnalyticsHandler {
+
+    func handleScreenView(screenName: String, screenClass: String, application: String) {
+        Firebase.Crashlytics.crashlytics().log("\(screenName) (\(screenClass))")
+    }
+
+    func handleError(_ name: String, reason: String) {
+        let model = ExceptionModel(name: name, reason: reason)
+        Firebase.Crashlytics.crashlytics().record(exceptionModel: model)
+    }
+
     func handleEvent(_ name: String, parameters: [String: Any]?) {
         // Google Analytics needs to be disabled for now
 //        Analytics.logEvent("sharex_\(name)", parameters: parameters)


### PR DESCRIPTION
- Created dedicated methods for screen view and error events instead of using the generic logEvent method and parsing its payload.
- Merged two AnalyticsHandler mock instances into one.
- Added error logging to error cases.

refs: MBL-17047
affects: Student, Teacher, Parent
release note: none

test plan: Check crashlytics error logs after a new version is released with these changes.