### PR TITLE
Add background to rubric description popup

### DIFF
--- a/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricLongDescriptionViewController.swift
@@ -36,6 +36,7 @@ class RubricLongDescriptionViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        view.backgroundColor = .backgroundLightest
 
         self.addDoneButton()
 


### PR DESCRIPTION
refs: MBL-17217
affects: Student
release note: Fixed transparent background on rubric description popup.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/7281fd40-2d0f-4c4a-9508-7e559b063d36" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/ff593665-176d-47e5-b7d3-06115b85b3fd" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/8d54e888-df5f-413c-abb2-a53d58b5afd8" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/34bfb1b2-2b23-4340-811e-e40a39e13e36" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
