### PR TITLE
Fix parent remind me colors

### DIFF
--- a/Core/Core/SwiftUIViews/CoreDatePicker.swift
+++ b/Core/Core/SwiftUIViews/CoreDatePicker.swift
@@ -87,7 +87,7 @@ public struct CoreDatePickerActionSheetCard: View {
                     Text("Cancel", bundle: .core)
                         .font(.regular17)
                         .foregroundStyle(
-                            Color(uiColor: .electricHighContrast.ensureContrast(against: .backgroundLightest))
+                            Color(uiColor: Brand.shared.primary.darkenToEnsureContrast(against: .backgroundLightest))
                         )
                 }
                 Spacer()

--- a/Core/Core/SwiftUIViews/CoreDatePicker.swift
+++ b/Core/Core/SwiftUIViews/CoreDatePicker.swift
@@ -74,7 +74,7 @@ public struct CoreDatePickerActionSheetCard: View {
             }.ignoresSafeArea()
         }
         .onAppear {
-            grayViewOpacity = 0.5
+            grayViewOpacity = 0.05
         }
     }
 
@@ -86,6 +86,7 @@ public struct CoreDatePickerActionSheetCard: View {
                 } label: {
                     Text("Cancel", bundle: .core)
                         .font(.regular17)
+                        .foregroundStyle(Color.electric)
                 }
                 Spacer()
                 Button {
@@ -94,6 +95,7 @@ public struct CoreDatePickerActionSheetCard: View {
                 } label: {
                     Text("Done", bundle: .core)
                         .font(.regular17)
+                        .foregroundStyle(Color.electric)
                 }
             }
             .padding(.horizontal, 16)

--- a/Core/Core/SwiftUIViews/CoreDatePicker.swift
+++ b/Core/Core/SwiftUIViews/CoreDatePicker.swift
@@ -86,7 +86,9 @@ public struct CoreDatePickerActionSheetCard: View {
                 } label: {
                     Text("Cancel", bundle: .core)
                         .font(.regular17)
-                        .foregroundStyle(Color.electric)
+                        .foregroundStyle(
+                            Color(uiColor: .electricHighContrast.ensureContrast(against: .backgroundLightest))
+                        )
                 }
                 Spacer()
                 Button {
@@ -95,7 +97,9 @@ public struct CoreDatePickerActionSheetCard: View {
                 } label: {
                     Text("Done", bundle: .core)
                         .font(.regular17)
-                        .foregroundStyle(Color.electric)
+                        .foregroundStyle(
+                            Color(uiColor: Brand.shared.primary.darkenToEnsureContrast(against: .backgroundLightest))
+                        )
                 }
             }
             .padding(.horizontal, 16)

--- a/Core/Core/SwiftUIViews/CoreDatePicker.swift
+++ b/Core/Core/SwiftUIViews/CoreDatePicker.swift
@@ -74,7 +74,7 @@ public struct CoreDatePickerActionSheetCard: View {
             }.ignoresSafeArea()
         }
         .onAppear {
-            grayViewOpacity = 0.05
+            grayViewOpacity = 0.5
         }
     }
 
@@ -113,7 +113,7 @@ public struct CoreDatePickerActionSheetCard: View {
         Rectangle()
             .frame(width: .infinity,
                    height: .infinity)
-            .background(Color.clear)
+            .foregroundColor(.black)
             .ignoresSafeArea()
     }
 

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -99,7 +99,10 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         reminderSwitch.isEnabled = false
         reminderDateButton.isEnabled = false
         reminderDateButton.isHidden = true
-        reminderDateButton.setTitleColor(.electric, for: .normal)
+        reminderDateButton.setTitleColor(
+            Brand.shared.primary.ensureContrast(against: .backgroundLightest),
+            for: .normal
+        )
 
         statusLabel.text = ""
 

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -99,7 +99,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         reminderSwitch.isEnabled = false
         reminderDateButton.isEnabled = false
         reminderDateButton.isHidden = true
-        reminderDateButton.setTitleColor(Brand.shared.primary, for: .normal)
+        reminderDateButton.setTitleColor(.electric, for: .normal)
 
         statusLabel.text = ""
 


### PR DESCRIPTION
refs: MBL-17223
affects: Student, Parent
release note: Fixed accessibility color issues when selecting a reminder date
test plan: See ticket

## Screenshots

<table>
<tr><th>Before- Dark</th><th>After - Dark</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/1e743a85-9a70-4836-a403-9a7c7c4ca2b7" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/a6a7aca9-baf9-4a65-b595-3e647092a186" maxHeight=500></td>
</tr>
<tr><th>Before - Light</th><th>After - Light</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/efc67ef8-ffcc-471f-9a79-1d9ed37d3b21" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/42e51d6c-3b3a-45bd-98b0-3f548dac4db6" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
