### PR TITLE
Disable buttons on login screen in offline mode

### DIFF
--- a/Core/Core/Login/LoginNavigationController.swift
+++ b/Core/Core/Login/LoginNavigationController.swift
@@ -23,7 +23,7 @@ public class LoginNavigationController: UINavigationController {
     var app: App = .student
 
     public static func create(loginDelegate: LoginDelegate, fromLaunch: Bool = false, app: App) -> LoginNavigationController {
-        let startView = LoginStartViewController.create(loginDelegate: loginDelegate, fromLaunch: fromLaunch, app: app)
+        let startView = LoginStartViewController.create(loginDelegate: loginDelegate, fromLaunch: fromLaunch, app: app, offlineModeInteractor: OfflineModeAssembly.make())
         let controller = LoginNavigationController(rootViewController: startView)
         controller.app = app
         controller.loginDelegate = loginDelegate
@@ -38,7 +38,7 @@ public class LoginNavigationController: UINavigationController {
 
     public func login(host: String) {
         viewControllers = [
-            LoginStartViewController.create(loginDelegate: loginDelegate, fromLaunch: false, app: app),
+            LoginStartViewController.create(loginDelegate: loginDelegate, fromLaunch: false, app: app, offlineModeInteractor: OfflineModeAssembly.make()),
             LoginFindSchoolViewController.create(loginDelegate: loginDelegate, method: .normalLogin),
             LoginWebViewController.create(host: host, loginDelegate: loginDelegate, method: .normalLogin),
         ]

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -43,6 +43,7 @@ class LoginStartViewController: UIViewController {
     @IBOutlet weak var qrLoginStackViewTopConstraint: NSLayoutConstraint!
     @IBOutlet weak var buttonStackViewCenterYConstraint: NSLayoutConstraint!
     private var originalButtonStackViewCenterYConstraint: NSLayoutConstraint!
+    private var offlineModeInteractor: OfflineModeInteractor?
 
     let env = AppEnvironment.shared
     weak var loginDelegate: LoginDelegate?
@@ -61,11 +62,16 @@ class LoginStartViewController: UIViewController {
         }
     }
 
-    static func create(loginDelegate: LoginDelegate?, fromLaunch: Bool, app: App) -> LoginStartViewController {
+    static func create(loginDelegate: LoginDelegate?,
+                       fromLaunch: Bool,
+                       app: App,
+                       offlineModeInteractor: OfflineModeInteractor
+    ) -> LoginStartViewController {
         let controller = loadFromStoryboard()
         controller.loginDelegate = loginDelegate
         controller.shouldAnimateFromLaunchScreen = fromLaunch
         controller.app = app
+        controller.offlineModeInteractor = offlineModeInteractor
         return controller
     }
 
@@ -234,16 +240,19 @@ class LoginStartViewController: UIViewController {
     // MARK: - User Actions
 
     @IBAction func canvasNetworkTapped(_ sender: UIButton) {
+        guard isNetworkOnline() else { return }
         let controller = LoginWebViewController.create(host: "learn.canvas.net", loginDelegate: loginDelegate, method: method)
         env.router.show(controller, from: self)
     }
 
     @IBAction func findTapped(_ sender: UIButton) {
+        guard isNetworkOnline() else { return }
         let controller: UIViewController = LoginFindSchoolViewController.create(loginDelegate: loginDelegate, method: method)
         env.router.show(controller, from: self, analyticsRoute: "/login/find")
     }
 
     @IBAction func lastLoginTapped(_ sender: UIButton) {
+        guard isNetworkOnline() else { return }
         var controller: UIViewController = LoginFindSchoolViewController.create(loginDelegate: loginDelegate, method: method)
         var analyticsRoute = "/login/find"
 
@@ -279,6 +288,7 @@ class LoginStartViewController: UIViewController {
     }
 
     @IBAction func scanQRCode(_ sender: UIButton) {
+        guard isNetworkOnline() else { return }
         if app == .parent {
             let sheet = BottomSheetPickerViewController.create()
             sheet.addAction(image: nil, title: NSLocalizedString("I have a Canvas account", comment: "")) { [weak self] in
@@ -298,7 +308,7 @@ class LoginStartViewController: UIViewController {
     }
 
     @IBAction func whatsNewTapped(_ sender: UIButton) {
-        guard let url = loginDelegate?.whatsNewURL else { return }
+        guard let url = loginDelegate?.whatsNewURL, isNetworkOnline() else { return }
         loginDelegate?.openExternalURL(url)
     }
 
@@ -403,6 +413,12 @@ class LoginStartViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.view.layoutIfNeeded()
         }
+    }
+
+    private func isNetworkOnline() -> Bool {
+        guard let offlineModeInteractor = offlineModeInteractor, offlineModeInteractor.isNetworkOffline() else { return true }
+        UIAlertController.showItemNotAvailableInOfflineAlert()
+        return false
     }
 }
 

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -29,12 +29,6 @@ public protocol OfflineModeInteractor {
     func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never>
 }
 
-public extension OfflineModeInteractor {
-    func isNetworkOffline() -> Bool {
-        false
-    }
-}
-
 public final class OfflineModeInteractorLive: OfflineModeInteractor {
     // MARK: - Dependencies
     private let availabilityService: NetworkAvailabilityService

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -23,9 +23,16 @@ import CoreData
 public protocol OfflineModeInteractor {
     func isFeatureFlagEnabled() -> Bool
     func isOfflineModeEnabled() -> Bool
+    func isNetworkOffline() -> Bool
     func observeIsFeatureFlagEnabled() -> AnyPublisher<Bool, Never>
     func observeIsOfflineMode() -> AnyPublisher<Bool, Never>
     func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never>
+}
+
+public extension OfflineModeInteractor {
+    func isNetworkOffline() -> Bool {
+        false
+    }
 }
 
 public final class OfflineModeInteractorLive: OfflineModeInteractor {
@@ -67,6 +74,10 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
         isFeatureFlagEnabled() && isNetworkOffline()
     }
 
+    public func isNetworkOffline() -> Bool {
+        !availabilityService.status.isConnected
+    }
+
     /** Values are published on the main thread. */
     public func observeIsOfflineMode() -> AnyPublisher<Bool, Never> {
         return availabilityService
@@ -93,10 +104,6 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
     }
 
     // MARK: - Private Methods
-
-    private func isNetworkOffline() -> Bool {
-        !availabilityService.status.isConnected
-    }
 
     private func subscribeToOfflineFeatureFlagChanges() {
         offlineFlagStore

--- a/Core/Core/Offline/Model/OfflineModeInteractorMock.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractorMock.swift
@@ -42,6 +42,10 @@ public class OfflineModeInteractorMock: OfflineModeInteractor {
         mockIsInOfflineMode.value
     }
 
+    public func isNetworkOffline() -> Bool {
+        mockIsInOfflineMode.value
+    }
+
     public func observeIsFeatureFlagEnabled() -> AnyPublisher<Bool, Never> {
         mockIsFeatureFlagEnabled.eraseToAnyPublisher()
     }

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractorLiveTests.swift
@@ -106,4 +106,6 @@ class AlwaysOfflineModeInteractor: OfflineModeInteractor {
     func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
         Just(NetworkAvailabilityStatus.disconnected).eraseToAnyPublisher()
     }
+
+    func isNetworkOffline() -> Bool { true }
 }

--- a/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
@@ -312,4 +312,6 @@ private class MockOfflineModeInteractorEnabled: OfflineModeInteractor {
     }
 
     func isOfflineModeEnabled() -> Bool { true }
+
+    func isNetworkOffline() -> Bool { true }
 }

--- a/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
+++ b/Core/CoreTests/DocViewer/DocViewerViewControllerTests.swift
@@ -67,6 +67,8 @@ class DocViewerViewControllerTests: CoreTestCase {
         }
 
         func isOfflineModeEnabled() -> Bool { false }
+
+        func isNetworkOffline() -> Bool { false }
     }
 
     class MockOfflineModeInteractorEnabled: OfflineModeInteractor {
@@ -87,6 +89,8 @@ class DocViewerViewControllerTests: CoreTestCase {
         }
 
         func isOfflineModeEnabled() -> Bool { true }
+
+        func isNetworkOffline() -> Bool { true }
     }
 
     lazy var session: MockSession = {

--- a/Core/CoreTests/Login/LoginStartViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginStartViewControllerTests.swift
@@ -28,7 +28,7 @@ class LoginStartViewControllerTests: CoreTestCase {
     var helpURL: URL?
     var whatsNewURL = URL(string: "whats-new")
 
-    lazy var controller = LoginStartViewController.create(loginDelegate: self, fromLaunch: false, app: .student)
+    lazy var controller = LoginStartViewController.create(loginDelegate: self, fromLaunch: false, app: .student, offlineModeInteractor: OfflineModeInteractorMock())
 
     override func setUp() {
         super.setUp()
@@ -47,7 +47,7 @@ class LoginStartViewControllerTests: CoreTestCase {
             }
         }
 
-        controller = LoginStartViewController.create(loginDelegate: self, fromLaunch: true, app: .student)
+        controller = LoginStartViewController.create(loginDelegate: self, fromLaunch: true, app: .student, offlineModeInteractor: OfflineModeInteractorMock())
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
         XCTAssertEqual(controller.animatableLogo.alpha, 1)
@@ -209,6 +209,28 @@ class LoginStartViewControllerTests: CoreTestCase {
         XCTAssertTrue(controller.canvasNetworkButton.isHidden)
         XCTAssertFalse(controller.useQRCodeButton.isHidden)
         XCTAssertTrue(controller.useQRCodeDivider.isHidden)
+    }
+
+    func testDisabledButtonsWhenOffline() throws {
+        controller = LoginStartViewController.create(loginDelegate: self, fromLaunch: true, app: .student, offlineModeInteractor: OfflineModeInteractorMock(mockIsInOfflineMode: true))
+        controller.view.layoutIfNeeded()
+
+        controller.canvasNetworkButton.sendActions(for: .primaryActionTriggered)
+        XCTAssert(router.viewControllerCalls.last?.0 is UIAlertController)
+        var alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Offline mode")
+
+        controller.findSchoolButton.sendActions(for: .primaryActionTriggered)
+        alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Offline mode")
+
+        controller.lastLoginButton.sendActions(for: .primaryActionTriggered)
+        alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Offline mode")
+
+        controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
+        alert = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(alert.title, "Offline mode")
     }
 }
 

--- a/Core/CoreTests/Login/LoginStartViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginStartViewControllerTests.swift
@@ -219,18 +219,22 @@ class LoginStartViewControllerTests: CoreTestCase {
         XCTAssert(router.viewControllerCalls.last?.0 is UIAlertController)
         var alert = try XCTUnwrap(router.presented as? UIAlertController)
         XCTAssertEqual(alert.title, "Offline mode")
+        router.dismiss()
 
         controller.findSchoolButton.sendActions(for: .primaryActionTriggered)
         alert = try XCTUnwrap(router.presented as? UIAlertController)
         XCTAssertEqual(alert.title, "Offline mode")
+        router.dismiss()
 
         controller.lastLoginButton.sendActions(for: .primaryActionTriggered)
         alert = try XCTUnwrap(router.presented as? UIAlertController)
         XCTAssertEqual(alert.title, "Offline mode")
+        router.dismiss()
 
         controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
         alert = try XCTUnwrap(router.presented as? UIAlertController)
         XCTAssertEqual(alert.title, "Offline mode")
+        router.dismiss()
     }
 }
 

--- a/Core/CoreTests/Offline/View/UITabBarItemOfflineSupportTests.swift
+++ b/Core/CoreTests/Offline/View/UITabBarItemOfflineSupportTests.swift
@@ -64,4 +64,8 @@ private class OfflineModeInteractorMock: OfflineModeInteractor {
     func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
         Just(NetworkAvailabilityStatus.connected(.wifi)).eraseToAnyPublisher()
     }
+
+    func isNetworkOffline() -> Bool {
+        mockedIsInOfflineMode.value
+    }
 }

--- a/Core/CoreTests/Offline/ViewModel/OfflineBannerViewModelTests.swift
+++ b/Core/CoreTests/Offline/ViewModel/OfflineBannerViewModelTests.swift
@@ -114,4 +114,8 @@ private class MockOfflineModeInteractor: OfflineModeInteractor {
             .map { $0 ? NetworkAvailabilityStatus.disconnected : .connected(.wifi)}
             .eraseToAnyPublisher()
     }
+
+    func isNetworkOffline() -> Bool {
+        offlineMode.value
+    }
 }

--- a/Core/CoreTests/Offline/ViewModel/OfflineModeViewModelTests.swift
+++ b/Core/CoreTests/Offline/ViewModel/OfflineModeViewModelTests.swift
@@ -79,4 +79,6 @@ private class MockOfflineModeInteractor: OfflineModeInteractor {
         Just(.disconnected)
             .eraseToAnyPublisher()
     }
+
+    func isNetworkOffline() -> Bool { true }
 }


### PR DESCRIPTION
refs: MBL-17003
affects: Student
release note: none

test plan:
- Go offline
- Any button should result in error popup
- Previous login should work

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
