### PR TITLE
Fix grade circle being tappable while in offline mode.

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -90,13 +90,19 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     let titleSubtitleView = TitleSubtitleView.create()
     var presenter: AssignmentDetailsPresenter?
     private let webView = CoreWebView()
+    private var offlineModeInteractor: OfflineModeInteractor?
 
-    static func create(courseID: String, assignmentID: String, fragment: String? = nil) -> AssignmentDetailsViewController {
+    static func create(courseID: String,
+                       assignmentID: String,
+                       fragment: String? = nil,
+                       offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()
+    ) -> AssignmentDetailsViewController {
         let controller = loadFromStoryboard()
         controller.assignmentID = assignmentID
         controller.courseID = courseID
         controller.fragment = fragment
         controller.presenter = AssignmentDetailsPresenter(view: controller, courseID: courseID, assignmentID: assignmentID, fragment: fragment)
+        controller.offlineModeInteractor = offlineModeInteractor
         return controller
     }
 
@@ -408,6 +414,10 @@ extension AssignmentDetailsViewController {
     }
 
     @IBAction func didTapSubmission(_ sender: UIButton) {
-        presenter?.routeToSubmission(view: self)
+        if offlineModeInteractor?.isOfflineModeEnabled() == true {
+            UIAlertController.showItemNotAvailableInOfflineAlert()
+        } else {
+            presenter?.routeToSubmission(view: self)
+        }
     }
 }


### PR DESCRIPTION
refs: MBL-17216
affects: Student
release note: none

test plan:
- Tap the grade circle on the assignment details page while offline.
- A dialog notifying about action not available in offline mode should appear.