### PR TITLE
Handle K5 and other WebView embedded LTI button launches

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -358,8 +358,8 @@ extension CoreWebView: WKNavigationDelegate {
 
         // Handle "Launch External Tool" button OR 
         // LTI app buttons embedded in K5 WebViews when there's no additional JavaScript
-        // is involved (Zoom, Microsoft).
-        // When there's additional JavaScript code behind an LTI Button (DBQ Online), we don't want to
+        // is involved (like Zoom and Microsoft).
+        // When there's additional JavaScript code behind an LTI Button (like DBQ Online), we don't want to
         // handle those cases here, because `createWebViewWith` already opened a new popup window.
         if (action.navigationType == .linkActivated || action.navigationType == .other),
             let tools = LTITools(link: action.request.url),

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -361,8 +361,7 @@ extension CoreWebView: WKNavigationDelegate {
         // involved (like Zoom and Microsoft).
         // When there's additional JavaScript code behind an LTI Button (like DBQ Online), we don't want to
         // handle those cases here, because `createWebViewWith` already opened a new popup window.
-        if (action.navigationType == .linkActivated || action.navigationType == .other),
-            let tools = LTITools(link: action.request.url),
+        if let tools = LTITools(link: action.request.url, navigationType: action.navigationType),
             let from = linkDelegate?.routeLinksFrom {
             tools.presentTool(from: from, animated: true)
             return decisionHandler(.cancel)

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -358,7 +358,7 @@ extension CoreWebView: WKNavigationDelegate {
 
         // Handle "Launch External Tool" button OR 
         // LTI app buttons embedded in K5 WebViews when there's no additional JavaScript
-        // is involved (like Zoom and Microsoft).
+        // involved (like Zoom and Microsoft).
         // When there's additional JavaScript code behind an LTI Button (like DBQ Online), we don't want to
         // handle those cases here, because `createWebViewWith` already opened a new popup window.
         if (action.navigationType == .linkActivated || action.navigationType == .other),

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -356,8 +356,13 @@ extension CoreWebView: WKNavigationDelegate {
             return decisionHandler(.allow) // let web view scroll to link too, if necessary
         }
 
-        // Handle "Launch External Tool" button
-        if action.navigationType == .linkActivated, let tools = LTITools(link: action.request.url),
+        // Handle "Launch External Tool" button OR 
+        // LTI app buttons embedded in K5 WebViews when there's no additional JavaScript
+        // is involved (Zoom, Microsoft).
+        // When there's additional JavaScript code behind an LTI Button (DBQ Online), we don't want to
+        // handle those cases here, because `createWebViewWith` already opened a new popup window.
+        if (action.navigationType == .linkActivated || action.navigationType == .other),
+            let tools = LTITools(link: action.request.url),
             let from = linkDelegate?.routeLinksFrom {
             tools.presentTool(from: from, animated: true)
             return decisionHandler(.cancel)

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import SafariServices
+import WebKit
 
 @objc
 public class LTITools: NSObject {
@@ -88,17 +89,19 @@ public class LTITools: NSObject {
 
     var openInSafari: Bool { UserDefaults.standard.bool(forKey: "open_lti_safari") }
 
-    public convenience init?(env: AppEnvironment = .shared, link: URL?) {
+    public convenience init?(env: AppEnvironment = .shared, link: URL?, navigationType: WKNavigationType) {
         guard let link, link.host == env.api.baseURL.host else { return nil }
 
-        if let (context, url, resourceLinkUUID) = Self.parseRegularExternalToolURL(url: link) {
+        if let (context, url, resourceLinkUUID) = Self.parseRegularExternalToolURL(url: link),
+           navigationType == .linkActivated {
             self.init(
                 env: env,
                 context: context,
                 url: url,
                 resourceLinkLookupUUID: resourceLinkUUID
             )
-        } else if let (courseID, toolID) = Self.parseQuerylessExternalToolURL(url: link) {
+            return
+        } else if let (courseID, toolID) = Self.parseQuerylessExternalToolURL(url: link), navigationType == .other {
             self.init(
                 env: env,
                 context: .course(courseID),

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -109,7 +109,6 @@ public class LTITools: NSObject {
         } else {
             return nil
         }
-
     }
 
     private static func parseRegularExternalToolURL(url: URL) -> (
@@ -144,14 +143,13 @@ public class LTITools: NSObject {
     private static func parseQuerylessExternalToolURL(url: URL) -> (courseID: String, toolID: String)? {
         guard url.pathComponents.count == 5 else { return nil }
 
-        if let queryItems =  URLComponents.parse(url).queryItems, !queryItems.isEmpty {
+        if let queryItems = URLComponents.parse(url).queryItems, !queryItems.isEmpty {
             return nil
-        } else {
-            var pathComponents = url.pathComponents
-            pathComponents.removeFirst()
-            guard pathComponents[0] == "courses", pathComponents[2] == "external_tools" else { return nil }
-            return (pathComponents[1], pathComponents[3])
         }
+
+        var components = url.pathComponents
+        guard components[1] == "courses", components[3] == "external_tools" else { return nil }
+        return (components[2], components[4])
     }
 
     public func presentTool(from view: UIViewController, animated: Bool = true, completionHandler: ((Bool) -> Void)? = nil) {

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -38,33 +38,48 @@ class LTIToolsTests: CoreTestCase {
     }
 
     func testInitLink() {
-        XCTAssertNil(LTITools(link: nil))
-        XCTAssertNil(LTITools(link: URL(string: "/")))
-        XCTAssertNil(LTITools(link: URL(string: "https://else.where/external_tools/retrieve?url=/")))
-        XCTAssertEqual(LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))?.url, URL(string: "/"))
-        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL))?.id, "2")
-        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL))?.id, nil)
+        XCTAssertNil(LTITools(link: nil, navigationType: .linkActivated))
+        XCTAssertNil(LTITools(link: URL(string: "/"), navigationType: .linkActivated))
+        XCTAssertNil(LTITools(link: URL(string: "https://else.where/external_tools/retrieve?url=/"), navigationType: .linkActivated))
+        XCTAssertEqual(LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL), navigationType: .linkActivated)?.url, URL(string: "/"))
+        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL), navigationType: .other)?.id, "2")
+        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL), navigationType: .linkActivated)?.id, nil)
     }
 
     func testInitLinkContext() {
-        let defaultContext = LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        let defaultContext = LTITools(
+            link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL),
+            navigationType: .linkActivated
+        )
         XCTAssertEqual(defaultContext?.context.contextType, .account)
         XCTAssertEqual(defaultContext?.context.id, "self")
 
-        let course = LTITools(link: URL(string: "/courses/1/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        let course = LTITools(
+            link: URL(string: "/courses/1/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL),
+            navigationType: .linkActivated
+        )
         XCTAssertEqual(course?.context.contextType, .course)
         XCTAssertEqual(course?.context.id, "1")
 
-        let account = LTITools(link: URL(string: "/accounts/2/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
+        let account = LTITools(
+            link: URL(string: "/accounts/2/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL),
+            navigationType: .linkActivated
+        )
         XCTAssertEqual(account?.context.contextType, .account)
         XCTAssertEqual(account?.context.id, "2")
 
-        let querylessExternalTool = LTITools(link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL))
+        let querylessExternalTool = LTITools(
+            link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL),
+            navigationType: .other
+        )
         XCTAssertEqual(querylessExternalTool?.context.contextType, .course)
         XCTAssertEqual(querylessExternalTool?.context.id, "1")
         XCTAssertEqual(querylessExternalTool?.launchType, .course_navigation)
 
-        let queriedExternalTool = LTITools(link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL))
+        let queriedExternalTool = LTITools(
+            link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL),
+            navigationType: .linkActivated
+        )
         XCTAssertEqual(queriedExternalTool, nil)
     }
 
@@ -246,7 +261,7 @@ class LTIToolsTests: CoreTestCase {
 
     func testConvenienceInitSucceedingWithResourceLinkLookupUUID() {
         let url = URL(string: "https://canvas.instructure.com/courses/1/external_tools/retrieve?resource_link_lookup_uuid=123")!
-        let testee = LTITools(env: environment, link: url)
+        let testee = LTITools(env: environment, link: url, navigationType: .linkActivated)
 
         guard let testee = testee else {
             return XCTFail()

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -42,6 +42,8 @@ class LTIToolsTests: CoreTestCase {
         XCTAssertNil(LTITools(link: URL(string: "/")))
         XCTAssertNil(LTITools(link: URL(string: "https://else.where/external_tools/retrieve?url=/")))
         XCTAssertEqual(LTITools(link: URL(string: "/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))?.url, URL(string: "/"))
+        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL))?.id, "2")
+        XCTAssertEqual(LTITools(link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL))?.id, nil)
     }
 
     func testInitLinkContext() {
@@ -56,6 +58,14 @@ class LTIToolsTests: CoreTestCase {
         let account = LTITools(link: URL(string: "/accounts/2/external_tools/retrieve?url=/", relativeTo: environment.api.baseURL))
         XCTAssertEqual(account?.context.contextType, .account)
         XCTAssertEqual(account?.context.id, "2")
+
+        let querylessExternalTool = LTITools(link: URL(string: "/courses/1/external_tools/2", relativeTo: environment.api.baseURL))
+        XCTAssertEqual(querylessExternalTool?.context.contextType, .course)
+        XCTAssertEqual(querylessExternalTool?.context.id, "1")
+        XCTAssertEqual(querylessExternalTool?.launchType, .course_navigation)
+
+        let queriedExternalTool = LTITools(link: URL(string: "/courses/1/external_tools/2?display=borderless", relativeTo: environment.api.baseURL))
+        XCTAssertEqual(queriedExternalTool, nil)
     }
 
     func testGetSessionlessLaunchURL() {


### PR DESCRIPTION
refs: MBL-17315
affects: Student, Teacher
release note: LTI apps like Zoom and Microsoft apps now open properly from K5 courses
test plan: See ticket

https://github.com/instructure/canvas-ios/assets/110813321/578807f7-1c49-4d82-9b01-0557722766f9


## Checklist

- [x] Tested on phone
- [x] Tested on tablet
