### PR TITLE
Modified occasionally failing test cases

### DIFF
--- a/Parent/ParentE2ETests/Grades/GradesTests.swift
+++ b/Parent/ParentE2ETests/Grades/GradesTests.swift
@@ -88,8 +88,8 @@ class GradesTests: E2ETestCase {
         Helper.createSubmissionsForAssignments(course: course, student: student, assignments: assignments)
 
         // MARK: Grade assignments, get the user logged in, tap on course
-        let grades = ["6", "7", "8"]
-        let totalGrade = "D"
+        let grades = ["7.9", "79%", "complete"]
+        let totalGrade = "B"
         Helper.gradeAssignments(grades: grades, course: course, assignments: assignments, user: student)
 
         logInDSUser(parent)

--- a/TestsFoundation/TestsFoundation/DataSeeding/User/DataSeeder+DSUser.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/User/DataSeeder+DSUser.swift
@@ -25,6 +25,7 @@ extension DataSeeder {
 
         for _ in 0..<count {
             users.append(createUser())
+            sleep(1) // To avoid creating users with the same name
         }
 
         return users


### PR DESCRIPTION
refs: MBL-17326
affects: None
release note: None
test plan: Tests to pass

### Parent
#### testLetterGradeOnly()
Modified grade values

### Teacher
#### testPeopleListAndContextCard()
An implicit sleep has been added to the createUsers function of DataSeeder so that we can avoid users having the same name