### PR TITLE
Add submission and rubric button to assignment details when there is no submission

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -29,10 +29,10 @@
                                 <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="QTp-Qq-8ZA">
-                                        <rect key="frame" x="0.0" y="0.0" width="375" height="2356.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="2484.5"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VdI-qu-MC8">
-                                                <rect key="frame" x="0.0" y="24" width="375" height="2332.5"/>
+                                                <rect key="frame" x="0.0" y="24" width="375" height="2460.5"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Assignment Name" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kpV-J8-jIO" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
                                                         <rect key="frame" x="16" y="0.0" width="343" height="20.5"/>
@@ -186,8 +186,46 @@
                                                             <constraint firstItem="haT-9w-5d7" firstAttribute="centerY" secondItem="CDm-Ca-2nK" secondAttribute="centerY" id="uLE-Wc-w1L"/>
                                                         </constraints>
                                                     </view>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="C6K-SW-2gW">
+                                                        <rect key="frame" x="0.0" y="247" width="375" height="128"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="omk-ZS-VzM" customClass="DividerView" customModule="Student" customModuleProvider="target">
+                                                                <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="1" id="txP-st-xmY"/>
+                                                                </constraints>
+                                                                <userDefinedRuntimeAttributes>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="tintColorName" value="borderMedium"/>
+                                                                </userDefinedRuntimeAttributes>
+                                                            </view>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ub-yI-yVY">
+                                                                <rect key="frame" x="16" y="17" width="343" height="94"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="2g5-P9-DtH"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Button"/>
+                                                                <buttonConfiguration key="configuration" style="plain"/>
+                                                                <connections>
+                                                                    <action selector="didTapSubmission:" destination="dvz-Jp-ehK" eventType="primaryActionTriggered" id="Ub8-3J-Oat"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstItem="8ub-yI-yVY" firstAttribute="centerY" secondItem="C6K-SW-2gW" secondAttribute="centerY" id="POv-nd-Fze"/>
+                                                            <constraint firstItem="omk-ZS-VzM" firstAttribute="width" secondItem="C6K-SW-2gW" secondAttribute="width" id="Ppq-0j-2PT"/>
+                                                            <constraint firstItem="8ub-yI-yVY" firstAttribute="leading" secondItem="C6K-SW-2gW" secondAttribute="leading" constant="16" id="SLi-pF-97r"/>
+                                                            <constraint firstItem="8ub-yI-yVY" firstAttribute="centerX" secondItem="C6K-SW-2gW" secondAttribute="centerX" id="WIZ-Po-9vU"/>
+                                                            <constraint firstItem="omk-ZS-VzM" firstAttribute="top" secondItem="C6K-SW-2gW" secondAttribute="top" id="isH-EG-gY9"/>
+                                                            <constraint firstAttribute="trailing" secondItem="8ub-yI-yVY" secondAttribute="trailing" constant="16" id="kiL-F4-bEl"/>
+                                                            <constraint firstItem="8ub-yI-yVY" firstAttribute="top" secondItem="omk-ZS-VzM" secondAttribute="bottom" constant="16" id="qd7-lz-G0f"/>
+                                                            <constraint firstItem="omk-ZS-VzM" firstAttribute="centerX" secondItem="C6K-SW-2gW" secondAttribute="centerX" id="rD9-UL-0Pz"/>
+                                                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="55" id="whg-rS-wGG"/>
+                                                        </constraints>
+                                                    </view>
                                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="uqK-cv-6c4" userLabel="Grade Card">
-                                                        <rect key="frame" x="16" y="247" width="343" height="358"/>
+                                                        <rect key="frame" x="16" y="375" width="343" height="358"/>
                                                         <subviews>
                                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S5K-EU-rcH">
                                                                 <rect key="frame" x="16" y="16" width="311" height="30"/>
@@ -309,14 +347,14 @@
                                                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="40" right="16"/>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2dw-BH-GAc" userLabel="Spacer - 32pt">
-                                                        <rect key="frame" x="32" y="605" width="311" height="32"/>
+                                                        <rect key="frame" x="32" y="733" width="311" height="32"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="32" id="yAM-hn-3HI"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cjm-nL-hdm" customClass="DividerView" customModule="Student" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="637" width="375" height="1"/>
+                                                        <rect key="frame" x="0.0" y="765" width="375" height="1"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="1" id="WYO-57-E8S"/>
@@ -326,14 +364,14 @@
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Upl-ga-ug3" userLabel="Spacer - 16pt">
-                                                        <rect key="frame" x="32" y="638" width="311" height="24"/>
+                                                        <rect key="frame" x="32" y="766" width="311" height="24"/>
                                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstAttribute="height" constant="24" id="8nb-8g-EbL"/>
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="RBf-wD-x1b">
-                                                        <rect key="frame" x="0.0" y="662" width="375" height="271.5"/>
+                                                        <rect key="frame" x="0.0" y="790" width="375" height="271.5"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Settings" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wuJ-9M-78d" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
                                                                 <rect key="frame" x="16" y="0.0" width="343" height="154"/>
@@ -443,7 +481,7 @@
                                                         </constraints>
                                                     </view>
                                                     <view alpha="0.0" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TO1-FI-dAE">
-                                                        <rect key="frame" x="0.0" y="933.5" width="375" height="144"/>
+                                                        <rect key="frame" x="0.0" y="1061.5" width="375" height="144"/>
                                                         <subviews>
                                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Core.PandaLocked" translatesAutoresizingMaskIntoConstraints="NO" id="Yw2-71-XHM" userLabel="LockedIconView">
                                                                 <rect key="frame" x="97" y="0.0" width="181" height="144"/>
@@ -462,11 +500,11 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s8P-wF-IX6" customClass="AssignmentDetailsSectionContainerView" customModule="Student" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="1077.5" width="375" height="267"/>
+                                                        <rect key="frame" x="0.0" y="1205.5" width="375" height="267"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="AssingmentDetails.dueSection"/>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="U3Y-Im-VWs">
-                                                        <rect key="frame" x="0.0" y="1344.5" width="375" height="267"/>
+                                                        <rect key="frame" x="0.0" y="1472.5" width="375" height="267"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Attempts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="EkA-bh-wFX" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="192"/>
@@ -550,21 +588,21 @@
                                                         </constraints>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Plt-HB-bKp" customClass="AssignmentDetailsSectionContainerView" customModule="Student" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="1611.5" width="375" height="267"/>
+                                                        <rect key="frame" x="0.0" y="1739.5" width="375" height="267"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="AssingmentDetails.submissionTypesSection"/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="headerText" value="Submission Types"/>
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hil-LN-kZQ" customClass="AssignmentDetailsSectionContainerView" customModule="Student" customModuleProvider="target">
-                                                        <rect key="frame" x="0.0" y="1878.5" width="375" height="267.5"/>
+                                                        <rect key="frame" x="0.0" y="2006.5" width="375" height="267.5"/>
                                                         <accessibility key="accessibilityConfiguration" identifier="AssingmentDetails.fileTypesSection"/>
                                                         <userDefinedRuntimeAttributes>
                                                             <userDefinedRuntimeAttribute type="string" keyPath="headerText" value="File Types"/>
                                                         </userDefinedRuntimeAttributes>
                                                     </view>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="G3G-xF-An6" userLabel="Description Header">
-                                                        <rect key="frame" x="0.0" y="2146" width="375" height="186.5"/>
+                                                        <rect key="frame" x="0.0" y="2274" width="375" height="186.5"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SXw-qc-FaX" userLabel="Description Divider" customClass="DividerView" customModule="Student" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="20" width="375" height="1"/>
@@ -626,6 +664,8 @@
                                                     <constraint firstAttribute="trailing" secondItem="kpV-J8-jIO" secondAttribute="trailing" constant="16" id="pBZ-Ud-31u"/>
                                                     <constraint firstAttribute="trailing" secondItem="TO1-FI-dAE" secondAttribute="trailing" id="qnT-4Z-HXJ"/>
                                                     <constraint firstAttribute="trailing" secondItem="RBf-wD-x1b" secondAttribute="trailing" id="rzx-DU-0Rc"/>
+                                                    <constraint firstItem="C6K-SW-2gW" firstAttribute="leading" secondItem="VdI-qu-MC8" secondAttribute="leading" id="tBk-0X-AqT"/>
+                                                    <constraint firstAttribute="trailing" secondItem="C6K-SW-2gW" secondAttribute="trailing" id="v7T-7v-5cb"/>
                                                 </constraints>
                                             </stackView>
                                         </subviews>
@@ -637,7 +677,7 @@
                                         </constraints>
                                     </view>
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="q3R-vd-zmQ">
-                                        <rect key="frame" x="0.0" y="2356.5" width="375" height="100"/>
+                                        <rect key="frame" x="0.0" y="2484.5" width="375" height="100"/>
                                         <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.description">
                                             <bool key="isElement" value="NO"/>
                                         </accessibility>
@@ -732,6 +772,8 @@
                         <outlet property="statusIconView" destination="Tdl-M0-B5e" id="11O-xE-tnq"/>
                         <outlet property="statusLabel" destination="co0-jJ-6sI" id="P3s-MG-6Xw"/>
                         <outlet property="submissionButton" destination="bN3-2w-CuG" id="uhR-2z-p6S"/>
+                        <outlet property="submissionRubricButton" destination="8ub-yI-yVY" id="arA-mM-JBh"/>
+                        <outlet property="submissionRubricButtonSection" destination="C6K-SW-2gW" id="uLt-ss-qFK"/>
                         <outlet property="submissionTypesSection" destination="Plt-HB-bKp" id="u7h-p0-QTm"/>
                         <outlet property="submitAssignmentButton" destination="Oo1-Sb-iO9" id="Ufa-HQ-uVu"/>
                         <outlet property="submittedDetailsLabel" destination="ePD-c3-2H7" id="7Wc-Ri-A3A"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -211,7 +211,7 @@
                                                                 </connections>
                                                             </button>
                                                         </subviews>
-                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <constraints>
                                                             <constraint firstItem="8ub-yI-yVY" firstAttribute="centerY" secondItem="C6K-SW-2gW" secondAttribute="centerY" id="POv-nd-Fze"/>
                                                             <constraint firstItem="omk-ZS-VzM" firstAttribute="width" secondItem="C6K-SW-2gW" secondAttribute="width" id="Ppq-0j-2PT"/>

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -84,6 +84,36 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var fileTypesSection: AssignmentDetailsSectionContainerView?
     @IBOutlet weak var submissionTypesSection: AssignmentDetailsSectionContainerView?
     @IBOutlet weak var dueSection: AssignmentDetailsSectionContainerView?
+    /** This is shown when there are no submissions on the assignment but we still want the user to reach rubrics. */
+    @IBOutlet weak var submissionRubricButton: UIButton? {
+        didSet {
+            var buttonConfig = UIButton.Configuration.plain()
+            buttonConfig.title = String(localized: "Submission & Rubric")
+            buttonConfig.baseForegroundColor = Brand.shared.linkColor
+            buttonConfig.imagePlacement = .trailing
+            buttonConfig.imagePadding = 4
+            buttonConfig.image = .arrowOpenRightSolid
+                .scaleTo(.init(width: 14, height: 14))
+                .withRenderingMode(.alwaysTemplate)
+            buttonConfig.contentInsets = {
+                var result = buttonConfig.contentInsets
+                result.trailing = 0
+                return result
+            }()
+            buttonConfig.titleTextAttributesTransformer = .init { attributes in
+                var result = attributes
+                result.font = UIFont.scaledNamedFont(.regular16)
+                return result
+            }
+            submissionRubricButton?.configuration = buttonConfig
+            submissionRubricButton?.layer.borderColor = UIColor.borderDark.cgColor
+            submissionRubricButton?.layer.borderWidth = 1.0 / UIScreen.main.scale
+            submissionRubricButton?.layer.cornerRadius = 6
+            submissionRubricButton?.makeUnavailableInOfflineMode()
+        }
+    }
+    /** The view containing a separator and the rubruc button. */
+    @IBOutlet weak var submissionRubricButtonSection: UIView?
 
     @IBOutlet weak var lockedIconContainerView: UIView!
     @IBOutlet weak var lockedIconImageView: UIImageView!
@@ -272,6 +302,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             return
         }
 
+        submissionRubricButtonSection?.isHidden = true
         submittedLabel?.textColor = .textDarkest
         submittedLabel?.text = NSLocalizedString("Successfully submitted!", bundle: .student, comment: "")
         submittedDetailsLabel?.isHidden = false
@@ -298,6 +329,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         if submission.workflowState == .unsubmitted {
             hideGradeCell()
+            submissionRubricButtonSection?.isHidden = false
             return
         }
 


### PR DESCRIPTION
refs: MBL-17399
affects: Student
release note: Fixed submission and rubric button not appearing for unsubmitted assignments.

test plan:
- Open an assignment that has no submissions.
- Assignment details screen should show the submission and rubric button.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/bb849aa2-c3fc-4a8d-9778-81303fa7f9a4" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/a2566c3f-bcc5-4d4c-a49d-18f864dd70a6" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
