### PR TITLE
Update translation import script

### DIFF
--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -68,7 +68,6 @@ function run(cmd, args, opts) {
     command.on('error', reject)
     command.on('exit', code => {
       if (code === 0) return resolve()
-      console.error(command.stderr.toString())
       reject(`${cmd} failed with code ${code}.`)
     })
   })

--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -21,7 +21,7 @@ const program = require('commander')
 const { spawn } = require('child_process')
 const { createReadStream, readFileSync, writeFileSync } = require('fs')
 const S3 = require('aws-sdk/clients/s3')
-const projects = require('./projects.json')
+const localizables = require('./localizables.json')
 
 program
   .version(require('../../package.json').version)
@@ -75,7 +75,9 @@ function run(cmd, args, opts) {
 
 async function exportTranslations() {
   const toUpload = []
-  await processReactLocalizations(toUpload)
+  // install react dependencies
+  const reactProjectFolder = 'rn/Teacher/i18n/locales'
+  await run('yarn', [], { cwd: `${reactProjectFolder}/../..` })
   await run('make', ['pod'])
   await processNativeLocalizations(toUpload)
   await pushToS3(toUpload)
@@ -92,13 +94,6 @@ async function processNativeLocalizations(toUpload) {
   xml = removeNonLocalizedKeys(xml)
   writeFileSync(outputFile, xml, 'utf8')
   toUpload.push({ from: outputFile, to: `all.xliff` })
-}
-
-async function processReactLocalizations(toUpload) {
-  const reactProjectFolder = 'rn/Teacher/i18n/locales'
-  await run('yarn', [], { cwd: `${reactProjectFolder}/../..` }) // install dependencies
-  await run('yarn', ['extract-strings'], { cwd: `${reactProjectFolder}/../..` })
-  toUpload.push({ from: `${reactProjectFolder}/en.json`, to: 'teacher.json' })
 }
 
 async function pushToS3(toUpload) {
@@ -131,29 +126,12 @@ async function exportLocalizations(outputPath) {
 }
 
 function removeNonLocalizedFiles(xml) {
-  // Remove files we don't want to localize
-  const filesToLocalize = [
-	'Core/Core/Localizable.xcstrings',
-    'CanvasCore/CanvasCore/Localizable.xcstrings',
-    'Parent/Parent/InfoPlist.xcstrings',
-    'Parent/Parent/Localizable.xcstrings',
-    'rn/Teacher/ios/Teacher/InfoPlist.xcstrings',
-    'rn/Teacher/ios/Teacher/Localizable.xcstrings',
-    'Student/Student/InfoPlist.xcstrings',
-    'Student/Student/Localizable.xcstrings',
-    'Student/SubmitAssignment/InfoPlist.xcstrings',
-    'Student/SubmitAssignment/Localizable.xcstrings',
-    'Student/Widgets/Resources/InfoPlist.xcstrings',
-    'Student/Widgets/Resources/Localizable.xcstrings'
-    // TODO: Add settings bundle strings
-  ]
-
   // Matches file tags with original attribute
   const pattern = new RegExp(`<file\\s+original="([^"]+)"[^>]*>[\\s\\S]*?<\\/file>`, 'g')
 
   // Replace non-matching files with an empty string
   let result = xml.replace(pattern, (match, p1) => {
-    return filesToLocalize.includes(p1) ? match : ''
+    return localizables.includes(p1) ? match : ''
   })
   
   // Remove empty lines

--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -26,7 +26,7 @@ const projects = require('./projects.json')
 program
   .version(require('../../package.json').version)
   .option('-s, --skipPush', 'Skip pushing to S3')
-  .option('-v, --verbose', 'Print xcodebuild output to console')
+  .option('-v, --verbose', 'Print all outputs to console')
 
 program.on('--help', () => {
   console.log(`

--- a/scripts/translations/import.js
+++ b/scripts/translations/import.js
@@ -29,7 +29,7 @@ program
   .version(require('../../package.json').version)
   .option('-s, --skip-pull', 'Skip pulling from S3')
   .option('-n, --no-import', 'Skip importing downloaded files')
-  .option('-v, --verbose', 'Print xcodebuild output to console')
+  .option('-v, --verbose', 'Print all outputs to console')
 
 program.on('--help', () => {
   console.log(`
@@ -127,8 +127,9 @@ async function importTranslations() {
 async function importXcodeTranslations() {
   console.log(`Importing Xcode translations`)
   
+  // install react dependencies
   const reactProjectFolder = 'rn/Teacher/i18n/locales'
-  await run('yarn', [], { cwd: `${reactProjectFolder}/../..` }) // install react dependencies
+  await run('yarn', [], { cwd: `${reactProjectFolder}/../..` }) 
 
   await run('make', ['pod'])
   const folder = 'scripts/translations/imports/all'

--- a/scripts/translations/import.js
+++ b/scripts/translations/import.js
@@ -127,6 +127,9 @@ async function importTranslations() {
 async function importXcodeTranslations() {
   console.log(`Importing Xcode translations`)
   
+  const reactProjectFolder = 'rn/Teacher/i18n/locales'
+  await run('yarn', [], { cwd: `${reactProjectFolder}/../..` }) // install react dependencies
+
   await run('make', ['pod'])
   const folder = 'scripts/translations/imports/all'
   const files = await new Promise(resolve =>

--- a/scripts/translations/import.js
+++ b/scripts/translations/import.js
@@ -78,7 +78,7 @@ function run(cmd, args, opts) {
 
 async function importTranslations() {
   if (!program.skipPull) {
-  	await pullTranslationsFromS3()
+    await pullTranslationsFromS3()
   }
 
   if (program.import) {

--- a/scripts/translations/localizables.json
+++ b/scripts/translations/localizables.json
@@ -1,0 +1,14 @@
+[
+  "Core/Core/Localizable.xcstrings",
+  "CanvasCore/CanvasCore/Localizable.xcstrings",
+  "Parent/Parent/InfoPlist.xcstrings",
+  "Parent/Parent/Localizable.xcstrings",
+  "rn/Teacher/ios/Teacher/InfoPlist.xcstrings",
+  "rn/Teacher/ios/Teacher/Localizable.xcstrings",
+  "Student/Student/InfoPlist.xcstrings",
+  "Student/Student/Localizable.xcstrings",
+  "Student/SubmitAssignment/InfoPlist.xcstrings",
+  "Student/SubmitAssignment/Localizable.xcstrings",
+  "Student/Widgets/Resources/InfoPlist.xcstrings",
+  "Student/Widgets/Resources/Localizable.xcstrings"
+]

--- a/scripts/translations/projects.json
+++ b/scripts/translations/projects.json
@@ -1,6 +1,0 @@
-[{"name": "core",             "location": "Core/Core.xcodeproj"},
- {"name": "parent",           "location": "Parent/Parent.xcodeproj"},
- {"name": "teacher_native",   "location": "rn/Teacher/ios/Teacher.xcodeproj"},
- {"name": "teacher",          "location": "rn/Teacher/i18n/locales", "json": true},
- {"name": "student",          "location": "Student/Student.xcodeproj"},
- {"name": "canvas_core",      "location": "CanvasCore/CanvasCore.xcodeproj"}]


### PR DESCRIPTION
### Export Script
- Removed exporting of react-native translations.
- Deleted step that made PR of new english react strings.
- Removed hub dependency install step that was use by the PR creation step.
- Extracted localizable files list to external file so the import script also can use it.

### Import Script
- Modified the script to use new string catalogs.
- Builds now can fail in case of a misformatted translation so I added the `affects` line to the translations import PR to trigger all app builds and reveal any compilation errors.
- Removed importing of react-native translations.

refs: MBL-17281
affects: Student, Teacher, Parent
release note: none

test plan: New translations should be correctly imported.

Example [PR](https://github.com/instructure/canvas-ios/pull/2682) is here, just ignore the changes from this branch.
