### PR TITLE
Fix accent marks not appearing in discussions and announcements

### DIFF
--- a/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
@@ -24,12 +24,7 @@ import Foundation
 extension CoreWebView {
 
     public static func jsString(_ string: String?) -> String {
-        guard var string else { return "null" }
-
-        // These will cause JS syntax errors, removing them will alter character rendering however
-        if let stripped = string.applyingTransform(.stripCombiningMarks, reverse: false) {
-            string = stripped
-        }
+        guard let string else { return "null" }
 
         let escaped = string
             .replacingOccurrences(of: "\\", with: "\\\\")


### PR DESCRIPTION
refs: MBL-17167
affects: Student, Teacher
release note: Fixed accent marks not appearing in discussions and announcements.

test plan: See ticket for details. Check if special characters discussed in MBL-17012 load the web based discussion instead of showing an empty page.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/bef67831-d623-48e9-9f49-fb9898d882bc" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/80ed7735-cbb0-47cb-a690-ca7f1650d082" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
