### PR TITLE
Improve share extension file upload error handling

### DIFF
--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
@@ -104,7 +104,7 @@ public class AttachmentCopyService {
                 }
                 callback(.success(newURL))
             } catch {
-                Analytics.shared.logError(name: "Failed to get file data", reason: error.localizedDescription)
+                Analytics.shared.logError(name: "Failed to copy shared file to container folder", reason: error.localizedDescription)
                 callback(.failure(error))
             }
         }

--- a/Core/CoreTests/Files/FileSubmission/Model/Submission/BackgroundSessionCompletionTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/Submission/BackgroundSessionCompletionTests.swift
@@ -29,39 +29,20 @@ class BackgroundSessionCompletionTests: XCTestCase {
             callbackExpectation.fulfill()
             XCTAssertEqual(Thread.main, Thread.current)
         }
-        let completionExpectation = expectation(description: "Future completed")
-        let valueExpectation = expectation(description: "Future sent value")
 
-        // MARK: - GIVEN
-        let subscription = testee.backgroundOperationsFinished().sink { _ in
-            completionExpectation.fulfill()
-        } receiveValue: { _ in
-            valueExpectation.fulfill()
-        }
+        // MARK: - WHEN
+        testee.backgroundOperationsFinished()
 
         // MARK: - THEN
         waitForExpectations(timeout: 0.1)
         XCTAssertNil(testee.callback)
-
-        subscription.cancel()
     }
 
-    func testFutureCompletesWhenNoCallbackAvailable() {
+    func testMethodReturnsWhenNoCallbackAvailable() {
         // MARK: - GIVEN
         let testee = BackgroundSessionCompletion()
-        let completionExpectation = expectation(description: "Future completed")
-        let valueExpectation = expectation(description: "Future sent value")
-
-        // MARK: - GIVEN
-        let subscription = testee.backgroundOperationsFinished().sink { _ in
-            completionExpectation.fulfill()
-        } receiveValue: { _ in
-            valueExpectation.fulfill()
-        }
 
         // MARK: - THEN
-        waitForExpectations(timeout: 0.1)
-
-        subscription.cancel()
+        testee.backgroundOperationsFinished()
     }
 }


### PR DESCRIPTION
What changed?
- The app now re-connects to the background URLSession on launch so the status of the upload will be updated when the app is force closed while a background upload was in progress.
- Fixed callback from `handleEventsForBackgroundURLSession` not called when the upload failed.

refs: MBL-16283
affects: Student
release note: none

test plan:
- Start Student app.
- Go to iOS Files app.
- Start a long running file submission.
- Dismiss the upload progress screen.
- Go back to the app.
- Force close the student application.
- Notification regarding the upload state will not arrive due to how OS handles the force close event.
- Start the student app again.
- Failed notification and failed dashboard banner should be visible instead of an in-progress upload state.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet