### PR TITLE
Hide unpublished future courses

### DIFF
--- a/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
+++ b/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
@@ -44,11 +44,11 @@ public class CourseListInteractorLive: CourseListInteractor {
         }
 
         Publishers
-            .Zip3(activeCoursesListStore.allObjects.filter(with: searchQuery).print("🟪"),
-                            pastCoursesListStore.allObjects.filter(with: searchQuery).print("✅"),
+            .CombineLatest3(activeCoursesListStore.allObjects.filter(with: searchQuery),
+                            pastCoursesListStore.allObjects.filter(with: searchQuery),
                             futureCoursesListStore.allObjects
                                 .filter(with: searchQuery)
-                                .map { filterUnpublishedCoursesForStudents(env.app, $0) }.print("💎")
+                                .map { filterUnpublishedCoursesForStudents(env.app, $0) }
             )
             .map {
                 CourseListSections(current: $0.0, past: $0.1, future: $0.2)

--- a/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
+++ b/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
@@ -38,7 +38,10 @@ public class CourseListInteractorLive: CourseListInteractor {
         Publishers
             .CombineLatest3(activeCoursesListStore.allObjects.filter(with: searchQuery),
                             pastCoursesListStore.allObjects.filter(with: searchQuery),
-                            futureCoursesListStore.allObjects.filter(with: searchQuery))
+                            futureCoursesListStore.allObjects
+                                .filter(with: searchQuery)
+                                .map { $0.filter { $0.isPublished }}
+            )
             .map {
                 CourseListSections(current: $0.0, past: $0.1, future: $0.2)
             }

--- a/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
+++ b/Core/Core/Courses/CourseList/Model/CourseListInteractorLive.swift
@@ -70,14 +70,6 @@ public class CourseListInteractorLive: CourseListInteractor {
         futureCoursesListStore.exhaust()
     }
 
-    private func filterUnpublishedCoursesForStudents(env: AppEnvironment, _ items: [CourseListItem]) -> [CourseListItem] {
-        if case .student = env.app {
-            return items.filter { $0.isPublished }
-        } else {
-            return items
-        }
-    }
-
     // MARK: - Inputs
 
     public func refresh() -> Future<Void, Never> {

--- a/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
+++ b/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
@@ -80,14 +80,32 @@ class CourseListInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3"])
     }
 
-    func testFutureUnpublishedCourses() {
+    func testFutureUnpublishedCoursesAreHiddenForStudents() {
         let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
         api.mock(futureCourseRequest, value: [
             .make(id: "3", name: "ABC"),
             .make(id: "4", name: "unpublished", workflow_state: .unpublished),
         ])
 
-        XCTAssertFalse(testee.courseList.value.future.contains { $0.courseId == "4" })
+        performRefresh()
+        waitForState(.data)
+
+        XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3"])
+    }
+
+    func testFutureUnpublishedCoursesAreShownForTeachers() {
+        environment.app = .teacher
+
+        let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
+        api.mock(futureCourseRequest, value: [
+            .make(id: "3", name: "ABC"),
+            .make(id: "4", name: "unpublished", workflow_state: .unpublished),
+        ])
+
+        performRefresh()
+        waitForState(.data)
+
+        XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3", "4"])
     }
 
     private func performRefresh() {

--- a/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
+++ b/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
@@ -80,6 +80,16 @@ class CourseListInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3"])
     }
 
+    func testFutureUnpublishedCourses() {
+        let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
+        api.mock(futureCourseRequest, value: [
+            .make(id: "3", name: "ABC"),
+            .make(id: "4", name: "unpublished", workflow_state: .unpublished),
+        ])
+
+        XCTAssertFalse(testee.courseList.value.future.contains { $0.courseId == "4" })
+    }
+
     private func performRefresh() {
         let refreshed = expectation(description: "Expected state reached")
         testee

--- a/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
+++ b/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
@@ -32,7 +32,7 @@ class CourseListInteractorLiveTests: CoreTestCase {
         let pastCourseRequest = GetCourseListCourses(enrollmentState: .completed)
         api.mock(pastCourseRequest, value: [.make(id: "2", name: "AB")])
         let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
-        api.mock(futureCourseRequest, value: [.make(id: "3", name: "ABC")])
+        api.mock(futureCourseRequest, value: [.make(id: "3", name: "ABC", workflow_state: .available)])
 
         testee = CourseListInteractorLive(env: environment)
         testee.loadAsync()

--- a/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
+++ b/Core/CoreTests/Courses/CourseList/Model/CourseListInteractorLiveTests.swift
@@ -16,8 +16,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-@testable import Core
 import Combine
+@testable import Core
+import TestsFoundation
 import XCTest
 
 class CourseListInteractorLiveTests: CoreTestCase {
@@ -41,6 +42,7 @@ class CourseListInteractorLiveTests: CoreTestCase {
 
     override func tearDown() {
         subscriptions.removeAll()
+        testee = nil
         super.tearDown()
     }
 
@@ -83,14 +85,14 @@ class CourseListInteractorLiveTests: CoreTestCase {
     func testFutureUnpublishedCoursesAreHiddenForStudents() {
         let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
         api.mock(futureCourseRequest, value: [
-            .make(id: "3", name: "ABC"),
+            .make(id: "3", name: "ABC", workflow_state: .available),
             .make(id: "4", name: "unpublished", workflow_state: .unpublished),
         ])
 
         performRefresh()
-        waitForState(.data)
-
-        XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3"])
+        waitUntil(shouldFail: true) {
+            testee.courseList.value.future.map { $0.courseId } == ["3"]
+        }
     }
 
     func testFutureUnpublishedCoursesAreShownForTeachers() {
@@ -98,14 +100,14 @@ class CourseListInteractorLiveTests: CoreTestCase {
 
         let futureCourseRequest = GetCourseListCourses(enrollmentState: .invited_or_pending)
         api.mock(futureCourseRequest, value: [
-            .make(id: "3", name: "ABC"),
+            .make(id: "3", name: "ABC", workflow_state: .available),
             .make(id: "4", name: "unpublished", workflow_state: .unpublished),
         ])
 
         performRefresh()
-        waitForState(.data)
-
-        XCTAssertEqual(testee.courseList.value.future.map { $0.courseId }, ["3", "4"])
+        waitUntil(shouldFail: true) {
+            testee.courseList.value.future.map { $0.courseId } == ["3", "4"]
+        }
     }
 
     private func performRefresh() {


### PR DESCRIPTION
refs: MBL-16986
affects: Student
release note: Fixed an issue where future unpublished courses were shown in All Courses menu
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/d6b3baca-d6a5-472c-8109-5831a7df8aab" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/1e65fb51-2804-4fca-a302-7201cad0a21c" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

