### PR TITLE
Account level group discussion

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2231,7 +2231,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2469,7 +2469,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2806,7 +2806,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2850,7 +2850,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -572,6 +572,7 @@
 		58BC3DAF67041BF7D86C1228 /* CourseSyncPagesInteractorLiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E405146B4B926C52465CC4A9 /* CourseSyncPagesInteractorLiveTests.swift */; };
 		58C36DFEA549200978529250 /* APICourseSectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4767E14ACCF59121D48AEBDC /* APICourseSectionTests.swift */; };
 		58C5F58D123FF4E015C85B01 /* ContextBaseURLInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07F5213469F8CF3FD22FAFA8 /* ContextBaseURLInteractorTests.swift */; };
+		58EE379FC18F3B3BA34B5984 /* ViewAlignments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 730167FE33BB18FDC41367CC /* ViewAlignments.swift */; };
 		58FA698E377BC9B0FB0940E2 /* AnnotationExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09C41E57C513F181F70E45BB /* AnnotationExtensionsTests.swift */; };
 		59403CE9720F92E1057493C1 /* DeveloperMenuViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1ABEE939C0B67F0025AAFBDC /* DeveloperMenuViewController.storyboard */; };
 		5951D1F52B2AF19CA8A2A0EF /* EmbeddedWebPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42056F2E52A046E45BDFD6A4 /* EmbeddedWebPageView.swift */; };
@@ -826,6 +827,7 @@
 		7E7DEA3920DE41710E50E3A5 /* DiscussionReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00E2FEBB6DF08867D94E3CE1 /* DiscussionReplyViewController.swift */; };
 		7EEF6DB42B3B7902481974FF /* GetDashboardCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = C210EEFC3A570EB3CB53D8BC /* GetDashboardCards.swift */; };
 		7EFBFD79D35560A0216FC925 /* WrongAppViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42ED5F8D451890FE9CD85525 /* WrongAppViewController.swift */; };
+		7F0D964934F4B5849033E714 /* SegmentedPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52DE834A021371BC29AF78B5 /* SegmentedPicker.swift */; };
 		7F41FEE0D3C344372DBA4E06 /* PageListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E62C721CCB9860DB64036765 /* PageListViewController.storyboard */; };
 		7F7AA9C7343A3978ED3080C6 /* NotificationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = A18D6CECA93926E3D68A30A0 /* NotificationManager.swift */; };
 		7FE7AC928593722F3A439399 /* AboutInfoEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A495E4836C157AD8DB6BCDAB /* AboutInfoEntryTests.swift */; };
@@ -1159,8 +1161,6 @@
 		B47D227A0865E330DA75FE00 /* DiscussionEntryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E395BCD6AB59AC2045342498 /* DiscussionEntryTests.swift */; };
 		B489A81D6037AD16A513F2BB /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0CC82562D352809583B9955 /* MockURLSession.swift */; };
 		B4A9F8F38D3E9471376494D2 /* UIImageViewExtensionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32E7F1F3185A5D719A85B955 /* UIImageViewExtensionsTests.swift */; };
-		B4D861A42B1A1E72006C6149 /* SegmentedPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D861A32B1A1E72006C6149 /* SegmentedPicker.swift */; };
-		B4D861A62B1A1ECF006C6149 /* ViewAlignments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D861A52B1A1ECF006C6149 /* ViewAlignments.swift */; };
 		B4DF4C098A48DF5D8D497B95 /* CommentListViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F1F0DD981A30F2F8DEF4E68D /* CommentListViewController.storyboard */; };
 		B4FE033171D1FCD00FD1D462 /* FileUploadNotificationCardListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55F96E0F2753D6B4E37E45CF /* FileUploadNotificationCardListViewModel.swift */; };
 		B51884AD83FC462A08BF6B7D /* GoogleCloudAssignmentViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC0DE3267FE05FE686605D8 /* GoogleCloudAssignmentViewController.swift */; };
@@ -1362,7 +1362,6 @@
 		D2FD9F0CE35154CDA63EB588 /* APIAssignmentPickerListItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C977681048E778C187FD119 /* APIAssignmentPickerListItem.swift */; };
 		D31E83925422BBA1373AB854 /* ContextCardGradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E9B361985FD0F05D7C61646 /* ContextCardGradesView.swift */; };
 		D3325F79CCA32071098A7DA9 /* GetQuizSubmissionUsers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58DFFDB020E0A5A5ED8973F0 /* GetQuizSubmissionUsers.swift */; };
-		D3F20F602B2760D500038D00 /* RecipientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F20F5F2B2760D500038D00 /* RecipientTests.swift */; };
 		D3F2C000008898A8049AFEF7 /* CourseSyncItemSelection.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7B3812EED19B5A501744522 /* CourseSyncItemSelection.swift */; };
 		D4439C92D9E84E13A1847D51 /* CoreBGTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5698277AF43025DEFA6BE220 /* CoreBGTask.swift */; };
 		D484C74E299214157F4B69BC /* PageDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2B36ECA65D3C45F7DE5084 /* PageDetailsViewController.swift */; };
@@ -1402,6 +1401,7 @@
 		D9362968957D59A05BC62344 /* Plannable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14CD0262DAB15588F58F27D0 /* Plannable.swift */; };
 		D97BDAC107D3762D85D3745C /* APIAssignmentList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4384A8CE204434E93A84C5E6 /* APIAssignmentList.swift */; };
 		D9B1ECD0B9711A99A5821135 /* GradeListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F06164E46550F7E51ABEAB /* GradeListViewController.swift */; };
+		D9B8634C77E870ACDC207E55 /* RecipientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E6E87E280F764D08C06783F /* RecipientTests.swift */; };
 		D9EF266A1C9C464C142CA7A9 /* APIAssignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA09177DD49B46FB2B46FDFF /* APIAssignment.swift */; };
 		DA434423003DFEFA2F3A1988 /* UIViewExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CED26037996232D09E927A44 /* UIViewExtensions.swift */; };
 		DA9DFE454859799465B4AEA9 /* APISubmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7329E84934D800FEB26F3643 /* APISubmissionTests.swift */; };
@@ -1506,6 +1506,7 @@
 		E8D13CD95C453A5F8ADE0105 /* DashboardInvitationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CE4259E5A4C39F116CE07A /* DashboardInvitationViewModel.swift */; };
 		E8D9105EB889AC8D02C4FBCF /* FileSubmissionStateEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC8DFF2F9C9DE3128272EA3 /* FileSubmissionStateEnumTests.swift */; };
 		E90FF93D771026D3F9185440 /* NavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08EEC4065AFBA4B3184D45A /* NavBarItems.swift */; };
+		E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 39C01BEDACCD811D2E26E465 /* Assets.xcassets */; };
 		E96E73CEE262CF3031FB57F1 /* UITableViewCellExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF940D2EDE1FFDAABED534C /* UITableViewCellExtensions.swift */; };
 		E97625C23463E6E2C5720F0C /* ComposeReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D073364D1D137113E79E7EE /* ComposeReplyViewController.swift */; };
 		E9943F3D5301879352B974C2 /* AnnotationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9B2D4B502A07FB43F83A6C /* AnnotationExtensions.swift */; };
@@ -2093,6 +2094,7 @@
 		398100E89391565EEF55D06E /* InboxFilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFilterBarView.swift; sourceTree = "<group>"; };
 		39A76B2BA67C66D85FFA8C3B /* APIQuizTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIQuizTests.swift; sourceTree = "<group>"; };
 		39B71BCCFA0C836F3827FFEE /* GroupContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModel.swift; sourceTree = "<group>"; };
+		39C01BEDACCD811D2E26E465 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		39DA29562F6F3DBAC71046EA /* DocViewerAnnotationContextMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationContextMenuModelTests.swift; sourceTree = "<group>"; };
 		39DB2B1FD43C6260361A041F /* UITabBarItemOfflineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITabBarItemOfflineSupport.swift; sourceTree = "<group>"; };
 		3A001B6CBC3808DD42C98894 /* FileUploadNotificationCardItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModelTests.swift; sourceTree = "<group>"; };
@@ -2229,7 +2231,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2243,6 +2245,7 @@
 		4DE5E625618CE2A35186A3E3 /* TabBarMessageCountUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarMessageCountUpdaterTests.swift; sourceTree = "<group>"; };
 		4E249DD6423E938E1DE581C9 /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4E2555FE53C883B84B75BE7C /* CommentListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentListViewController.swift; sourceTree = "<group>"; };
+		4E6E87E280F764D08C06783F /* RecipientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipientTests.swift; sourceTree = "<group>"; };
 		4E7806F487365B1F44FD143E /* CoreWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreWebView.swift; sourceTree = "<group>"; };
 		4E7A16122D559CDD2F497160 /* FileProgressListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProgressListViewModel.swift; sourceTree = "<group>"; };
 		4E83E7A273A75E697C4BEB3A /* CourseSyncNotificationInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncNotificationInteractor.swift; sourceTree = "<group>"; };
@@ -2270,6 +2273,7 @@
 		527D59CCA06C67480BDA9CF2 /* SideMenuTransitioning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SideMenuTransitioning.swift; sourceTree = "<group>"; };
 		52808CCD8D47131CF45AB410 /* Todo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Todo.swift; sourceTree = "<group>"; };
 		52B61668FB83D25B11FDB7BE /* ErrorReportViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ErrorReportViewController.storyboard; sourceTree = "<group>"; };
+		52DE834A021371BC29AF78B5 /* SegmentedPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedPicker.swift; sourceTree = "<group>"; };
 		52EA173913BF43B2C7940DCF /* UISplitViewControllerExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensionsTests.swift; sourceTree = "<group>"; };
 		52FB54B48A238C19A44CCEFA /* PreviewStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewStoreTests.swift; sourceTree = "<group>"; };
 		532EB48DBC7D799EBFD5BB20 /* TodoListViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = TodoListViewController.storyboard; sourceTree = "<group>"; };
@@ -2465,7 +2469,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2476,6 +2480,7 @@
 		729E97A807A98834ED225918 /* AssignmentAssigneeList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneeList.swift; sourceTree = "<group>"; };
 		72E958E5413DD54AED7852D5 /* CDCourseSyncDownloadProgressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDCourseSyncDownloadProgressTests.swift; sourceTree = "<group>"; };
 		730093AD8A28FED3B2A5456E /* CourseSyncAnnouncementsInteractorLiveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncAnnouncementsInteractorLiveTests.swift; sourceTree = "<group>"; };
+		730167FE33BB18FDC41367CC /* ViewAlignments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewAlignments.swift; sourceTree = "<group>"; };
 		731D76252A59191DE05173A8 /* K5HomeroomDueItemCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5HomeroomDueItemCount.swift; sourceTree = "<group>"; };
 		7329E84934D800FEB26F3643 /* APISubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APISubmissionTests.swift; sourceTree = "<group>"; };
 		73822829EC7008F774B5DF24 /* AlertThresholdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertThresholdTests.swift; sourceTree = "<group>"; };
@@ -2801,7 +2806,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2845,7 +2850,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
@@ -2913,8 +2918,6 @@
 		B408E358BA052F9B08697E7E /* Hidden.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Hidden.swift; sourceTree = "<group>"; };
 		B455F8753438D40CC45D5A87 /* QuizDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		B467615FEB9F47B169A18150 /* PrimaryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryButton.swift; sourceTree = "<group>"; };
-		B4D861A32B1A1E72006C6149 /* SegmentedPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegmentedPicker.swift; sourceTree = "<group>"; };
-		B4D861A52B1A1ECF006C6149 /* ViewAlignments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewAlignments.swift; sourceTree = "<group>"; };
 		B4F936DF23DC61D04F89DFE0 /* APILatePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APILatePolicyTests.swift; sourceTree = "<group>"; };
 		B52803DBEDEDD92FF68782A9 /* K5GradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesViewModelTests.swift; sourceTree = "<group>"; };
 		B5606C2158AEEDA3F5D8C94A /* APIConference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConference.swift; sourceTree = "<group>"; };
@@ -3113,7 +3116,6 @@
 		D3ABC68A7725FDFC09EDC581 /* NSPersistentStoreExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSPersistentStoreExtensions.swift; sourceTree = "<group>"; };
 		D3B0873C4E11AF89B004B474 /* PermissionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionsTests.swift; sourceTree = "<group>"; };
 		D3EC7B75FA36FECB82127245 /* GetSearchRecipients.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSearchRecipients.swift; sourceTree = "<group>"; };
-		D3F20F5F2B2760D500038D00 /* RecipientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecipientTests.swift; sourceTree = "<group>"; };
 		D41D70AB17259CCFBAFF5796 /* K5ResourcesContactViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ResourcesContactViewModel.swift; sourceTree = "<group>"; };
 		D47D7E0F71DA49A7F37CCE38 /* QuizSubmissionUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizSubmissionUser.swift; sourceTree = "<group>"; };
 		D491E7CDF766D7D8CE20C938 /* NetworkAvailabilityServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkAvailabilityServiceTests.swift; sourceTree = "<group>"; };
@@ -3624,6 +3626,13 @@
 			path = LoginUsePolicy;
 			sourceTree = "<group>";
 		};
+		06E316B51DD023288F6F5F2A /* Container */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Container;
+			sourceTree = "<group>";
+		};
 		07366D79C25F3EDCF5602E22 /* AnnotationTypes */ = {
 			isa = PBXGroup;
 			children = (
@@ -3798,8 +3807,8 @@
 			children = (
 				728252F934E8CC43D49DD373 /* ComposeMessageInteractorLiveTests.swift */,
 				93F29F0201803F6A55FE737D /* ComposeMessageViewModelTests.swift */,
+				4E6E87E280F764D08C06783F /* RecipientTests.swift */,
 				0AADF1A375892CCEA57AE607 /* ReplyMessageInteractorLiveTests.swift */,
-				D3F20F5F2B2760D500038D00 /* RecipientTests.swift */,
 			);
 			path = ComposeMessage;
 			sourceTree = "<group>";
@@ -3912,6 +3921,20 @@
 			path = Dashboard;
 			sourceTree = "<group>";
 		};
+		15769FCE677A9C9F5B0A7CA6 /* CoreWebView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CoreWebView;
+			sourceTree = "<group>";
+		};
+		15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SubmitAssignmentExtension;
+			sourceTree = "<group>";
+		};
 		16AA6C7702C406B9B5672D4C /* CourseSyncProgress */ = {
 			isa = PBXGroup;
 			children = (
@@ -3938,6 +3961,13 @@
 				FD0C7341652D59C8217924A5 /* AllCoursesViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		19958B6AD0248B53014070C5 /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Inbox;
 			sourceTree = "<group>";
 		};
 		19A1E69CFC2A77F0C16AE5EE /* View */ = {
@@ -3978,6 +4008,13 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		1A9F89F6842024B7DC45676B /* Conference */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Conference;
+			sourceTree = "<group>";
+		};
 		1BF94E892CD865E3A2705BC4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -4005,6 +4042,13 @@
 				6947DDE7E7694FBEBD5A9CD1 /* RubricTests.swift */,
 			);
 			path = Assignments;
+			sourceTree = "<group>";
+		};
+		1D548C4AD07209A12F6FCEDE /* FileUploadNotification */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = FileUploadNotification;
 			sourceTree = "<group>";
 		};
 		1F2923A8D008143C233C0A25 /* Logger */ = {
@@ -4056,6 +4100,19 @@
 				12BB118DE8F1D84A956D9291 /* ViewModel */,
 			);
 			path = K5;
+			sourceTree = "<group>";
+		};
+		21207C91941273BDFF517366 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				1A9F89F6842024B7DC45676B /* Conference */,
+				06E316B51DD023288F6F5F2A /* Container */,
+				1D548C4AD07209A12F6FCEDE /* FileUploadNotification */,
+				5F428018966094C386A045C4 /* Group */,
+				78EBA7B29813A53D5A9AD872 /* K5 */,
+				6A3541D8D144C9A887F17564 /* Notification */,
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		21C9309B7D55C2D368DD2B23 /* Model */ = {
@@ -4194,6 +4251,13 @@
 				8133B84109D3E4BEC42DF9B1 /* TermsOfServiceViewController.swift */,
 			);
 			path = TermsOfService;
+			sourceTree = "<group>";
+		};
+		289119BA945905CEECDC6404 /* DocViewer */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DocViewer;
 			sourceTree = "<group>";
 		};
 		29A681523032C9F0460D13DF /* View */ = {
@@ -4939,6 +5003,13 @@
 			path = Syllabus;
 			sourceTree = "<group>";
 		};
+		433DDC5EFFE3D9FE3809D483 /* Quizzes */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Quizzes;
+			sourceTree = "<group>";
+		};
 		436DAF3ABE6692A54F6E1584 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -5005,6 +5076,13 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
+		45AE6AA24575C49F0A193D7F /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
 		45F2AB93913E94E1EB859A8F /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5034,6 +5112,25 @@
 				61A1E8C4C40ECFEDE96D43D0 /* DocViewerAnnotationUploadResponseHandler.swift */,
 			);
 			path = ResponseHandling;
+			sourceTree = "<group>";
+		};
+		46E180A5270BE50B1BAE6E44 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				15769FCE677A9C9F5B0A7CA6 /* CoreWebView */,
+				45AE6AA24575C49F0A193D7F /* Courses */,
+				5C8063761CEE6EF4856E77C9 /* CourseSync */,
+				71D97A1D591434A33BCB62F5 /* Dashboard */,
+				5693A9621060A98BB2BD6BB6 /* DocViewer */,
+				7ACA639B28690D26E3B4BFB8 /* Files */,
+				19958B6AD0248B53014070C5 /* Inbox */,
+				B2525E0E11159C3FC91DB478 /* People */,
+				6A979E40A3CC558130B78B0F /* Profile */,
+				BE9C131EF7967804F6B514B1 /* Quizzes */,
+				15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */,
+				D28C27753F8FCDC43A393D49 /* SwiftUIViews */,
+			);
+			path = Sources;
 			sourceTree = "<group>";
 		};
 		481AA5EAFCF724C6F0F8400C /* Addressbook */ = {
@@ -5241,6 +5338,25 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		52B4A01AA5EDF9DB2E435557 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				A7872205234C480312539802 /* Assignments */,
+				F9F236A5D1B6E9EDBAC590BC /* CoreWebView */,
+				B1C027449ED3388ECF692C1F /* Courses */,
+				F5E62DF4F777D9127A8F5103 /* CourseSync */,
+				21207C91941273BDFF517366 /* Dashboard */,
+				289119BA945905CEECDC6404 /* DocViewer */,
+				A0A4835C7FC94C053347D394 /* Files */,
+				6BC8F6F217D27C91CBF0EA9A /* Inbox */,
+				840120F9E6E51BA5C14E5D6C /* People */,
+				8503617909F61F7E3B54C767 /* Profile */,
+				433DDC5EFFE3D9FE3809D483 /* Quizzes */,
+				602E002B0A978C34B1047394 /* SwiftUIViews */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		53032D265BEF6E1A76A57C41 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -5301,6 +5417,13 @@
 				08A7A5A46E49E3761398CA93 /* K5ImportantDatesViewModel.swift */,
 			);
 			path = ImportantDates;
+			sourceTree = "<group>";
+		};
+		5693A9621060A98BB2BD6BB6 /* DocViewer */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DocViewer;
 			sourceTree = "<group>";
 		};
 		57134DDA24547C9F07DF08CA /* Model */ = {
@@ -5559,6 +5682,13 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		5C8063761CEE6EF4856E77C9 /* CourseSync */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CourseSync;
+			sourceTree = "<group>";
+		};
 		5CDC7EAC7F9AD4B81A819533 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5602,6 +5732,13 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
+		5F428018966094C386A045C4 /* Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Group;
+			sourceTree = "<group>";
+		};
 		5F8CE6C5C98643B733EADFB1 /* Enrollments */ = {
 			isa = PBXGroup;
 			children = (
@@ -5611,6 +5748,13 @@
 				E853CACABF36E865C5682822 /* RoleTests.swift */,
 			);
 			path = Enrollments;
+			sourceTree = "<group>";
+		};
+		602E002B0A978C34B1047394 /* SwiftUIViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SwiftUIViews;
 			sourceTree = "<group>";
 		};
 		61E04C5F9E5CDDF397B8E840 /* Analytics */ = {
@@ -5759,6 +5903,27 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		6A3541D8D144C9A887F17564 /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Notification;
+			sourceTree = "<group>";
+		};
+		6A979E40A3CC558130B78B0F /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		6BC8F6F217D27C91CBF0EA9A /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Inbox;
+			sourceTree = "<group>";
+		};
 		6BD95991C2010238C37A8D4F /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -5806,6 +5971,7 @@
 			isa = PBXGroup;
 			children = (
 				B93949D5CAD36EF43399EDF9 /* Fonts */,
+				39C01BEDACCD811D2E26E465 /* Assets.xcassets */,
 				8E5D3EAD5E2135988C032705 /* defaultHeaderImage.png */,
 			);
 			path = Resources;
@@ -5920,6 +6086,13 @@
 				562A0E1BA178E4D5780B67CD /* TypeSafeCodableTests.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		71D97A1D591434A33BCB62F5 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		71E4B1098694A1A88ECF9D75 /* View */ = {
@@ -6067,6 +6240,14 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		78EBA7B29813A53D5A9AD872 /* K5 */ = {
+			isa = PBXGroup;
+			children = (
+				EE1D34E5E7F6630810F1AA02 /* ViewModel */,
+			);
+			path = K5;
+			sourceTree = "<group>";
+		};
 		792E587F8B67FDCF0560AA5A /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -6092,6 +6273,14 @@
 				0AA93F8945151E6D5E0DA439 /* AssignmentPickerListService.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		7ACA639B28690D26E3B4BFB8 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				81449C16A62B4EE5455B2EE1 /* View */,
+			);
+			path = Files;
 			sourceTree = "<group>";
 		};
 		7CA17FD2C1EABD309B108A6F /* ContextCard */ = {
@@ -6203,6 +6392,13 @@
 			path = Grades;
 			sourceTree = "<group>";
 		};
+		81449C16A62B4EE5455B2EE1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		81B5D9C3B0D9151DDE9446AC /* WidgetsSupport */ = {
 			isa = PBXGroup;
 			children = (
@@ -6276,6 +6472,13 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		840120F9E6E51BA5C14E5D6C /* People */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = People;
+			sourceTree = "<group>";
+		};
 		8418B1360F4D720B0F67277E /* NetworkAvailability */ = {
 			isa = PBXGroup;
 			children = (
@@ -6300,6 +6503,13 @@
 				5C79DD83EC46C1780A24D067 /* ObserverAlertTests.swift */,
 			);
 			path = ObserverAlerts;
+			sourceTree = "<group>";
+		};
+		8503617909F61F7E3B54C767 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Profile;
 			sourceTree = "<group>";
 		};
 		85077BC58E1BBCB5DB69EA98 /* Modules */ = {
@@ -6804,6 +7014,7 @@
 				90C4F82791B3B883003B49C5 /* Quizzes */,
 				01AC5166B8C7F12BA9DCBB93 /* RichContentEditor */,
 				7775E906C5B94F5EEF674386 /* Router */,
+				46E180A5270BE50B1BAE6E44 /* Sources */,
 				9C46FAD063BA96A6109A885E /* Store */,
 				D742111A4E51B5683CB6F9E5 /* Submissions */,
 				13BB69D0F5082096DC44486E /* SubmitAssignmentExtension */,
@@ -7078,6 +7289,13 @@
 			path = QuizDetails;
 			sourceTree = "<group>";
 		};
+		A0A4835C7FC94C053347D394 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
 		A0BB17ACB29B50382F946175 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
@@ -7200,6 +7418,13 @@
 				3C1FF7B151B7D76ED706ACA1 /* Model */,
 			);
 			path = GradingStandard;
+			sourceTree = "<group>";
+		};
+		A7872205234C480312539802 /* Assignments */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Assignments;
 			sourceTree = "<group>";
 		};
 		A7969A53EFE2E8A6649F49D7 /* Announcements */ = {
@@ -7435,6 +7660,14 @@
 			path = Planner;
 			sourceTree = "<group>";
 		};
+		B1C027449ED3388ECF692C1F /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				D808C7EBF928E6D6716D675E /* AllCourses */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
 		B1C34AF4857F4CF312828B87 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
@@ -7444,6 +7677,13 @@
 				DF6B7233D6E932755EAEFF16 /* UserAgent.swift */,
 			);
 			path = Constants;
+			sourceTree = "<group>";
+		};
+		B2525E0E11159C3FC91DB478 /* People */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = People;
 			sourceTree = "<group>";
 		};
 		B28074855E192D3DD1135F4B /* Products */ = {
@@ -7486,13 +7726,6 @@
 				DDECF18B90E29075F2437AA4 /* SnackBarViewModel.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		B4D861A22B1A1D95006C6149 /* SegmentedPicker */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SegmentedPicker;
 			sourceTree = "<group>";
 		};
 		B4E40E49FDE81BC72A546BD8 /* FileList */ = {
@@ -7682,6 +7915,13 @@
 			path = SideMenu;
 			sourceTree = "<group>";
 		};
+		BE9C131EF7967804F6B514B1 /* Quizzes */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Quizzes;
+			sourceTree = "<group>";
+		};
 		BEBC6868A9E2321EAE6FE19E /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -7730,6 +7970,13 @@
 				4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CourseSyncDownloader;
 			sourceTree = "<group>";
 		};
 		C2F6233AB51C459BF3A66F2E /* Model */ = {
@@ -8001,6 +8248,13 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		D28C27753F8FCDC43A393D49 /* SwiftUIViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SwiftUIViews;
+			sourceTree = "<group>";
+		};
 		D2B97380463243815383FBA0 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -8135,6 +8389,13 @@
 				40EE3742920BE5C74E1D7CEB /* CourseSyncProgressViewModelTests.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		D808C7EBF928E6D6716D675E /* AllCourses */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = AllCourses;
 			sourceTree = "<group>";
 		};
 		D820AD1E2667F989BE655351 /* CourseDetails */ = {
@@ -8286,7 +8547,6 @@
 		E23A8DEF257706A56B749495 /* SwiftUIViews */ = {
 			isa = PBXGroup;
 			children = (
-				B4D861A22B1A1D95006C6149 /* SegmentedPicker */,
 				8B63A2B69148EE7B6B72087B /* SnackBar */,
 				19CD1263396ED2F33ECCC0E8 /* TopBar */,
 				DDF8CCBE68133D937B373DC0 /* UIKitSwiftUIBridging */,
@@ -8336,10 +8596,10 @@
 				C195D0C7A18C12BAB2F37B80 /* RemoteImage.swift */,
 				477F146693FF2F5997AC2FA3 /* ScrollViewWithReader.swift */,
 				5865E456E3A9AB65C5D99F2C /* SearchBar.swift */,
+				52DE834A021371BC29AF78B5 /* SegmentedPicker.swift */,
+				730167FE33BB18FDC41367CC /* ViewAlignments.swift */,
 				31FA57BE8C96F27B6DF96068 /* WebSession.swift */,
 				59EA0D1168903B97B0E5EB58 /* WebView.swift */,
-				B4D861A32B1A1E72006C6149 /* SegmentedPicker.swift */,
-				B4D861A52B1A1ECF006C6149 /* ViewAlignments.swift */,
 			);
 			path = SwiftUIViews;
 			sourceTree = "<group>";
@@ -8611,6 +8871,13 @@
 			path = Help;
 			sourceTree = "<group>";
 		};
+		EE1D34E5E7F6630810F1AA02 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		EE47A667792D181291BC8D12 /* BackgroundUpdates */ = {
 			isa = PBXGroup;
 			children = (
@@ -8755,6 +9022,14 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		F5E62DF4F777D9127A8F5103 /* CourseSync */ = {
+			isa = PBXGroup;
+			children = (
+				C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */,
+			);
+			path = CourseSync;
+			sourceTree = "<group>";
+		};
 		F696335407E9880E6BD3C7EA /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -8822,6 +9097,13 @@
 				C28BD7040645C5AE1ADDA23F /* K5ResourcesViewModelTests.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		F9F236A5D1B6E9EDBAC590BC /* CoreWebView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CoreWebView;
 			sourceTree = "<group>";
 		};
 		FA5A00EC8BF93DA0E4394AF8 /* AllCourses */ = {
@@ -8898,6 +9180,7 @@
 				4514D62DB85771B622259882 /* RichContentEditor */,
 				5BB8D351610D5E4BEC708D1D /* Router */,
 				461F876D89C3F74044C343B1 /* ScreenViewLogger */,
+				52B4A01AA5EDF9DB2E435557 /* Sources */,
 				2EEBA6D6C1B2CFC32E23E8A8 /* Store */,
 				7CF3349E196B2FB15B5877A7 /* Submissions */,
 				81DC2E96AD7CC08AD4C6F79C /* SubmitAssignmentExtension */,
@@ -9202,6 +9485,7 @@
 				079FA0F2ED8D8269AF96C452 /* ActAsUserViewController.storyboard in Resources */,
 				8E44734F8D26D951C93716F5 /* AnnouncementListViewController.storyboard in Resources */,
 				EAEF98AAC2663BEC33A37127 /* Assets.xcassets in Resources */,
+				E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */,
 				C12D2EAC3DC60C738EC8807F /* AudioPlayerViewController.storyboard in Resources */,
 				C406485DE3B48D2D910E34F8 /* AudioRecorderViewController.storyboard in Resources */,
 				4061B82BCF8B18D412CF5E6B /* CalendarDayIconView.xib in Resources */,
@@ -9806,6 +10090,7 @@
 				39F5AA922CE54EE63B4C36B8 /* QuizTests.swift in Sources */,
 				0FA5588258533E5EB134522F /* QuizTypeTests.swift in Sources */,
 				531598D6C96B136E0944C1DB /* ReactiveStoreTests.swift in Sources */,
+				D9B8634C77E870ACDC207E55 /* RecipientTests.swift in Sources */,
 				F1A2403DFFCF53BC6A623AA6 /* ReplyMessageInteractorLiveTests.swift in Sources */,
 				2439654E0276FEACFB693030 /* RichContentEditorFileUploadContextTests.swift in Sources */,
 				4476D8F5D2F12C52F3785DE3 /* RichContentEditorViewControllerTests.swift in Sources */,
@@ -9818,7 +10103,6 @@
 				A49430CA2A8761203CB6C96D /* ScriptTests.swift in Sources */,
 				415E3F33B78F1626B43A9EAB /* SearchRecipientTests.swift in Sources */,
 				B20895B04344C8750E52D019 /* SecretTests.swift in Sources */,
-				D3F20F602B2760D500038D00 /* RecipientTests.swift in Sources */,
 				A2F5E6CEE21857A9E716F267 /* SequenceExtensionsTests.swift in Sources */,
 				4A7690949AAA89F186CE2E0E /* SessionDefaultsTests.swift in Sources */,
 				A7AF4AE76E7D89E42604D411 /* SideMenuViewTests.swift in Sources */,
@@ -9996,7 +10280,6 @@
 				9553D105C268C28D20AC6F8E /* AllCoursesViewModel.swift in Sources */,
 				53DE1E7BCEAD43E9C54F0F5A /* AllFileUploadFinishedCheck.swift in Sources */,
 				B5F831A2299EA7366ACC94E3 /* Analytics.swift in Sources */,
-				B4D861A42B1A1E72006C6149 /* SegmentedPicker.swift in Sources */,
 				09A37F808FB98FEEEE4473AA /* AnnotationDragGestureDelegate.swift in Sources */,
 				6F7FCCFFFDC7418816A34808 /* AnnotationDragGestureViewModel.swift in Sources */,
 				E9943F3D5301879352B974C2 /* AnnotationExtensions.swift in Sources */,
@@ -10643,7 +10926,6 @@
 				75B9CA497E0527749565675F /* OfflineBannerViewModel.swift in Sources */,
 				78C6DB6653BAB187BE11BA9E /* OfflineFileInteractor.swift in Sources */,
 				F43A6AD53D12F296F80C54BD /* OfflineModeAssembly.swift in Sources */,
-				B4D861A62B1A1ECF006C6149 /* ViewAlignments.swift in Sources */,
 				1AD12AEDF5BDA186CF3FF2A0 /* OfflineModeEnabledByApp.swift in Sources */,
 				88B8C676C0AFFC04953F57DA /* OfflineModeInteractor.swift in Sources */,
 				449D692F46AD63B08300F679 /* OfflineModeInteractorMock.swift in Sources */,
@@ -10747,6 +11029,7 @@
 				D152C586A3E7451E7CFAA2A1 /* SearchRecipient.swift in Sources */,
 				421CC7BF210AAF12788CB31F /* Secret.swift in Sources */,
 				9E209F3D08AC46FB65ECBBC7 /* SectionHeaderView.swift in Sources */,
+				7F0D964934F4B5849033E714 /* SegmentedPicker.swift in Sources */,
 				D564E55758CBC42949597792 /* SequenceExtensions.swift in Sources */,
 				6B8D12C73ECEC194A243E905 /* SessionDefaults.swift in Sources */,
 				4A74377BB3DB4D76260EFCCA /* SideMenuBottomSection.swift in Sources */,
@@ -10872,6 +11155,7 @@
 				FBBA6988026E5AC7C5EF0FEF /* VideoPlayer.swift in Sources */,
 				2C47F4E69713ECDE9F228538 /* VideoRecorder.swift in Sources */,
 				AE93F2D0240A9FE37E13A227 /* View.swift in Sources */,
+				58EE379FC18F3B3BA34B5984 /* ViewAlignments.swift in Sources */,
 				82979ADFC2A5F3C13423A4AA /* ViewModelState.swift in Sources */,
 				104AA9B442B689BF55FD90B5 /* WKWebViewExtensions.swift in Sources */,
 				D7F30D136C7C9DD00D3DE5AC /* WeakViewController.swift in Sources */,

--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -29,7 +29,6 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case nativeStudentInbox = "native_student_inbox"
     case nativeTeacherInbox = "native_teacher_inbox"
     case K5Dashboard = "enable_K5_dashboard"
-    case hybridDiscussionDetails = "hybrid_discussion_details"
 
     public var isEnabled: Bool {
         get {

--- a/Core/Core/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
+++ b/Core/Core/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
@@ -22,6 +22,7 @@ import Foundation
 public enum EnvironmentFeatureFlags: String {
     case send_usage_metrics
     case mobile_offline_mode
+    case react_discussions_post
 }
 
 public class GetEnvironmentFeatureFlags: CollectionUseCase {

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
@@ -35,15 +35,24 @@ public class EmbeddedWebPageViewModelLive: EmbeddedWebPageViewModel {
      This method assumes that feature flags for the given context are already in CoreData.
      */
     public static func isRedesignEnabled(in context: Context) -> Bool {
-        var featureFlagContext = context
-
         if context.contextType == .group {
+            var featureFlagContext = context
             let group = AppEnvironment.shared.subscribe(GetGroup(groupID: context.id))
             if let courseID = group.first?.courseID {
                 featureFlagContext = Context.course(courseID)
             }
+            return AppEnvironment.shared.subscribe(
+                GetEnvironmentFeatureFlags(context: .currentUser)
+            ).isFeatureEnabled(.react_discussions_post) ||
+            AppEnvironment.shared.subscribe(
+                GetEnabledFeatureFlags(context: featureFlagContext)
+            ).isFeatureFlagEnabled(.discussionRedesign)
+        } else {
+            return AppEnvironment.shared.subscribe(
+                GetEnabledFeatureFlags(context: context)
+            ).isFeatureFlagEnabled(.discussionRedesign)
         }
-        return AppEnvironment.shared.subscribe(GetEnabledFeatureFlags(context: featureFlagContext)).isFeatureFlagEnabled(.discussionRedesign)
+
     }
     @Published public private(set) var subTitle: String?
     @Published public private(set) var contextColor: UIColor?

--- a/Core/CoreTests/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlagsTests.swift
+++ b/Core/CoreTests/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlagsTests.swift
@@ -53,6 +53,7 @@ class GetEnvironmentFeatureFlagsTests: CoreTestCase {
         let response = [
             "send_usage_metrics": true,
             "new_discussions": false,
+            "react_discussions_post": true,
         ]
 
         // UseCase
@@ -63,7 +64,7 @@ class GetEnvironmentFeatureFlagsTests: CoreTestCase {
             to: databaseClient
         )
         let all: [FeatureFlag] = databaseClient.fetch()
-        XCTAssertEqual(all.count, 2)
+        XCTAssertEqual(all.count, 3)
 
         // send_usage_metrics
         let sendUsageMetrics: FeatureFlag? = databaseClient.first(
@@ -100,6 +101,25 @@ class GetEnvironmentFeatureFlagsTests: CoreTestCase {
         )
         XCTAssertEqual(
             newDiscussions?.context?.canvasContextID,
+            context.canvasContextID
+        )
+
+        // react_discussion
+        let reactDiscussionsPost: FeatureFlag? = databaseClient.first(
+            where: #keyPath(FeatureFlag.name),
+            equals: "react_discussions_post"
+        )
+        XCTAssertNotNil(reactDiscussionsPost)
+        XCTAssertEqual(
+            reactDiscussionsPost?.name,
+            "react_discussions_post"
+        )
+        XCTAssertEqual(
+            reactDiscussionsPost?.enabled,
+            true
+        )
+        XCTAssertEqual(
+            reactDiscussionsPost?.context?.canvasContextID,
             context.canvasContextID
         )
     }

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -509,8 +509,7 @@ private func discussionViewController(url: URLComponents, params: [String: Strin
         )
     }
 
-    if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
-       EmbeddedWebPageViewModelLive.isRedesignEnabled(in: context) {
+    if EmbeddedWebPageViewModelLive.isRedesignEnabled(in: context) {
         let viewModel = EmbeddedWebPageViewModelLive(
             context: context,
             webPageType: webPageType

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -41,7 +41,11 @@ class RoutesTests: XCTestCase {
         AppEnvironment.shared.currentSession = LoginSession.make()
         AppEnvironment.shared.loginDelegate = login
         AppEnvironment.shared.router = router
+    }
+
+    override func tearDown() {
         try? AppEnvironment.shared.database.clearAllRecords()
+        super.tearDown()
     }
 
     func testRoutes() {

--- a/Student/StudentUnitTests/RoutesTests.swift
+++ b/Student/StudentUnitTests/RoutesTests.swift
@@ -41,6 +41,7 @@ class RoutesTests: XCTestCase {
         AppEnvironment.shared.currentSession = LoginSession.make()
         AppEnvironment.shared.loginDelegate = login
         AppEnvironment.shared.router = router
+        try? AppEnvironment.shared.database.clearAllRecords()
     }
 
     func testRoutes() {
@@ -87,13 +88,12 @@ class RoutesTests: XCTestCase {
     }
 
     func testNativeDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
         XCTAssert(router.match("/courses/2/discussions/3?origin=module_item_details") is DiscussionDetailsViewController)
         XCTAssert(router.match("/courses/2/discussion_topics/3?origin=module_item_details") is DiscussionDetailsViewController)
     }
 
     func testHybridDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockCourseDiscussionRedesignFlagEnabled(courseId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
@@ -104,13 +104,12 @@ class RoutesTests: XCTestCase {
     }
 
     func testNativeGroupDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
         XCTAssert(router.match("/groups/2/discussions/3?origin=module_item_details") is DiscussionDetailsViewController)
         XCTAssert(router.match("/groups/2/discussion_topics/3?origin=module_item_details") is DiscussionDetailsViewController)
     }
 
     func testHybridGroupDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockGroupDiscussionRedesignFlagEnabled(groupId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
@@ -125,12 +124,11 @@ class RoutesTests: XCTestCase {
     }
 
     func testNativeAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
         XCTAssert(router.match("/courses/2/announcements/3?origin=module_item_details") is DiscussionDetailsViewController)
     }
 
     func testHybridAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockCourseDiscussionRedesignFlagEnabled(courseId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
@@ -140,12 +138,11 @@ class RoutesTests: XCTestCase {
     }
 
     func testNativeGroupAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
         XCTAssert(router.match("/groups/2/announcements/3") is DiscussionDetailsViewController)
     }
 
     func testHybridGroupAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockGroupDiscussionRedesignFlagEnabled(groupId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
@@ -293,5 +290,28 @@ class RoutesTests: XCTestCase {
         api.mock(GetWebSessionRequest(to: expected), error: NSError.internalError())
         router.route(to: "https://canvas.com", from: UIViewController())
         XCTAssertEqual(login.opened, expected)
+    }
+
+    private func mockGroupDiscussionRedesignFlagEnabled(groupId: String = "1") {
+        let context = Context(.group, id: groupId)
+        let response = ["react_discussions_post": true]
+        let useCase = GetEnvironmentFeatureFlags(context: context)
+        useCase.write(
+            response: response,
+            urlResponse: nil,
+            to: AppEnvironment.shared.database.viewContext
+        )
+
+    }
+
+    private func mockCourseDiscussionRedesignFlagEnabled(courseId: String = "1") {
+        let context = Context(.course, id: courseId)
+        let response = ["new_discussions", "no_more_html"]
+        let useCase = GetEnabledFeatureFlags(context: context)
+        useCase.write(
+            response: response,
+            urlResponse: nil,
+            to: AppEnvironment.shared.database.viewContext
+        )
     }
 }

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -199,6 +199,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
+		};
+		B4DA5E972B3094C200E68AE7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
+			remoteInfo = CoreTester;
+		};
+		B4DA5E992B3094C200E68AE7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
+			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -730,6 +744,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
+				B4DA5E982B3094C200E68AE7 /* CoreTester.app */,
+				B4DA5E9A2B3094C200E68AE7 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1019,6 +1035,20 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B4DA5E982B3094C200E68AE7 /* CoreTester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CoreTester.app;
+			remoteRef = B4DA5E972B3094C200E68AE7 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B4DA5E9A2B3094C200E68AE7 /* CoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CoreTests.xctest;
+			remoteRef = B4DA5E992B3094C200E68AE7 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/rn/Teacher/ios/Teacher/Localizable.xcstrings
+++ b/rn/Teacher/ios/Teacher/Localizable.xcstrings
@@ -2673,6 +2673,9 @@
         }
       }
     },
+    "Attempt %lld" : {
+
+    },
     "Attendance" : {
       "localizations" : {
         "ar" : {
@@ -9994,6 +9997,9 @@
         }
       }
     },
+    "Files ((count))" : {
+
+    },
     "Files (%@)" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -10238,9 +10244,6 @@
           }
         }
       }
-    },
-    "Files (%lld)" : {
-
     },
     "Filter" : {
       "localizations" : {

--- a/rn/Teacher/ios/Teacher/Routes.swift
+++ b/rn/Teacher/ios/Teacher/Routes.swift
@@ -374,8 +374,7 @@ private func discussionDetails(url: URLComponents, params: [String: String], use
         return nil
     }
 
-    if ExperimentalFeature.hybridDiscussionDetails.isEnabled,
-       EmbeddedWebPageViewModelLive.isRedesignEnabled(in: context) {
+    if EmbeddedWebPageViewModelLive.isRedesignEnabled(in: context) {
         let viewModel = EmbeddedWebPageViewModelLive(
             context: context,
             webPageType: webPageType

--- a/rn/Teacher/ios/TeacherTests/RoutesTests.swift
+++ b/rn/Teacher/ios/TeacherTests/RoutesTests.swift
@@ -43,6 +43,11 @@ class RoutesTests: XCTestCase {
         AppEnvironment.shared.router = router
     }
 
+    override func tearDown() {
+        try? AppEnvironment.shared.database.clearAllRecords()
+        super.tearDown()
+    }
+
     func testRoutes() {
         XCTAssert(router.match("/courses/2/attendance/5") is AttendanceViewController)
         XCTAssert(router.match("/courses") is CoreHostingController<AllCoursesView>)
@@ -104,13 +109,12 @@ class RoutesTests: XCTestCase {
     }
 
     func testNativeDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
         XCTAssert(router.match("/courses/2/discussions/3") is DiscussionDetailsViewController)
         XCTAssert(router.match("/courses/2/discussion_topics/3") is DiscussionDetailsViewController)
     }
 
     func testHybridDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockCourseDiscussionRedesignFlagEnabled(courseId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
@@ -120,18 +124,41 @@ class RoutesTests: XCTestCase {
         XCTAssert(router.match("/courses/2/discussion_topics/3") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
     }
 
-    func testNativeAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = false
+    func testNativeAnnouncementDiscussionDetailsRoute() throws {
+        try AppEnvironment.shared.database.clearAllRecords()
         XCTAssert(router.match("/courses/2/announcements/3") is DiscussionDetailsViewController)
     }
 
     func testHybridAnnouncementDiscussionDetailsRoute() {
-        ExperimentalFeature.hybridDiscussionDetails.isEnabled = true
+        mockCourseDiscussionRedesignFlagEnabled(courseId: "2")
         let flag = FeatureFlag(context: AppEnvironment.shared.database.viewContext)
         flag.name = "react_discussions_post"
         flag.enabled = true
         flag.context = .course("2")
 
         XCTAssert(router.match("/courses/2/announcements/3") is CoreHostingController<EmbeddedWebPageView<EmbeddedWebPageViewModelLive>>)
+    }
+
+    private func mockGroupDiscussionRedesignFlagEnabled(groupId: String = "1") {
+        let context = Context(.group, id: groupId)
+        let response = ["react_discussions_post": true]
+        let useCase = GetEnvironmentFeatureFlags(context: context)
+        useCase.write(
+            response: response,
+            urlResponse: nil,
+            to: AppEnvironment.shared.database.viewContext
+        )
+
+    }
+
+    private func mockCourseDiscussionRedesignFlagEnabled(courseId: String = "1") {
+        let context = Context(.course, id: courseId)
+        let response = ["new_discussions", "no_more_html"]
+        let useCase = GetEnabledFeatureFlags(context: context)
+        useCase.write(
+            response: response,
+            urlResponse: nil,
+            to: AppEnvironment.shared.database.viewContext
+        )
     }
 }


### PR DESCRIPTION
Added support for `react_discussions_post` environment feature flag to support account level group discussion. 

refs: MBL-16420
affects: Student, Teacher
release note: Added support for Redesigned Discussions
test plan: Test account level group discussions

## Screenshots

<table>
<tr><th>Account level group discussion</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/297b4a2d-030b-42ad-becd-597fdc2756b3" height=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
