### PR TITLE
Fix text annotation type not being recognized when creating context menu items

### DIFF
--- a/Core/Core/DocViewer/Model/AnnotationContextMenu/DocViewerAnnotationContextMenuModel.swift
+++ b/Core/Core/DocViewer/Model/AnnotationContextMenu/DocViewerAnnotationContextMenuModel.swift
@@ -62,7 +62,7 @@ struct DocViewerAnnotationContextMenuModel {
             newMenuElements.appendUnwrapped(commentMenu)
 
             switch annotation {
-            case is DocViewerFreeTextAnnotation:
+            case is DocViewerFreeTextAnnotation, is FreeTextAnnotation:
                 newMenuElements.append(UIAction.style(annotation: annotation, pageView: pageView))
                 newMenuElements.appendUnwrapped(oldMenu.firstAction(with: .PSPDFKit.editFreeText))
             case is DocViewerInkAnnotation, is DocViewerSquareAnnotation, is DocViewerPointAnnotation:

--- a/Core/CoreTests/DocViewer/Model/AnnotationContextMenu/DocViewerAnnotationContextMenuModelTests.swift
+++ b/Core/CoreTests/DocViewer/Model/AnnotationContextMenu/DocViewerAnnotationContextMenuModelTests.swift
@@ -146,6 +146,20 @@ class DocViewerAnnotationContextMenuModelTests: CoreTestCase {
         XCTAssertEqual(menu[3].title, "Remove")
     }
 
+    func testMenuForTextAnnotationByPSPDFKit() {
+        let testee = makeTestee(isAnnotatingEnabledInApp: true, isAPIEnabledAnnotations: true)
+        let menu = testee.menu(for: [FreeTextAnnotation()],
+                               pageView: pageView,
+                               basedOn: UIMenu(children: [editTextAction]),
+                               container: container)
+            .children
+        XCTAssertEqual(menu.count, 4)
+        XCTAssertEqual(menu[0].title, "Comments")
+        XCTAssertEqual(menu[1].title, "Style")
+        XCTAssertEqual(menu[2].title, "Edit Text")
+        XCTAssertEqual(menu[3].title, "Remove")
+    }
+
     func testMenuForTextStrikeoutAnnotation() {
         let testee = makeTestee(isAnnotatingEnabledInApp: true, isAPIEnabledAnnotations: true)
         let menu = testee.menu(for: [DocViewerStrikeOutAnnotation()],


### PR DESCRIPTION
refs: MBL-17128
affects: Student, Teacher
release note: Fixed text annotation context menu not showing all edit actions without the document being re-opened.

test plan:
- Create a text annotation.
- Tap on it to make its context menu appear.
- 4 context items should appear: Comments, Style, Edit, Remove.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/7e67eb53-1726-4ac2-994b-954e7e23b047" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/1353cc43-2b6f-4644-a903-b425b32cd10f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet