### PR TITLE
Add attempt picker to assignment details

### DIFF
--- a/Core/Core/AppEnvironment/FeatureFlags/GetEnabledFeatureFlags.swift
+++ b/Core/Core/AppEnvironment/FeatureFlags/GetEnabledFeatureFlags.swift
@@ -63,7 +63,7 @@ public class GetEnabledFeatureFlags: CollectionUseCase {
     }
 }
 
-extension Store where U == GetEnabledFeatureFlags {
+public extension Store where U == GetEnabledFeatureFlags {
 
     func isFeatureFlagEnabled(_ key: APIFeatureFlag.Key) -> Bool {
         all.contains { flag in

--- a/Core/Core/Store/Store.swift
+++ b/Core/Core/Store/Store.swift
@@ -72,6 +72,10 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate, Ob
     public private(set) var requested: Bool = false
     public private(set) var error: Error?
 
+    #if DEBUG
+    public var isDebugLoggingEnabled = false
+    #endif
+
     private var next: GetNextRequest<U.Response>? {
         didSet {
             hasNextPageSubject.send(next != nil)
@@ -372,10 +376,30 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate, Ob
 
     @objc
     public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        #if DEBUG
+        if isDebugLoggingEnabled {
+            logDebugInfo(controller: controller)
+        }
+        #endif
+
         notify()
         allObjectsSubject.send(all)
         publishState()
     }
+
+    #if DEBUG
+
+    private func logDebugInfo(controller: NSFetchedResultsController<NSFetchRequestResult>) {
+        let objectsInContext = controller.managedObjectContext.registeredObjects.filter { $0 is U.Model }
+        print("====================")
+        print("\(type(of: self)) controllerDidChangeContent")
+        print("\nObjects in context\n", objectsInContext)
+        print("\nFetch request\n", controller.fetchRequest)
+        print("\nFetched objects\n", controller.fetchedObjects ?? [])
+        print("\n====================")
+    }
+
+    #endif
 
     // MARK: -
 }

--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -69,9 +69,10 @@ public class GradeCircleView: UIView {
 
     /**
      - parameters:
+       - submission: If there's no submission the view will become hidden.
        - circleColor: The color of the grade circle. If not specified it will use the default color specified in `CircleProgressView`.
      */
-    public func update(_ assignment: Assignment, circleColor: UIColor? = nil) {
+    public func update(_ assignment: Assignment, submission: Submission?, circleColor: UIColor? = nil) {
         gradeCircle.progress = 1 // make sure it's never spinning
 
         if let circleColor = circleColor {
@@ -81,7 +82,7 @@ public class GradeCircleView: UIView {
         circleComplete.isAccessibilityElement = true
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case
-        guard let submission = assignment.submission, submission.workflowState != .unsubmitted else {
+        guard let submission, submission.workflowState != .unsubmitted else {
             isHidden = true
             return
         }
@@ -117,7 +118,7 @@ public class GradeCircleView: UIView {
 
         // Update the display grade
         displayGrade.isHidden = assignment.gradingType == .points || submission.late == true
-        let gradeText = GradeFormatter.string(from: assignment, style: .short) ?? ""
+        let gradeText = GradeFormatter.string(from: assignment, submission: submission, style: .short) ?? ""
         displayGrade.attributedText = NSAttributedString(string: gradeText, attributes: [NSAttributedString.Key.accessibilitySpeechPunctuation: true])
 
         // Update the outOf label

--- a/Core/CoreTests/UIViews/GradeCircleViewTests.swift
+++ b/Core/CoreTests/UIViews/GradeCircleViewTests.swift
@@ -29,14 +29,14 @@ class GradeCircleViewTests: CoreTestCase {
 
     func testItHidesWhenNoSubmission() {
         let a = Assignment.make()
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.isHidden)
     }
 
     func testItHidesWhenSubmissionIsUnsubmitted() {
         let a = Assignment.make()
         a.submission = Submission.make(from: .make(workflow_state: .unsubmitted))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.isHidden)
     }
 
@@ -46,7 +46,7 @@ class GradeCircleViewTests: CoreTestCase {
             grade: nil,
             workflow_state: .submitted
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.isHidden)
     }
 
@@ -56,14 +56,14 @@ class GradeCircleViewTests: CoreTestCase {
             grade: "complete",
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.circlePoints.isHidden)
         XCTAssertTrue(view.circleLabel.isHidden)
         XCTAssertFalse(view.circleComplete.isHidden)
         XCTAssertTrue(view.circleComplete.image == UIImage.checkSolid)
 
         a.submission?.grade = "incomplete"
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.circleComplete.isHidden)
         XCTAssertTrue(view.circleComplete.image == UIImage.xLine)
     }
@@ -75,7 +75,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 10,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.circlePoints.isHidden)
         XCTAssertFalse(view.circleLabel.isHidden)
         XCTAssertTrue(view.circleComplete.isHidden)
@@ -89,7 +89,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 10,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.circlePoints.isHidden)
         XCTAssertTrue(view.circleLabel.isHidden)
         XCTAssertFalse(view.circleComplete.isHidden)
@@ -105,7 +105,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertEqual(view.circlePoints.text, "80")
         XCTAssertEqual(view.gradeCircle?.progress, 0.8)
         XCTAssertEqual(view.gradeCircle?.accessibilityLabel, "Scored 80 out of 100 points possible")
@@ -122,7 +122,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertEqual(view.circlePoints.isHidden, true)
         XCTAssertEqual(view.gradeCircle?.progress, 1.0)
         XCTAssertEqual(view.gradeCircle?.accessibilityLabel, nil)
@@ -140,7 +140,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.latePenaltyLabel.isHidden)
         XCTAssertFalse(view.finalGradeLabel.isHidden)
         XCTAssertEqual(view.latePenaltyLabel.text, "Late Penalty: -10 pts")
@@ -160,7 +160,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.latePenaltyLabel.isHidden)
         XCTAssertTrue(view.finalGradeLabel.isHidden)
     }
@@ -175,17 +175,17 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.displayGrade.isHidden)
 
         a.gradingType = .gpa_scale
         a.submission?.grade = "3.8"
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.displayGrade.isHidden)
         XCTAssertEqual(view.displayGrade.text, "3.8 GPA")
 
         a.submission?.late = true
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.displayGrade.isHidden)
     }
 
@@ -200,16 +200,16 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.displayGrade.isHidden)
 
         a.gradingType = .gpa_scale
         a.submission?.grade = "3.8"
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.displayGrade.isHidden)
 
         a.submission?.late = true
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertTrue(view.displayGrade.isHidden)
     }
 
@@ -223,7 +223,7 @@ class GradeCircleViewTests: CoreTestCase {
             score: 80,
             workflow_state: .graded
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertEqual(view.circleLabel.text, "Points")
         XCTAssertEqual(view.outOfLabel.text, "Out of 100 pts")
         XCTAssertTrue(view.latePenaltyLabel.isHidden)
@@ -234,7 +234,7 @@ class GradeCircleViewTests: CoreTestCase {
         let a = Assignment.make(from: .make(
             submission: .make(excused: true)
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.isHidden)
         XCTAssertTrue(view.circlePoints.isHidden)
         XCTAssertTrue(view.circleLabel.isHidden)
@@ -251,7 +251,7 @@ class GradeCircleViewTests: CoreTestCase {
                                                               score: 77,
                                                               workflow_state: .graded)
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.isHidden)
         XCTAssertFalse(view.circlePoints.isHidden)
         XCTAssertEqual(view.circlePoints.text, "77")
@@ -271,7 +271,7 @@ class GradeCircleViewTests: CoreTestCase {
                                                               score: 77,
                                                               workflow_state: .graded)
         ))
-        view.update(a)
+        view.update(a, submission: a.submission)
         XCTAssertFalse(view.isHidden)
         XCTAssertTrue(view.circlePoints.isHidden)
         XCTAssertTrue(view.circleLabel.isHidden)

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -214,7 +214,7 @@ class AssignmentDetailsPresenter {
     }
 
     private func updateSubmissionPickerButton() {
-        let isActive = validSubmissions.count > 1
+        let isActive = validSubmissions.count > 1 && features.isFeatureFlagEnabled(.assignmentEnhancements)
         let items: [UIAction] = {
             guard isActive else { return [] }
             return validSubmissions.map { submission in

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -68,6 +68,7 @@ class AssignmentDetailsPresenter {
         self?.update()
     }
     lazy var features = env.subscribe(GetEnabledFeatureFlags(context: .course(courseID))) { [weak self] in
+        self?.updateSubmissionPickerButton()
         self?.update()
     }
 

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -115,6 +115,20 @@ class AssignmentDetailsPresenter {
     }
     private var fileCleanupPending = true
     private var submissionFinishedNotification: NSObjectProtocol?
+    private var validSubmissions: [Submission] {
+        submissions.all.filter { $0.submittedAt != nil }
+    }
+    private var selectedSubmission: Submission? {
+        didSet {
+            if let selectedSubmission {
+                updateAttemptInfo(submission: selectedSubmission)
+            }
+
+            if let assignment {
+                view?.updateGradeCell(assignment, submission: selectedSubmission)
+            }
+        }
+    }
 
     init(view: AssignmentDetailsViewProtocol, courseID: String, assignmentID: String, fragment: String? = nil) {
         self.view = view
@@ -161,7 +175,7 @@ class AssignmentDetailsPresenter {
         let title = submissionButtonPresenter.buttonText(course: course, assignment: assignment, quiz: quizzes?.first, onlineUpload: onlineUploadState)
         view?.showSubmitAssignmentButton(title: title)
         view?.updateNavBar(subtitle: course.name, backgroundColor: course.color)
-        view?.update(assignment: assignment, quiz: quizzes?.first, submission: selectedSubmission, baseURL: baseURL)
+        view?.update(assignment: assignment, quiz: quizzes?.first, submission: selectedSubmission ?? assignment.submission, baseURL: baseURL)
     }
 
     func updateArc() {
@@ -195,21 +209,6 @@ class AssignmentDetailsPresenter {
             onlineUploadState = .uploading
         } else {
             onlineUploadState = .staged
-        }
-    }
-
-    var validSubmissions: [Submission] {
-        submissions.all.filter { $0.submittedAt != nil }
-    }
-    var selectedSubmission: Submission? {
-        didSet {
-            if let selectedSubmission {
-                updateAttemptInfo(submission: selectedSubmission)
-            }
-
-            if let assignment {
-                view?.updateGradeCell(assignment, submission: selectedSubmission)
-            }
         }
     }
 

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -237,18 +237,19 @@
                                                                 <rect key="frame" x="16" y="318" width="311" height="28"/>
                                                                 <subviews>
                                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aEs-0G-CDt">
-                                                                        <rect key="frame" x="31" y="20" width="249" height="0.0"/>
+                                                                        <rect key="frame" x="45" y="20" width="221" height="0.0"/>
                                                                         <subviews>
                                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="completeLine" translatesAutoresizingMaskIntoConstraints="NO" id="dJs-9l-nx3">
-                                                                                <rect key="frame" x="0.0" y="-12" width="24" height="24"/>
+                                                                                <rect key="frame" x="0.0" y="-12" width="0.0" height="24"/>
                                                                                 <color key="tintColor" name="textDarkest"/>
                                                                                 <constraints>
-                                                                                    <constraint firstAttribute="width" constant="24" id="r14-Rk-fJC"/>
+                                                                                    <constraint firstAttribute="width" id="6WF-Zs-pFi"/>
+                                                                                    <constraint firstAttribute="width" priority="999" constant="24" id="r14-Rk-fJC"/>
                                                                                     <constraint firstAttribute="height" constant="24" id="xaN-fk-PHp"/>
                                                                                 </constraints>
                                                                             </imageView>
                                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Successfully submitted!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x12-ry-KqJ" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                                <rect key="frame" x="28" y="0.0" width="221" height="0.0"/>
+                                                                                <rect key="frame" x="0.0" y="0.0" width="221" height="0.0"/>
                                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.submittedText"/>
                                                                                 <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="20"/>
                                                                                 <nil key="textColor"/>
@@ -263,14 +264,15 @@
                                                                         <constraints>
                                                                             <constraint firstItem="x12-ry-KqJ" firstAttribute="top" secondItem="aEs-0G-CDt" secondAttribute="top" id="8wv-Ww-YaN"/>
                                                                             <constraint firstItem="dJs-9l-nx3" firstAttribute="leading" secondItem="aEs-0G-CDt" secondAttribute="leading" id="Pkg-O3-S1f"/>
-                                                                            <constraint firstItem="x12-ry-KqJ" firstAttribute="leading" secondItem="dJs-9l-nx3" secondAttribute="trailing" constant="4" id="V27-4e-tRj"/>
+                                                                            <constraint firstItem="x12-ry-KqJ" firstAttribute="leading" secondItem="dJs-9l-nx3" secondAttribute="trailing" priority="999" constant="4" id="V27-4e-tRj"/>
                                                                             <constraint firstItem="dJs-9l-nx3" firstAttribute="centerY" secondItem="x12-ry-KqJ" secondAttribute="centerY" id="e1h-hG-wCK"/>
                                                                             <constraint firstAttribute="bottom" secondItem="x12-ry-KqJ" secondAttribute="bottom" id="kmx-vE-ksr"/>
                                                                             <constraint firstAttribute="trailing" secondItem="x12-ry-KqJ" secondAttribute="trailing" id="l5n-HB-cRX"/>
+                                                                            <constraint firstItem="x12-ry-KqJ" firstAttribute="leading" secondItem="dJs-9l-nx3" secondAttribute="trailing" id="xjy-t7-zWy"/>
                                                                         </constraints>
                                                                     </view>
                                                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="4TE-cB-TlA" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
-                                                                        <rect key="frame" x="-8" y="28" width="311" height="30"/>
+                                                                        <rect key="frame" x="0.0" y="28" width="311" height="30"/>
                                                                         <state key="normal" title="Button"/>
                                                                         <userDefinedRuntimeAttributes>
                                                                             <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="linkColor"/>
@@ -291,8 +293,8 @@
                                                                     </label>
                                                                 </subviews>
                                                                 <constraints>
-                                                                    <constraint firstItem="4TE-cB-TlA" firstAttribute="leadingMargin" secondItem="A1G-mN-QCX" secondAttribute="leading" id="6oC-8k-h5Z"/>
-                                                                    <constraint firstAttribute="trailingMargin" secondItem="4TE-cB-TlA" secondAttribute="trailing" id="BE6-bh-MVm"/>
+                                                                    <constraint firstItem="4TE-cB-TlA" firstAttribute="leading" secondItem="A1G-mN-QCX" secondAttribute="leading" id="6oC-8k-h5Z"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="4TE-cB-TlA" secondAttribute="trailing" id="BE6-bh-MVm"/>
                                                                     <constraint firstAttribute="bottom" secondItem="ePD-c3-2H7" secondAttribute="bottom" id="Gvg-vX-znb"/>
                                                                     <constraint firstItem="aEs-0G-CDt" firstAttribute="centerX" secondItem="A1G-mN-QCX" secondAttribute="centerX" id="UiM-56-9gA"/>
                                                                     <constraint firstItem="ePD-c3-2H7" firstAttribute="centerX" secondItem="A1G-mN-QCX" secondAttribute="centerX" id="Xjn-JH-Okv"/>
@@ -734,6 +736,8 @@
                         <outlet property="submittedIcon" destination="dJs-9l-nx3" id="hB2-xL-BPA"/>
                         <outlet property="submittedLabel" destination="x12-ry-KqJ" id="VGU-Wa-O6O"/>
                         <outlet property="submittedView" destination="A1G-mN-QCX" id="cgl-eO-esL"/>
+                        <outletCollection property="submittedIconHiddenConstraints" destination="xjy-t7-zWy" collectionClass="NSMutableArray" id="JMa-KK-wGk"/>
+                        <outletCollection property="submittedIconHiddenConstraints" destination="6WF-Zs-pFi" collectionClass="NSMutableArray" id="fbu-Da-Oqh"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cNx-5Z-vOQ" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -163,7 +163,7 @@
                                                                     <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
                                                                 </userDefinedRuntimeAttributes>
                                                             </label>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="haT-9w-5d7" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
+                                                            <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="right" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="haT-9w-5d7" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
                                                                 <rect key="frame" x="97" y="16.5" width="262" height="34"/>
                                                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
                                                                 <state key="normal" title="Button"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -26,7 +26,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var statusLabel: UILabel?
     @IBOutlet weak var attemptPickerSection: UIView?
     @IBOutlet weak var attemptLabel: UILabel?
-    @IBOutlet weak var attemptDateButton: DynamicButton?
+    @IBOutlet weak var attemptDateButton: DynamicButton!
     @IBOutlet weak var gradeHeadingLabel: UILabel?
     @IBOutlet weak var scrollView: UIScrollView?
     @IBOutlet weak var scrollViewBottom: NSLayoutConstraint!
@@ -337,8 +337,6 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         statusLabel?.isHidden = assignment.submissionStatusIsHidden
         statusLabel?.textColor = assignment.submissionStatusColor
         statusLabel?.text = assignment.submissionStatusText
-        attemptLabel?.text = assignment.submissionAttemptNumberText
-        attemptDateButton?.setTitle(assignment.submissionDateText, for: .normal)
         dueSection?.subHeader.text = assignment.dueAt.flatMap {
             $0.dateTimeString
         } ?? NSLocalizedString("No Due Date", bundle: .core, comment: "")
@@ -369,14 +367,6 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         if assignment.hideQuantitativeData, (gradeText ?? "").isEmpty == true {
             showGradeSection = false
         }
-        attemptDateButton?.isEnabled = presenter.isAttemptPickerButtonActive
-
-        if presenter.isAttemptPickerButtonActive {
-            // These will make the icon to display at the end of the label
-            attemptDateButton?.semanticContentAttribute = isLeftToRightLayout ? .forceRightToLeft : .forceLeftToRight
-            attemptDateButton?.setImage(.arrowOpenDownSolid.scaleTo(.init(width: 14, height: 14)), for: .normal)
-            // TODO: Add text <-> image padding when business logic is completed
-        }
 
         attemptsView.isHidden = presenter.attemptsIsHidden()
         gradeSection?.isHidden = !showGradeSection
@@ -395,6 +385,30 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         loadingView.stopAnimating()
         refreshControl?.endRefreshing()
         UIAccessibility.post(notification: .screenChanged, argument: view)
+    }
+
+    func updateAttemptInfo(attemptNumber: String) {
+        attemptLabel?.text = attemptNumber
+    }
+
+    func updateAttemptPickerButton(isActive: Bool,
+                                   attemptDate: String,
+                                   items: [UIAction]) {
+        attemptDateButton.isEnabled = isActive
+        attemptDateButton.setTitle(attemptDate, for: .normal)
+
+        // Since submissions can't be deleted we don't have to handle the case of
+        // turning the active picker to inactive
+        if isActive {
+            // These will make the icon to display at the end of the label
+            attemptDateButton.semanticContentAttribute = isLeftToRightLayout ? .forceRightToLeft : .forceLeftToRight
+            attemptDateButton.setImage(.arrowOpenDownSolid.scaleTo(.init(width: 14, height: 14)), for: .normal)
+            attemptDateButton.changesSelectionAsPrimaryAction = true
+            attemptDateButton.showsMenuAsPrimaryAction = true
+            // TODO: Add text <-> image padding when business logic is completed
+
+            attemptDateButton.menu = UIMenu(children: items)
+        }
     }
 
     func centerLockedIconContainerView() {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -242,8 +242,8 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         navigationController?.navigationBar.useContextColor(backgroundColor)
     }
 
-    func updateGradeCell(_ assignment: Assignment) {
-        self.gradedView?.update(assignment, circleColor: presenter?.courses.first?.color)
+    func updateGradeCell(_ assignment: Assignment, submission: Submission?) {
+        self.gradedView?.update(assignment, submission: submission, circleColor: presenter?.courses.first?.color)
 
         // Update grade statistics view
         if let presenter = presenter {
@@ -256,7 +256,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         // in this case the submission should always be there because canvas generates
         // submissions for every user for every assignment but just in case
-        guard let submission = assignment.submission else {
+        guard let submission else {
             hideGradeCell()
             return
         }
@@ -326,7 +326,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         }
     }
 
-    func update(assignment: Assignment, quiz: Quiz?, baseURL: URL?) {
+    func update(assignment: Assignment, quiz: Quiz?, submission: Submission?, baseURL: URL?) {
         let hideScores = assignment.hideQuantitativeData
         nameLabel?.text = assignment.name
         pointsLabel?.text = hideScores ? nil : assignment.pointsPossibleText
@@ -351,7 +351,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             ? NSLocalizedString("Description", bundle: .student, comment: "")
             : NSLocalizedString("Instructions", bundle: .student, comment: "")
         webView.loadHTMLString(presenter?.assignmentDescription() ?? "", baseURL: baseURL)
-        updateGradeCell(assignment)
+        updateGradeCell(assignment, submission: submission)
 
         guard let presenter = presenter else { return }
 

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -45,6 +45,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var submittedLabel: UILabel?
     @IBOutlet weak var submittedDetailsLabel: UILabel?
     @IBOutlet weak var submittedIcon: UIImageView?
+    @IBOutlet private var submittedIconHiddenConstraints: [NSLayoutConstraint]!
     @IBOutlet weak var submitAssignmentButton: DynamicButton!
 
     @IBOutlet weak var quizAttemptsLabel: UILabel?
@@ -269,6 +270,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         submittedLabel?.textColor = .textDarkest
         submittedLabel?.text = NSLocalizedString("Successfully submitted!", bundle: .student, comment: "")
+        changeSubmittedIconVisibility(to: true)
 
         fileSubmissionButton?.isHidden = true
 
@@ -308,21 +310,25 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             submittedLabel?.text = NSLocalizedString("Resubmission Failed", bundle: .core, comment: "")
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
+            changeSubmittedIconVisibility(to: false)
             return
         case .failed:
             submittedLabel?.text = NSLocalizedString("Submission Failed", bundle: .core, comment: "")
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
+            changeSubmittedIconVisibility(to: false)
             return
         case .uploading:
             submittedLabel?.text = NSLocalizedString("Submission Uploading...", bundle: .core, comment: "")
             submittedLabel?.textColor = .textDarkest
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
+            changeSubmittedIconVisibility(to: false)
             return
         case .staged:
             submittedLabel?.text = NSLocalizedString("Submission In Progress...", bundle: .core, comment: "")
             submittedLabel?.textColor = .textDarkest
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
+            changeSubmittedIconVisibility(to: false)
             return
         case .completed:
             fileSubmissionButton?.isHidden = true
@@ -330,6 +336,10 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
                 filePicker.dismiss(animated: true, completion: nil)
             }
         }
+    }
+
+    private func changeSubmittedIconVisibility(to visible: Bool) {
+        submittedIconHiddenConstraints.forEach { $0.isActive = !visible }
     }
 
     func update(assignment: Assignment, quiz: Quiz?, submission: Submission?, baseURL: URL?) {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -31,7 +31,27 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var scrollView: UIScrollView?
     @IBOutlet weak var scrollViewBottom: NSLayoutConstraint!
     @IBOutlet weak var loadingView: CircleProgressView!
-    @IBOutlet weak var submissionButton: DynamicButton?
+    @IBOutlet weak var submissionButton: DynamicButton! {
+        didSet {
+            var buttonConfig = UIButton.Configuration.plain()
+            buttonConfig.imagePlacement = .trailing
+            buttonConfig.imagePadding = 4
+            buttonConfig.image = .arrowOpenRightSolid
+                .scaleTo(.init(width: 14, height: 14))
+                .withRenderingMode(.alwaysTemplate)
+            buttonConfig.contentInsets = {
+                var result = buttonConfig.contentInsets
+                result.trailing = 0
+                return result
+            }()
+            buttonConfig.titleTextAttributesTransformer = .init { attributes in
+                var result = attributes
+                result.font = UIFont.scaledNamedFont(.regular16)
+                return result
+            }
+            submissionButton?.configuration = buttonConfig
+        }
+    }
     @IBOutlet weak var fileSubmissionButton: DynamicButton?
 
     /** Container for the description title and the divider above it */
@@ -173,23 +193,6 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         fileSubmissionButton?.makeUnavailableInOfflineMode()
         submissionButton?.makeUnavailableInOfflineMode()
 
-        var buttonConfig = UIButton.Configuration.plain()
-        buttonConfig.imagePlacement = .trailing
-        buttonConfig.image = .arrowOpenRightSolid
-            .scaleTo(.init(width: 14, height: 14))
-            .withRenderingMode(.alwaysTemplate)
-        buttonConfig.contentInsets = {
-            var result = buttonConfig.contentInsets
-            result.trailing = 0
-            return result
-        }()
-        buttonConfig.titleTextAttributesTransformer = .init { attributes in
-            var result = attributes
-            result.font = UIFont.scaledNamedFont(.regular16)
-            return result
-        }
-        submissionButton?.configuration = buttonConfig
-
         let border = CAShapeLayer()
         border.strokeColor = UIColor.borderDark.cgColor
         border.lineWidth = 0.5
@@ -270,6 +273,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         submittedLabel?.textColor = .textDarkest
         submittedLabel?.text = NSLocalizedString("Successfully submitted!", bundle: .student, comment: "")
+        submittedDetailsLabel?.isHidden = false
         changeSubmittedIconVisibility(to: true)
 
         fileSubmissionButton?.isHidden = true
@@ -309,24 +313,28 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         case .reSubmissionFailed:
             submittedLabel?.text = NSLocalizedString("Resubmission Failed", bundle: .core, comment: "")
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
+            submittedDetailsLabel?.isHidden = true
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .failed:
             submittedLabel?.text = NSLocalizedString("Submission Failed", bundle: .core, comment: "")
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
+            submittedDetailsLabel?.isHidden = true
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .uploading:
             submittedLabel?.text = NSLocalizedString("Submission Uploading...", bundle: .core, comment: "")
             submittedLabel?.textColor = .textDarkest
+            submittedDetailsLabel?.isHidden = true
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .staged:
             submittedLabel?.text = NSLocalizedString("Submission In Progress...", bundle: .core, comment: "")
             submittedLabel?.textColor = .textDarkest
+            submittedDetailsLabel?.isHidden = true
             fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
@@ -416,13 +424,29 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         // Since submissions can't be deleted we don't have to handle the case of
         // turning the active picker to inactive
         if isActive {
-            // These will make the icon to display at the end of the label
-            attemptDateButton.semanticContentAttribute = isLeftToRightLayout ? .forceRightToLeft : .forceLeftToRight
-            attemptDateButton.setImage(.arrowOpenDownSolid.scaleTo(.init(width: 14, height: 14)), for: .normal)
+            var buttonConfig = UIButton.Configuration.plain()
+            buttonConfig.imagePlacement = .trailing
+            buttonConfig.imagePadding = 6
+            buttonConfig.image = .arrowOpenDownSolid
+                .scaleTo(.init(width: 14, height: 14))
+                .withRenderingMode(.alwaysTemplate)
+            buttonConfig.contentInsets = {
+                var result = buttonConfig.contentInsets
+                result.trailing = 0
+                return result
+            }()
+            if #available(iOS 16.0, *) {
+                buttonConfig.indicator = .none
+            }
+            buttonConfig.titleTextAttributesTransformer = .init { attributes in
+                var result = attributes
+                result.font = UIFont.scaledNamedFont(.regular14)
+                return result
+            }
+            attemptDateButton?.configuration = buttonConfig
+
             attemptDateButton.changesSelectionAsPrimaryAction = true
             attemptDateButton.showsMenuAsPrimaryAction = true
-            // TODO: Add text <-> image padding when business logic is completed
-
             attemptDateButton.menu = UIMenu(children: items)
         }
     }

--- a/Student/Student/Submissions/SubmissionRubric/RubricViewController.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricViewController.swift
@@ -82,7 +82,7 @@ class RubricViewController: UIViewController {
     func addGradeHeader() {
         if let assignment = presenter.assignments.first, showGradeHeader() {
             let gradeCircleView = GradeCircleView(frame: CGRect.zero)
-            gradeCircleView.update(assignment)
+            gradeCircleView.update(assignment, submission: assignment.submission)
             contentStackView.addArrangedSubview(gradeCircleView)
             gradeCircleView.pinToLeftAndRightOfSuperview()
             gradeCircleView.addConstraintsWithVFL("V:[view(156)]")

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -29,7 +29,11 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
     var resultingBaseURL: URL?
     var resultingSubtitle: String?
     var resultingBackgroundColor: UIColor?
-    var presenter: AssignmentDetailsPresenter!
+    var presenter: AssignmentDetailsPresenter! {
+        didSet {
+            (presenter.submissions as! TestStore).overrideRequested = true
+        }
+    }
     var presentedView: UIViewController?
     var resultingButtonTitle: String?
     var navigationController: UINavigationController?
@@ -82,7 +86,7 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         ContextColor.make(canvasContextID: c.canvasContextID)
 
         presenter.colors.eventHandler()
-        XCTAssertEqual(resultingBackgroundColor!.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
+        XCTAssertEqual(resultingBackgroundColor?.hexString, UIColor.red.ensureContrast(against: .backgroundLightest).hexString)
     }
 
     func testLoadAssignment() {
@@ -92,7 +96,7 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         presenter.assignments.eventHandler()
 
         XCTAssertEqual(resultingAssignment, expected)
-        XCTAssertEqual(presenter!.userID!, expected.submission!.userID)
+        XCTAssertEqual(presenter!.userID, expected.submission!.userID)
     }
 
     func testLoadQuiz() {
@@ -559,7 +563,7 @@ class MockView: UIViewController, AssignmentDetailsViewProtocol {
         test?.resultingButtonTitle = title
     }
 
-    func update(assignment: Assignment, quiz: Quiz?, baseURL: URL?) {
+    func update(assignment: Assignment, quiz: Quiz?, submission: Submission?, baseURL: URL?) {
         test?.resultingAssignment = assignment
         test?.resultingBaseURL = baseURL
         test?.resultingQuiz = quiz
@@ -575,5 +579,17 @@ class MockView: UIViewController, AssignmentDetailsViewProtocol {
     func updateNavBar(subtitle: String?, backgroundColor: UIColor?) {
         test?.resultingSubtitle = subtitle
         test?.resultingBackgroundColor = backgroundColor
+    }
+
+    func updateAttemptPickerButton(isActive: Bool, attemptDate: String, items: [UIAction]) {
+
+    }
+
+    func updateGradeCell(_ assignment: Core.Assignment, submission: Core.Submission?) {
+
+    }
+
+    func updateAttemptInfo(attemptNumber: String) {
+
     }
 }

--- a/TestsFoundation/TestsFoundation/Helpers/TestEnvironment.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/TestEnvironment.swift
@@ -67,4 +67,9 @@ public class TestStore<U: UseCase>: Store<U> {
     public override var pending: Bool {
         overridePending ?? super.pending
     }
+
+    public var overrideRequested: Bool?
+    public override var requested: Bool {
+        overrideRequested ?? super.requested
+    }
 }


### PR DESCRIPTION
refs: MBL-16516
affects: Student
release note: Added attempt selector to the assignment details page to institutes where Assignment Enhancements is turned on.

test plan: Go to assignment details and select a previous attempt. Grade box should update to reflect that attempt's grade.

## Screenshots

<table>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/3a631ceb-a317-4e19-bdb7-1496c3bb2fa9" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/c2b49f6e-bead-42b7-8fdc-3590280a81e6" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
