### PR TITLE
Fix multi-line file names are not left aligned in SpeedGrader

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListCell.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListCell.swift
@@ -146,6 +146,7 @@ struct SubmissionCommentFile: View {
                 VStack(alignment: .leading, spacing: 0) {
                     Text(file.displayName ?? file.filename)
                         .font(.semibold14).foregroundColor(.textDarkest)
+                        .multilineTextAlignment(.leading)
                     Text(file.size.humanReadableFileSize)
                         .font(.medium12).foregroundColor(.textDark)
                 }


### PR DESCRIPTION
refs: MBL-16501
affects: Teacher
release note: Fixed multi-line file names are not left aligned in SpeedGrader
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/fcd72669-b2df-4d0f-93ad-c1f12e0891ae" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/e86454da-994d-4270-b975-bc760b197f65" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

