### PR TITLE
Fix manage student screen alert and threshold behaviour

### DIFF
--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -53,10 +53,11 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
     }
 
     lazy var thresholds = env.subscribe(GetAlertThresholds(studentID: studentID)) { [weak self] in
+        guard self?.loadingCount == 0 else {
+            return
+        }
         self?.updateThresholds()
     }
-
-    private let semaphore = DispatchSemaphore(value: 0)
 
     func threshold(for type: AlertThresholdType) -> AlertThreshold? {
         return thresholds.first { $0.type == type }
@@ -201,8 +202,6 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
     func fetch<U: UseCase>(_ useCase: U) {
         loadingCount += 1
         useCase.fetch(force: true) { [weak self] _, _, error in
-            self?.semaphore.signal()
-
             performUIUpdate {
                 self?.loadingCount -= 1
                 if let error = error {
@@ -211,7 +210,6 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
                 }
             }
         }
-        semaphore.wait()
     }
 
     func updateLoading() {

--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -207,6 +207,8 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
                 if let error = error {
                     self?.updateThresholds()
                     self?.showError(error)
+                } else if self?.loadingCount == 0 {
+                    self?.updateThresholds()
                 }
             }
         }


### PR DESCRIPTION
refs: MBL-17155
affects: Parent
release note: Fixed an issue on the Manage Student screen where text field got reset after toggling an alert switch
test plan: See ticket

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet