### PR TITLE
Fix profile images being inverted when viewing graded discussions in dark mode

### DIFF
--- a/Core/Core/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
+++ b/Core/Core/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
@@ -26,6 +26,10 @@ private class InvertColorsInDarkMode: CoreWebViewFeature {
             img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), .ignore-color-scheme {
                 filter: invert(100%) hue-rotate(180deg) !important;
             }
+            /* Invert old graded discussion profile images again to get them back to their original look in SpeedGrader. */
+            a.fs-exclude.avatar {
+                filter: invert(100%) hue-rotate(180deg) !important;
+            }
         }
         """
 


### PR DESCRIPTION
refs: MBL-17366
affects: Teacher
release note: Fixed profile images being inverted when viewing graded discussions in dark mode.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/b613801b-2423-42c5-be21-e256623a0573" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/dcf8c2fe-2d09-47b3-b12e-7824e12777f4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested in dark mode
- [x] Tested in light mode
