### PR TITLE
Login screen logo color improvements

### DIFF
--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -85,7 +85,7 @@ class LoginStartViewController: UIViewController {
         }
         authenticationMethodLabel.isHidden = true
         logoView.tintColor = .currentLogoColor()
-        wordmark.tintColor = .currentLogoColor()
+        wordmark.tintColor = .ash
         animatableLogo.tintColor = logoView.tintColor
         previousLoginsView.isHidden = true
         self.lastLoginAccount = nil
@@ -98,7 +98,7 @@ class LoginStartViewController: UIViewController {
             : Bundle.main.isTeacherApp ? "TEACHER"
             : "STUDENT"
         ), attributes: [.kern: 2])
-        wordmarkLabel.textColor = .textDarkest
+        wordmarkLabel.textColor = .currentLogoColor()
         logoView.superview?.accessibilityLabel = "Canvas " + (wordmarkLabel.text ?? "")
         let loginText = NSLocalizedString("Log In", bundle: .core, comment: "")
         if MDMManager.shared.host != nil {


### PR DESCRIPTION
refs: MBL-17163
affects: Student, Teacher, Parent
release note: Updated the login screen logo colors to improve accessibility
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/e47c3ace-5795-4d6d-8ee8-c360d77fdda2" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/fd49db2f-f883-41c7-84fe-d2fdde59d466" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/4b18113d-9b58-4a94-8f68-561a12147b76" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/0ba3c8fe-4bd3-4520-8a08-c9dc28296164" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/d2e9e614-a4dd-461a-ac89-3f09a4fc64db" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/09dd50a8-1110-41c0-b2c7-80c75a522fa4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
