### PR TITLE
Fixed module item screen dismissing itself sometimes

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -225,11 +225,6 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
     func update() {
         guard fixStudentGroupTopic() else { return }
 
-        if topic.state == .empty {
-            // Topic was deleted, go back.
-            env.router.dismiss(self)
-        }
-
         let courseID = context.contextType == .group ? group.first?.courseID : context.id
         if assignment?.useCase.assignmentID != topic.first?.assignmentID, let courseID = courseID {
             assignment = topic.first?.assignmentID.map {

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -406,16 +406,6 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
         XCTAssertEqual(sheet?.actions.first?.title, "Mark as Unread")
     }
 
-    func testDeletedAfterShown() throws {
-        controller.view.layoutIfNeeded()
-        controller.viewWillAppear(false)
-
-        databaseClient.delete(controller.topic.all)
-        try databaseClient.save()
-
-        XCTAssert(router.dismissed == controller)
-    }
-
     func testDetectsNewReplyFromUser() {
         controller.view.layoutIfNeeded()
 


### PR DESCRIPTION
refs: MBL-17219
affects: Student, Teacher
release note: Fixed module item screen dismissing itself sometimes.

test plan:
- See ticket for video.
- Try these:
  - Go to a module item.
  - Switch between module items.
  - Go to a module item after a fresh install.
- Rarely the module item screen pops back to modules list (sometimes it does 2 pops) after a short loading.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
- [x] Approve from product
