### PR TITLE
File scanner makes PDF instead of images now.

### DIFF
--- a/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
+++ b/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
@@ -20,6 +20,7 @@ import UIKit
 import MobileCoreServices
 import VisionKit
 import UniformTypeIdentifiers
+import PDFKit
 
 public enum FilePickerSource: Int, CaseIterable {
     case camera, library, files, audio, documentScan
@@ -378,14 +379,17 @@ extension FilePickerViewController: UITableViewDelegate, UITableViewDataSource {
 extension FilePickerViewController: VNDocumentCameraViewControllerDelegate {
     public func documentCameraViewController(_ controller: VNDocumentCameraViewController, didFinishWith scan: VNDocumentCameraScan) {
         controller.dismiss(animated: true)
+        let pdfDocument = PDFDocument()
         for i in 0..<scan.pageCount {
             do {
                 let image = scan.imageOfPage(at: i)
-                add(try image.write())
+                let pdfPage = PDFPage(image: image)
+                pdfDocument.insert(pdfPage, at: i)
             } catch {
                 showError(error)
             }
         }
+        add(pdfDocument.documentURL)
     }
 }
 


### PR DESCRIPTION
refs: MBL-17176
affects: Teacher, Student
release note: Scanner results are merged into a single PDF file.

**What changed?**
The `FilePickerViewController`'s scanner extension no longer adds individual JPEG pages.
The `FilePickerViewController`'s scanner extension now combines JPEG pages into a PDF to submit.


**Test Plan:**
1. Start the Student app.
2. Open an assignment with a file upload.
3. Use the scanner feature.
4. Watch images combine into a PDF for submission.

- [ ] Tested on phone
- [ ] Tested on tablet