### PR TITLE
Fix links to renamed pages showing an empty screen

### DIFF
--- a/Core/Core/Store/Store.swift
+++ b/Core/Core/Store/Store.swift
@@ -277,6 +277,12 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate, Ob
     // MARK: - Private Methods
 
     private func notify() {
+        #if DEBUG
+        if isDebugLoggingEnabled {
+            logDebugInfo(controller: frc)
+        }
+        #endif
+
         performUIUpdate {
             self.eventHandler()
             self.changes = []
@@ -376,12 +382,6 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate, Ob
 
     @objc
     public func controllerDidChangeContent(_ controller: NSFetchedResultsController<NSFetchRequestResult>) {
-        #if DEBUG
-        if isDebugLoggingEnabled {
-            logDebugInfo(controller: controller)
-        }
-        #endif
-
         notify()
         allObjectsSubject.send(all)
         publishState()
@@ -389,7 +389,7 @@ public class Store<U: UseCase>: NSObject, NSFetchedResultsControllerDelegate, Ob
 
     #if DEBUG
 
-    private func logDebugInfo(controller: NSFetchedResultsController<NSFetchRequestResult>) {
+    private func logDebugInfo(controller: NSFetchedResultsController<U.Model>) {
         let objectsInContext = controller.managedObjectContext.registeredObjects.filter { $0 is U.Model }
         print("====================")
         print("\(type(of: self)) controllerDidChangeContent")

--- a/Core/CoreTests/Pages/GetPageTests.swift
+++ b/Core/CoreTests/Pages/GetPageTests.swift
@@ -73,4 +73,17 @@ class GetPageTests: CoreTestCase {
         GetPage(context: context, url: "front_page").reset(context: databaseClient)
         XCTAssertFalse(previous.isFrontPage)
     }
+
+    /// We request a page by URL and the response is a renamed page with a different url
+    func testRenamedPage() {
+        let useCase = GetPage(context: .course("42"), url: "original-url")
+        useCase.write(response: .make(url: "renamed-url"), urlResponse: nil, to: databaseClient)
+        let pages: [Page] = databaseClient.fetch(scope: useCase.scope)
+
+        guard pages.count == 1, let page = pages.first else {
+            return XCTFail()
+        }
+
+        XCTAssertEqual(page.url, "original-url")
+    }
 }


### PR DESCRIPTION
refs: MBL-17227
affects: Student, Teacher
release note: Fixed links to renamed pages showing an empty screen.

test plan: See ticket

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet