### PR TITLE
Fix manage offline content course list tabs missing

### DIFF
--- a/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
@@ -52,12 +52,12 @@ public class CourseSyncListInteractorLive: CourseSyncListInteractor {
                     scope: .where(#keyPath(CourseSyncSelectorCourse.courseId), equals: courseId)
                 )
             )
-            publisher = courseListStore.getEntities()
+            publisher = courseListStore.getEntities(ignoreCache: true)
         case .all:
             courseListStore = ReactiveStore(
                 useCase: GetCourseSyncSelectorCourses()
             )
-            publisher = courseListStore.getEntities()
+            publisher = courseListStore.getEntities(ignoreCache: true)
         case let .courseIds(courseIds):
             let predicate = NSPredicate(format: "courseId IN %@", courseIds)
             courseListStore = ReactiveStore(


### PR DESCRIPTION
Fix manage offline content course list tabs missing. 

Manage offline content screen now (again) ignores cache and uses fresh data from the API  to display the list of courses and their tabs. 

Test plan:
- Open a course while you are online
- Do a pull to refresh on the course, open tabs, do pull to refreshes
- Open Manage Offline Content 
- Expand a course
- Previously you may have seen a No Content screen, but this should be resolved now.   

affects: Student

[ignore-commit-lint]

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
