### PR TITLE
Fix course menu in offline mode

### DIFF
--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -147,9 +147,18 @@ public class CourseDetailsViewModel: ObservableObject {
         guard let offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
             return
         }
-        if offlineSelectionsForCourse.contains(where: { $0 == "courses/\(courseID)" }) {
-            return cells.forEach { $0.isSupportedOffline = true }
+        let wholeCourseSelected = offlineSelectionsForCourse.contains("courses/\(courseID)")
+
+        if wholeCourseSelected {
+            let offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
+
+            cells.forEach {
+                $0.isSupportedOffline = offlineTabs.contains($0.tabID)
+            }
+
+            return
         }
+
         cells.forEach { cell in
             if offlineSelectionsForCourse.contains("courses/\(courseID)/tabs/\(cell.tabID)") {
                 cell.isSupportedOffline = true


### PR DESCRIPTION
Only enable offline syncable tabs in course details while device is offline and the whole course is selected for offline sync.

affects: Student
test plan:
- Select a course as a whole for offline sync and sync it.
- Go offline and enter the synced course.
- Only offline available tabs should be enabled, LTI tools should be disabled.

[ignore-commit-lint]