### PR TITLE
Make dashboard the landing page in offline mode

### DIFF
--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -36,9 +36,13 @@ class StudentTabBarController: UITabBarController {
             viewControllers?.append(inboxTab())
         }
 
-        let paths = [ "/", "/calendar", "/to-do", "/notifications", "/conversations" ]
-        selectedIndex = AppEnvironment.shared.userDefaults?.landingPath
-            .flatMap { paths.firstIndex(of: $0) } ?? 0
+        if OfflineModeAssembly.make().isOfflineModeEnabled() {
+            selectedIndex = 0
+        } else {
+            let paths = [ "/", "/calendar", "/to-do", "/notifications", "/conversations" ]
+            selectedIndex = AppEnvironment.shared.userDefaults?.landingPath
+                .flatMap { paths.firstIndex(of: $0) } ?? 0
+        }
         tabBar.useGlobalNavStyle()
         NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])


### PR DESCRIPTION
refs: MBL-17111
affects: Student
release note: none

test plan:
- Change landing page to something other than the Dashboard
- Go offline
- Change user
- Select the previous user
- Landing page should be the dashboard
- Go back online
- Repeat change user, landing page should be the set value

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
