### PR TITLE
Student - E2E test for the new discussion screen

### DIFF
--- a/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
+++ b/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
@@ -22,6 +22,11 @@ class DiscussionsTests: E2ETestCase {
     typealias Helper = DiscussionsHelper
     typealias DetailsHelper = Helper.Details
     typealias ReplyHelper = DetailsHelper.Reply
+    typealias NewDiscussion = Helper.NewDetails
+
+    override func tearDown() {
+        seeder.setFeatureFlag(featureFlag: .newDiscussion, state: .off)
+    }
 
     func testDiscussionLabels() {
         // MARK: Seed the usual stuff with a discussion
@@ -232,5 +237,78 @@ class DiscussionsTests: E2ETestCase {
 
         gradesAssignmentSubmittedLabel.actionUntilElementCondition(action: .pullToRefresh, condition: .label(expected: "Submitted"))
         XCTAssertTrue(gradesAssignmentSubmittedLabel.hasLabel(label: "Submitted"))
+    }
+
+    func testNewDiscussionScreen() {
+        // MARK: Seed the usual stuff with a discussion, enable NewDiscussion feature
+        seeder.setFeatureFlag(featureFlag: .newDiscussion, state: .allowedOn)
+        let student = seeder.createUser()
+        let course = seeder.createCourse()
+        seeder.enrollStudent(student, in: course)
+        let discussion = Helper.createDiscussion(course: course)
+
+        // MARK: Get the user logged in
+        logInDSUser(student)
+        let courseCard = DashboardHelper.courseCard(course: course).waitUntil(.visible)
+        XCTAssertTrue(courseCard.isVisible)
+
+        // MARK: Navigate to Discussions and check visibility of buttons and labels
+        Helper.navigateToDiscussions(course: course)
+        let discussionButton = Helper.discussionButton(discussion: discussion).waitUntil(.visible)
+        XCTAssertTrue(discussionButton.isVisible)
+        XCTAssertTrue(discussionButton.hasLabel(label: discussion.title, strict: false))
+
+        discussionButton.hit()
+        let searchField = NewDiscussion.searchField.waitUntil(.visible)
+        let filterByLabel = NewDiscussion.filterByLabel.waitUntil(.visible)
+        let sortButton = NewDiscussion.sortButton.waitUntil(.visible)
+        let viewSplitScreenButton = NewDiscussion.viewSplitScreenButton.waitUntil(.visible)
+        let subscribeButton = NewDiscussion.subscribeButton.waitUntil(.visible)
+        let manageDiscussionButton = NewDiscussion.manageDiscussionButton.waitUntil(.visible)
+        let discussionTitle = NewDiscussion.discussionTitle(discussion: discussion).waitUntil(.visible)
+        let discussionBody = NewDiscussion.discussionBody(discussion: discussion).waitUntil(.visible)
+        var replyButton = NewDiscussion.replyButton.waitUntil(.visible)
+        XCTAssertTrue(searchField.isVisible)
+        XCTAssertTrue(searchField.hasValue(value: "Search entries or author..."))
+        XCTAssertTrue(filterByLabel.isVisible)
+        XCTAssertTrue(sortButton.isVisible)
+        XCTAssertTrue(sortButton.hasLabel(label: "Sorted by Descending", strict: false))
+        XCTAssertTrue(viewSplitScreenButton.isVisible)
+        XCTAssertTrue(subscribeButton.isVisible)
+        XCTAssertTrue(manageDiscussionButton.isVisible)
+        XCTAssertTrue(discussionTitle.isVisible)
+        XCTAssertTrue(discussionBody.isVisible)
+        XCTAssertTrue(replyButton.isVisible)
+
+        viewSplitScreenButton.hit()
+        let viewInlineButton = NewDiscussion.viewInlineButton.waitUntil(.visible)
+        XCTAssertTrue(viewSplitScreenButton.isVanished)
+        XCTAssertTrue(viewInlineButton.isVisible)
+
+        subscribeButton.hit()
+        let unsubscribeButton = NewDiscussion.unsubscribeButton.waitUntil(.visible)
+        XCTAssertTrue(subscribeButton.isVanished)
+        XCTAssertTrue(unsubscribeButton.isVisible)
+
+        manageDiscussionButton.hit()
+        let markAllAsReadButton = NewDiscussion.markAllAsRead.waitUntil(.visible)
+        let markAllAsUnreadButton = NewDiscussion.markAllAsUnread.waitUntil(.visible)
+        XCTAssertTrue(markAllAsReadButton.isVisible)
+        XCTAssertTrue(markAllAsUnreadButton.isVisible)
+
+        markAllAsUnreadButton.hit()
+        replyButton.hit()
+        let textInput = NewDiscussion.Reply.textInput.waitUntil(.visible)
+        let attachButton = NewDiscussion.Reply.attachButton.waitUntil(.visible)
+        let cancelButton = NewDiscussion.Reply.cancelButton.waitUntil(.visible)
+        replyButton = NewDiscussion.Reply.replyButton.waitUntil(.visible)
+        XCTAssertTrue(textInput.isVisible)
+        XCTAssertTrue(attachButton.isVisible)
+        XCTAssertTrue(cancelButton.isVisible)
+        XCTAssertTrue(replyButton.isVisible)
+
+        cancelButton.actionUntilElementCondition(action: .swipeUp(.onApp), condition: .hittable)
+        cancelButton.hit()
+        XCTAssertTrue(cancelButton.waitUntil(.vanish).isVanished)
     }
 }

--- a/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DSFeature.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DSFeature.swift
@@ -20,5 +20,4 @@ public struct DSFeature: Codable {
     public let feature: String
     public let display_name: String?
     public let applies_to: String?
-    public let feature_flag: DSFeatureFlag?
 }

--- a/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DSFeatureFlag.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DSFeatureFlag.swift
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-public struct DSFeatureFlag: Codable {
-    public let feature: String
-    public let state: String
+public enum DSFeatureFlag: String {
+    case newDiscussion = "react_discussions_post"
 }

--- a/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DataSeeder+DSFeatureFlag.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/DataSeeder+DSFeatureFlag.swift
@@ -23,9 +23,9 @@ extension DataSeeder {
         return makeRequest(request)
     }
 
-    public func setFeatureFlag(courseId: String, feature: DSFeature, state: DSFeatureFlagState) -> DSFeatureFlag {
+    public func setFeatureFlag(featureFlag: DSFeatureFlag, state: DSFeatureFlagState) {
         let requestBody = SetDSFeatureFlagRequest.Body(state: state)
-        let request = SetDSFeatureFlagRequest(body: requestBody, courseId: courseId, feature: feature)
-        return makeRequest(request)
+        let request = SetDSFeatureFlagRequest(body: requestBody, featureFlag: featureFlag)
+        makeRequest(request)
     }
 }

--- a/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/SetDSFeatureFlagRequest.swift
+++ b/TestsFoundation/TestsFoundation/DataSeeding/FeatureFlags/SetDSFeatureFlagRequest.swift
@@ -20,15 +20,15 @@ import Core
 
 // https://canvas.instructure.com/doc/api/feature_flags.html#method.feature_flags.update
 public struct SetDSFeatureFlagRequest: APIRequestable {
-    public typealias Response = DSFeatureFlag
+    public typealias Response = APINoContent
 
     public let method = APIMethod.put
     public let path: String
     public let body: Body?
 
-    public init(body: Body, courseId: String, feature: DSFeature) {
+    public init(body: Body, featureFlag: DSFeatureFlag) {
         self.body = body
-        self.path = "courses/\(courseId)/features/flags/\(feature.feature)"
+        self.path = "accounts/self/features/flags/\(featureFlag.rawValue)"
     }
 }
 
@@ -57,4 +57,5 @@ public enum DSFeatureFlagState: String {
     case off
     case allowed
     case on
+    case allowedOn = "allowed_on"
 }

--- a/TestsFoundation/TestsFoundation/Helpers/DiscussionsHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/DiscussionsHelper.swift
@@ -83,6 +83,36 @@ public class DiscussionsHelper: BaseHelper {
         }
     }
 
+    public struct NewDetails {
+        public static var searchField: XCUIElement { app.find(type: .textField) }
+        public static var filterByLabel: XCUIElement { app.find(label: "Filter by", type: .staticText) }
+        public static var sortButton: XCUIElement { app.find(labelContaining: "Sorted by", type: .button) }
+        public static var viewSplitScreenButton: XCUIElement { app.find(labelContaining: "View Split Screen", type: .button) }
+        public static var viewInlineButton: XCUIElement { app.find(labelContaining: "View Inline", type: .button) }
+        public static var manageDiscussionButton: XCUIElement { app.find(label: "Manage Discussion", type: .button) }
+        public static var subscribeButton: XCUIElement { app.find(label: "Unsubscribed", type: .button) }
+        public static var unsubscribeButton: XCUIElement { app.find(label: "Subscribed", type: .button) }
+        public static var replyButton: XCUIElement { app.find(label: "Reply", type: .button) }
+        public static var markAllAsRead: XCUIElement { app.find(label: "Mark All as Read", type: .menuItem) }
+        public static var markAllAsUnread: XCUIElement { app.find(label: "Mark All as Unread", type: .menuItem) }
+
+        public static func discussionTitle(discussion: DSDiscussionTopic) -> XCUIElement {
+            return app.find(label: "Discussion Topic: \(discussion.title)", type: .staticText)
+        }
+
+        public static func discussionBody(discussion: DSDiscussionTopic) -> XCUIElement {
+            return app.find(label: discussion.message, type: .staticText)
+        }
+
+        public struct Reply {
+            public static var textInput: XCUIElement { app.find(labelContaining: "Rich Text Area", type: .other).find(type: .textView) }
+            public static var attachButton: XCUIElement { app.find(label: "Attach", type: .button) }
+            public static var replyButton: XCUIElement { app.find(label: "Reply", type: .button) }
+            public static var cancelButton: XCUIElement { app.find(label: "Cancel", type: .button) }
+        }
+
+    }
+
     public struct Editor {
         public static var allowRatingToggle: XCUIElement { app.find(id: "DiscussionEditor.allowRatingToggle").find(type: .switch) }
         public static var attachmentButton: XCUIElement { app.find(id: "DiscussionEditor.attachmentButton") }

--- a/TestsFoundation/TestsFoundation/Helpers/NewQuizzesHelper.swift
+++ b/TestsFoundation/TestsFoundation/Helpers/NewQuizzesHelper.swift
@@ -39,13 +39,6 @@ public class NewQuizzesHelper: BaseHelper {
     }
 
     @discardableResult
-    public static func enableFeatureFlagForCourse(course: DSCourse,
-                                                  feature: DSFeature,
-                                                  state: DSFeatureFlagState = .on) -> DSFeatureFlag {
-        return seeder.setFeatureFlag(courseId: course.id, feature: feature, state: state)
-    }
-
-    @discardableResult
     public static func listFeaturesForCourse(course: DSCourse) -> [DSFeature] {
         return seeder.getFeatures(courseId: course.id)
     }


### PR DESCRIPTION
refs: MBL-17336
affects: None
release note: None
test plan: Tests to pass

### E2E test case for the new discussion screen
1.  Turns on the feature flag with API call
2. Creates a user, course, discussion with DataSeeder
3. Gets the user logged in
4. Navigates to Discussions screen and taps on the discussion
5. Checks elements on the new discussion details screen
6. Turns off the feature flag (in teardown function)