### PR TITLE
Add handler for sharepoint LTI tools.

### DIFF
--- a/Core/Core.xcodeproj/project.pbxproj
+++ b/Core/Core.xcodeproj/project.pbxproj
@@ -890,6 +890,7 @@
 		88B8C676C0AFFC04953F57DA /* OfflineModeInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 450AE3E1E678497BDDC57FB8 /* OfflineModeInteractor.swift */; };
 		88CAB3756A315A8E23402E0D /* ErrorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9AFA4DDC9F66EFAFE5795E0 /* ErrorViewController.swift */; };
 		88D31E573C11B7BF5BE45E0E /* AboutInfoEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE581E58EA949C49C03C952F /* AboutInfoEntry.swift */; };
+		88F79752B5B46199DD43EE6F /* EmbeddedExternalToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8506C5823B23D499E91D9D3F /* EmbeddedExternalToolsTests.swift */; };
 		88FE93F62257EEFC0BF87021 /* GetArc.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E9735AB298A611E00A778A /* GetArc.swift */; };
 		8912EA212181949E5426EB26 /* ComposeMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835D6135BC668E0143179B37 /* ComposeMessageView.swift */; };
 		899C933A5BB540701F0541C1 /* DashboardGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A6897DCF3BF65F57A73E5C7 /* DashboardGrid.swift */; };
@@ -1211,6 +1212,7 @@
 		BB4EF46850550E3621E96551 /* GetEnabledFeatureFlagsRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D76D702D639BBFCB710DD675 /* GetEnabledFeatureFlagsRequestTests.swift */; };
 		BB7221E1AFC07E9FEA7279E2 /* GradeStatisticsGraphViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C834B7BF749F9804B2AEB6C4 /* GradeStatisticsGraphViewTests.swift */; };
 		BB7ABA42ABC08C57466595F2 /* ErrorReportViewController.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52B61668FB83D25B11FDB7BE /* ErrorReportViewController.storyboard */; };
+		BBB6EC24920FDA629096D6F7 /* EmbeddedExternalTools.swift in Sources */ = {isa = PBXBuildFile; fileRef = D199772E8E383D8CDDEDFF85 /* EmbeddedExternalTools.swift */; };
 		BBD0A6B1AF9AC0B41D7324DA /* K5ScheduleSubjectViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A7D0E388C0B114CEC3EFC24 /* K5ScheduleSubjectViewModel.swift */; };
 		BBDCA3A2A9A80224BD013ECC /* APITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AF2E58DF84B10504193AB0 /* APITests.swift */; };
 		BBE9E03123EC91E51BDA305A /* ConversationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 009AABA1AA8F119BF160E836 /* ConversationMessage.swift */; };
@@ -1339,7 +1341,6 @@
 		CEC97448F930BB18B9BE614A /* GetCourseSections.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7DA8B03B9279BBBDBCF285F /* GetCourseSections.swift */; };
 		CEEB69AC4E74B054E4F61BAB /* PageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88E31090C62EE2CD151388F /* PageTests.swift */; };
 		CF3596045A31EF9F0F47070E /* AllCoursesCellViewItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59E59C0AE8781FD42484E7A /* AllCoursesCellViewItemTests.swift */; };
-		CF431F022B501CC1004DAE16 /* DarkModeForWebDiscussionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF431F012B501CC1004DAE16 /* DarkModeForWebDiscussionsTests.swift */; };
 		CF77186DABC99EF4A2704BD3 /* APIEnrollmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79ED41813910F1C973820502 /* APIEnrollmentTests.swift */; };
 		CF78BC37E1EF05678E6831F1 /* UIFontExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C87806EF88EDE9BB02134F7 /* UIFontExtensions.swift */; };
 		CF848A454985D319B862329B /* InboxCourse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 534C5973089478FB911C2D40 /* InboxCourse.swift */; };
@@ -1469,6 +1470,7 @@
 		E1849C5B0E2F396DCD066876 /* K5HomeroomSubjectCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E51F32B5254FBD8267A65B93 /* K5HomeroomSubjectCardViewModelTests.swift */; };
 		E19017C3E581AF9EBE21C7A7 /* AddMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441BAEAB800A8160FAFD1619 /* AddMessage.swift */; };
 		E1DE27821844316BF3BD0526 /* FolderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4901C45D3489C29617DA4916 /* FolderTests.swift */; };
+		E1F70E3D94CCB9C114D72390 /* DarkModeForWebDiscussionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1DF88B47C0171C61BA8B7C4 /* DarkModeForWebDiscussionsTests.swift */; };
 		E1F961E80F6300AE58E3D784 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = E25D8616D2EB4DC92B0D7FFF /* Typography.swift */; };
 		E22895438D26D9AC3D6694DD /* AssignmentOverridesEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B5C2F2FB5EFAD07BFDAC94 /* AssignmentOverridesEditor.swift */; };
 		E26552D5D56301165B2FE986 /* ContextColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9BF33E05607BE1B419DB09 /* ContextColor.swift */; };
@@ -2618,6 +2620,7 @@
 		84C201831475CB7777CA86D0 /* lato_bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = lato_bold.ttf; sourceTree = "<group>"; };
 		84D54360A6C683647935BB31 /* DocViewerAnnotationDeleteResponseHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocViewerAnnotationDeleteResponseHandler.swift; sourceTree = "<group>"; };
 		84D7F20136B99ADD6EAB7F8B /* SessionDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDefaults.swift; sourceTree = "<group>"; };
+		8506C5823B23D499E91D9D3F /* EmbeddedExternalToolsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedExternalToolsTests.swift; sourceTree = "<group>"; };
 		855D71FBBD73DF4B9A8D8683 /* GroupContextCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupContextCardViewModelTests.swift; sourceTree = "<group>"; };
 		85A5B6D6D9B884DBDDBEC647 /* GetSubmissionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetSubmissionsTests.swift; sourceTree = "<group>"; };
 		85D0E3FC18C36A8077C654DD /* ComposeViewController.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ComposeViewController.storyboard; sourceTree = "<group>"; };
@@ -2808,6 +2811,7 @@
 		A17BD18F5CBB9E241988E300 /* CourseSyncProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseSyncProgressView.swift; sourceTree = "<group>"; };
 		A18D6CECA93926E3D68A30A0 /* NotificationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationManager.swift; sourceTree = "<group>"; };
 		A1AA470B674E223BC460314B /* GradeSubmissionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSubmissionTests.swift; sourceTree = "<group>"; };
+		A1DF88B47C0171C61BA8B7C4 /* DarkModeForWebDiscussionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeForWebDiscussionsTests.swift; sourceTree = "<group>"; };
 		A212DAC8DEAD47E99509624E /* InstColorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstColorExtensionsTests.swift; sourceTree = "<group>"; };
 		A22BD8F31591B30BBAD5CC09 /* FilterHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterHeaderView.swift; sourceTree = "<group>"; };
 		A2347D7E8FE1CAB2C0F02A5C /* CDCourseSyncStateProgress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CDCourseSyncStateProgress.swift; sourceTree = "<group>"; };
@@ -3101,7 +3105,6 @@
 		CE9E0D5012DE444FB93B7661 /* GradeCircleView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = GradeCircleView.xib; sourceTree = "<group>"; };
 		CED26037996232D09E927A44 /* UIViewExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewExtensions.swift; sourceTree = "<group>"; };
 		CF3B1A2B2EEDE4847384B3ED /* NSAttributedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSAttributedString.swift; sourceTree = "<group>"; };
-		CF431F012B501CC1004DAE16 /* DarkModeForWebDiscussionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DarkModeForWebDiscussionsTests.swift; sourceTree = "<group>"; };
 		CF50AAD392DC03765A4F4C9E /* ErrorExtensionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorExtensionsTests.swift; sourceTree = "<group>"; };
 		CF76AA92A0745A9D16189BB8 /* GetDiscussionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetDiscussionsTests.swift; sourceTree = "<group>"; };
 		CFAD2AE1CF6B4872E30170B5 /* FileEditorViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileEditorViewTests.swift; sourceTree = "<group>"; };
@@ -3118,6 +3121,7 @@
 		D127195ADBA1D03BA926F9F9 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		D17B696ED72984B71B28122C /* FontPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontPreview.swift; sourceTree = "<group>"; };
 		D1935F71056F24DFF7F64432 /* DashboardSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSettingsView.swift; sourceTree = "<group>"; };
+		D199772E8E383D8CDDEDFF85 /* EmbeddedExternalTools.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedExternalTools.swift; sourceTree = "<group>"; };
 		D1D30EB5D7310B4F5B66CDB8 /* ProcessInfoExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoExtensions.swift; sourceTree = "<group>"; };
 		D216096E1F65E2A59B10896D /* DiscussionDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscussionDetailsViewController.swift; sourceTree = "<group>"; };
 		D24715C56FC9C045B256FAB7 /* LoginSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginSessionTests.swift; sourceTree = "<group>"; };
@@ -7000,6 +7004,7 @@
 			isa = PBXGroup;
 			children = (
 				9619C56CCA704EF04CCE1771 /* APIExternalToolTests.swift */,
+				8506C5823B23D499E91D9D3F /* EmbeddedExternalToolsTests.swift */,
 				C5CA169866CCE0D6FD9EC812 /* GetArcTests.swift */,
 				86BC1E024A5F75785A492247 /* GoogleCloudAssignmentViewControllerTests.swift */,
 				6DFA0222E5FA9B12E3EDA0F7 /* LTIToolsTests.swift */,
@@ -8041,6 +8046,7 @@
 			isa = PBXGroup;
 			children = (
 				75A7B033982BB92DBD3C20C9 /* APIExternalTool.swift */,
+				D199772E8E383D8CDDEDFF85 /* EmbeddedExternalTools.swift */,
 				22BD0168BE0B5688354EB62D /* ExternalTool.swift */,
 				E3E9735AB298A611E00A778A /* GetArc.swift */,
 				9EC0DE3267FE05FE686605D8 /* GoogleCloudAssignmentViewController.swift */,
@@ -8600,6 +8606,7 @@
 			isa = PBXGroup;
 			children = (
 				C29BB7879BA492FBDE60514F /* CustomUserAgentTests.swift */,
+				A1DF88B47C0171C61BA8B7C4 /* DarkModeForWebDiscussionsTests.swift */,
 				541B64DD5B16491B9B993A8E /* DisableZoomTests.swift */,
 				F4DF4ABB86DA4BBF2AD048E7 /* ForceDisableHorizontalScrollTests.swift */,
 				C8FA3C7541CEB61F71F15060 /* InvertColorsInDarkModeTests.swift */,
@@ -8608,7 +8615,6 @@
 				84A96C427819EEDE0C621AF6 /* PullToRefreshTests.swift */,
 				704CF9439B155059D53DE4DB /* ScriptTests.swift */,
 				A6FE4016AD6D1051A06BFBA0 /* SkipJSInjectionTests.swift */,
-				CF431F012B501CC1004DAE16 /* DarkModeForWebDiscussionsTests.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -9453,7 +9459,6 @@
 				BFF70AC206C15080992D5823 /* APIAccountTests.swift in Sources */,
 				9D6D4F20B23DE6D37E6BB983 /* APIActivityTests.swift in Sources */,
 				5F7DEFE306C63CBB96A2D13A /* APIAssignmentListTests.swift in Sources */,
-				CF431F022B501CC1004DAE16 /* DarkModeForWebDiscussionsTests.swift in Sources */,
 				C8334187E3144139EC05A67B /* APIAssignmentTests.swift in Sources */,
 				8DDF049879B4EFA6680A326B /* APIBrandVariablesTests.swift in Sources */,
 				AC35317432FFBF5A3DB69AB1 /* APICalendarEventTests.swift in Sources */,
@@ -9641,6 +9646,7 @@
 				5233197D4D23D21ABD6A7FE9 /* CreateTextCommentTests.swift in Sources */,
 				4BE541B0E3CC093200B367DE /* CreateTodoViewControllerTests.swift in Sources */,
 				CC5D3D08A25872A7DE67F5DE /* CustomUserAgentTests.swift in Sources */,
+				E1F70E3D94CCB9C114D72390 /* DarkModeForWebDiscussionsTests.swift in Sources */,
 				26E31B6F2E2A5270004AC64A /* DashboardCardTests.swift in Sources */,
 				DAF38F4F7F63ECF135E98D65 /* DashboardCardsViewModelTests.swift in Sources */,
 				2FE4FD28A8BDDAAEE3721BF9 /* DashboardConferencesViewModelTests.swift in Sources */,
@@ -9682,6 +9688,7 @@
 				BC305225F8FDAF17CC0EBF25 /* DynamicButtonTests.swift in Sources */,
 				971DE97F4C352837AE057048 /* DynamicLabelTests.swift in Sources */,
 				D4D31354957AF4E8D7AEF9D5 /* EditComposeRecipientsViewControllerTests.swift in Sources */,
+				88F79752B5B46199DD43EE6F /* EmbeddedExternalToolsTests.swift in Sources */,
 				13E00D0D83850D66833DA2B3 /* EmptyViewControllerTests.swift in Sources */,
 				595AB45A7D8CD6E1693F3E6B /* EnrollmentTests.swift in Sources */,
 				C5CF5C39D3826BCD75FB6DB0 /* ErrorExtensionsTests.swift in Sources */,
@@ -10416,6 +10423,7 @@
 				2E992A9181D106596A664A6E /* DynamicTextField.swift in Sources */,
 				AD489D2636341F1C744CC2AB /* EditComposeRecipientsViewController.swift in Sources */,
 				32BDE84B5507C6FB7F903FD8 /* EditorForm.swift in Sources */,
+				BBB6EC24920FDA629096D6F7 /* EmbeddedExternalTools.swift in Sources */,
 				5951D1F52B2AF19CA8A2A0EF /* EmbeddedWebPageView.swift in Sources */,
 				A6A01B72E99A9B91FBBD4C70 /* EmbeddedWebPageViewModel.swift in Sources */,
 				A96EA2CEF81958ADC9A74209 /* EmbeddedWebPageViewModelLive.swift in Sources */,

--- a/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
@@ -101,7 +101,12 @@ extension CoreWebView {
                     a.href = iframe.src
                     iframe.parentNode.replaceChild(a, iframe)
                 }
-                if (/\\/(courses|accounts)\\/[^\\/]+\\/external_tools\\/retrieve/.test(iframe.src)) {
+                if (
+                    // Office 365 embeds use sharepoint.com host with a custom path, not following regular LTI launch urls.
+                    // Tapping on the Launch External Tool button will treat this as an external url dropping the user to Safari.
+                    /sharepoint\\.com.*embed/.test(iframe.src) ||
+                    /\\/(courses|accounts)\\/[^\\/]+\\/external_tools\\/retrieve/.test(iframe.src)
+                ) {
                     replace(iframe)
                 } else if (/\\/media_objects_iframe\\/m-\\w+/.test(iframe.src)) {
                     const match = iframe.src.match(/\\/media_objects_iframe\\/(m-\\w+)/)

--- a/Core/Core/LTI/EmbeddedExternalTools.swift
+++ b/Core/Core/LTI/EmbeddedExternalTools.swift
@@ -1,0 +1,61 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SafariServices
+
+/**
+ This helper opens LTI launch urls that are not Canvas LTI launch urls in Safari.
+ */
+enum EmbeddedExternalTools {
+    // swiftlint:disable opening_brace
+    private static let externalToolChecks: [(URL) -> Bool] = [
+        {
+            $0.host?.contains("sharepoint.com") == true &&
+            $0.path.contains("embed")
+        },
+    ]
+    // swiftlint:enable opening_brace
+
+    /**
+     - returns: `True` if the LTI launch was handled by this method.
+     */
+    static func handle(
+        url: URL,
+        view: UIViewController,
+        loginDelegate: LoginDelegate?,
+        router: Router
+    ) -> Bool {
+        // If there's one check that passes for the url then we're safe to handle it
+        guard
+            externalToolChecks.contains(where: { check in check(url) })
+        else {
+            return false
+        }
+
+        let openInSystemSafari = UserDefaults.standard.bool(forKey: "open_lti_safari")
+
+        if openInSystemSafari {
+            loginDelegate?.openExternalURLinSafari(url)
+        } else {
+            let safariModal = SFSafariViewController(url: url)
+            router.show(safariModal, from: view, options: .modal(.overFullScreen))
+        }
+
+        return true
+    }
+}

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -174,8 +174,8 @@ public class LTITools: NSObject {
                     completionHandler(true)
                 }
             } else if self.openInSafari {
-                    self.env.loginDelegate?.openExternalURLinSafari(url)
-                    completionHandler(true)
+                self.env.loginDelegate?.openExternalURLinSafari(url)
+                completionHandler(true)
             } else {
                 let safari = SFSafariViewController(url: url)
                 self.env.router.show(safari, from: view, options: .modal(.overFullScreen)) {

--- a/Core/CoreTests/LTI/EmbeddedExternalToolsTests.swift
+++ b/Core/CoreTests/LTI/EmbeddedExternalToolsTests.swift
@@ -1,0 +1,75 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import SafariServices
+import XCTest
+
+class EmbeddedExternalToolsTests: CoreTestCase {
+    // swiftlint:disable:next line_length
+    private let sharePointURL = URL(string: "https://instructure-my.sharepoint.com/personal/test_instructure_com/_layouts/15/embed.aspx?UniqueId=redacted&embed=%7B%22ust%22%3Atrue%2C%22hv%22%3A%22CopyEmbedCode%22%7D&referrer=StreamWebApp&referrerScenario=EmbedDialog.Create")!
+    private let viewHost = UIViewController()
+
+    override func tearDown() {
+        UserDefaults.standard.setValue(nil, forKey: "open_lti_safari")
+        super.tearDown()
+    }
+
+    func testHandlesSharePointURLInSafari() {
+        UserDefaults.standard.setValue(true, forKey: "open_lti_safari")
+        let result = EmbeddedExternalTools.handle(url: sharePointURL,
+                                                  view: viewHost,
+                                                  loginDelegate: login,
+                                                  router: router)
+
+        XCTAssertTrue(result)
+        XCTAssertEqual(login.externalURL, sharePointURL)
+        XCTAssertNil(router.viewControllerCalls.last)
+    }
+
+    func testHandlesSharePointURLInApp() {
+        UserDefaults.standard.setValue(false, forKey: "open_lti_safari")
+        let result = EmbeddedExternalTools.handle(url: sharePointURL,
+                                                  view: viewHost,
+                                                  loginDelegate: login,
+                                                  router: router)
+
+        XCTAssertTrue(result)
+        XCTAssertNil(login.externalURL)
+        XCTAssertTrue(router.viewControllerCalls.last?.0 is SFSafariViewController)
+        XCTAssertEqual(router.viewControllerCalls.last?.1, viewHost)
+        XCTAssertEqual(router.viewControllerCalls.last?.2, .modal(.overFullScreen))
+    }
+
+    func testNotHandlesCanvasLTIURLs() {
+        let canvasLTIURL1 = URL(string: "https://canvas.instructure.com/courses/1/external_tools/sessionless_launch")!
+        var result = EmbeddedExternalTools.handle(url: canvasLTIURL1,
+                                                  view: viewHost,
+                                                  loginDelegate: login,
+                                                  router: router)
+        XCTAssertFalse(result)
+
+        let canvasLTIURL2 = URL(string: "https://canvas.instructure.com/courses/1/external_tools/retrieve?resource_link_lookup_uuid=123")!
+        result = EmbeddedExternalTools.handle(url: canvasLTIURL2,
+                                              view: viewHost,
+                                              loginDelegate: login,
+                                              router: router)
+
+        XCTAssertFalse(result)
+    }
+}


### PR DESCRIPTION
Sharepoint LTI iframes were not using the canvas LTI launch urls so I added custom handlers (one for the iframe to button replacement and another one for opening the url) for this specific LTI with the ability to add more if we need any in the future.

refs: MBL-17321
affects: Student, Teacher, Parent
release note: Fixed embedded sharepoint content not allowing to log in.

test plan:
- See ticket for account details.
- If the login screen appears we are good.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/d82cd1af-46ce-4392-8a06-41bf879c0558" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/b528b79d-6cc8-482b-b971-b2ec824054ae" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
