### PR TITLE
Fix Announcement widget to sort by newest first

### DIFF
--- a/Student/Widgets/AnnouncementsWidget/Model/GetWidgetAnnouncements.swift
+++ b/Student/Widgets/AnnouncementsWidget/Model/GetWidgetAnnouncements.swift
@@ -29,7 +29,7 @@ public class GetWidgetAnnouncements: CollectionUseCase {
         GetAllAnnouncementsRequest(contextCodes: courseContextCodes)
     }
     public var scope: Scope {
-        .all(orderBy: #keyPath(CDWidgetAnnouncement.date))
+        .all(orderBy: #keyPath(CDWidgetAnnouncement.date), ascending: false)
     }
     public var ttl: TimeInterval {
         Self.Timeout


### PR DESCRIPTION
refs: [MBL-17380](https://instructure.atlassian.net/browse/MBL-17380)
affects: Student
release note: Fixed the Announcements widget to sort by newest first

test plan: Verify the latest Announcements are shown first in Announcements widgets (test all 3 widget variants)

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/6e9eedbb-9fc2-426a-a2aa-f7d35bc51d2a" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/c07ef4b3-d55f-4b22-9823-abc51fae2450" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet

[MBL-17380]: https://instructure.atlassian.net/browse/MBL-17380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ