### PR TITLE
E2ETest that covers the K5 missing assignments notification limit bug

### DIFF
--- a/Parent/ParentE2ETests/About/AboutTests.swift
+++ b/Parent/ParentE2ETests/About/AboutTests.swift
@@ -41,19 +41,19 @@ class AboutTests: E2ETestCase {
 
         let appLabel = SettingsHelper.About.appLabel.waitUntil(.visible)
         XCTAssertTrue(appLabel.isVisible)
-        XCTAssertEqual(appLabel.label, "Canvas Parent")
+        XCTAssertTrue(appLabel.hasLabel(label: "Canvas Parent"))
 
         let domainLabel = SettingsHelper.About.domainLabel.waitUntil(.visible)
         XCTAssertTrue(domainLabel.isVisible)
-        XCTAssertEqual(domainLabel.label, "https://\(user.host)")
+        XCTAssertTrue(domainLabel.hasLabel(label: "https://\(user.host)"))
 
         let loginIdLabel = SettingsHelper.About.loginIdLabel.waitUntil(.visible)
         XCTAssertTrue(loginIdLabel.isVisible)
-        XCTAssertEqual(loginIdLabel.label, parent.id)
+        XCTAssertTrue(loginIdLabel.hasLabel(label: parent.id))
 
         let emailLabel = SettingsHelper.About.emailLabel.waitUntil(.visible)
         XCTAssertTrue(emailLabel.isVisible)
-        XCTAssertEqual(emailLabel.label, "-")
+        XCTAssertTrue(emailLabel.hasLabel(label: "-"))
 
         let versionLabel = SettingsHelper.About.versionLabel.waitUntil(.visible)
         XCTAssertTrue(versionLabel.isVisible)

--- a/Parent/ParentE2ETests/Help/HelpTests.swift
+++ b/Parent/ParentE2ETests/Help/HelpTests.swift
@@ -25,7 +25,7 @@ class HelpTests: E2ETestCase {
         let course = seeder.createCourse()
         seeder.enrollParent(parent, in: course)
 
-        // MARK: Get the user logged in, navigate to Help
+        // MARK: Get the user logged in
         logInDSUser(parent)
         let profileButton = DashboardHelper.profileButton.waitUntil(.visible)
         XCTAssertTrue(profileButton.isVisible)
@@ -34,37 +34,40 @@ class HelpTests: E2ETestCase {
         let helpButton = ProfileHelper.helpButton.waitUntil(.visible)
         XCTAssertTrue(helpButton.isVisible)
 
+        // MARK: Navigate to Help, check "Search the Canvas Guides" button
         helpButton.hit()
-
-        // MARK: Check "Search the Canvas Guides" button
         let searchTheCanvasGuidesButton = HelpHelper.searchTheCanvasGuides.waitUntil(.visible)
         XCTAssertTrue(searchTheCanvasGuidesButton.isVisible)
+
         searchTheCanvasGuidesButton.hit()
         HelpHelper.openInSafariButton.hit()
         var browserURL = SafariAppHelper.browserURL
         XCTAssertTrue(browserURL.contains("https://community.canvaslms.com/t5/Canvas-LMS/ct-p/canvaslms"))
-        HelpHelper.returnToHelpPage(teacher: true)
 
         // MARK: Check "Report a Problem" button
+        HelpHelper.returnToHelpPage(teacher: true)
         let reportAProblemButton = HelpHelper.reportAProblem.waitUntil(.visible)
         XCTAssertTrue(reportAProblemButton.isVisible)
+
         reportAProblemButton.hit()
         XCTAssertTrue(app.find(label: "Report a Problem").waitUntil(.visible).isVisible)
-        app.find(label: "Cancel").hit()
-        HelpHelper.navigateToHelpPage()
 
         // MARK: Check "Submit a Feature Idea" button
+        app.find(label: "Cancel").hit()
+        HelpHelper.navigateToHelpPage()
         let submitAFeatureButton = HelpHelper.submitAFeatureIdea.waitUntil(.visible)
         XCTAssertTrue(submitAFeatureButton.isVisible)
+
         submitAFeatureButton.hit()
         HelpHelper.openInSafariButton.hit()
         browserURL = SafariAppHelper.browserURL
         XCTAssertTrue(browserURL.contains("https://community.canvaslms.com/t5/Canvas-Ideas-and-Themes/ct-p/canvas-ideas-themes"))
-        HelpHelper.returnToHelpPage(teacher: true)
 
         // MARK: Check "COVID-19 Canvas Resources" button
+        HelpHelper.returnToHelpPage(teacher: true)
         let covid19Button = HelpHelper.covid19.waitUntil(.visible)
         XCTAssertTrue(covid19Button.isVisible)
+
         covid19Button.hit()
         HelpHelper.openInSafariButton.hit()
         browserURL = SafariAppHelper.browserURL

--- a/Student/StudentE2ETests/K5/K5Tests.swift
+++ b/Student/StudentE2ETests/K5/K5Tests.swift
@@ -194,4 +194,25 @@ class K5Tests: K5E2ETestCase {
         let googleDriveButton = CourseDetailsHelper.cell(type: .googleDrive).waitUntil(.visible)
         XCTAssertTrue(googleDriveButton.actionUntilElementCondition(action: .swipeUp(), condition: .hittable))
     }
+
+    // Covers MBL-15737 bug
+    func testK5DashboardNotificationLimit() {
+        // MARK: Seed the usual stuff with homeroom and 12 missed assignments
+        let student = seeder.createK5User()
+        let homeroom = seeder.createK5Course()
+        let course = seeder.createCourse()
+        let assignmentsCount = 12
+        let assignments = AssignmentsHelper.createAssignments(in: course, count: assignmentsCount, dueDate: .now.addDays(-1))
+        seeder.enrollStudent(student, in: homeroom)
+        seeder.enrollStudent(student, in: course)
+
+        // MARK: Get the user logged in, navigate to course details
+        logInDSUser(student)
+        let courseCard = DashboardHelper.courseCard(course: course).waitUntil(.visible)
+        XCTAssertTrue(courseCard.isVisible)
+
+        let courseCardAssigmentMissingButton = DashboardHelper.courseCardAssignmentMissingButton(course: course).waitUntil(.visible)
+        XCTAssertTrue(courseCardAssigmentMissingButton.isVisible)
+        XCTAssertTrue(courseCardAssigmentMissingButton.hasLabel(label: "\(assignmentsCount) missing"))
+    }
 }

--- a/TestsFoundation/TestsFoundation/Helpers/AssignmentsHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/AssignmentsHelper.swift
@@ -192,4 +192,21 @@ public class AssignmentsHelper: BaseHelper {
         }
         CourseDetailsHelper.cell(type: .assignments).hit()
     }
+
+    public static func createAssignments(in course: DSCourse, count: Int, dueDate: Date? = nil) -> [DSAssignment] {
+        var assignments = [DSAssignment]()
+        for i in 1...count {
+            let name = "Sample Assignment \(i)"
+            let assignmentBody = CreateDSAssignmentRequest.RequestedDSAssignment(
+                name: name,
+                description: "Description of \(name)",
+                published: true,
+                submission_types: [.online_text_entry],
+                points_possible: 1.0,
+                grading_type: .letter_grade,
+                due_at: dueDate)
+            assignments.append(seeder.createAssignment(courseId: course.id, assignementBody: assignmentBody))
+        }
+        return assignments
+    }
 }

--- a/TestsFoundation/TestsFoundation/Helpers/DashboardHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/DashboardHelper.swift
@@ -35,6 +35,10 @@ public class DashboardHelper: BaseHelper {
         return app.find(id: "DashboardCourseCell.\(course?.id ?? courseId!)")
     }
 
+    public static func courseCardAssignmentMissingButton(course: DSCourse) -> XCUIElement {
+        return app.find(id: "DashboardCourseCell.\(course.id)").find(type: .button)
+    }
+
     public static func courseCardGradeLabel(course: DSCourse) -> XCUIElement {
         return app.find(id: "DashboardCourseCell.\(course.id).gradePill")
     }


### PR DESCRIPTION
refs: MBL-17779
affects: None
release note: None
test plan: Tests to pass

- testK5DashboardNotificationLimit: Creates 12 assignments with past due date and checks if the dashboard course card shows the correct number
- Some other minor changes in parent tests to be consistent with other tests
