### PR TITLE
Fix comments added to annotations not being visible on web

### DIFF
--- a/Core/Core/DocViewer/Model/APIDocViewer.swift
+++ b/Core/Core/DocViewer/Model/APIDocViewer.swift
@@ -74,10 +74,10 @@ struct APIDocViewerAnnotation: Codable, Equatable, Comparable {
     let contents: String?
     let inreplyto: String?
     let coords: [[[Double]]]?
-    let rect: [[Double]]?
+    var rect: [[Double]]?
     let font: String?
     let inklist: APIDocViewerInklist?
-    let width: Double?
+    var width: Double?
 
     static func < (lhs: APIDocViewerAnnotation, rhs: APIDocViewerAnnotation) -> Bool {
         guard let lhsCreationDate = lhs.created_at, let rhsCreationDate = rhs.created_at else {

--- a/Core/Core/DocViewer/Model/AnnotationTypes/PSPDFAnnotationExtension.swift
+++ b/Core/Core/DocViewer/Model/AnnotationTypes/PSPDFAnnotationExtension.swift
@@ -132,6 +132,9 @@ extension Annotation {
         let type: APIDocViewerAnnotationType
         var inreplyto: String?
         var inklist: APIDocViewerInklist?
+        var width: Double? = Double(lineWidth)
+        var rect: [[Double]]? = pointsFrom(boundingBox)
+
         switch self {
         case is HighlightAnnotation:
             type = .highlight
@@ -158,6 +161,8 @@ extension Annotation {
         case is DocViewerCommentReplyAnnotation:
             type = .commentReply
             inreplyto = (self as? DocViewerCommentReplyAnnotation)?.inReplyToName
+            width = nil
+            rect = nil
         case is DocViewerPointAnnotation, is NoteAnnotation:
             type = .text // point
         default:
@@ -182,10 +187,10 @@ extension Annotation {
             contents: contents,
             inreplyto: inreplyto,
             coords: rects?.map { coordsFrom($0) },
-            rect: pointsFrom(boundingBox),
+            rect: rect,
             font: fontName.flatMap { "\(Int(fontSize / fontSizeTransform))pt \($0)" },
             inklist: inklist,
-            width: Double(lineWidth)
+            width: width
         )
     }
 }

--- a/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
+++ b/Core/CoreTests/DocViewer/PSPDFAnnotationExtensionTests.swift
@@ -124,7 +124,13 @@ class PSPDFAnnotationExtensionTests: XCTestCase {
         let annotation = Annotation.from(apiAnnotation, metadata: metadata)
         annotation?.lastModified = nil
         XCTAssert(annotation is DocViewerCommentReplyAnnotation)
-        XCTAssertEqual(annotation?.apiAnnotation(), apiAnnotation)
+
+        // Reply comment annotations shouldn't have any dimensions otherwise they won't render on web
+        var expectedAPIAnnotation = apiAnnotation
+        expectedAPIAnnotation.width = nil
+        expectedAPIAnnotation.rect = nil
+
+        XCTAssertEqual(annotation?.apiAnnotation(), expectedAPIAnnotation)
         XCTAssertEqual(annotation?.contents, "comment")
         XCTAssertEqual((annotation as! DocViewerCommentReplyAnnotation).inReplyToName, "5")
     }


### PR DESCRIPTION
Remove zero dimensions from annotation comment uploads.

refs: MBL-17376
affects: Student, Teacher
release note: Fixed comments added to annotations not being visible on web.

test plan: See ticket.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
