### PR TITLE
Rework ReactiveStore to prevent crashes

### DIFF
--- a/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -86,8 +86,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
-        "version" : "2.3.0"
+        "revision" : "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
+        "version" : "1.7.2"
       }
     },
     {

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3935,20 +3935,6 @@
 			path = Dashboard;
 			sourceTree = "<group>";
 		};
-		15769FCE677A9C9F5B0A7CA6 /* CoreWebView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CoreWebView;
-			sourceTree = "<group>";
-		};
-		15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SubmitAssignmentExtension;
-			sourceTree = "<group>";
-		};
 		16AA6C7702C406B9B5672D4C /* CourseSyncProgress */ = {
 			isa = PBXGroup;
 			children = (
@@ -3975,13 +3961,6 @@
 				FD0C7341652D59C8217924A5 /* AllCoursesViewModel.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		19958B6AD0248B53014070C5 /* Inbox */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Inbox;
 			sourceTree = "<group>";
 		};
 		19A1E69CFC2A77F0C16AE5EE /* View */ = {
@@ -5057,13 +5036,6 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
-		45AE6AA24575C49F0A193D7F /* Courses */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Courses;
-			sourceTree = "<group>";
-		};
 		45F2AB93913E94E1EB859A8F /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5093,25 +5065,6 @@
 				61A1E8C4C40ECFEDE96D43D0 /* DocViewerAnnotationUploadResponseHandler.swift */,
 			);
 			path = ResponseHandling;
-			sourceTree = "<group>";
-		};
-		46E180A5270BE50B1BAE6E44 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				15769FCE677A9C9F5B0A7CA6 /* CoreWebView */,
-				45AE6AA24575C49F0A193D7F /* Courses */,
-				5C8063761CEE6EF4856E77C9 /* CourseSync */,
-				71D97A1D591434A33BCB62F5 /* Dashboard */,
-				5693A9621060A98BB2BD6BB6 /* DocViewer */,
-				7ACA639B28690D26E3B4BFB8 /* Files */,
-				19958B6AD0248B53014070C5 /* Inbox */,
-				B2525E0E11159C3FC91DB478 /* People */,
-				6A979E40A3CC558130B78B0F /* Profile */,
-				BE9C131EF7967804F6B514B1 /* Quizzes */,
-				15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */,
-				D28C27753F8FCDC43A393D49 /* SwiftUIViews */,
-			);
-			path = Sources;
 			sourceTree = "<group>";
 		};
 		481AA5EAFCF724C6F0F8400C /* Addressbook */ = {
@@ -5381,13 +5334,6 @@
 			path = ImportantDates;
 			sourceTree = "<group>";
 		};
-		5693A9621060A98BB2BD6BB6 /* DocViewer */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = DocViewer;
-			sourceTree = "<group>";
-		};
 		57134DDA24547C9F07DF08CA /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5645,13 +5591,6 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
-		5C8063761CEE6EF4856E77C9 /* CourseSync */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CourseSync;
-			sourceTree = "<group>";
-		};
 		5CDC7EAC7F9AD4B81A819533 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5852,13 +5791,6 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
-		6A979E40A3CC558130B78B0F /* Profile */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Profile;
-			sourceTree = "<group>";
-		};
 		6B2903A3F8C8721E762E2014 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -6039,13 +5971,6 @@
 			path = API;
 			sourceTree = "<group>";
 		};
-		71D97A1D591434A33BCB62F5 /* Dashboard */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Dashboard;
-			sourceTree = "<group>";
-		};
 		71E4B1098694A1A88ECF9D75 /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -6218,14 +6143,6 @@
 			path = API;
 			sourceTree = "<group>";
 		};
-		7ACA639B28690D26E3B4BFB8 /* Files */ = {
-			isa = PBXGroup;
-			children = (
-				81449C16A62B4EE5455B2EE1 /* View */,
-			);
-			path = Files;
-			sourceTree = "<group>";
-		};
 		7CA17FD2C1EABD309B108A6F /* ContextCard */ = {
 			isa = PBXGroup;
 			children = (
@@ -6333,13 +6250,6 @@
 				30A1E11BAE258EC133022808 /* K5GradesViewModel.swift */,
 			);
 			path = Grades;
-			sourceTree = "<group>";
-		};
-		81449C16A62B4EE5455B2EE1 /* View */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = View;
 			sourceTree = "<group>";
 		};
 		81B5D9C3B0D9151DDE9446AC /* WidgetsSupport */ = {
@@ -6943,7 +6853,6 @@
 				90C4F82791B3B883003B49C5 /* Quizzes */,
 				01AC5166B8C7F12BA9DCBB93 /* RichContentEditor */,
 				7775E906C5B94F5EEF674386 /* Router */,
-				46E180A5270BE50B1BAE6E44 /* Sources */,
 				9C46FAD063BA96A6109A885E /* Store */,
 				D742111A4E51B5683CB6F9E5 /* Submissions */,
 				13BB69D0F5082096DC44486E /* SubmitAssignmentExtension */,
@@ -7596,13 +7505,6 @@
 			path = Constants;
 			sourceTree = "<group>";
 		};
-		B2525E0E11159C3FC91DB478 /* People */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = People;
-			sourceTree = "<group>";
-		};
 		B28074855E192D3DD1135F4B /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -7839,13 +7741,6 @@
 				1A6EBA2448D0A3C082CF64F5 /* SideMenuView.swift */,
 			);
 			path = SideMenu;
-			sourceTree = "<group>";
-		};
-		BE9C131EF7967804F6B514B1 /* Quizzes */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Quizzes;
 			sourceTree = "<group>";
 		};
 		BEBC6868A9E2321EAE6FE19E /* Model */ = {
@@ -8165,13 +8060,6 @@
 				1824DDDCF5087692F6013995 /* SplitViewModeObserver.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		D28C27753F8FCDC43A393D49 /* SwiftUIViews */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SwiftUIViews;
 			sourceTree = "<group>";
 		};
 		D2B97380463243815383FBA0 /* ViewModel */ = {

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -1511,7 +1511,6 @@
 		E8D13CD95C453A5F8ADE0105 /* DashboardInvitationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CE4259E5A4C39F116CE07A /* DashboardInvitationViewModel.swift */; };
 		E8D9105EB889AC8D02C4FBCF /* FileSubmissionStateEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC8DFF2F9C9DE3128272EA3 /* FileSubmissionStateEnumTests.swift */; };
 		E90FF93D771026D3F9185440 /* NavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08EEC4065AFBA4B3184D45A /* NavBarItems.swift */; };
-		E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 39C01BEDACCD811D2E26E465 /* Assets.xcassets */; };
 		E96E73CEE262CF3031FB57F1 /* UITableViewCellExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF940D2EDE1FFDAABED534C /* UITableViewCellExtensions.swift */; };
 		E97625C23463E6E2C5720F0C /* ComposeReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D073364D1D137113E79E7EE /* ComposeReplyViewController.swift */; };
 		E9943F3D5301879352B974C2 /* AnnotationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9B2D4B502A07FB43F83A6C /* AnnotationExtensions.swift */; };
@@ -2100,7 +2099,6 @@
 		398100E89391565EEF55D06E /* InboxFilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFilterBarView.swift; sourceTree = "<group>"; };
 		39A76B2BA67C66D85FFA8C3B /* APIQuizTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIQuizTests.swift; sourceTree = "<group>"; };
 		39B71BCCFA0C836F3827FFEE /* GroupContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModel.swift; sourceTree = "<group>"; };
-		39C01BEDACCD811D2E26E465 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		39DA29562F6F3DBAC71046EA /* DocViewerAnnotationContextMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationContextMenuModelTests.swift; sourceTree = "<group>"; };
 		39DB2B1FD43C6260361A041F /* UITabBarItemOfflineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITabBarItemOfflineSupport.swift; sourceTree = "<group>"; };
 		3A001B6CBC3808DD42C98894 /* FileUploadNotificationCardItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModelTests.swift; sourceTree = "<group>"; };
@@ -5846,7 +5844,6 @@
 			isa = PBXGroup;
 			children = (
 				B93949D5CAD36EF43399EDF9 /* Fonts */,
-				39C01BEDACCD811D2E26E465 /* Assets.xcassets */,
 				8E5D3EAD5E2135988C032705 /* defaultHeaderImage.png */,
 			);
 			path = Resources;
@@ -9310,7 +9307,6 @@
 				079FA0F2ED8D8269AF96C452 /* ActAsUserViewController.storyboard in Resources */,
 				8E44734F8D26D951C93716F5 /* AnnouncementListViewController.storyboard in Resources */,
 				EAEF98AAC2663BEC33A37127 /* Assets.xcassets in Resources */,
-				E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */,
 				C12D2EAC3DC60C738EC8807F /* AudioPlayerViewController.storyboard in Resources */,
 				C406485DE3B48D2D910E34F8 /* AudioRecorderViewController.storyboard in Resources */,
 				4061B82BCF8B18D412CF5E6B /* CalendarDayIconView.xib in Resources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2238,7 +2238,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2476,7 +2476,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2816,7 +2816,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2860,7 +2860,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2238,7 +2238,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2476,7 +2476,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2816,7 +2816,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2860,7 +2860,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
@@ -3638,13 +3638,6 @@
 			path = LoginUsePolicy;
 			sourceTree = "<group>";
 		};
-		06E316B51DD023288F6F5F2A /* Container */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Container;
-			sourceTree = "<group>";
-		};
 		07366D79C25F3EDCF5602E22 /* AnnotationTypes */ = {
 			isa = PBXGroup;
 			children = (
@@ -4029,13 +4022,6 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
-		1A9F89F6842024B7DC45676B /* Conference */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Conference;
-			sourceTree = "<group>";
-		};
 		1BF94E892CD865E3A2705BC4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -4063,13 +4049,6 @@
 				6947DDE7E7694FBEBD5A9CD1 /* RubricTests.swift */,
 			);
 			path = Assignments;
-			sourceTree = "<group>";
-		};
-		1D548C4AD07209A12F6FCEDE /* FileUploadNotification */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = FileUploadNotification;
 			sourceTree = "<group>";
 		};
 		1F2923A8D008143C233C0A25 /* Logger */ = {
@@ -4121,19 +4100,6 @@
 				12BB118DE8F1D84A956D9291 /* ViewModel */,
 			);
 			path = K5;
-			sourceTree = "<group>";
-		};
-		21207C91941273BDFF517366 /* Dashboard */ = {
-			isa = PBXGroup;
-			children = (
-				1A9F89F6842024B7DC45676B /* Conference */,
-				06E316B51DD023288F6F5F2A /* Container */,
-				1D548C4AD07209A12F6FCEDE /* FileUploadNotification */,
-				5F428018966094C386A045C4 /* Group */,
-				78EBA7B29813A53D5A9AD872 /* K5 */,
-				6A3541D8D144C9A887F17564 /* Notification */,
-			);
-			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		21C9309B7D55C2D368DD2B23 /* Model */ = {
@@ -4280,13 +4246,6 @@
 				3B4FAB8418C8320F79FE2592 /* PutDashboardCardPositionsTests.swift */,
 			);
 			path = UseCase;
-			sourceTree = "<group>";
-		};
-		289119BA945905CEECDC6404 /* DocViewer */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = DocViewer;
 			sourceTree = "<group>";
 		};
 		29A681523032C9F0460D13DF /* View */ = {
@@ -5033,13 +4992,6 @@
 			path = Syllabus;
 			sourceTree = "<group>";
 		};
-		433DDC5EFFE3D9FE3809D483 /* Quizzes */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Quizzes;
-			sourceTree = "<group>";
-		};
 		436DAF3ABE6692A54F6E1584 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -5365,25 +5317,6 @@
 				67A4BA6AB510EF147B06121E /* AnnotationDrag */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		52B4A01AA5EDF9DB2E435557 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				A7872205234C480312539802 /* Assignments */,
-				F9F236A5D1B6E9EDBAC590BC /* CoreWebView */,
-				B1C027449ED3388ECF692C1F /* Courses */,
-				F5E62DF4F777D9127A8F5103 /* CourseSync */,
-				21207C91941273BDFF517366 /* Dashboard */,
-				289119BA945905CEECDC6404 /* DocViewer */,
-				A0A4835C7FC94C053347D394 /* Files */,
-				6BC8F6F217D27C91CBF0EA9A /* Inbox */,
-				840120F9E6E51BA5C14E5D6C /* People */,
-				8503617909F61F7E3B54C767 /* Profile */,
-				433DDC5EFFE3D9FE3809D483 /* Quizzes */,
-				602E002B0A978C34B1047394 /* SwiftUIViews */,
-			);
-			path = Sources;
 			sourceTree = "<group>";
 		};
 		53032D265BEF6E1A76A57C41 /* ViewModel */ = {
@@ -5762,13 +5695,6 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
-		5F428018966094C386A045C4 /* Group */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Group;
-			sourceTree = "<group>";
-		};
 		5F8CE6C5C98643B733EADFB1 /* Enrollments */ = {
 			isa = PBXGroup;
 			children = (
@@ -5778,13 +5704,6 @@
 				E853CACABF36E865C5682822 /* RoleTests.swift */,
 			);
 			path = Enrollments;
-			sourceTree = "<group>";
-		};
-		602E002B0A978C34B1047394 /* SwiftUIViews */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = SwiftUIViews;
 			sourceTree = "<group>";
 		};
 		61E04C5F9E5CDDF397B8E840 /* Analytics */ = {
@@ -5933,13 +5852,6 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
-		6A3541D8D144C9A887F17564 /* Notification */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Notification;
-			sourceTree = "<group>";
-		};
 		6A979E40A3CC558130B78B0F /* Profile */ = {
 			isa = PBXGroup;
 			children = (
@@ -5953,13 +5865,6 @@
 				287547C5CC7374AF99E38731 /* UseCase */,
 			);
 			path = Model;
-			sourceTree = "<group>";
-		};
-		6BC8F6F217D27C91CBF0EA9A /* Inbox */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Inbox;
 			sourceTree = "<group>";
 		};
 		6BD95991C2010238C37A8D4F /* View */ = {
@@ -6286,14 +6191,6 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
-		78EBA7B29813A53D5A9AD872 /* K5 */ = {
-			isa = PBXGroup;
-			children = (
-				EE1D34E5E7F6630810F1AA02 /* ViewModel */,
-			);
-			path = K5;
-			sourceTree = "<group>";
-		};
 		792E587F8B67FDCF0560AA5A /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -6518,13 +6415,6 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
-		840120F9E6E51BA5C14E5D6C /* People */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = People;
-			sourceTree = "<group>";
-		};
 		8418B1360F4D720B0F67277E /* NetworkAvailability */ = {
 			isa = PBXGroup;
 			children = (
@@ -6549,13 +6439,6 @@
 				5C79DD83EC46C1780A24D067 /* ObserverAlertTests.swift */,
 			);
 			path = ObserverAlerts;
-			sourceTree = "<group>";
-		};
-		8503617909F61F7E3B54C767 /* Profile */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Profile;
 			sourceTree = "<group>";
 		};
 		85077BC58E1BBCB5DB69EA98 /* Modules */ = {
@@ -7344,13 +7227,6 @@
 			path = QuizDetails;
 			sourceTree = "<group>";
 		};
-		A0A4835C7FC94C053347D394 /* Files */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Files;
-			sourceTree = "<group>";
-		};
 		A0BB17ACB29B50382F946175 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
@@ -7473,13 +7349,6 @@
 				3C1FF7B151B7D76ED706ACA1 /* Model */,
 			);
 			path = GradingStandard;
-			sourceTree = "<group>";
-		};
-		A7872205234C480312539802 /* Assignments */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Assignments;
 			sourceTree = "<group>";
 		};
 		A7969A53EFE2E8A6649F49D7 /* Announcements */ = {
@@ -7714,14 +7583,6 @@
 				26EE7E2834C85B2C2FC32460 /* PlannerViewControllerTests.swift */,
 			);
 			path = Planner;
-			sourceTree = "<group>";
-		};
-		B1C027449ED3388ECF692C1F /* Courses */ = {
-			isa = PBXGroup;
-			children = (
-				D808C7EBF928E6D6716D675E /* AllCourses */,
-			);
-			path = Courses;
 			sourceTree = "<group>";
 		};
 		B1C34AF4857F4CF312828B87 /* Constants */ = {
@@ -8035,13 +7896,6 @@
 				4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CourseSyncDownloader;
 			sourceTree = "<group>";
 		};
 		C2F6233AB51C459BF3A66F2E /* Model */ = {
@@ -8454,13 +8308,6 @@
 				40EE3742920BE5C74E1D7CEB /* CourseSyncProgressViewModelTests.swift */,
 			);
 			path = ViewModel;
-			sourceTree = "<group>";
-		};
-		D808C7EBF928E6D6716D675E /* AllCourses */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = AllCourses;
 			sourceTree = "<group>";
 		};
 		D820AD1E2667F989BE655351 /* CourseDetails */ = {
@@ -8945,13 +8792,6 @@
 			path = Help;
 			sourceTree = "<group>";
 		};
-		EE1D34E5E7F6630810F1AA02 /* ViewModel */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = ViewModel;
-			sourceTree = "<group>";
-		};
 		EE47A667792D181291BC8D12 /* BackgroundUpdates */ = {
 			isa = PBXGroup;
 			children = (
@@ -9096,14 +8936,6 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
-		F5E62DF4F777D9127A8F5103 /* CourseSync */ = {
-			isa = PBXGroup;
-			children = (
-				C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */,
-			);
-			path = CourseSync;
-			sourceTree = "<group>";
-		};
 		F696335407E9880E6BD3C7EA /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -9171,13 +9003,6 @@
 				C28BD7040645C5AE1ADDA23F /* K5ResourcesViewModelTests.swift */,
 			);
 			path = Resources;
-			sourceTree = "<group>";
-		};
-		F9F236A5D1B6E9EDBAC590BC /* CoreWebView */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = CoreWebView;
 			sourceTree = "<group>";
 		};
 		FA5A00EC8BF93DA0E4394AF8 /* AllCourses */ = {
@@ -9254,7 +9079,6 @@
 				4514D62DB85771B622259882 /* RichContentEditor */,
 				5BB8D351610D5E4BEC708D1D /* Router */,
 				461F876D89C3F74044C343B1 /* ScreenViewLogger */,
-				52B4A01AA5EDF9DB2E435557 /* Sources */,
 				2EEBA6D6C1B2CFC32E23E8A8 /* Store */,
 				7CF3349E196B2FB15B5877A7 /* Submissions */,
 				81DC2E96AD7CC08AD4C6F79C /* SubmitAssignmentExtension */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1511,6 +1511,7 @@
 		E8D13CD95C453A5F8ADE0105 /* DashboardInvitationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CE4259E5A4C39F116CE07A /* DashboardInvitationViewModel.swift */; };
 		E8D9105EB889AC8D02C4FBCF /* FileSubmissionStateEnumTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DC8DFF2F9C9DE3128272EA3 /* FileSubmissionStateEnumTests.swift */; };
 		E90FF93D771026D3F9185440 /* NavBarItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = A08EEC4065AFBA4B3184D45A /* NavBarItems.swift */; };
+		E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 39C01BEDACCD811D2E26E465 /* Assets.xcassets */; };
 		E96E73CEE262CF3031FB57F1 /* UITableViewCellExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AF940D2EDE1FFDAABED534C /* UITableViewCellExtensions.swift */; };
 		E97625C23463E6E2C5720F0C /* ComposeReplyViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D073364D1D137113E79E7EE /* ComposeReplyViewController.swift */; };
 		E9943F3D5301879352B974C2 /* AnnotationExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9B2D4B502A07FB43F83A6C /* AnnotationExtensions.swift */; };
@@ -2099,6 +2100,7 @@
 		398100E89391565EEF55D06E /* InboxFilterBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxFilterBarView.swift; sourceTree = "<group>"; };
 		39A76B2BA67C66D85FFA8C3B /* APIQuizTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIQuizTests.swift; sourceTree = "<group>"; };
 		39B71BCCFA0C836F3827FFEE /* GroupContextCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModel.swift; sourceTree = "<group>"; };
+		39C01BEDACCD811D2E26E465 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		39DA29562F6F3DBAC71046EA /* DocViewerAnnotationContextMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationContextMenuModelTests.swift; sourceTree = "<group>"; };
 		39DB2B1FD43C6260361A041F /* UITabBarItemOfflineSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITabBarItemOfflineSupport.swift; sourceTree = "<group>"; };
 		3A001B6CBC3808DD42C98894 /* FileUploadNotificationCardItemViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileUploadNotificationCardItemViewModelTests.swift; sourceTree = "<group>"; };
@@ -2236,7 +2238,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2474,7 +2476,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2814,7 +2816,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2858,7 +2860,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
@@ -3636,6 +3638,13 @@
 			path = LoginUsePolicy;
 			sourceTree = "<group>";
 		};
+		06E316B51DD023288F6F5F2A /* Container */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Container;
+			sourceTree = "<group>";
+		};
 		07366D79C25F3EDCF5602E22 /* AnnotationTypes */ = {
 			isa = PBXGroup;
 			children = (
@@ -3933,6 +3942,20 @@
 			path = Dashboard;
 			sourceTree = "<group>";
 		};
+		15769FCE677A9C9F5B0A7CA6 /* CoreWebView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CoreWebView;
+			sourceTree = "<group>";
+		};
+		15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SubmitAssignmentExtension;
+			sourceTree = "<group>";
+		};
 		16AA6C7702C406B9B5672D4C /* CourseSyncProgress */ = {
 			isa = PBXGroup;
 			children = (
@@ -3959,6 +3982,13 @@
 				FD0C7341652D59C8217924A5 /* AllCoursesViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		19958B6AD0248B53014070C5 /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Inbox;
 			sourceTree = "<group>";
 		};
 		19A1E69CFC2A77F0C16AE5EE /* View */ = {
@@ -3999,6 +4029,13 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		1A9F89F6842024B7DC45676B /* Conference */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Conference;
+			sourceTree = "<group>";
+		};
 		1BF94E892CD865E3A2705BC4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
@@ -4026,6 +4063,13 @@
 				6947DDE7E7694FBEBD5A9CD1 /* RubricTests.swift */,
 			);
 			path = Assignments;
+			sourceTree = "<group>";
+		};
+		1D548C4AD07209A12F6FCEDE /* FileUploadNotification */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = FileUploadNotification;
 			sourceTree = "<group>";
 		};
 		1F2923A8D008143C233C0A25 /* Logger */ = {
@@ -4077,6 +4121,19 @@
 				12BB118DE8F1D84A956D9291 /* ViewModel */,
 			);
 			path = K5;
+			sourceTree = "<group>";
+		};
+		21207C91941273BDFF517366 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+				1A9F89F6842024B7DC45676B /* Conference */,
+				06E316B51DD023288F6F5F2A /* Container */,
+				1D548C4AD07209A12F6FCEDE /* FileUploadNotification */,
+				5F428018966094C386A045C4 /* Group */,
+				78EBA7B29813A53D5A9AD872 /* K5 */,
+				6A3541D8D144C9A887F17564 /* Notification */,
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		21C9309B7D55C2D368DD2B23 /* Model */ = {
@@ -4223,6 +4280,13 @@
 				3B4FAB8418C8320F79FE2592 /* PutDashboardCardPositionsTests.swift */,
 			);
 			path = UseCase;
+			sourceTree = "<group>";
+		};
+		289119BA945905CEECDC6404 /* DocViewer */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DocViewer;
 			sourceTree = "<group>";
 		};
 		29A681523032C9F0460D13DF /* View */ = {
@@ -4969,6 +5033,13 @@
 			path = Syllabus;
 			sourceTree = "<group>";
 		};
+		433DDC5EFFE3D9FE3809D483 /* Quizzes */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Quizzes;
+			sourceTree = "<group>";
+		};
 		436DAF3ABE6692A54F6E1584 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -5034,6 +5105,13 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
+		45AE6AA24575C49F0A193D7F /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
 		45F2AB93913E94E1EB859A8F /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5063,6 +5141,25 @@
 				61A1E8C4C40ECFEDE96D43D0 /* DocViewerAnnotationUploadResponseHandler.swift */,
 			);
 			path = ResponseHandling;
+			sourceTree = "<group>";
+		};
+		46E180A5270BE50B1BAE6E44 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				15769FCE677A9C9F5B0A7CA6 /* CoreWebView */,
+				45AE6AA24575C49F0A193D7F /* Courses */,
+				5C8063761CEE6EF4856E77C9 /* CourseSync */,
+				71D97A1D591434A33BCB62F5 /* Dashboard */,
+				5693A9621060A98BB2BD6BB6 /* DocViewer */,
+				7ACA639B28690D26E3B4BFB8 /* Files */,
+				19958B6AD0248B53014070C5 /* Inbox */,
+				B2525E0E11159C3FC91DB478 /* People */,
+				6A979E40A3CC558130B78B0F /* Profile */,
+				BE9C131EF7967804F6B514B1 /* Quizzes */,
+				15CFE96D45F44C688F7D05C1 /* SubmitAssignmentExtension */,
+				D28C27753F8FCDC43A393D49 /* SwiftUIViews */,
+			);
+			path = Sources;
 			sourceTree = "<group>";
 		};
 		481AA5EAFCF724C6F0F8400C /* Addressbook */ = {
@@ -5270,6 +5367,25 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		52B4A01AA5EDF9DB2E435557 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+				A7872205234C480312539802 /* Assignments */,
+				F9F236A5D1B6E9EDBAC590BC /* CoreWebView */,
+				B1C027449ED3388ECF692C1F /* Courses */,
+				F5E62DF4F777D9127A8F5103 /* CourseSync */,
+				21207C91941273BDFF517366 /* Dashboard */,
+				289119BA945905CEECDC6404 /* DocViewer */,
+				A0A4835C7FC94C053347D394 /* Files */,
+				6BC8F6F217D27C91CBF0EA9A /* Inbox */,
+				840120F9E6E51BA5C14E5D6C /* People */,
+				8503617909F61F7E3B54C767 /* Profile */,
+				433DDC5EFFE3D9FE3809D483 /* Quizzes */,
+				602E002B0A978C34B1047394 /* SwiftUIViews */,
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		53032D265BEF6E1A76A57C41 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -5330,6 +5446,13 @@
 				08A7A5A46E49E3761398CA93 /* K5ImportantDatesViewModel.swift */,
 			);
 			path = ImportantDates;
+			sourceTree = "<group>";
+		};
+		5693A9621060A98BB2BD6BB6 /* DocViewer */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DocViewer;
 			sourceTree = "<group>";
 		};
 		57134DDA24547C9F07DF08CA /* Model */ = {
@@ -5589,6 +5712,13 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		5C8063761CEE6EF4856E77C9 /* CourseSync */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CourseSync;
+			sourceTree = "<group>";
+		};
 		5CDC7EAC7F9AD4B81A819533 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -5632,6 +5762,13 @@
 			path = AudioVideo;
 			sourceTree = "<group>";
 		};
+		5F428018966094C386A045C4 /* Group */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Group;
+			sourceTree = "<group>";
+		};
 		5F8CE6C5C98643B733EADFB1 /* Enrollments */ = {
 			isa = PBXGroup;
 			children = (
@@ -5641,6 +5778,13 @@
 				E853CACABF36E865C5682822 /* RoleTests.swift */,
 			);
 			path = Enrollments;
+			sourceTree = "<group>";
+		};
+		602E002B0A978C34B1047394 /* SwiftUIViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SwiftUIViews;
 			sourceTree = "<group>";
 		};
 		61E04C5F9E5CDDF397B8E840 /* Analytics */ = {
@@ -5789,12 +5933,33 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		6A3541D8D144C9A887F17564 /* Notification */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Notification;
+			sourceTree = "<group>";
+		};
+		6A979E40A3CC558130B78B0F /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
 		6B2903A3F8C8721E762E2014 /* Model */ = {
 			isa = PBXGroup;
 			children = (
 				287547C5CC7374AF99E38731 /* UseCase */,
 			);
 			path = Model;
+			sourceTree = "<group>";
+		};
+		6BC8F6F217D27C91CBF0EA9A /* Inbox */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Inbox;
 			sourceTree = "<group>";
 		};
 		6BD95991C2010238C37A8D4F /* View */ = {
@@ -5844,6 +6009,7 @@
 			isa = PBXGroup;
 			children = (
 				B93949D5CAD36EF43399EDF9 /* Fonts */,
+				39C01BEDACCD811D2E26E465 /* Assets.xcassets */,
 				8E5D3EAD5E2135988C032705 /* defaultHeaderImage.png */,
 			);
 			path = Resources;
@@ -5966,6 +6132,13 @@
 				562A0E1BA178E4D5780B67CD /* TypeSafeCodableTests.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		71D97A1D591434A33BCB62F5 /* Dashboard */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Dashboard;
 			sourceTree = "<group>";
 		};
 		71E4B1098694A1A88ECF9D75 /* View */ = {
@@ -6113,6 +6286,14 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		78EBA7B29813A53D5A9AD872 /* K5 */ = {
+			isa = PBXGroup;
+			children = (
+				EE1D34E5E7F6630810F1AA02 /* ViewModel */,
+			);
+			path = K5;
+			sourceTree = "<group>";
+		};
 		792E587F8B67FDCF0560AA5A /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -6138,6 +6319,14 @@
 				0AA93F8945151E6D5E0DA439 /* AssignmentPickerListService.swift */,
 			);
 			path = API;
+			sourceTree = "<group>";
+		};
+		7ACA639B28690D26E3B4BFB8 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+				81449C16A62B4EE5455B2EE1 /* View */,
+			);
+			path = Files;
 			sourceTree = "<group>";
 		};
 		7CA17FD2C1EABD309B108A6F /* ContextCard */ = {
@@ -6249,6 +6438,13 @@
 			path = Grades;
 			sourceTree = "<group>";
 		};
+		81449C16A62B4EE5455B2EE1 /* View */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
 		81B5D9C3B0D9151DDE9446AC /* WidgetsSupport */ = {
 			isa = PBXGroup;
 			children = (
@@ -6322,6 +6518,13 @@
 			path = Settings;
 			sourceTree = "<group>";
 		};
+		840120F9E6E51BA5C14E5D6C /* People */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = People;
+			sourceTree = "<group>";
+		};
 		8418B1360F4D720B0F67277E /* NetworkAvailability */ = {
 			isa = PBXGroup;
 			children = (
@@ -6346,6 +6549,13 @@
 				5C79DD83EC46C1780A24D067 /* ObserverAlertTests.swift */,
 			);
 			path = ObserverAlerts;
+			sourceTree = "<group>";
+		};
+		8503617909F61F7E3B54C767 /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Profile;
 			sourceTree = "<group>";
 		};
 		85077BC58E1BBCB5DB69EA98 /* Modules */ = {
@@ -6850,6 +7060,7 @@
 				90C4F82791B3B883003B49C5 /* Quizzes */,
 				01AC5166B8C7F12BA9DCBB93 /* RichContentEditor */,
 				7775E906C5B94F5EEF674386 /* Router */,
+				46E180A5270BE50B1BAE6E44 /* Sources */,
 				9C46FAD063BA96A6109A885E /* Store */,
 				D742111A4E51B5683CB6F9E5 /* Submissions */,
 				13BB69D0F5082096DC44486E /* SubmitAssignmentExtension */,
@@ -7133,6 +7344,13 @@
 			path = QuizDetails;
 			sourceTree = "<group>";
 		};
+		A0A4835C7FC94C053347D394 /* Files */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Files;
+			sourceTree = "<group>";
+		};
 		A0BB17ACB29B50382F946175 /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
@@ -7255,6 +7473,13 @@
 				3C1FF7B151B7D76ED706ACA1 /* Model */,
 			);
 			path = GradingStandard;
+			sourceTree = "<group>";
+		};
+		A7872205234C480312539802 /* Assignments */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Assignments;
 			sourceTree = "<group>";
 		};
 		A7969A53EFE2E8A6649F49D7 /* Announcements */ = {
@@ -7491,6 +7716,14 @@
 			path = Planner;
 			sourceTree = "<group>";
 		};
+		B1C027449ED3388ECF692C1F /* Courses */ = {
+			isa = PBXGroup;
+			children = (
+				D808C7EBF928E6D6716D675E /* AllCourses */,
+			);
+			path = Courses;
+			sourceTree = "<group>";
+		};
 		B1C34AF4857F4CF312828B87 /* Constants */ = {
 			isa = PBXGroup;
 			children = (
@@ -7500,6 +7733,13 @@
 				DF6B7233D6E932755EAEFF16 /* UserAgent.swift */,
 			);
 			path = Constants;
+			sourceTree = "<group>";
+		};
+		B2525E0E11159C3FC91DB478 /* People */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = People;
 			sourceTree = "<group>";
 		};
 		B28074855E192D3DD1135F4B /* Products */ = {
@@ -7740,6 +7980,13 @@
 			path = SideMenu;
 			sourceTree = "<group>";
 		};
+		BE9C131EF7967804F6B514B1 /* Quizzes */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Quizzes;
+			sourceTree = "<group>";
+		};
 		BEBC6868A9E2321EAE6FE19E /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -7788,6 +8035,13 @@
 				4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CourseSyncDownloader;
 			sourceTree = "<group>";
 		};
 		C2F6233AB51C459BF3A66F2E /* Model */ = {
@@ -8059,6 +8313,13 @@
 			path = ViewModel;
 			sourceTree = "<group>";
 		};
+		D28C27753F8FCDC43A393D49 /* SwiftUIViews */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = SwiftUIViews;
+			sourceTree = "<group>";
+		};
 		D2B97380463243815383FBA0 /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
@@ -8193,6 +8454,13 @@
 				40EE3742920BE5C74E1D7CEB /* CourseSyncProgressViewModelTests.swift */,
 			);
 			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		D808C7EBF928E6D6716D675E /* AllCourses */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = AllCourses;
 			sourceTree = "<group>";
 		};
 		D820AD1E2667F989BE655351 /* CourseDetails */ = {
@@ -8677,6 +8945,13 @@
 			path = Help;
 			sourceTree = "<group>";
 		};
+		EE1D34E5E7F6630810F1AA02 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
 		EE47A667792D181291BC8D12 /* BackgroundUpdates */ = {
 			isa = PBXGroup;
 			children = (
@@ -8821,6 +9096,14 @@
 			path = Entities;
 			sourceTree = "<group>";
 		};
+		F5E62DF4F777D9127A8F5103 /* CourseSync */ = {
+			isa = PBXGroup;
+			children = (
+				C1720F7195B92286C9B8EB46 /* CourseSyncDownloader */,
+			);
+			path = CourseSync;
+			sourceTree = "<group>";
+		};
 		F696335407E9880E6BD3C7EA /* View */ = {
 			isa = PBXGroup;
 			children = (
@@ -8888,6 +9171,13 @@
 				C28BD7040645C5AE1ADDA23F /* K5ResourcesViewModelTests.swift */,
 			);
 			path = Resources;
+			sourceTree = "<group>";
+		};
+		F9F236A5D1B6E9EDBAC590BC /* CoreWebView */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = CoreWebView;
 			sourceTree = "<group>";
 		};
 		FA5A00EC8BF93DA0E4394AF8 /* AllCourses */ = {
@@ -8964,6 +9254,7 @@
 				4514D62DB85771B622259882 /* RichContentEditor */,
 				5BB8D351610D5E4BEC708D1D /* Router */,
 				461F876D89C3F74044C343B1 /* ScreenViewLogger */,
+				52B4A01AA5EDF9DB2E435557 /* Sources */,
 				2EEBA6D6C1B2CFC32E23E8A8 /* Store */,
 				7CF3349E196B2FB15B5877A7 /* Submissions */,
 				81DC2E96AD7CC08AD4C6F79C /* SubmitAssignmentExtension */,
@@ -9204,46 +9495,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				Base,
-				ar,
-				ca,
-				cy,
-				da,
-				"da-instk12",
-				de,
 				en,
-				"en-AU",
-				"en-AU-unimelb",
-				"en-CA",
-				"en-CY",
-				"en-GB",
-				"en-GB-instukhe",
-				es,
-				"es-ES",
-				fi,
-				fr,
-				"fr-CA",
-				ht,
-				is,
-				it,
-				ja,
-				mi,
-				ms,
-				nb,
-				"nb-instk12",
-				nl,
-				pl,
-				pt,
-				"pt-BR",
-				ru,
-				sl,
-				sv,
-				"sv-instk12",
-				th,
-				vi,
-				zh,
-				"zh-HK",
-				"zh-Hans",
-				"zh-Hant",
 			);
 			mainGroup = 62824534F75515F48E8114A7;
 			packageReferences = (
@@ -9307,6 +9559,7 @@
 				079FA0F2ED8D8269AF96C452 /* ActAsUserViewController.storyboard in Resources */,
 				8E44734F8D26D951C93716F5 /* AnnouncementListViewController.storyboard in Resources */,
 				EAEF98AAC2663BEC33A37127 /* Assets.xcassets in Resources */,
+				E92E3ACDBB298DABF813C847 /* Assets.xcassets in Resources */,
 				C12D2EAC3DC60C738EC8807F /* AudioPlayerViewController.storyboard in Resources */,
 				C406485DE3B48D2D910E34F8 /* AudioRecorderViewController.storyboard in Resources */,
 				4061B82BCF8B18D412CF5E6B /* CalendarDayIconView.xib in Resources */,

--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -2238,7 +2238,7 @@
 		4BD5DD42D6197C30DAC5415E /* AssignmentAssigneePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentAssigneePicker.swift; sourceTree = "<group>"; };
 		4BDF0042C4EC9719269D89FE /* AssignmentDueDatesInteractorLive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentDueDatesInteractorLive.swift; sourceTree = "<group>"; };
 		4BF91515A5A28F35FBD75E03 /* GetObservedStudents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedStudents.swift; sourceTree = "<group>"; };
-		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = TestImage.svg; sourceTree = "<group>"; };
+		4C02C87B4FD4AD4D7489EE6D /* TestImage.svg */ = {isa = PBXFileReference; path = TestImage.svg; sourceTree = "<group>"; };
 		4C0C49ADE7F2DE21CE36FB77 /* CourseSyncDiskSpaceInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncDiskSpaceInfoView.swift; sourceTree = "<group>"; };
 		4C11E387DD144E7B7A7D7405 /* DateSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateSection.swift; sourceTree = "<group>"; };
 		4C310E09D98CD58CE1C3D781 /* AssignmentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AssignmentListViewModel.swift; sourceTree = "<group>"; };
@@ -2476,7 +2476,7 @@
 		710985C08016CBBD13536D08 /* UISplitViewControllerExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISplitViewControllerExtensions.swift; sourceTree = "<group>"; };
 		714916675A9B46CCF678AF57 /* GetContextUsersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetContextUsersTests.swift; sourceTree = "<group>"; };
 		716ACC276087D94ABC0767A5 /* TopBarItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBarItemViewModel.swift; sourceTree = "<group>"; };
-		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		719D01C52A9B62676C43DBA5 /* Localizable.xcstrings */ = {isa = PBXFileReference; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		71A7FCCB6211DB618DE3501F /* K5ScheduleMissingItemsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5ScheduleMissingItemsView.swift; sourceTree = "<group>"; };
 		71D50565B45B984F260FB78F /* CalendarViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarViewController.swift; sourceTree = "<group>"; };
 		71EAD005E184B589BAC02E31 /* K5GradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5GradesView.swift; sourceTree = "<group>"; };
@@ -2816,7 +2816,7 @@
 		A3CBD2A123330769319E0D7D /* CourseSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSettingsTests.swift; sourceTree = "<group>"; };
 		A3EA58F752AE33267DC3D54C /* CourseSyncProgressInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressInfoViewModel.swift; sourceTree = "<group>"; };
 		A3F215916DB26B661EA4FC39 /* APIGradingSchemeEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIGradingSchemeEntry.swift; sourceTree = "<group>"; };
-		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = preview_test.mp4; sourceTree = "<group>"; };
+		A42096D6B21359616953C14C /* preview_test.mp4 */ = {isa = PBXFileReference; path = preview_test.mp4; sourceTree = "<group>"; };
 		A428BBF27D3A0637022B49F2 /* FileListViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileListViewControllerTests.swift; sourceTree = "<group>"; };
 		A42E6D4DF3963671589B5A3A /* DashboardCardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCardTests.swift; sourceTree = "<group>"; };
 		A43DD0C2A830D421979AEF65 /* InboxMessageScopeFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxMessageScopeFilterTests.swift; sourceTree = "<group>"; };
@@ -2860,7 +2860,7 @@
 		A9193DA17C6897AC20A0F645 /* ClosedRangeExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedRangeExtensions.swift; sourceTree = "<group>"; };
 		A92489739FA867834EE67DA3 /* APIBrandVariables.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIBrandVariables.swift; sourceTree = "<group>"; };
 		A9328E630A8C08D6995EDCC8 /* LoginFindSchoolViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginFindSchoolViewControllerTests.swift; sourceTree = "<group>"; };
-		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
+		A9860AECF67572B989503005 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorViewController.swift; sourceTree = "<group>"; };
 		A9F8E88E51C265BD7A6ADED7 /* PageListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageListViewController.swift; sourceTree = "<group>"; };
 		AA233A607AC160DF923CE1D7 /* K5StateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = K5StateTests.swift; sourceTree = "<group>"; };
@@ -9495,7 +9495,46 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				Base,
+				ar,
+				ca,
+				cy,
+				da,
+				"da-instk12",
+				de,
 				en,
+				"en-AU",
+				"en-AU-unimelb",
+				"en-CA",
+				"en-CY",
+				"en-GB",
+				"en-GB-instukhe",
+				es,
+				"es-ES",
+				fi,
+				fr,
+				"fr-CA",
+				ht,
+				is,
+				it,
+				ja,
+				mi,
+				ms,
+				nb,
+				"nb-instk12",
+				nl,
+				pl,
+				pt,
+				"pt-BR",
+				ru,
+				sl,
+				sv,
+				"sv-instk12",
+				th,
+				vi,
+				zh,
+				"zh-HK",
+				"zh-Hans",
+				"zh-Hant",
 			);
 			mainGroup = 62824534F75515F48E8114A7;
 			packageReferences = (

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAnnouncementsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAnnouncementsInteractor.swift
@@ -56,7 +56,7 @@ public final class CourseSyncAnnouncementsInteractorLive: CourseSyncAnnouncement
 
     private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: useCase)
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAnnouncementsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAnnouncementsInteractor.swift
@@ -56,7 +56,7 @@ public final class CourseSyncAnnouncementsInteractorLive: CourseSyncAnnouncement
 
     private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: useCase)
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAssignmentsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAssignmentsInteractor.swift
@@ -31,7 +31,7 @@ public final class CourseSyncAssignmentsInteractorLive: CourseSyncAssignmentsInt
         ReactiveStore(
             useCase: GetAssignmentsByGroup(courseID: courseId)
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .flatMap { Publishers.Sequence(sequence: $0).setFailureType(to: Error.self) }
         .filter { $0.submission != nil }
         .flatMap { Self.getSubmissionComments(courseID: courseId, assignmentID: $0.id, userID: $0.submission!.userID) }
@@ -52,7 +52,7 @@ public final class CourseSyncAssignmentsInteractorLive: CourseSyncAssignmentsInt
                 userID: userID
             )
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .map { _ in () }
         .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAssignmentsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncAssignmentsInteractor.swift
@@ -31,7 +31,7 @@ public final class CourseSyncAssignmentsInteractorLive: CourseSyncAssignmentsInt
         ReactiveStore(
             useCase: GetAssignmentsByGroup(courseID: courseId)
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .flatMap { Publishers.Sequence(sequence: $0).setFailureType(to: Error.self) }
         .filter { $0.submission != nil }
         .flatMap { Self.getSubmissionComments(courseID: courseId, assignmentID: $0.id, userID: $0.submission!.userID) }
@@ -52,7 +52,7 @@ public final class CourseSyncAssignmentsInteractorLive: CourseSyncAssignmentsInt
                 userID: userID
             )
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .map { _ in () }
         .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractor.swift
@@ -51,7 +51,7 @@ public final class CourseSyncConferencesInteractorLive: CourseSyncConferencesInt
 
     private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: useCase)
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncConferencesInteractor.swift
@@ -51,7 +51,7 @@ public final class CourseSyncConferencesInteractorLive: CourseSyncConferencesInt
 
     private func fetchUseCase<U: UseCase>(_ useCase: U) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: useCase)
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncDiscussionsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncDiscussionsInteractor.swift
@@ -41,7 +41,7 @@ public class CourseSyncDiscussionsInteractorLive: CourseSyncDiscussionsInteracto
 
     private static func fetchTopics(courseId: String) -> AnyPublisher<[DiscussionTopic], Error> {
         ReactiveStore(useCase: GetDiscussionTopics(context: .course(courseId)))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .eraseToAnyPublisher()
     }
 
@@ -50,7 +50,7 @@ public class CourseSyncDiscussionsInteractorLive: CourseSyncDiscussionsInteracto
         topicId: String
     ) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetDiscussionView(context: .course(courseId), topicID: topicId))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncDiscussionsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncDiscussionsInteractor.swift
@@ -41,7 +41,7 @@ public class CourseSyncDiscussionsInteractorLive: CourseSyncDiscussionsInteracto
 
     private static func fetchTopics(courseId: String) -> AnyPublisher<[DiscussionTopic], Error> {
         ReactiveStore(useCase: GetDiscussionTopics(context: .course(courseId)))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .eraseToAnyPublisher()
     }
 
@@ -50,7 +50,7 @@ public class CourseSyncDiscussionsInteractorLive: CourseSyncDiscussionsInteracto
         topicId: String
     ) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetDiscussionView(context: .course(courseId), topicID: topicId))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
@@ -67,7 +67,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
                 context: .course(courseId)
             )
         )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities()
+        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(forceFetch: true)
 
         return publisher
             .flatMap {
@@ -127,7 +127,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
                 folderID: folderID
             )
         )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities()
+        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(forceFetch: true)
 
         return publisher
             .tryCatch { error -> AnyPublisher<[FolderItem], Error> in

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
@@ -67,7 +67,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
                 context: .course(courseId)
             )
         )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(forceFetch: true)
+        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(ignoreCache: true)
 
         return publisher
             .flatMap {
@@ -127,7 +127,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
                 folderID: folderID
             )
         )
-        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(forceFetch: true)
+        let publisher = useCache ? store.getEntitiesFromDatabase() : store.getEntities(ignoreCache: true)
 
         return publisher
             .tryCatch { error -> AnyPublisher<[FolderItem], Error> in

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractor.swift
@@ -53,21 +53,21 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
 
     private static func fetchCourseColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchGradingPeriods(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetGradingPeriods(courseID: courseId))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchCourseAndGetGradingPeriodID(courseId: String, userId: String) -> AnyPublisher<CurrentGradingPeriodID?, Error> {
         ReactiveStore(useCase: GetCourse(courseID: courseId))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .map { $0.first?.enrollmentForGrades(userId: userId)?.currentGradingPeriodID }
             .eraseToAnyPublisher()
     }
@@ -79,7 +79,7 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
                                      types: ["StudentEnrollment"],
                                      states: [.active])
         return ReactiveStore(useCase: useCase)
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
@@ -89,7 +89,7 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
                                             gradingPeriodID: gradingPeriodID,
                                             gradedOnly: true)
         return ReactiveStore(useCase: useCase)
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractor.swift
@@ -53,21 +53,21 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
 
     private static func fetchCourseColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchGradingPeriods(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetGradingPeriods(courseID: courseId))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchCourseAndGetGradingPeriodID(courseId: String, userId: String) -> AnyPublisher<CurrentGradingPeriodID?, Error> {
         ReactiveStore(useCase: GetCourse(courseID: courseId))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .map { $0.first?.enrollmentForGrades(userId: userId)?.currentGradingPeriodID }
             .eraseToAnyPublisher()
     }
@@ -79,7 +79,7 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
                                      types: ["StudentEnrollment"],
                                      states: [.active])
         return ReactiveStore(useCase: useCase)
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
@@ -89,7 +89,7 @@ public class CourseSyncGradesInteractorLive: CourseSyncGradesInteractor {
                                             gradingPeriodID: gradingPeriodID,
                                             gradedOnly: true)
         return ReactiveStore(useCase: useCase)
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -35,7 +35,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
         ReactiveStore(
             useCase: GetModules(courseID: courseId)
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .flatMap { $0.publisher }
         .flatMap { Self.getModuleItemSequence(courseID: $0.courseID, moduleItems: $0.items) }
         .collect()
@@ -56,7 +56,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                         assetID: $0.id
                     )
                 )
-                .getEntities(forceFetch: true)
+                .getEntities(ignoreCache: true)
             }
             .collect()
             .map { _ in moduleItems }
@@ -100,7 +100,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetPage(context: .course(courseId), url: $0)
                 )
-                .getEntities(forceFetch: true)
+                .getEntities(ignoreCache: true)
             }
             .collect()
             .mapToVoid()
@@ -118,7 +118,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetQuiz(courseID: courseId, quizID: $0)
                 )
-                .getEntities(forceFetch: true)
+                .getEntities(ignoreCache: true)
             }
             .collect()
             .mapToVoid()
@@ -137,7 +137,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetFile(context: .course(courseId), fileID: $0)
                 )
-                .getEntities(forceFetch: true)
+                .getEntities(ignoreCache: true)
                 .flatMap { [filesInteractor] files -> AnyPublisher<Void, Error> in
                     guard let file = files.first, let url = file.url, let fileID = file.id, let mimeClass = file.mimeClass else {
                         return Empty(completeImmediately: false)

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -35,7 +35,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
         ReactiveStore(
             useCase: GetModules(courseID: courseId)
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .flatMap { $0.publisher }
         .flatMap { Self.getModuleItemSequence(courseID: $0.courseID, moduleItems: $0.items) }
         .collect()
@@ -56,7 +56,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                         assetID: $0.id
                     )
                 )
-                .getEntities()
+                .getEntities(forceFetch: true)
             }
             .collect()
             .map { _ in moduleItems }
@@ -100,7 +100,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetPage(context: .course(courseId), url: $0)
                 )
-                .getEntities()
+                .getEntities(forceFetch: true)
             }
             .collect()
             .mapToVoid()
@@ -118,7 +118,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetQuiz(courseID: courseId, quizID: $0)
                 )
-                .getEntities()
+                .getEntities(forceFetch: true)
             }
             .collect()
             .mapToVoid()
@@ -137,7 +137,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 ReactiveStore(
                     useCase: GetFile(context: .course(courseId), fileID: $0)
                 )
-                .getEntities()
+                .getEntities(forceFetch: true)
                 .flatMap { [filesInteractor] files -> AnyPublisher<Void, Error> in
                     guard let file = files.first, let url = file.url, let fileID = file.id, let mimeClass = file.mimeClass else {
                         return Empty(completeImmediately: false)

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPagesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPagesInteractor.swift
@@ -34,13 +34,13 @@ public final class CourseSyncPagesInteractorLive: CourseSyncPagesInteractor, Cou
                     context: .course(courseId)
                 )
             )
-            .getEntities(forceFetch: true),
+            .getEntities(ignoreCache: true),
             ReactiveStore(
                 useCase: GetPages(
                     context: .course(courseId)
                 )
             )
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
         )
         .map { _ in () }
         .eraseToAnyPublisher()

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPagesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPagesInteractor.swift
@@ -34,13 +34,13 @@ public final class CourseSyncPagesInteractorLive: CourseSyncPagesInteractor, Cou
                     context: .course(courseId)
                 )
             )
-            .getEntities(),
+            .getEntities(forceFetch: true),
             ReactiveStore(
                 useCase: GetPages(
                     context: .course(courseId)
                 )
             )
-            .getEntities()
+            .getEntities(forceFetch: true)
         )
         .map { _ in () }
         .eraseToAnyPublisher()

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPeopleInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPeopleInteractor.swift
@@ -42,28 +42,28 @@ class CourseSyncPeopleInteractorLive: CourseSyncPeopleInteractor {
 
     private static func fetchCourseColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchCourse(context: Context) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourse(courseID: context.id))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchUsers(context: Context) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetPeopleListUsers(context: context))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchSections(courseID: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourseSections(courseID: courseID))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPeopleInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncPeopleInteractor.swift
@@ -42,28 +42,28 @@ class CourseSyncPeopleInteractorLive: CourseSyncPeopleInteractor {
 
     private static func fetchCourseColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchCourse(context: Context) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourse(courseID: context.id))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchUsers(context: Context) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetPeopleListUsers(context: context))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchSections(courseID: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourseSections(courseID: courseID))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncQuizzesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncQuizzesInteractor.swift
@@ -41,7 +41,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetCustomColors()
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .map { _ in () }
         .eraseToAnyPublisher()
     }
@@ -50,7 +50,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetQuizzes(courseID: courseId)
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .flatMap {
             $0.publisher
                 .filter { $0.quizType != .quizzes_next }
@@ -65,7 +65,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetQuiz(courseID: courseId, quizID: quizId)
         )
-        .getEntities(forceFetch: true)
+        .getEntities(ignoreCache: true)
         .mapToVoid()
         .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncQuizzesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncQuizzesInteractor.swift
@@ -41,7 +41,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetCustomColors()
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .map { _ in () }
         .eraseToAnyPublisher()
     }
@@ -50,7 +50,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetQuizzes(courseID: courseId)
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .flatMap {
             $0.publisher
                 .filter { $0.quizType != .quizzes_next }
@@ -65,7 +65,7 @@ public final class CourseSyncQuizzesInteractorLive: CourseSyncQuizzesInteractor,
         ReactiveStore(
             useCase: GetQuiz(courseID: courseId, quizID: quizId)
         )
-        .getEntities()
+        .getEntities(forceFetch: true)
         .mapToVoid()
         .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractor.swift
@@ -54,21 +54,21 @@ public final class CourseSyncSyllabusInteractorLive: CourseSyncSyllabusInteracto
     typealias SyllabusSummaryEnabled = Bool
     private func fetchCourseSettingsAndGetSyllabusSummaryState(courseId: String) -> AnyPublisher<SyllabusSummaryEnabled, Error> {
         ReactiveStore(useCase: GetCourseSettings(courseID: courseId))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .map { $0.first?.syllabusCourseSummary == true }
             .eraseToAnyPublisher()
     }
 
     private static func fetchAssignments(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCalendarEvents(context: .course(courseId), type: .assignment))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchEvents(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCalendarEvents(context: .course(courseId), type: .event))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
@@ -85,14 +85,14 @@ public final class CourseSyncSyllabusInteractorLive: CourseSyncSyllabusInteracto
 
     private func fetchCourse(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourse(courseID: courseId))
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private func fetchColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities()
+            .getEntities(forceFetch: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractor.swift
@@ -54,21 +54,21 @@ public final class CourseSyncSyllabusInteractorLive: CourseSyncSyllabusInteracto
     typealias SyllabusSummaryEnabled = Bool
     private func fetchCourseSettingsAndGetSyllabusSummaryState(courseId: String) -> AnyPublisher<SyllabusSummaryEnabled, Error> {
         ReactiveStore(useCase: GetCourseSettings(courseID: courseId))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .map { $0.first?.syllabusCourseSummary == true }
             .eraseToAnyPublisher()
     }
 
     private static func fetchAssignments(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCalendarEvents(context: .course(courseId), type: .assignment))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private static func fetchEvents(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCalendarEvents(context: .course(courseId), type: .event))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
@@ -85,14 +85,14 @@ public final class CourseSyncSyllabusInteractorLive: CourseSyncSyllabusInteracto
 
     private func fetchCourse(courseId: String) -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCourse(courseID: courseId))
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }
 
     private func fetchColors() -> AnyPublisher<Void, Error> {
         ReactiveStore(useCase: GetCustomColors())
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .mapToVoid()
             .eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
@@ -48,7 +48,7 @@ final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserver
 
     func observeDownloadProgress() -> AnyPublisher<CourseSyncDownloadProgress, Never> {
         fileProgressUseCase
-            .getEntities(publishDatabaseChanges: true)
+            .getEntities(keepObservingDatabaseChanges: true)
             .replaceError(with: [])
             .compactMap { $0.first }
             .map { CourseSyncDownloadProgress.init(from: $0) }
@@ -57,7 +57,7 @@ final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserver
 
     func observeStateProgress() -> AnyPublisher<[CourseSyncStateProgress], Never> {
         entryProgressUseCase
-            .getEntities(publishDatabaseChanges: true)
+            .getEntities(keepObservingDatabaseChanges: true)
             .replaceError(with: [])
             .compactMap { $0 }
             .map { $0.makeItems() }

--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
@@ -46,11 +46,6 @@ final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserver
         context.automaticallyMergesChangesFromParent = true
     }
 
-//    deinit {
-//        fileProgressUseCase.cancel()
-//        entryProgressUseCase.cancel()
-//    }
-
     func observeDownloadProgress() -> AnyPublisher<CourseSyncDownloadProgress, Never> {
         fileProgressUseCase
             .getEntities(publishDatabaseChanges: true)

--- a/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/Model/CourseSyncProgressObserverInteractor.swift
@@ -46,23 +46,25 @@ final class CourseSyncProgressObserverInteractorLive: CourseSyncProgressObserver
         context.automaticallyMergesChangesFromParent = true
     }
 
-    deinit {
-        fileProgressUseCase.cancel()
-        entryProgressUseCase.cancel()
-    }
+//    deinit {
+//        fileProgressUseCase.cancel()
+//        entryProgressUseCase.cancel()
+//    }
 
     func observeDownloadProgress() -> AnyPublisher<CourseSyncDownloadProgress, Never> {
         fileProgressUseCase
-            .observeEntities()
-            .compactMap { $0.firstItem }
+            .getEntities(publishDatabaseChanges: true)
+            .replaceError(with: [])
+            .compactMap { $0.first }
             .map { CourseSyncDownloadProgress.init(from: $0) }
             .eraseToAnyPublisher()
     }
 
     func observeStateProgress() -> AnyPublisher<[CourseSyncStateProgress], Never> {
         entryProgressUseCase
-            .observeEntities()
-            .compactMap { $0.allItems }
+            .getEntities(publishDatabaseChanges: true)
+            .replaceError(with: [])
+            .compactMap { $0 }
             .map { $0.makeItems() }
             .eraseToAnyPublisher()
     }

--- a/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
@@ -86,15 +86,15 @@ public class CourseListInteractorLive: CourseListInteractor {
 
         return Publishers.CombineLatest3(
             activeCoursesStore
-                .getEntities(publishDatabaseChanges: true)
+                .getEntities(keepObservingDatabaseChanges: true)
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}},
             pastCoursesStore
-                .getEntities(publishDatabaseChanges: true)
+                .getEntities(keepObservingDatabaseChanges: true)
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}},
             futureCoursesStore
-                .getEntities(publishDatabaseChanges: true)
+                .getEntities(keepObservingDatabaseChanges: true)
                 .map { [env] in filterUnpublishedCoursesForStudents(env.app, $0) }
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}}

--- a/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
@@ -86,15 +86,15 @@ public class CourseListInteractorLive: CourseListInteractor {
 
         return Publishers.CombineLatest3(
             activeCoursesStore
-                .observeEntitiesWithError()
+                .getEntities(publishDatabaseChanges: true)
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}},
             pastCoursesStore
-                .observeEntitiesWithError()
+                .getEntities(publishDatabaseChanges: true)
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}},
             futureCoursesStore
-                .observeEntitiesWithError()
+                .getEntities(publishDatabaseChanges: true)
                 .map { [env] in filterUnpublishedCoursesForStudents(env.app, $0) }
                 .filter(with: searchQuery)
                 .map { $0.map { AllCoursesCourseItem.init(from: $0)}}

--- a/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/CourseListInteractor.swift
@@ -122,9 +122,9 @@ public class CourseListInteractorLive: CourseListInteractor {
 
     public func refresh() -> AnyPublisher<Void, Never> {
         Publishers.CombineLatest3(
-            activeCoursesStore.forceFetchEntities(),
-            pastCoursesStore.forceFetchEntities(),
-            futureCoursesStore.forceFetchEntities()
+            activeCoursesStore.forceRefresh(),
+            pastCoursesStore.forceRefresh(),
+            futureCoursesStore.forceRefresh()
         )
         .mapToVoid()
         .eraseToAnyPublisher()

--- a/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
@@ -82,7 +82,7 @@ public class GroupListInteractorLive: GroupListInteractor {
         guard shouldListGroups else {
             return Just(()).eraseToAnyPublisher()
         }
-        return groupListStore.forceFetchEntities()
+        return groupListStore.forceRefresh()
     }
 
     public func setFilter(_ filter: String) -> AnyPublisher<Void, Never> {

--- a/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
@@ -60,7 +60,7 @@ public class GroupListInteractorLive: GroupListInteractor {
                 .eraseToAnyPublisher()
         }
         return groupListStore
-            .observeEntitiesWithError()
+            .getEntities(publishDatabaseChanges: true)
             .filter(with: searchQuery)
             .map { $0.map { AllCoursesGroupItem(from: $0) }}
             .eraseToAnyPublisher()

--- a/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
+++ b/Core/Core/Courses/AllCourses/Model/GroupListInteractor.swift
@@ -60,7 +60,7 @@ public class GroupListInteractorLive: GroupListInteractor {
                 .eraseToAnyPublisher()
         }
         return groupListStore
-            .getEntities(publishDatabaseChanges: true)
+            .getEntities(keepObservingDatabaseChanges: true)
             .filter(with: searchQuery)
             .map { $0.map { AllCoursesGroupItem(from: $0) }}
             .eraseToAnyPublisher()

--- a/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
+++ b/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
@@ -58,7 +58,7 @@ public class DashboardContainerViewModel: ObservableObject {
             useCase: GetDashboardGroups()
         )
 
-        groupListStore.observeEntitiesWithError()
+        groupListStore.getEntities(publishDatabaseChanges: true)
             .replaceError(with: [])
             .assign(to: &$groups)
 

--- a/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
+++ b/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
@@ -71,7 +71,7 @@ public class DashboardContainerViewModel: ObservableObject {
 
     public func refreshGroups(onComplete: (() -> Void)? = nil) {
         groupListStore
-            .forceFetchEntities()
+            .forceRefresh()
             .sink { _ in
                 onComplete?()
             }

--- a/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
+++ b/Core/Core/Dashboard/Container/ViewModel/DashboardContainerViewModel.swift
@@ -58,7 +58,7 @@ public class DashboardContainerViewModel: ObservableObject {
             useCase: GetDashboardGroups()
         )
 
-        groupListStore.getEntities(publishDatabaseChanges: true)
+        groupListStore.getEntities(keepObservingDatabaseChanges: true)
             .replaceError(with: [])
             .assign(to: &$groups)
 

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
@@ -36,7 +36,6 @@ public class EmbeddedWebPageViewModelLive: EmbeddedWebPageViewModel {
      */
     public static func isRedesignEnabled(in context: Context) -> Bool {
         if context.contextType == .group {
-            var featureFlagContext = context
             let group = AppEnvironment.shared.subscribe(GetGroup(groupID: context.id))
             if let courseID = group.first?.courseID {   // If it's group inside a course
                 return AppEnvironment.shared.subscribe( // return the course's feature flag value

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -56,9 +56,9 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
         }
     }
 
-    deinit {
-        offlineFlagStore.cancel()
-    }
+//    deinit {
+//        offlineFlagStore.cancel()
+//    }
 
     public func isFeatureFlagEnabled() -> Bool {
         featureFlagEnabled.value
@@ -101,8 +101,9 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
 
     private func subscribeToOfflineFeatureFlagChanges() {
         offlineFlagStore
-            .observeEntities()
-            .compactMap { $0.firstItem }
+            .getEntities(publishDatabaseChanges: true)
+            .replaceError(with: [])
+            .compactMap { $0.first }
             .map { $0.enabled }
             .subscribe(featureFlagEnabled)
             .store(in: &subscriptions)

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -56,10 +56,6 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
         }
     }
 
-//    deinit {
-//        offlineFlagStore.cancel()
-//    }
-
     public func isFeatureFlagEnabled() -> Bool {
         featureFlagEnabled.value
     }

--- a/Core/Core/Offline/Model/OfflineModeInteractor.swift
+++ b/Core/Core/Offline/Model/OfflineModeInteractor.swift
@@ -97,7 +97,7 @@ public final class OfflineModeInteractorLive: OfflineModeInteractor {
 
     private func subscribeToOfflineFeatureFlagChanges() {
         offlineFlagStore
-            .getEntities(publishDatabaseChanges: true)
+            .getEntities(keepObservingDatabaseChanges: true)
             .replaceError(with: [])
             .compactMap { $0.first }
             .map { $0.enabled }

--- a/Core/Core/Store/ReactiveStore.swift
+++ b/Core/Core/Store/ReactiveStore.swift
@@ -22,50 +22,11 @@ import CoreData
 import Foundation
 
 public class ReactiveStore<U: UseCase> {
-    public enum State: Equatable {
-        public static func == (lhs: ReactiveStore<U>.State, rhs: ReactiveStore<U>.State) -> Bool {
-            switch (lhs, rhs) {
-            case (.loading, .loading): return true
-            case let (.error(lError), .error(rError)):
-                guard type(of: lhs) == type(of: rhs) else { return false }
-                let error1 = lError as NSError
-                let error2 = rError as NSError
-                return error1.domain == error2.domain && error1.code == error2.code
-            case let (.data(lData), .data(rData)): return lData == rData
-            default: return false
-            }
-        }
-
-        case loading, error(Error), data([U.Model])
-
-        /// If the enum's case is `.data` then extracts and returns all models.
-        public var allItems: [U.Model]? {
-            if case let .data(data) = self {
-                return data
-            } else {
-                return nil
-            }
-        }
-
-        /// If the enum's case is `.data` then extracts and returns the first item.
-        public var firstItem: U.Model? {
-            allItems?.first
-        }
-    }
-
     private let offlineModeInteractor: OfflineModeInteractor?
     private let useCase: U
     private let context: NSManagedObjectContext
 
-    private var next: GetNextRequest<U.Response>?
-
-    private let forceRefreshRelay = PassthroughRelay<Void>()
-    private let stateRelay = CurrentValueRelay<State>(.loading)
-
-    private var cancellable: AnyCancellable?
-    private var subscriptions = Set<AnyCancellable>()
-
-    // MARK: -
+    // MARK: - Init
 
     public init(
         offlineModeInteractor: OfflineModeInteractor? = OfflineModeAssembly.make(),
@@ -75,107 +36,55 @@ public class ReactiveStore<U: UseCase> {
         self.offlineModeInteractor = offlineModeInteractor
         self.useCase = useCase
         self.context = context
-
-        unowned let unownedSelf = self
-
-        forceRefreshRelay
-            .flatMap { _ in unownedSelf.getEntities().replaceError(with: []) }
-            .sink()
-            .store(in: &subscriptions)
     }
 
-    public func cancel() {
-        cancellable?.cancel()
-        cancellable = nil
-    }
-
-    public func forceFetchEntities() -> AnyPublisher<Void, Never> {
-        forceRefreshRelay.accept(())
-        return Just(())
-            .setFailureType(to: Never.self)
-            .eraseToAnyPublisher()
-    }
-
-    /// Calling this function will keep the instance in memory until `cancel()` is called. The recommended approach is calling `cancel()` from the interactor's deinit function.
-    public func observeEntities(forceFetch: Bool = false, loadAllPages: Bool = false) -> AnyPublisher<State, Never> {
-        cancellable?.cancel()
-        cancellable = nil
-
+    /// Produces a list of entities for the given UseCase.
+    /// When the device is connected to the internet, it will fetch data from the API by downloading all pages, unless specificied differently. The result is then cached to the database
+    /// emitted by the publisher.
+    /// When the device is offline, it will read data from Core Data.
+    /// - Parameters:
+    ///     - forceFetch: Tells the fetch request if it should get data from the API or from cache. Defaults to **true**.
+    ///     - loadAllPages: Tells the fetch request if it should load all the pages or just the first one. Defaults to **true**.
+    ///     - publishDatabaseChanges: Tells the fetch request to keep observing database changes after the API response is downloaded and saved. Defaults to **false**.
+    ///
+    /// - Returns: A list of entities or an error.
+    public func getEntities(
+        forceFetch: Bool = true,
+        loadAllPages: Bool = true,
+        publishDatabaseChanges: Bool = false
+    ) -> AnyPublisher<[U.Model], Error> {
         let scope = useCase.scope
         let request = NSFetchRequest<U.Model>(entityName: String(describing: U.Model.self))
         request.predicate = scope.predicate
         request.sortDescriptors = scope.order
 
-        let entitiesPublisher: AnyPublisher<[U.Model], Error>
+        var entitiesPublisher: AnyPublisher<[U.Model], Error>
 
         if offlineModeInteractor?.isOfflineModeEnabled() == true {
-            entitiesPublisher = fetchEntitiesFromDatabase(fetchRequest: request)
+            entitiesPublisher = Self.fetchEntitiesFromDatabase(
+                fetchRequest: request,
+                context: context
+            )
         } else {
             entitiesPublisher = forceFetch ?
-                fetchEntitiesFromAPI(useCase: useCase, loadAllPages: loadAllPages, fetchRequest: request) :
-                fetchEntitiesFromCache(fetchRequest: request)
+                Self.fetchEntitiesFromAPI(
+                    useCase: useCase,
+                    loadAllPages: loadAllPages,
+                    fetchRequest: request,
+                    context: context
+                ) :
+                Self.fetchEntitiesFromCache(
+                    useCase: useCase,
+                    fetchRequest: request,
+                    context: context
+                )
         }
 
-        unowned let unownedSelf = self
-
-        cancellable = entitiesPublisher
-            .handleEvents(receiveSubscription: { _ in
-                unownedSelf.stateRelay.accept(.loading)
-            })
-            .catch {
-                unownedSelf.stateRelay.accept(.error($0))
-                return Empty<[U.Model], Never>(completeImmediately: false)
-                    .setFailureType(to: Never.self)
-                    .eraseToAnyPublisher()
-            }
-            .sink(
-                receiveValue: { value in
-                    unownedSelf.stateRelay.accept(.data(value))
-                }
-            )
-
-        return stateRelay.eraseToAnyPublisher()
-    }
-
-    public func observeEntitiesWithError(forceFetch: Bool = false, loadAllPages: Bool = false) -> AnyPublisher<[U.Model], Error> {
-        let scope = useCase.scope
-        let request = NSFetchRequest<U.Model>(entityName: String(describing: U.Model.self))
-        request.predicate = scope.predicate
-        request.sortDescriptors = scope.order
-
-        let entitiesPublisher: AnyPublisher<[U.Model], Error>
-
-        if offlineModeInteractor?.isOfflineModeEnabled() == true {
-            entitiesPublisher = fetchEntitiesFromDatabase(fetchRequest: request)
-        } else {
-            entitiesPublisher = forceFetch ?
-                fetchEntitiesFromAPI(useCase: useCase, loadAllPages: loadAllPages, fetchRequest: request) :
-                fetchEntitiesFromCache(fetchRequest: request)
+        if !publishDatabaseChanges {
+            entitiesPublisher = entitiesPublisher.first().eraseToAnyPublisher()
         }
 
         return entitiesPublisher
-    }
-
-    /**
-     This method returns entities for the UseCase from CoreData if the application is in offline mode.
-     In online mode entities are always fetched from the API by downloading all pages. The result is then cached
-     to the database and emitted by the publisher this method returns. After this the publisher finishes.
-     */
-    public func getEntities() -> AnyPublisher<[U.Model], Error> {
-        let scope = useCase.scope
-        let request = NSFetchRequest<U.Model>(entityName: String(describing: U.Model.self))
-        request.predicate = scope.predicate
-        request.sortDescriptors = scope.order
-
-        if offlineModeInteractor?.isOfflineModeEnabled() == true {
-            return fetchEntitiesFromDatabase(fetchRequest: request)
-                .first()
-                .eraseToAnyPublisher()
-        } else {
-            return fetchEntitiesFromAPI(useCase: useCase, loadAllPages: true, fetchRequest: request)
-                .first()
-                .eraseToAnyPublisher()
-        }
     }
 
     public func getEntitiesFromDatabase() -> AnyPublisher<[U.Model], Error> {
@@ -184,57 +93,84 @@ public class ReactiveStore<U: UseCase> {
         request.predicate = scope.predicate
         request.sortDescriptors = scope.order
 
-        return fetchEntitiesFromDatabase(fetchRequest: request)
+        return Self.fetchEntitiesFromDatabase(fetchRequest: request, context: context)
             .first()
             .eraseToAnyPublisher()
     }
 
-    private func fetchEntitiesFromCache<T: NSManagedObject>(
-        fetchRequest: NSFetchRequest<T>
-    ) -> AnyPublisher<[T], Error> {
-        unowned let unownedSelf = self
+    public func forceFetchEntities() -> AnyPublisher<Void, Never> {
+        getEntities(
+            forceFetch: true,
+            loadAllPages: true,
+            publishDatabaseChanges: false
+        )
+        .replaceError(with: [])
+        .setFailureType(to: Never.self)
+        .map { _ in () }
+        .eraseToAnyPublisher()
+    }
 
+    private static func fetchEntitiesFromCache<T: NSManagedObject>(
+        useCase: U,
+        fetchRequest: NSFetchRequest<T>,
+        context: NSManagedObjectContext
+    ) -> AnyPublisher<[T], Error> {
         return useCase.hasCacheExpired()
             .setFailureType(to: Error.self)
             .flatMap { hasExpired -> AnyPublisher<[T], Error> in
                 if hasExpired {
-                    return unownedSelf.fetchEntitiesFromAPI(
-                        useCase: unownedSelf.useCase,
+                    return Self.fetchEntitiesFromAPI(
+                        useCase: useCase,
                         loadAllPages: false,
-                        fetchRequest: fetchRequest
+                        fetchRequest: fetchRequest,
+                        context: context
                     )
                 } else {
-                    return unownedSelf.fetchEntitiesFromDatabase(fetchRequest: fetchRequest)
+                    return Self.fetchEntitiesFromDatabase(fetchRequest: fetchRequest, context: context)
                 }
             }
             .eraseToAnyPublisher()
     }
 
-    private func fetchEntitiesFromAPI<T: NSManagedObject>(
-        useCase: any UseCase,
+    private static func fetchEntitiesFromAPI<T: NSManagedObject>(
+        useCase: U,
+        getNextUseCase: GetNextUseCase<U>? = nil,
         loadAllPages: Bool,
-        fetchRequest: NSFetchRequest<T>
+        fetchRequest: NSFetchRequest<T>,
+        context: NSManagedObjectContext
     ) -> AnyPublisher<[T], Error> {
+        var next: GetNextRequest<U.Response>?
 
-        return useCase.fetchWithFuture()
-            .handleEvents(receiveOutput: { [weak self] urlResponse in
-                if let urlResponse {
-                    self?.next = self?.useCase.getNext(from: urlResponse)
-                } else {
-                    self?.next = nil
-                }
-            })
-            .flatMap { _ in self.fetchAllPagesIfNeeded(loadAllPages, fetchRequest: fetchRequest) }
-            .flatMap { _ in self.fetchEntitiesFromDatabase(fetchRequest: fetchRequest) }
+        let useCaseToFetch: Future<URLResponse?, Error>
+
+        if let getNextUseCase {
+            useCaseToFetch = getNextUseCase.fetchWithFuture()
+        } else {
+            useCaseToFetch = useCase.fetchWithFuture()
+        }
+
+        return useCaseToFetch
+            .map { useCase.getNext(from: $0) }
+            .flatMap { _ in
+                Self.fetchAllPagesIfNeeded(
+                    useCase: useCase,
+                    loadAllPages: loadAllPages,
+                    fetchRequest: fetchRequest,
+                    context: context,
+                    next: next
+                )
+            }
+            .flatMap { _ in Self.fetchEntitiesFromDatabase(fetchRequest: fetchRequest, context: context) }
             .eraseToAnyPublisher()
     }
 
-    private func fetchAllPagesIfNeeded<T: NSManagedObject>(
-        _ loadAllPages: Bool,
-        fetchRequest: NSFetchRequest<T>
+    private static func fetchAllPagesIfNeeded<T: NSManagedObject>(
+        useCase: U,
+        loadAllPages: Bool,
+        fetchRequest: NSFetchRequest<T>,
+        context: NSManagedObjectContext,
+        next: GetNextRequest<U.Response>?
     ) -> AnyPublisher<Void, Error> {
-        unowned let unownedSelf = self
-
         let voidPublisher: () -> AnyPublisher<Void, Error> = {
             Just(())
                 .setFailureType(to: Error.self)
@@ -245,14 +181,16 @@ public class ReactiveStore<U: UseCase> {
             return voidPublisher()
         }
 
-        return getNextPage()
+        return getNextPage(useCase: useCase, next: next)
             .setFailureType(to: Error.self)
             .flatMap { nextPageUseCase -> AnyPublisher<Void, Error> in
                 if let nextPageUseCase {
-                    return unownedSelf.fetchEntitiesFromAPI(
-                        useCase: nextPageUseCase,
+                    return Self.fetchEntitiesFromAPI(
+                        useCase: useCase,
+                        getNextUseCase: nextPageUseCase,
                         loadAllPages: true,
-                        fetchRequest: fetchRequest
+                        fetchRequest: fetchRequest,
+                        context: context
                     )
                     .map { _ in () }
                     .eraseToAnyPublisher()
@@ -263,7 +201,7 @@ public class ReactiveStore<U: UseCase> {
             .eraseToAnyPublisher()
     }
 
-    private func getNextPage() -> AnyPublisher<GetNextUseCase<U>?, Never> {
+    private static func getNextPage(useCase: U, next: GetNextRequest<U.Response>?) -> AnyPublisher<GetNextUseCase<U>?, Never> {
         if let next {
             return Just(
                 GetNextUseCase(
@@ -272,15 +210,15 @@ public class ReactiveStore<U: UseCase> {
                 )
             ).eraseToAnyPublisher()
         } else {
-            next = nil
             return Just(nil).eraseToAnyPublisher()
         }
     }
 
-    private func fetchEntitiesFromDatabase<T: NSManagedObject>(
+    private static func fetchEntitiesFromDatabase<T: NSManagedObject>(
         fetchRequest: NSFetchRequest<T>,
         sectionNameKeyPath _: String? = nil,
-        cacheName _: String? = nil
+        cacheName _: String? = nil,
+        context: NSManagedObjectContext
     ) -> AnyPublisher<[T], Error> {
         FetchedResultsPublisher(
             request: fetchRequest,

--- a/Core/Core/Store/ReactiveStore.swift
+++ b/Core/Core/Store/ReactiveStore.swift
@@ -45,13 +45,13 @@ public class ReactiveStore<U: UseCase> {
     /// - Parameters:
     ///     - forceFetch: Tells the fetch request if it should get data from the API or from cache. Defaults to **false**.
     ///     - loadAllPages: Tells the fetch request if it should load all the pages or just the first one. Defaults to **true**.
-    ///     - publishDatabaseChanges: Tells the fetch request to keep observing database changes after the API response is downloaded and saved. Defaults to **false**.
+    ///     - keepObservingDatabaseChanges: Tells the fetch request to keep observing database changes after the API response is downloaded and saved. Defaults to **false**.
     ///
     /// - Returns: A list of entities or an error.
     public func getEntities(
         forceFetch: Bool = false,
         loadAllPages: Bool = true,
-        publishDatabaseChanges: Bool = false
+        keepObservingDatabaseChanges: Bool = false
     ) -> AnyPublisher<[U.Model], Error> {
         let scope = useCase.scope
         let request = NSFetchRequest<U.Model>(entityName: String(describing: U.Model.self))
@@ -80,7 +80,7 @@ public class ReactiveStore<U: UseCase> {
                 )
         }
 
-        if !publishDatabaseChanges {
+        if !keepObservingDatabaseChanges {
             entitiesPublisher = entitiesPublisher.first().eraseToAnyPublisher()
         }
 
@@ -102,7 +102,7 @@ public class ReactiveStore<U: UseCase> {
         getEntities(
             forceFetch: true,
             loadAllPages: loadAllPages,
-            publishDatabaseChanges: false
+            keepObservingDatabaseChanges: false
         )
         .replaceError(with: [])
         .setFailureType(to: Never.self)

--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -48,6 +48,8 @@ public extension UseCase {
         return nil
     }
 
+    func getNext(from _: URLResponse?) -> GetNextRequest<Response>? { nil }
+
     func reset(context _: NSManagedObjectContext) {
         // no-op
     }
@@ -146,6 +148,8 @@ public extension APIUseCase {
     func getNext(from response: URLResponse) -> GetNextRequest<Request.Response>? {
         return request.getNext(from: response)
     }
+
+    func getNext(from response: URLResponse?) -> GetNextRequest<Request.Response>? { nil }
 }
 
 public extension APIUseCase where Response == Request.Response {

--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -48,8 +48,6 @@ public extension UseCase {
         return nil
     }
 
-    func getNext(from _: URLResponse?) -> GetNextRequest<Response>? { nil }
-
     func reset(context _: NSManagedObjectContext) {
         // no-op
     }

--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -146,8 +146,6 @@ public extension APIUseCase {
     func getNext(from response: URLResponse) -> GetNextRequest<Request.Response>? {
         return request.getNext(from: response)
     }
-
-    func getNext(from response: URLResponse?) -> GetNextRequest<Request.Response>? { nil }
 }
 
 public extension APIUseCase where Response == Request.Response {

--- a/Core/CoreTests/Store/ReactiveStoreTests.swift
+++ b/Core/CoreTests/Store/ReactiveStoreTests.swift
@@ -147,7 +147,7 @@ class ReactiveStoreTests: CoreTestCase {
         expectation2.expectedFulfillmentCount = 2
         var fulfillmentCount = 0
         let subscription = testee
-            .getEntities(forceFetch: false, publishDatabaseChanges: true)
+            .getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in
@@ -187,7 +187,7 @@ class ReactiveStoreTests: CoreTestCase {
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee
-            .getEntities(publishDatabaseChanges: true)
+            .getEntities(keepObservingDatabaseChanges: true)
             .dropFirst() // Skip the initial empty data as we wait for the new item to be added
             .sink(
                 receiveCompletion: { _ in },
@@ -213,7 +213,7 @@ class ReactiveStoreTests: CoreTestCase {
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee
-            .getEntities(forceFetch: false, publishDatabaseChanges: true)
+            .getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
             .dropFirst() // Skip initial data as we wait for the "name" field update
             .sink(
                 receiveCompletion: { _ in },
@@ -237,7 +237,7 @@ class ReactiveStoreTests: CoreTestCase {
         let store = createStore(useCase: TestUseCase())
 
         let expectation1 = expectation(description: "Publisher sends value")
-        let subscription1 = store.getEntities(forceFetch: false, publishDatabaseChanges: true)
+        let subscription1 = store.getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
             .dropFirst() // Skip initial data as we wait for the delete update
             .sink(
                 receiveCompletion: { _ in },
@@ -359,7 +359,7 @@ class ReactiveStoreTests: CoreTestCase {
 
     func testSubscriptionCancellation() {
         let store = createStore(useCase: TestUseCase(courses: [.make(id: "1")]))
-        let interactor = TestInteractor(store: store, publishDatabaseChanges: false)
+        let interactor = TestInteractor(store: store, keepObservingDatabaseChanges: false)
         let expectation1 = expectation(description: "Publisher sends value")
         let expectation2 = expectation(description: "Publisher wont send value")
         expectation2.isInverted = true
@@ -429,10 +429,10 @@ extension ReactiveStoreTests {
 
         private var subscriptions = Set<AnyCancellable>()
 
-        init(store: ReactiveStore<TestUseCase>, publishDatabaseChanges: Bool) {
+        init(store: ReactiveStore<TestUseCase>, keepObservingDatabaseChanges: Bool) {
             self.store = store
 
-            self.store.getEntities(publishDatabaseChanges: publishDatabaseChanges)
+            self.store.getEntities(keepObservingDatabaseChanges: keepObservingDatabaseChanges)
                 .sink(
                     receiveCompletion: { _ in },
                     receiveValue: { [weak self] in

--- a/Core/CoreTests/Store/ReactiveStoreTests.swift
+++ b/Core/CoreTests/Store/ReactiveStoreTests.swift
@@ -66,7 +66,7 @@ class ReactiveStoreTests: CoreTestCase {
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee
-            .getEntities(forceFetch: false)
+            .getEntities(ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in
@@ -86,7 +86,7 @@ class ReactiveStoreTests: CoreTestCase {
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee
-            .getEntities(forceFetch: true)
+            .getEntities(ignoreCache: true)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in
@@ -131,7 +131,7 @@ class ReactiveStoreTests: CoreTestCase {
 
     // MARK: - Force fetch
 
-    func testForceFetch() {
+    func testIgnoreCache() {
         Course.save(.make(id: "0"), in: databaseClient)
         try! databaseClient.save()
         let useCase = TestUseCase(courses: [.make(id: "1")])
@@ -147,7 +147,7 @@ class ReactiveStoreTests: CoreTestCase {
         expectation2.expectedFulfillmentCount = 2
         var fulfillmentCount = 0
         let subscription = testee
-            .getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
+            .getEntities(ignoreCache: false, keepObservingDatabaseChanges: true)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in
@@ -213,7 +213,7 @@ class ReactiveStoreTests: CoreTestCase {
 
         let expectation = expectation(description: "Publisher sends value")
         let subscription = testee
-            .getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
+            .getEntities(ignoreCache: false, keepObservingDatabaseChanges: true)
             .dropFirst() // Skip initial data as we wait for the "name" field update
             .sink(
                 receiveCompletion: { _ in },
@@ -237,7 +237,7 @@ class ReactiveStoreTests: CoreTestCase {
         let store = createStore(useCase: TestUseCase())
 
         let expectation1 = expectation(description: "Publisher sends value")
-        let subscription1 = store.getEntities(forceFetch: false, keepObservingDatabaseChanges: true)
+        let subscription1 = store.getEntities(ignoreCache: false, keepObservingDatabaseChanges: true)
             .dropFirst() // Skip initial data as we wait for the delete update
             .sink(
                 receiveCompletion: { _ in },
@@ -270,7 +270,7 @@ class ReactiveStoreTests: CoreTestCase {
         let expectation1 = XCTestExpectation(description: "exhausted")
         let store = createStore(useCase: useCase)
 
-        let subscription1 = store.getEntities(forceFetch: true, loadAllPages: false)
+        let subscription1 = store.getEntities(ignoreCache: true, loadAllPages: false)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in
@@ -283,7 +283,7 @@ class ReactiveStoreTests: CoreTestCase {
         subscription1.cancel()
 
         let expectation2 = XCTestExpectation(description: "Publisher sends value")
-        let subscription2 = store.getEntities(forceFetch: true, loadAllPages: true)
+        let subscription2 = store.getEntities(ignoreCache: true, loadAllPages: true)
             .sink(
                 receiveCompletion: { _ in },
                 receiveValue: { courses in

--- a/Core/CoreTests/Store/ReactiveStoreTests.swift
+++ b/Core/CoreTests/Store/ReactiveStoreTests.swift
@@ -30,202 +30,228 @@ class ReactiveStoreTests: CoreTestCase {
         store = nil
     }
 
-    // MARK: State
+    func testErrorHandling() {
+        let useCase = TestUseCase(courses: nil, requestError: NSError.instructureError("TestError"))
+        let testee = createStore(useCase: useCase)
 
-//    func testLoadingState() {
-//        let useCase = TestUseCase(courses: [])
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .sink { state in
-//                XCTAssertEqual(state, .loading)
-//                expectation.fulfill()
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    func testDataState() {
-//        let useCase = TestUseCase(courses: [.make()])
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .dropFirst()
-//            .sink { state in
-//                if case .data = state {
-//                    expectation.fulfill()
-//                }
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    func testErrorState() {
-//        let useCase = TestUseCase(courses: nil, requestError: NSError.instructureError("TestError"))
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .sink { state in
-//                if case .error = state {
-//                    expectation.fulfill()
-//                }
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    // MARK: Publishing from Network and Cache
-//
-//    func testObjectsAreReturnedFromCache() {
-//        Course.save(.make(id: "0"), in: databaseClient)
-//        try! databaseClient.save()
-//        let useCase = TestUseCase()
-//        let testee = createStore(useCase: useCase)
-//
-//        let cache: TTL = databaseClient.insert()
-//        cache.key = useCase.cacheKey ?? ""
-//        cache.lastRefresh = Date()
-//        try! databaseClient.save()
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .dropFirst()
-//            .sink { state in
-//                switch state {
-//                case let .data(courses):
-//                    XCTAssertEqual(courses.map { $0.id }, ["0"])
-//                default:
-//                    break
-//                }
-//                expectation.fulfill()
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    func testObjectsAreReturnedFromNetwork() {
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .dropFirst()
-//            .sink { state in
-//                switch state {
-//                case let .data(courses):
-//                    XCTAssertEqual(courses.map { $0.id }, ["1"])
-//                default:
-//                    break
-//                }
-//                expectation.fulfill()
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    // MARK: - Database changes
-//
-//    func testNewlyAddedObjectsArePublished() {
-//        let useCase = TestUseCase(courses: [])
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities()
-//            .dropFirst(2) // drop .loading and initialy .data[]
-//            .sink { state in
-//                switch state {
-//                case let .data(courses):
-//                    XCTAssertEqual(courses.map { $0.id }, ["3rdpartyinsert"])
-//                default:
-//                    break
-//                }
-//                expectation.fulfill()
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        drainMainQueue()
-//        Course.save(.make(id: "3rdpartyinsert"), in: databaseClient)
-//
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    func testDatabaseChangesArePublished() {
-//        let course = Course.save(.make(id: "1"), in: databaseClient)
-//        try! databaseClient.save()
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let testee = createStore(useCase: useCase)
-//
-//        let expectation = expectation(description: "Publisher sends value")
-//        let subscription = testee
-//            .observeEntities(forceFetch: false)
-//            .dropFirst()
-//            .sink { state in
-//                switch state {
-//                case let .data(courses):
-//                    XCTAssertEqual(courses.map { $0.id }, ["1"])
-//                    XCTAssertEqual(courses.first?.name, "updatedName")
-//                default:
-//                    break
-//                }
-//                expectation.fulfill()
-//                XCTAssertTrue(Thread.isMainThread)
-//            }
-//
-//        course.name = "updatedName"
-//        waitForExpectations(timeout: 1)
-//        subscription.cancel()
-//    }
-//
-//    func testDatabaseDeletionsArePublished() {
-//        let store = createStore(useCase: TestUseCase())
-//        let course = Course.make()
-//
-//        let expectation1 = expectation(description: "Publisher sends value")
-//        let subscription1 = store.observeEntities(forceFetch: false)
-//            .sink { state in
-//                if case let .data(courses) = state {
-//                    XCTAssertEqual(courses.count, 1)
-//                    expectation1.fulfill()
-//                }
-//            }
-//
-//        wait(for: [expectation1], timeout: 0.1)
-//        subscription1.cancel()
-//
-//        let expectation2 = expectation(description: "Publisher sends value")
-//        let subscription2 = store.observeEntities(forceFetch: false)
-//            .dropFirst() // Drop previously saved data
-//            .sink { state in
-//                if case let .data(courses) = state {
-//                    XCTAssertEqual(courses.count, 0)
-//                    expectation2.fulfill()
-//                }
-//            }
-//
-//        databaseClient.delete(course)
-//        wait(for: [expectation2], timeout: 0.1)
-//        subscription2.cancel()
-//    }
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntities()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure = completion {
+                        expectation.fulfill()
+                        XCTAssertTrue(Thread.isMainThread)
+                    }
+                },
+                receiveValue: { _ in }
+            )
+
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    // MARK: Publishing from Network and Cache
+
+    func testObjectsAreReturnedFromCache() {
+        Course.save(.make(id: "0"), in: databaseClient)
+        try! databaseClient.save()
+        let useCase = TestUseCase()
+        let testee = createStore(useCase: useCase)
+
+        let cache: TTL = databaseClient.insert()
+        cache.key = useCase.cacheKey ?? ""
+        cache.lastRefresh = Date()
+        try! databaseClient.save()
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntities(forceFetch: false)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.map { $0.id }, ["0"])
+                    expectation.fulfill()
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    func testObjectsAreReturnedFromNetwork() {
+        let useCase = TestUseCase(courses: [.make(id: "1")])
+        let testee = createStore(useCase: useCase)
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntities(forceFetch: true)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.map { $0.id }, ["1"])
+                    expectation.fulfill()
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    // MARK: - Direct database calling
+
+    func testObjectsAreReturnedFromDatabase() {
+        Course.save(.make(id: "0"), in: databaseClient)
+        try! databaseClient.save()
+        let useCase = TestUseCase()
+        let testee = createStore(useCase: useCase)
+
+        let cache: TTL = databaseClient.insert()
+        cache.key = useCase.cacheKey ?? ""
+        cache.lastRefresh = Date()
+        try! databaseClient.save()
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntitiesFromDatabase()
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.map { $0.id }, ["0"])
+                    expectation.fulfill()
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    // MARK: - Force fetch
+
+    func testForceFetch() {
+        Course.save(.make(id: "0"), in: databaseClient)
+        try! databaseClient.save()
+        let useCase = TestUseCase(courses: [.make(id: "1")])
+        let testee = createStore(useCase: useCase)
+
+        let cache: TTL = databaseClient.insert()
+        cache.key = useCase.cacheKey ?? ""
+        cache.lastRefresh = Date()
+        try! databaseClient.save()
+
+        let expectation1 = expectation(description: "Publisher sends value")
+        let expectation2 = expectation(description: "Publisher sends value")
+        expectation2.expectedFulfillmentCount = 2
+        var fulfillmentCount = 0
+        let subscription = testee
+            .getEntities(forceFetch: false, publishDatabaseChanges: true)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    fulfillmentCount += 1
+                    if fulfillmentCount == 1 {
+                        XCTAssertEqual(courses.map { $0.id }, ["0"])
+                        expectation1.fulfill()
+                    }
+
+                    if fulfillmentCount == 2 {
+                        XCTAssertEqual(courses.map { $0.id }, ["1", "0"])
+                        expectation2.fulfill()
+                    }
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        wait(for: [expectation1], timeout: 0.1)
+        let subscription2 = testee.forceRefresh(loadAllPages: true)
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { _ in
+                    expectation2.fulfill()
+                }
+            )
+
+        wait(for: [expectation2], timeout: 0.1)
+        subscription2.cancel()
+        subscription.cancel()
+    }
+
+    // MARK: - Database changes
+
+    func testNewlyAddedObjectsArePublished() {
+        let useCase = TestUseCase(courses: [])
+        let testee = createStore(useCase: useCase)
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntities(publishDatabaseChanges: true)
+            .dropFirst() // Skip the initial empty data as we wait for the new item to be added
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.map { $0.id }, ["3rdpartyinsert"])
+                    expectation.fulfill()
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        drainMainQueue()
+        Course.save(.make(id: "3rdpartyinsert"), in: databaseClient)
+
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    func testDatabaseChangesArePublished() {
+        let course = Course.save(.make(id: "1"), in: databaseClient)
+        try! databaseClient.save()
+        let useCase = TestUseCase(courses: [])
+        let testee = createStore(useCase: useCase)
+
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee
+            .getEntities(forceFetch: false, publishDatabaseChanges: true)
+            .dropFirst() // Skip initial data as we wait for the "name" field update
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.map { $0.id }, ["1"])
+                    XCTAssertEqual(courses.first?.name, "updatedName")
+                    expectation.fulfill()
+                    XCTAssertTrue(Thread.isMainThread)
+                }
+            )
+
+        drainMainQueue()
+        course.name = "updatedName"
+        waitForExpectations(timeout: 1)
+        subscription.cancel()
+    }
+
+    func testDatabaseDeletionsArePublished() {
+        let course = Course.save(.make(id: "1"), in: databaseClient)
+        try! databaseClient.save()
+        let store = createStore(useCase: TestUseCase())
+
+        let expectation1 = expectation(description: "Publisher sends value")
+        let subscription1 = store.getEntities(forceFetch: false, publishDatabaseChanges: true)
+            .dropFirst() // Skip initial data as we wait for the delete update
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.count, 0)
+                    expectation1.fulfill()
+                }
+            )
+
+        drainMainQueue()
+        databaseClient.delete(course)
+        waitForExpectations(timeout: 0.1)
+        subscription1.cancel()
+    }
 
     // MARK: - LoadAllPages
 
@@ -270,179 +296,96 @@ class ReactiveStoreTests: CoreTestCase {
         subscription2.cancel()
     }
 
-//    // MARK: - Offline
-//
-//    func test_OfflineModeIsEnabled_ObserveEntitiesCalled_ObjectsAreReturnedFromDatabase() {
-//        // Given
-//        let course = Course.make(from: .make(id: "0"))
-//        injectOfflineFeatureFlag(isEnabled: true)
-//
-//        // When
-//        let expectation = expectation(description: "Refresh callback called")
-//        expectation.expectedFulfillmentCount = 2
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let store = createStore(useCase: useCase)
-//
-//        var states = [ReactiveStore<TestUseCase>.State]()
-//        let subscription = store.observeEntities(forceFetch: false)
-//            .sink { state in
-//                expectation.fulfill()
-//                states.append(state)
-//            }
-//
-//        // Then
-//        waitForExpectations(timeout: 0.3)
-//        let ids = states.map {
-//            switch $0 {
-//            case let .data(course):
-//                return course
-//            default:
-//                return []
-//            }
-//        }.flatMap { $0.map { $0.id } }
-//
-//        XCTAssertEqual(states.count, 2)
-//        XCTAssertEqual(states[0], .loading)
-//        XCTAssertEqual(states[1], .data([course]))
-//        XCTAssertEqual(ids.count, 1)
-//        XCTAssert(ids.contains("0"))
-//        XCTAssert(!ids.contains("1"))
-//        subscription.cancel()
-//    }
-//
-//    func test_OfflineModeIsEnabled_GetEntitiesCalled_ObjectsAreReturnedFromDatabase() {
-//        // Given
-//        Course.make(from: .make(id: "0"))
-//        injectOfflineFeatureFlag(isEnabled: true)
-//
-//        // When
-//        let expectation = expectation(description: "Refresh callback called")
-//        expectation.expectedFulfillmentCount = 1
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let store = createStore(useCase: useCase)
-//
-//        var courseList = [Course]()
-//        let subscription = store.getEntities()
-//            .sink(
-//                receiveCompletion: { _ in },
-//                receiveValue: { courses in
-//                    expectation.fulfill()
-//                    courseList.append(contentsOf: courses)
-//                }
-//            )
-//
-//        // Then
-//        waitForExpectations(timeout: 0.3)
-//        let ids = courseList.map { $0.id }
-//
-//        XCTAssertEqual(courseList.count, 1)
-//        XCTAssertEqual(ids.count, 1)
-//        XCTAssert(ids.contains("0"))
-//        XCTAssert(!ids.contains("1"))
-//        subscription.cancel()
-//    }
-//
-//    func test_OfflineModeIsNotEnabled_ObserveEntitiesCalled_ObjectsAreReturnedFromNetwork() {
-//        // Given
-//        Course.make(from: .make(id: "0"))
-//        injectOfflineFeatureFlag(isEnabled: false)
-//
-//        // When
-//        let expectation = expectation(description: "Refresh callback called")
-//        expectation.expectedFulfillmentCount = 2
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let store = createStore(useCase: useCase)
-//
-//        var states = [ReactiveStore<TestUseCase>.State]()
-//        let subscription = store.observeEntities(forceFetch: false)
-//            .sink { state in
-//                expectation.fulfill()
-//                states.append(state)
-//            }
-//
-//        // Then
-//        waitForExpectations(timeout: 0.3)
-//        let ids = states.map {
-//            switch $0 {
-//            case let .data(course):
-//                return course
-//            default:
-//                return []
-//            }
-//        }.flatMap { $0.map { $0.id } }
-//
-//        XCTAssertEqual(states.count, 2)
-//        XCTAssertEqual(states[0], .loading)
-//        XCTAssertEqual(ids.count, 2)
-//        XCTAssert(ids.contains("0"))
-//        XCTAssert(ids.contains("1"))
-//        subscription.cancel()
-//    }
-//
-//    func test_OfflineModeIsNotEnabled_GetEntitiesCalled_ObjectsAreReturnedFromNetwork() {
-//        // Given
-//        Course.make(from: .make(id: "0"))
-//        injectOfflineFeatureFlag(isEnabled: false)
-//
-//        // When
-//        let expectation = expectation(description: "Refresh callback called")
-//        expectation.expectedFulfillmentCount = 1
-//        let useCase = TestUseCase(courses: [.make(id: "1")])
-//        let store = createStore(useCase: useCase)
-//
-//        var courseList = [Course]()
-//        let subscription = store.getEntities()
-//            .sink(
-//                receiveCompletion: { _ in },
-//                receiveValue: { courses in
-//                    expectation.fulfill()
-//                    courseList.append(contentsOf: courses)
-//                }
-//            )
-//
-//        // Then
-//        waitForExpectations(timeout: 0.3)
-//        let ids = courseList.map { $0.id }
-//
-//        XCTAssertEqual(courseList.count, 2)
-//        XCTAssertEqual(ids.count, 2)
-//        XCTAssert(ids.contains("0"))
-//        XCTAssert(ids.contains("1"))
-//        subscription.cancel()
-//    }
-//
-//    // MARK: - Subscription cancellation
-//
-//    func testSubscriptionCancellation() {
-//        let store = createStore(useCase: TestUseCase(courses: [.make(id: "1")]))
-//        let interactor = TestInteractor(store: store)
-//        let expectation1 = expectation(description: "Publisher sends value")
-//        let expectation2 = expectation(description: "Publisher wont send value")
-//        expectation2.isInverted = true
-//        var expectationCount = 0
-//
-//        let subscription = interactor.state
-//            .dropFirst()
-//            .sink(receiveValue: { _ in
-//                if expectationCount == 0 {
-//                    expectation1.fulfill()
-//                    expectationCount += 1
-//                } else {
-//                    expectation2.fulfill()
-//                }
-//            })
-//
-//        wait(for: [expectation1], timeout: 0.1)
-//        subscription.cancel()
-//
-//        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-//            Course.save(.make(id: "2"), in: self.databaseClient)
-//        }
-//
-//        wait(for: [expectation2], timeout: 0.3)
-//        subscription.cancel()
-//    }
-//
+    // MARK: - Offline
+
+    func test_OfflineModeIsEnabled_ObjectsAreReturnedFromDatabase() {
+        // Given
+        Course.make(from: .make(id: "0"))
+        injectOfflineFeatureFlag(isEnabled: true)
+
+        // When
+        let expectation = expectation(description: "Refresh callback called")
+        let useCase = TestUseCase(courses: [.make(id: "1")])
+        let store = createStore(useCase: useCase)
+
+        let subscription = store.getEntities()
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.count, 1)
+                    let ids = courses.map { $0.id }
+                    XCTAssertEqual(ids.count, 1)
+                    XCTAssert(ids.contains("0"))
+                    XCTAssert(!ids.contains("1"))
+                    expectation.fulfill()
+                }
+            )
+
+        // Then
+        waitForExpectations(timeout: 0.3)
+        subscription.cancel()
+    }
+
+    func test_OfflineModeIsNotEnabled_ObjectsAreReturnedFromNetwork() {
+        // Given
+        Course.make(from: .make(id: "0"))
+        injectOfflineFeatureFlag(isEnabled: false)
+
+        // When
+        let expectation = expectation(description: "Refresh callback called")
+        expectation.expectedFulfillmentCount = 1
+        let useCase = TestUseCase(courses: [.make(id: "1")])
+        let store = createStore(useCase: useCase)
+
+        let subscription = store.getEntities()
+            .sink(
+                receiveCompletion: { _ in },
+                receiveValue: { courses in
+                    XCTAssertEqual(courses.count, 2)
+                    let ids = courses.map { $0.id }
+                    XCTAssertEqual(ids.count, 2)
+                    XCTAssert(ids.contains("0"))
+                    XCTAssert(ids.contains("1"))
+                    expectation.fulfill()
+                }
+            )
+
+        // Then
+        waitForExpectations(timeout: 0.3)
+        subscription.cancel()
+    }
+
+    // MARK: - Subscription cancellation
+
+    func testSubscriptionCancellation() {
+        let store = createStore(useCase: TestUseCase(courses: [.make(id: "1")]))
+        let interactor = TestInteractor(store: store, publishDatabaseChanges: false)
+        let expectation1 = expectation(description: "Publisher sends value")
+        let expectation2 = expectation(description: "Publisher wont send value")
+        expectation2.isInverted = true
+        var expectationCount = 0
+
+        let subscription = interactor.$entities
+            .sink(receiveValue: { _ in
+                if expectationCount == 0 {
+                    expectation1.fulfill()
+                    expectationCount += 1
+                } else {
+                    expectation2.fulfill()
+                }
+            })
+
+        wait(for: [expectation1], timeout: 0.1)
+        subscription.cancel()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            Course.save(.make(id: "2"), in: self.databaseClient)
+        }
+
+        wait(for: [expectation2], timeout: 0.3)
+        subscription.cancel()
+    }
+
     private func createStore<U: UseCase>(useCase: U) -> ReactiveStore<U> {
         ReactiveStore(
             offlineModeInteractor: createOfflineModeInteractor(),
@@ -459,41 +402,46 @@ class ReactiveStoreTests: CoreTestCase {
         drainMainQueue()
         return result
     }
-//
-//    private func injectOfflineFeatureFlag(isEnabled: Bool) {
-//        let scope: Scope = .where(#keyPath(FeatureFlag.name),
-//                                  equals: EnvironmentFeatureFlags.mobile_offline_mode.rawValue,
-//                                  sortDescriptors: [])
-//        let flag: FeatureFlag = databaseClient.fetch(scope: scope).first ?? databaseClient.insert()
-//        flag.name = EnvironmentFeatureFlags.mobile_offline_mode.rawValue
-//        flag.isEnvironmentFlag = true
-//        flag.enabled = isEnabled
-//        flag.context = .currentUser
-//    }
+
+    private func injectOfflineFeatureFlag(isEnabled: Bool) {
+        let scope: Scope = .where(#keyPath(FeatureFlag.name),
+                                  equals: EnvironmentFeatureFlags.mobile_offline_mode.rawValue,
+                                  sortDescriptors: [])
+        let flag: FeatureFlag = databaseClient.fetch(scope: scope).first ?? databaseClient.insert()
+        flag.name = EnvironmentFeatureFlags.mobile_offline_mode.rawValue
+        flag.isEnvironmentFlag = true
+        flag.enabled = isEnabled
+        flag.context = .currentUser
+    }
 }
 
 extension ReactiveStoreTests {
-//    struct TestInteractor {
-//        // MARK: - Output
-//
-//        public let state = CurrentValueSubject<ReactiveStore<TestUseCase>.State, Never>(.loading)
-//
-//        // MARK: - Depenencies
-//
-//        private let store: ReactiveStore<TestUseCase>
-//
-//        // MARK: - Private properties
-//
-//        private var subscriptions = Set<AnyCancellable>()
-//
-//        init(store: ReactiveStore<TestUseCase>) {
-//            self.store = store
-//
-//            self.store.observeEntities()
-//                .subscribe(state)
-//                .store(in: &subscriptions)
-//        }
-//    }
+    class TestInteractor {
+        // MARK: - Output
+
+        @Published public var entities: [Course] = []
+
+        // MARK: - Depenencies
+
+        private let store: ReactiveStore<TestUseCase>
+
+        // MARK: - Private properties
+
+        private var subscriptions = Set<AnyCancellable>()
+
+        init(store: ReactiveStore<TestUseCase>, publishDatabaseChanges: Bool) {
+            self.store = store
+
+            self.store.getEntities(publishDatabaseChanges: publishDatabaseChanges)
+                .sink(
+                    receiveCompletion: { _ in },
+                    receiveValue: { [weak self] in
+                        self?.entities = $0
+                    }
+                )
+                .store(in: &subscriptions)
+        }
+    }
 
     struct TestUseCase: UseCase {
         typealias Model = Course

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -200,14 +200,14 @@
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
 		};
-		B4DA5E972B3094C200E68AE7 /* PBXContainerItemProxy */ = {
+		B4B80AA52B55518B008F6FB2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
 			proxyType = 2;
 			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
 			remoteInfo = CoreTester;
 		};
-		B4DA5E992B3094C200E68AE7 /* PBXContainerItemProxy */ = {
+		B4B80AA72B55518B008F6FB2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
 			proxyType = 2;
@@ -744,8 +744,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				B4DA5E982B3094C200E68AE7 /* CoreTester.app */,
-				B4DA5E9A2B3094C200E68AE7 /* CoreTests.xctest */,
+				B4B80AA62B55518B008F6FB2 /* CoreTester.app */,
+				B4B80AA82B55518B008F6FB2 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1037,18 +1037,18 @@
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B4DA5E982B3094C200E68AE7 /* CoreTester.app */ = {
+		B4B80AA62B55518B008F6FB2 /* CoreTester.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = CoreTester.app;
-			remoteRef = B4DA5E972B3094C200E68AE7 /* PBXContainerItemProxy */;
+			remoteRef = B4B80AA52B55518B008F6FB2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		B4DA5E9A2B3094C200E68AE7 /* CoreTests.xctest */ = {
+		B4B80AA82B55518B008F6FB2 /* CoreTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = CoreTests.xctest;
-			remoteRef = B4DA5E992B3094C200E68AE7 /* PBXContainerItemProxy */;
+			remoteRef = B4B80AA72B55518B008F6FB2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -199,20 +199,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
-		};
-		B4B80AA52B55518B008F6FB2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		B4B80AA72B55518B008F6FB2 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -744,8 +730,6 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				B4B80AA62B55518B008F6FB2 /* CoreTester.app */,
-				B4B80AA82B55518B008F6FB2 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1035,20 +1019,6 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4B80AA62B55518B008F6FB2 /* CoreTester.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CoreTester.app;
-			remoteRef = B4B80AA52B55518B008F6FB2 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4B80AA82B55518B008F6FB2 /* CoreTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CoreTests.xctest;
-			remoteRef = B4B80AA72B55518B008F6FB2 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 56;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -199,6 +199,20 @@
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
+		};
+		B4B499652B5949AE00652153 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
+			remoteInfo = CoreTester;
+		};
+		B4B499672B5949AE00652153 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
+			proxyType = 2;
+			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
+			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -730,6 +744,8 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
+				B4B499662B5949AE00652153 /* CoreTester.app */,
+				B4B499682B5949AE00652153 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1019,6 +1035,20 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B4B499662B5949AE00652153 /* CoreTester.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CoreTester.app;
+			remoteRef = B4B499652B5949AE00652153 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		B4B499682B5949AE00652153 /* CoreTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CoreTests.xctest;
+			remoteRef = B4B499672B5949AE00652153 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
+++ b/TestsFoundation/TestsFoundation.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 56;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -199,20 +199,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = B90FCF66245CD7327BEE2CBF;
 			remoteInfo = Core;
-		};
-		B4B499652B5949AE00652153 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = 8F6731E780A5363E04E3620A;
-			remoteInfo = CoreTester;
-		};
-		B4B499672B5949AE00652153 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 19FB565ABEC6EA3620720E25 /* Core */;
-			proxyType = 2;
-			remoteGlobalIDString = DC35484E0C7EE977582AF3AE;
-			remoteInfo = CoreTests;
 		};
 		C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -744,8 +730,6 @@
 			isa = PBXGroup;
 			children = (
 				59FDA90639A28B677F0E6B7A /* Core.framework */,
-				B4B499662B5949AE00652153 /* CoreTester.app */,
-				B4B499682B5949AE00652153 /* CoreTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1035,20 +1019,6 @@
 			fileType = wrapper.framework;
 			path = Core.framework;
 			remoteRef = C62A32602F4B1A165BCFE80A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4B499662B5949AE00652153 /* CoreTester.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CoreTester.app;
-			remoteRef = B4B499652B5949AE00652153 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		B4B499682B5949AE00652153 /* CoreTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CoreTests.xctest;
-			remoteRef = B4B499672B5949AE00652153 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListViewModel.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListViewModel.swift
@@ -71,8 +71,8 @@ class SubmissionCommentListViewModel: ObservableObject {
         unowned let unownedSelf = self
 
         Publishers.CombineLatest(
-            submissionCommentsStore.observeEntitiesWithError(),
-            featureFlagsStore.observeEntitiesWithError()
+            submissionCommentsStore.getEntities(publishDatabaseChanges: true),
+            featureFlagsStore.getEntities(publishDatabaseChanges: true)
         )
         .eraseToAnyPublisher()
         .map { comments, featureFlags in

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListViewModel.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListViewModel.swift
@@ -71,8 +71,8 @@ class SubmissionCommentListViewModel: ObservableObject {
         unowned let unownedSelf = self
 
         Publishers.CombineLatest(
-            submissionCommentsStore.getEntities(publishDatabaseChanges: true),
-            featureFlagsStore.getEntities(publishDatabaseChanges: true)
+            submissionCommentsStore.getEntities(keepObservingDatabaseChanges: true),
+            featureFlagsStore.getEntities(keepObservingDatabaseChanges: true)
         )
         .eraseToAnyPublisher()
         .map { comments, featureFlags in


### PR DESCRIPTION
Rework ReactiveStore to prevent crashes

refs: MBL-17259
affects: Student, Parent, Teacher
release note: Fixed an issue that caused occasional crashes.
test plan: Test the whole app if everything works as before.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
