### PR TITLE
Add enrollment refresh to SpeedGrader load.

### DIFF
--- a/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -40,6 +40,9 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
     lazy var submissions = env.subscribe(GetSubmissions(context: context, assignmentID: assignmentID, filter: filter)) { [weak self] in
         self?.update()
     }
+    lazy var enrollments = env.subscribe(GetEnrollments(context: context)) { [weak self] in
+        self?.update()
+    }
 
     init(context: Context, assignmentID: String, userID: String, filter: [GetSubmissions.Filter]) {
         self.assignmentID = assignmentID
@@ -59,6 +62,7 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
         embed(loadingView, in: view)
         assignment.refresh()
         submissions.exhaust()
+        enrollments.exhaust()
     }
 
     override var supportedInterfaceOrientations: UIInterfaceOrientationMask {

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/SpeedGraderViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/SpeedGraderViewControllerTests.swift
@@ -45,4 +45,24 @@ class SpeedGraderViewControllerTests: TeacherTestCase {
         XCTAssertNil(controller.pages.parent)
         XCTAssertNotNil(controller.emptyView.parent)
     }
+
+    func testHidesInactiveStudentSubmissions() {
+        api.mock(GetAssignment(courseID: "1", assignmentID: "1", include: [ .overrides ]), value: .make())
+        api.mock(GetSubmissions(context: .course("1"), assignmentID: "1"), value: [
+            .make(id: "1", submission_history: [], submission_type: .online_upload, user_id: "1"),
+            .make(id: "2", submission_history: [], submission_type: .online_upload, user_id: "2"),
+        ])
+        // User2 should be inactive
+        api.mock(GetEnrollments(context: .course("1")), value: [
+            .make(id: "1", course_id: "1", enrollment_state: .active, user_id: "1"),
+            .make(id: "2", course_id: "1", enrollment_state: .inactive, user_id: "2"),
+        ])
+        controller = SpeedGraderViewController(context: .course("1"), assignmentID: "1", userID: "1", filter: [.needsGrading])
+
+        // WHEN
+        controller.view.layoutIfNeeded()
+
+        // THEN
+        XCTAssertEqual(controller.submissions.all.count, 1)
+    }
 }


### PR DESCRIPTION
refs: MBL-17324
affects: Teacher
release note: Fixed inactive students showing up in SpeedGrader when opened from the ToDo list.

test plan: See ticket. Only reproducible if you don't visit the submission list from the assignment details screen.