### PR TITLE
Respect WiFi only sync setting during background sync.

### DIFF
--- a/Core/Core/NetworkAvailability/NetworkAvailabilityService.swift
+++ b/Core/Core/NetworkAvailability/NetworkAvailabilityService.swift
@@ -24,8 +24,8 @@ public protocol NetworkAvailabilityService {
     func startMonitoring()
     func stopMonitoring()
 
-    func startObservingStatus() -> CurrentValueSubject<NetworkAvailabilityStatus, Never>
-    var status: NetworkAvailabilityStatus { get }
+    func startObservingStatus() -> CurrentValueSubject<NetworkAvailabilityStatus?, Never>
+    var status: NetworkAvailabilityStatus? { get }
 }
 
 public final class NetworkAvailabilityServiceLive: NetworkAvailabilityService {
@@ -35,13 +35,13 @@ public final class NetworkAvailabilityServiceLive: NetworkAvailabilityService {
 
     // MARK: - Properties
 
-    public private(set) var status: NetworkAvailabilityStatus = .disconnected {
+    public private(set) var status: NetworkAvailabilityStatus? {
         didSet {
             statusSubject.send(status)
         }
     }
 
-    private let statusSubject = CurrentValueSubject<NetworkAvailabilityStatus, Never>(.disconnected)
+    private let statusSubject = CurrentValueSubject<NetworkAvailabilityStatus?, Never>(nil)
     private var isMonitoring = false
     private let queue = DispatchQueue(label: "\(Bundle.main.appBundleIdentifier).network-availability")
 
@@ -84,7 +84,7 @@ public final class NetworkAvailabilityServiceLive: NetworkAvailabilityService {
         monitor.cancel()
     }
 
-    public func startObservingStatus() -> CurrentValueSubject<NetworkAvailabilityStatus, Never> {
+    public func startObservingStatus() -> CurrentValueSubject<NetworkAvailabilityStatus?, Never> {
         statusSubject
     }
 }

--- a/Core/Core/NetworkAvailability/NetworkAvailabilityStatus.swift
+++ b/Core/Core/NetworkAvailability/NetworkAvailabilityStatus.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public enum NetworkAvailabilityStatus {
+public enum NetworkAvailabilityStatus: Equatable {
     case connected(ConnectionType)
     case disconnected
 
@@ -37,16 +37,6 @@ public enum NetworkAvailabilityStatus {
         switch self {
         case let .connected(connectionType): return connectionType == .wifi
         case .disconnected: return false
-        }
-    }
-}
-
-extension NetworkAvailabilityStatus: Equatable {
-    public static func == (lhs: NetworkAvailabilityStatus, rhs: NetworkAvailabilityStatus) -> Bool {
-        switch (lhs, rhs) {
-        case (.disconnected, .disconnected): return true
-        case let (.connected(lhsType), .connected(rhsType)): return lhsType == rhsType
-        default: return false
         }
     }
 }

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -69,7 +69,7 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
     }
 
     public func isNetworkOffline() -> Bool {
-        !availabilityService.status.isConnected
+        availabilityService.status == nil || availabilityService.status == .disconnected
     }
 
     /** Values are published on the main thread. */
@@ -86,7 +86,7 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
     public func observeNetworkStatus() -> AnyPublisher<NetworkAvailabilityStatus, Never> {
         return availabilityService
             .startObservingStatus()
-            .map { $0 }
+            .compactMap { $0 }
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .eraseToAnyPublisher()


### PR DESCRIPTION
- Also changed the network availability interactor to have an initial state value of nil instead of disconnected so we can decide if the service have received a connection status update from the system or not.

refs: MBL-17134
affects: Student
release note: none

test plan:
- Do an offline sync in the background while sync only on wifi option is set to on.
- Sync should be skipped in this case and a next sync should be scheduled according to the schedule settings.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
