### PR TITLE
Fix double loading indicator on discussion details

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -289,6 +289,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
     }
 
     @objc func refresh() {
+        spinnerView.isHidden = true
         if context.contextType == .course {
             course.refresh(force: true)
         } else {


### PR DESCRIPTION
refs: MBL-16503
affects: Teacher, Student
release note: Fixed an issue where double loading indicators were visible on the discussion details screen
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/231d8b10-cf05-4423-9481-1d80f44a7580" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/e5dd67bd-1657-4b8c-aba2-451715d10b63" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
