### PR TITLE
Detect and swallow invalid presentation state to prevent crash.

### DIFF
--- a/Core/Core/Analytics/Analytics.swift
+++ b/Core/Core/Analytics/Analytics.swift
@@ -28,6 +28,9 @@ public protocol AnalyticsHandler: AnyObject {
 public class Analytics: NSObject {
     @objc public static var shared: Analytics = Analytics()
     public weak var handler: AnalyticsHandler?
+    #if DEBUG
+    public var logScreenViewToConsole = false
+    #endif
 
     /**
      Use this method to collect screen view events which will be uploaded when a crash happens
@@ -35,6 +38,11 @@ public class Analytics: NSObject {
      */
     @objc(logScreenView:viewController:)
     public func logScreenView(route: String, viewController: UIViewController? = nil) {
+        #if DEBUG
+        if logScreenViewToConsole {
+            print("ScreenView: \(route) (\(Self.analyticsClassName(for: viewController)))")
+        }
+        #endif
         handler?.handleScreenView(screenName: route,
                                   screenClass: Self.analyticsClassName(for: viewController),
                                   application: Self.analyticsAppName)

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -150,7 +150,7 @@ public class LTITools: NSObject {
             return nil
         }
 
-        var components = url.pathComponents
+        let components = url.pathComponents
         guard components[1] == "courses", components[3] == "external_tools" else { return nil }
         return (components[2], components[4])
     }

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -226,7 +226,17 @@ open class Router {
             from.present(nav ?? view, animated: animated, completion: completion)
         case .detail:
             if from.splitViewController == nil || from.isInSplitViewDetail || from.splitViewController?.isCollapsed == true {
-                from.show(view, sender: nil)
+                let presenterViewWithoutNavController = (from.navigationController == nil)
+                let viewIsEmbeddedInNavController = (view.navigationController != nil)
+
+                // If we call `show` on a viewcontroller without navigation controller it will present as a modal
+                // and will cause a crash since `view` already has a parent view controller (its freshly created navigation controller).
+                // This case is most probably an unintended navigation so we swallow it.
+                if presenterViewWithoutNavController, viewIsEmbeddedInNavController {
+                    Analytics.shared.logError(name: "Invalid presentation state.", reason: nil)
+                } else {
+                    from.show(view, sender: nil)
+                }
             } else {
                 from.showDetailViewController(nav ?? view, sender: from)
             }

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -159,6 +159,7 @@ class RouterTests: CoreTestCase {
 
     func testRouteDetailNotInSplitViewDoesAShow() {
         let mockView = MockViewController()
+        let nav = UINavigationController(rootViewController: mockView)
         let router = Router(routes: [
             RouteHandler("/detail") { _, _, _ in
                 return UIViewController()

--- a/Core/CoreTests/Router/RouterTests.swift
+++ b/Core/CoreTests/Router/RouterTests.swift
@@ -159,7 +159,7 @@ class RouterTests: CoreTestCase {
 
     func testRouteDetailNotInSplitViewDoesAShow() {
         let mockView = MockViewController()
-        let nav = UINavigationController(rootViewController: mockView)
+        _ = UINavigationController(rootViewController: mockView)
         let router = Router(routes: [
             RouteHandler("/detail") { _, _, _ in
                 return UIViewController()

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -175,6 +175,7 @@ extension ParentAppDelegate: LoginDelegate {
                 let safari = SFSafariViewController(url: url)
                 safari.modalPresentationStyle = .fullScreen
                 topVC.present(safari, animated: true, completion: nil)
+                Analytics.shared.logScreenView(route: "/external_url")
             }
         } else {
             UIApplication.shared.open(url, options: [:], completionHandler: nil)


### PR DESCRIPTION
refs: MBL-17260
affects: Student, Teacher, Parent
release note: Fixed a crash when swiping back to a previous screen.

test plan:
- Manual repro steps not available, most probably somehow a button that causes a navigation is activated on a view controller that is being dismissed with the swipe to back gesture.
- Add a delayed router.show call to a view controller's viewWillDisapper method.
- Do a swipe to back gesture from this view controller but don't finish the gesture just keep the view floating halfway on the screen.
- Wait until the delayed presentation kicks in.
- App shouldn't crash.
- All regular navigation should work just as before.

In the video below I added the following code to the `GradeListViewController.swift` file:
```
public override func viewWillDisappear(_ animated: Bool) {
    super.viewWillDisappear(animated)

    DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [self] in
        guard let assignment = assignments[0] else { return }
        env.router.route(to: "/courses/\(courseID)/assignments/\(assignment.id)", from: self, options: .detail)
    }
}
```

https://github.com/instructure/canvas-ios/assets/72396990/80b74a72-9f3d-4656-a9c1-bf139c009864

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet