### PR TITLE
Fix Student dashboard crash

### DIFF
--- a/Core/Core/Store/UseCase.swift
+++ b/Core/Core/Store/UseCase.swift
@@ -81,8 +81,10 @@ public extension UseCase {
             }
             self.makeRequest(environment: environment) { response, urlResponse, error in
                 if let error = error {
-                    callback?(response, urlResponse, error)
-                    return
+                    performUIUpdate {
+                        callback?(response, urlResponse, error)
+                        return
+                    }
                 }
                 database.performWriteTask { context in
                     do {


### PR DESCRIPTION
Fix Student dashboard crash

refs: MBL-17373
affects: Student
release note:  Fixed an occasional crash upon launching the application for the first time.
test plan: See below
1. Comment out `DashboardContainerView L84 and L86 so the Theme Switcher pops up when the app starts. 
2. When launching the application, abort every request via Charles/Proxyman
3. You should see the Theme Switcher appear. 

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
