### PR TITLE
Show selected attempt on submission details

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -302,7 +302,13 @@ class AssignmentDetailsPresenter {
     }
 
     func routeToSubmission(view: UIViewController) {
-        env.router.route(to: "/courses/\(courseID)/assignments/\(assignmentID)/submissions/\(userID)", from: view)
+        var route = "/courses/\(courseID)/assignments/\(assignmentID)/submissions/\(userID)"
+
+        if let selectedSubmission {
+            route += "?selectedAttempt=\(selectedSubmission.attempt)"
+        }
+
+        env.router.route(to: route, from: view)
     }
 
     func route(to url: URL, from view: UIViewController) -> Bool {

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -137,12 +137,14 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
         )
     },
 
-    "/courses/:courseID/assignments/:assignmentID/submissions": { _, params, _ in
+    "/courses/:courseID/assignments/:assignmentID/submissions": { url, params, _ in
         guard let courseID = params["courseID"], let assignmentID = params["assignmentID"] else { return nil }
+        let selectedAttempt = Int(url.queryValue(for: "selectedAttempt") ?? "")
         return SubmissionDetailsViewController.create(
             context: .course(ID.expandTildeID(courseID)),
             assignmentID: ID.expandTildeID(assignmentID),
-            userID: "self"
+            userID: "self",
+            selectedAttempt: selectedAttempt
         )
     },
 
@@ -155,10 +157,12 @@ let router = Router(routes: HelmManager.shared.routeHandlers([
                 fragment: url.fragment
             )
         } else {
+            let selectedAttempt = Int(url.queryValue(for: "selectedAttempt") ?? "")
             return SubmissionDetailsViewController.create(
                 context: .course(ID.expandTildeID(courseID)),
                 assignmentID: ID.expandTildeID(assignmentID),
-                userID: ID.expandTildeID(userID)
+                userID: ID.expandTildeID(userID),
+                selectedAttempt: selectedAttempt
             )
         }
     },

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -80,13 +80,14 @@ class SubmissionDetailsPresenter {
     private var docViewerSessionURL: URL?
     private var docViewerSessionRequest: APITask?
 
-    init(env: AppEnvironment = .shared, view: SubmissionDetailsViewProtocol, context: Context, assignmentID: String, userID: String) {
+    init(env: AppEnvironment = .shared, view: SubmissionDetailsViewProtocol, context: Context, assignmentID: String, userID: String, selectedAttempt: Int? = nil) {
         self.context = context
         self.assignmentID = assignmentID
         self.userID = userID
         self.env = env
         self.view = view
         self.submissionButtonPresenter = SubmissionButtonPresenter(view: view, assignmentID: assignmentID)
+        self.selectedAttempt = selectedAttempt
     }
 
     func viewIsReady() {

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -229,26 +229,69 @@ extension SubmissionDetailsViewController: UIPickerViewDataSource, UIPickerViewD
         return presenter?.pickerSubmissions.count ?? 0
     }
 
+    func pickerView(_ pickerView: UIPickerView, rowHeightForComponent component: Int) -> CGFloat {
+        guard presenter?.pickerSubmissions.isEmpty == false else { return 40 }
+
+        let renderSize = CGSize(width: pickerView.frame.width, height: .infinity)
+        let text = text(forRow: 0)
+        let textHeight = text.boundingRect(with: renderSize,
+                                           options: [.usesLineFragmentOrigin, .usesFontLeading],
+                                           context: nil).height
+        // Increase height to have some top/bottom padding
+        return textHeight + 2 * 8
+    }
+
     func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
-        let text: String
-
-        if let submittedAt = presenter?.pickerSubmissions[row].submittedAt {
-            text = DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short)
-        } else {
-            text = NSLocalizedString("No Submission Date", bundle: .student, comment: "")
-        }
-
         let label = UILabel()
-        label.textColor = .textDark
-        label.text = text
-        label.font = .scaledNamedFont(.regular23)
-        label.textAlignment = .center
-
+        label.attributedText = text(forRow: row)
+        label.textAlignment = .right
+        label.numberOfLines = 0
         return label
     }
 
     func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
         guard let attempt = presenter?.pickerSubmissions[row].attempt else { return }
         presenter?.select(attempt: attempt)
+    }
+
+    private func text(forRow row: Int) -> NSAttributedString {
+        let submissionDateText: String = {
+            guard let submittedAt = presenter?.pickerSubmissions[row].submittedAt else {
+                return NSLocalizedString("No Submission Date", bundle: .student, comment: "")
+            }
+
+            return DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short)
+        }()
+        let attemptText: String = {
+            guard let attempt = presenter?.pickerSubmissions[row].attempt else {
+                return ""
+            }
+
+            let format = NSLocalizedString("Attempt %d", bundle: .core, comment: "")
+            return String.localizedStringWithFormat(format, attempt)
+        }()
+
+        let text = NSMutableAttributedString(string: "\(submissionDateText)\n\(attemptText)")
+        let paragraphStyle = NSMutableParagraphStyle()
+        // This visually will match the top/bottom padding cells have
+        paragraphStyle.tailIndent = -12
+        text.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: text.length))
+        let dateRange = text.mutableString.range(of: submissionDateText)
+        let attemptRange = text.mutableString.range(of: attemptText)
+
+        if dateRange.location != NSNotFound, attemptRange.location != NSNotFound {
+            text.addAttributes([
+                                .font: UIFont.scaledNamedFont(.regular20),
+                                .foregroundColor: UIColor.textDarkest,
+                               ],
+                               range: dateRange)
+            text.addAttributes([
+                                .font: UIFont.scaledNamedFont(.regular17),
+                                .foregroundColor: UIColor.textDarkest,
+                                ],
+                               range: attemptRange)
+        }
+
+        return text
     }
 }

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -49,9 +49,9 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
     @IBOutlet weak var pickerButtonDivider: DividerView?
     @IBOutlet weak var picker: UIPickerView?
 
-    static func create(env: AppEnvironment = .shared, context: Context, assignmentID: String, userID: String) -> SubmissionDetailsViewController {
+    static func create(env: AppEnvironment = .shared, context: Context, assignmentID: String, userID: String, selectedAttempt: Int? = nil) -> SubmissionDetailsViewController {
         let controller = loadFromStoryboard()
-        controller.presenter = SubmissionDetailsPresenter(env: env, view: controller, context: context, assignmentID: assignmentID, userID: userID)
+        controller.presenter = SubmissionDetailsPresenter(env: env, view: controller, context: context, assignmentID: assignmentID, userID: userID, selectedAttempt: selectedAttempt)
         controller.env = env
         return controller
     }
@@ -94,6 +94,11 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
             return
         }
         picker?.reloadAllComponents()
+
+        if let selectedAttempt = presenter.selectedAttempt,
+           let pickerRow = presenter.pickerSubmissions.firstIndex(where: { $0.attempt == selectedAttempt}) {
+            picker?.selectRow(pickerRow, inComponent: 0, animated: false)
+        }
 
         let submission = presenter.currentSubmission
 

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/AssignmentDetailsPresenterTests.swift
@@ -606,6 +606,27 @@ class AssignmentDetailsPresenterTests: StudentTestCase {
         XCTAssertEqual(resultingAttemptNumber, "Attempt 1")
         XCTAssertEqual(resultingGradeCellSubmission, submission1)
     }
+
+    @available(iOS 16.0, *)
+    func testForwardsSelectedAttemptToSubmissionDetails() {
+        // GIVEN
+        Assignment.make()
+        Submission.make(from: .make(attempt: 1, id: "1", score: 1))
+        Submission.make(from: .make(attempt: 2, id: "2", score: 2))
+        FeatureFlag.make(name: APIFeatureFlag.Key.assignmentEnhancements.rawValue, enabled: true)
+
+        waitUntil(shouldFail: true) {
+            resultingAttemptPickerItems?.count == 2
+        }
+
+        resultingAttemptPickerItems?.first?.performWithSender(self, target: self)
+
+        // WHEN
+        presenter.routeToSubmission(view: UIViewController())
+
+        // THEN
+        XCTAssertTrue(router.lastRoutedTo("/courses/1/assignments/1/submissions/1?selectedAttempt=2"))
+    }
 }
 
 class MockView: UIViewController, AssignmentDetailsViewProtocol {

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsViewControllerTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsViewControllerTests.swift
@@ -29,4 +29,23 @@ class SubmissionDetailsViewControllerTests: StudentTestCase {
         NotificationCenter.default.post(name: UIResponder.keyboardWillShowNotification, object: nil, userInfo: [:])
         XCTAssertEqual(controller.drawer?.height, controller.drawer?.maxDrawerHeight)
     }
+
+    func testSelectsReceivedAttempt() {
+        // GIVEN
+        Assignment.make()
+        Submission.make(from: .make(attempt: 1, id: "1", score: 1))
+        Submission.make(from: .make(attempt: 7, id: "2", score: 2))
+
+        // WHEN
+        let testee = SubmissionDetailsViewController.create(context: .course("1"),
+                                                            assignmentID: "1",
+                                                            userID: "1",
+                                                            selectedAttempt: 1)
+        testee.loadViewIfNeeded()
+
+        // THEN
+        XCTAssertEqual(testee.presenter?.selectedAttempt, 1)
+        XCTAssertEqual(testee.picker?.selectedRow(inComponent: 0), 1)
+        XCTAssertEqual(testee.presenter?.pickerSubmissions[1].attempt, 1)
+    }
 }


### PR DESCRIPTION
### What's new?
- The selected attempt on the assignment details screen will also be shown on the submission and rubric screen.
- Added attempt number to attempt picker on the submission details screen.

refs: MBL-17245
affects: Student
release note: none

test plan:
- Select an attempt on the assignment details screen.
- Tap on submission and rubric button.
- Submission details screen should show the selected attempt.
- Tap on the attempt selector, attempt numbers should be visible below the attempt date.
- The showed attempt should be pre-selected.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/e11a75b5-45bd-484f-a060-9392ccca7f42" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/2405f493-0b04-4e03-9ff8-30250f0c0cd1" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product
