### PR TITLE
Hide future discussion replies

### DIFF
--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -361,7 +361,12 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
             )
         } else {
             let isFutureDiscussion: Bool = {
-                guard let unlockDate = topic.assignment?.unlockAt else {
+                // Discussions in the future might not have an assignment,
+                // but their posted at date can still be in the future.
+                guard let assignment = topic.assignment else {
+                    return topic.postedAt ?? Date.distantPast > Date()
+                }
+                guard let unlockDate = assignment.unlockAt else {
                     return false
                 }
                 return unlockDate > Date()


### PR DESCRIPTION
refs: MBL-17391
affects: Student, Teacher
release note: Discussions now hide topic replies until the discussion is available
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/a0b77a05-7eb4-4fb6-9da0-d58479576ded" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/205cbd3c-85f8-430e-97ce-7dd205593bee" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet
