### PR TITLE
Fix Widget background colors

### DIFF
--- a/Student/Widgets/AnnouncementsWidget/View/AnnouncementWidgetView.swift
+++ b/Student/Widgets/AnnouncementsWidget/View/AnnouncementWidgetView.swift
@@ -24,6 +24,12 @@ struct AnnouncementsWidgetView: View {
     @Environment(\.widgetFamily) var family
 
     var body: some View {
+        buildView()
+            .compatibleContainerBackground(Color.backgroundLightest)
+    }
+
+    @ViewBuilder
+    private func buildView() -> some View {
         if let firstAnnouncement = entry.announcements.first {
             switch family {
             case .systemSmall:

--- a/Student/Widgets/AnnouncementsWidget/View/MediumLarge/AnnouncementItemView.swift
+++ b/Student/Widgets/AnnouncementsWidget/View/MediumLarge/AnnouncementItemView.swift
@@ -55,7 +55,6 @@ struct AnnouncementItemView: View {
                     Spacer()
                 }
             }
-            .compatibleContainerBackground(Color.backgroundLightest)
         }
     }
 }

--- a/Student/Widgets/AnnouncementsWidget/View/Small/SmallAnnouncementsView.swift
+++ b/Student/Widgets/AnnouncementsWidget/View/Small/SmallAnnouncementsView.swift
@@ -35,7 +35,6 @@ struct SmallAnnouncementsView: View {
         }
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .leading)
         .compatibleContentMargins()
-        .compatibleContainerBackground()
         .widgetURL(announcement.url)
     }
 

--- a/Student/Widgets/Common/View/CompatibleContainerBackground.swift
+++ b/Student/Widgets/Common/View/CompatibleContainerBackground.swift
@@ -29,7 +29,9 @@ extension View {
                 backgroundView
             }
         } else {
-            return background(backgroundView)
+            return background {
+                backgroundView
+            }
         }
     }
 }

--- a/Student/Widgets/GradesWidget/View/GradesWidgetView.swift
+++ b/Student/Widgets/GradesWidget/View/GradesWidgetView.swift
@@ -24,22 +24,25 @@ struct GradesWidgetView: View {
     private var firstGrade: GradeItem? { model.assignmentGrades.first ?? model.courseGrades.first }
     @Environment(\.widgetFamily)
     private var family
-    private var lineCountByFamily: [WidgetFamily: Int] = {
-        var values: [WidgetFamily: Int] = [
-            .systemMedium: 2,
-            .systemLarge: 5,
-            .systemExtraLarge: 5,
-        ]
-        return values
-    }()
+    private let lineCountByFamily: [WidgetFamily: Int] = [
+        .systemMedium: 2,
+        .systemLarge: 5,
+        .systemExtraLarge: 5,
+    ]
 
     var body: some View {
-        if let firstGrade = firstGrade {
+        buildView()
+            .compatibleContainerBackground(Color.backgroundLightest)
+    }
+
+    @ViewBuilder
+    private func buildView() -> some View {
+        if let firstGrade {
             switch family {
             case .systemSmall:
                 SmallGradeView(gradeItem: firstGrade)
             default:
-                MediumLargeGradesView(model: model, lineCount: lineCountByFamily[family]!)
+                MediumLargeGradesView(model: model, lineCount: lineCountByFamily[family] ?? 1)
             }
         } else if model.isLoggedIn {
             EmptyView(title: Text("Grades"), message: Text("No Grades To Display"))

--- a/Student/Widgets/GradesWidget/View/MediumLarge/MediumLargeGradesView.swift
+++ b/Student/Widgets/GradesWidget/View/MediumLarge/MediumLargeGradesView.swift
@@ -56,7 +56,6 @@ struct MediumLargeGradesView: View {
                 Spacer()
             }.padding(.top, 4) // This is to vertically center the first header with the logo
         }
-        .compatibleContainerBackground()
         .compatibleContentMargins()
     }
 
@@ -74,8 +73,10 @@ struct MediumLargeGradesView: View {
 struct MediumLargeGradesViewPreviews: PreviewProvider {
     static var previews: some View {
         MediumLargeGradesView(model: .make(), lineCount: 2)
+            .compatibleContainerBackground()
             .previewContext(WidgetPreviewContext(family: .systemMedium))
         MediumLargeGradesView(model: .make(), lineCount: 5)
+            .compatibleContainerBackground()
             .previewContext(WidgetPreviewContext(family: .systemLarge))
     }
 }

--- a/Student/Widgets/GradesWidget/View/Small/SmallGradeView.swift
+++ b/Student/Widgets/GradesWidget/View/Small/SmallGradeView.swift
@@ -38,7 +38,6 @@ struct SmallGradeView: View {
             Spacer(minLength: 0)
         }
         .compatibleContentMargins()
-        .compatibleContainerBackground()
         .widgetURL(gradeItem.route)
     }
 
@@ -53,10 +52,11 @@ struct SmallGradeView: View {
 
 struct SmallGradeViewPreviews: PreviewProvider {
     static var previews: some View {
-            SmallGradeView(gradeItem: GradeItem(name: "Earth: The Pale Blue Dot on two lines or more since it's very long",
-                                                grade: "95.50 / 100",
-                                                color: .crimson))
-                .previewContext(WidgetPreviewContext(family: .systemSmall))
+        SmallGradeView(gradeItem: GradeItem(name: "Earth: The Pale Blue Dot on two lines or more since it's very long",
+                                            grade: "95.50 / 100",
+                                            color: .crimson))
+        .compatibleContainerBackground()
+        .previewContext(WidgetPreviewContext(family: .systemSmall))
     }
 }
 


### PR DESCRIPTION
refs: MBL-17360
affects: Student
release note: Changed background color on all widgets to match app colors
test plan: Please see ticket for details

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/64eb13a8-a8f3-4151-a603-cfb5bc02d312" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/81ade704-2a2b-41e7-b262-031779742844" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode