### PR TITLE
Base on graded assignment toggle

### DIFF
--- a/Core/Core/Enrollments/Enrollment.swift
+++ b/Core/Core/Enrollments/Enrollment.swift
@@ -107,6 +107,10 @@ extension Enrollment {
         return grades.first { $0.gradingPeriodID == gradingPeriodID }?.finalGrade
     }
 
+    public func finalScore(gradingPeriodID: String?) -> Double? {
+        return grades.first { $0.gradingPeriodID == gradingPeriodID }?.finalScore
+    }
+
     public func currentScore(gradingPeriodID: String?) -> Double? {
         return grades.first { $0.gradingPeriodID == gradingPeriodID }?.currentScore
     }
@@ -115,6 +119,7 @@ extension Enrollment {
         grades.first { $0.gradingPeriodID == gradingPeriodID }?.currentGrade
     }
 
+    // Used when "Base on graded assignment" is ON
     public func formattedCurrentScore(gradingPeriodID: String?) -> String {
         let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
@@ -126,12 +131,38 @@ extension Enrollment {
         return notAvailable
     }
 
+    // Used when "Base on graded assignment" is OFF
+    public func formattedFinalScore(gradingPeriodID: String?) -> String {
+        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
+            return notAvailable
+        }
+        if let score = finalScore(gradingPeriodID: gradingPeriodID) {
+            return Course.scoreFormatter.string(from: NSNumber(value: score)) ?? notAvailable
+        }
+        return notAvailable
+    }
+
+    // Used when "Base on graded assignment" is ON
     public func convertedLetterGrade(gradingPeriodID: String?, gradingScheme: [GradingSchemeEntry]) -> String {
         let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
             return notAvailable
         }
         if let score = currentScore(gradingPeriodID: gradingPeriodID) {
+            let normalizedScore = score / 100.0
+            return gradingScheme.convertScoreToLetterGrade(score: normalizedScore) ?? notAvailable
+        }
+        return notAvailable
+    }
+
+    // Used when "Base on graded assignment" is OFF
+    public func convertedFinalLetterGrade(gradingPeriodID: String?, gradingScheme: [GradingSchemeEntry]) -> String {
+        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
+            return notAvailable
+        }
+        if let score = finalScore(gradingPeriodID: gradingPeriodID) {
             let normalizedScore = score / 100.0
             return gradingScheme.convertScoreToLetterGrade(score: normalizedScore) ?? notAvailable
         }

--- a/Core/Core/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Grades/Model/GradeListInteractor.swift
@@ -295,9 +295,9 @@ public final class GradeListInteractorLive: GradeListInteractor {
         let hideQuantitativeData = course.hideQuantitativeData == true
 
         // When these conditions are met we don't show any grade, instead we display a lock icon.
-        if courseEnrollment?.multipleGradingPeriodsEnabled == true,
-           courseEnrollment?.totalsForAllGradingPeriodsOption == false,
-           gradingPeriodID == nil {
+        if (courseEnrollment?.multipleGradingPeriodsEnabled == true &&
+           courseEnrollment?.totalsForAllGradingPeriodsOption == false &&
+            gradingPeriodID == nil) || course.hideFinalGrades {
             return Just(nil).eraseToAnyPublisher()
         } else if hideQuantitativeData {
             if let gradingPeriodID = gradingPeriodID {

--- a/Core/Core/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Grades/Model/GradeListInteractor.swift
@@ -18,6 +18,7 @@
 
 import Combine
 import CombineExt
+import CombineSchedulers
 import Foundation
 
 public protocol GradeListInteractor {
@@ -35,6 +36,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
 
     public let courseID: String
     private let userID: String?
+    private let scheduler: AnySchedulerOf<DispatchQueue>
 
     // MARK: - Private properties
 
@@ -50,10 +52,12 @@ public final class GradeListInteractorLive: GradeListInteractor {
 
     public init(
         courseID: String,
-        userID: String?
+        userID: String?,
+        scheduler: AnySchedulerOf<DispatchQueue> = .global()
     ) {
         self.courseID = courseID
         self.userID = userID
+        self.scheduler = scheduler
 
         assignmentListStore = ReactiveStore(
             useCase: GetAssignmentsByGroup(
@@ -113,6 +117,8 @@ public final class GradeListInteractorLive: GradeListInteractor {
                 loadAllPages: true
             )
         )
+        .subscribe(on: scheduler)
+        .receive(on: scheduler)
         .flatMap { [unowned self] in
             let course = $0.0.1
             let gradingPeriods = $0.0.2

--- a/Core/Core/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Grades/Model/GradeListInteractor.swift
@@ -329,10 +329,11 @@ public final class GradeListInteractorLive: GradeListInteractor {
             if let gradingPeriodID = gradingPeriodID {
                 if baseOnGradedAssignments {
                     localGrade = gradeEnrollment?.formattedCurrentScore(gradingPeriodID: gradingPeriodID)
+                    letterGrade = gradeEnrollment?.currentGrade(gradingPeriodID: gradingPeriodID)
                 } else {
                     localGrade = gradeEnrollment?.formattedFinalScore(gradingPeriodID: gradingPeriodID)
+                    letterGrade = gradeEnrollment?.finalGrade(gradingPeriodID: gradingPeriodID)
                 }
-                letterGrade = gradeEnrollment?.currentGrade(gradingPeriodID: gradingPeriodID) ?? gradeEnrollment?.finalGrade(gradingPeriodID: gradingPeriodID)
             } else {
                 if baseOnGradedAssignments {
                     localGrade = courseEnrollment?.formattedCurrentScore(gradingPeriodID: nil)

--- a/Core/Core/Grades/Model/GradeListInteractorPreview.swift
+++ b/Core/Core/Grades/Model/GradeListInteractorPreview.swift
@@ -24,7 +24,7 @@ import Foundation
 final class GradeListInteractorPreview: GradeListInteractor {
     var courseID: String { "courseID" }
 
-    func getGrades(arrangeBy _: GradeArrangementOptions, ignoreCache _: Bool) -> AnyPublisher<GradeListData, Error> {
+    func getGrades(arrangeBy _: GradeArrangementOptions, baseOnGradedAssignment _: Bool, ignoreCache _: Bool) -> AnyPublisher<GradeListData, Error> {
         let context = PreviewEnvironment.shared.database.viewContext
         return Just(
             GradeListData(

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -273,17 +273,10 @@ public struct GradeListView: View, ScreenViewTrackable {
     @ViewBuilder
     private func togglesView() -> some View {
         VStack(spacing: 0) {
-            let binding = Binding {
-                viewModel.baseOnGradedAssignment.value
-            } set: { isOn in
-                viewModel.baseOnGradedAssignment.accept(isOn)
-            }
-            Toggle(isOn: binding) {
+            Toggle(isOn: $viewModel.baseOnGradedAssignment) {
                 Text("Base on graded assignments", bundle: .core)
                     .foregroundStyle(Color.textDarkest)
                     .font(.regular16)
-                    .fixedSize()
-                    .lineLimit(1)
             }
             .toggleStyle(SwitchToggleStyle(tint: Color(Brand.shared.primary)))
             .frame(height: 51)

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -391,8 +391,8 @@ public struct GradeListView: View, ScreenViewTrackable {
                 }
                 .background(Color.backgroundLight)
             ) {
-                ForEach(section.assignments) { assignment in
-                    LazyVStack(spacing: 0) {
+                LazyVStack(spacing: 0) {
+                    ForEach(section.assignments) { assignment in
                         Button {
                             viewModel.didSelectAssignment.accept((viewController, assignment))
                         } label: {

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -29,7 +29,7 @@ public struct GradeListView: View, ScreenViewTrackable {
     public let screenViewTrackingParameters: ScreenViewTrackingParameters
 
     // MARK: - Private properties
-
+    @State private var isBaseOnGradedAssignmentEnabled = true
     private var subscriptions = Set<AnyCancellable>()
 
     // MARK: - Init
@@ -276,6 +276,7 @@ public struct GradeListView: View, ScreenViewTrackable {
             let binding = Binding {
                 viewModel.baseOnGradedAssignment.value
             } set: { isOn in
+                isBaseOnGradedAssignmentEnabled = isOn
                 viewModel.baseOnGradedAssignment.accept(isOn)
             }
             Toggle(isOn: binding) {
@@ -286,6 +287,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                     .lineLimit(1)
             }
             .toggleStyle(SwitchToggleStyle(tint: Color(Brand.shared.primary)))
+            .accessibilityValue(isBaseOnGradedAssignmentEnabled ? "On" : "Off")
             .frame(height: 51)
             .padding(.horizontal, 16)
 

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -392,7 +392,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                 .background(Color.backgroundLight)
             ) {
                 ForEach(section.assignments) { assignment in
-                    VStack(spacing: 0) {
+                    LazyVStack(spacing: 0) {
                         Button {
                             viewModel.didSelectAssignment.accept((viewController, assignment))
                         } label: {

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -29,7 +29,7 @@ public struct GradeListView: View, ScreenViewTrackable {
     public let screenViewTrackingParameters: ScreenViewTrackingParameters
 
     // MARK: - Private properties
-    @State private var isBaseOnGradedAssignmentEnabled = true
+
     private var subscriptions = Set<AnyCancellable>()
 
     // MARK: - Init
@@ -276,7 +276,6 @@ public struct GradeListView: View, ScreenViewTrackable {
             let binding = Binding {
                 viewModel.baseOnGradedAssignment.value
             } set: { isOn in
-                isBaseOnGradedAssignmentEnabled = isOn
                 viewModel.baseOnGradedAssignment.accept(isOn)
             }
             Toggle(isOn: binding) {
@@ -287,7 +286,6 @@ public struct GradeListView: View, ScreenViewTrackable {
                     .lineLimit(1)
             }
             .toggleStyle(SwitchToggleStyle(tint: Color(Brand.shared.primary)))
-            .accessibilityValue(isBaseOnGradedAssignmentEnabled ? "On" : "Off")
             .frame(height: 51)
             .padding(.horizontal, 16)
 

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -277,9 +277,10 @@ public struct GradeListView: View, ScreenViewTrackable {
                 Text("Base on graded assignments", bundle: .core)
                     .foregroundStyle(Color.textDarkest)
                     .font(.regular16)
+                    .multilineTextAlignment(.leading)
             }
             .toggleStyle(SwitchToggleStyle(tint: Color(Brand.shared.primary)))
-            .frame(height: 51)
+            .frame(minHeight: 51)
             .padding(.horizontal, 16)
 
 //            Divider()

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -117,6 +117,8 @@ public final class GradeListViewModel: ObservableObject {
                     baseOnGradedAssignment: baseOnGradedAssignment,
                     ignoreCache: ignoreCache
                 )
+                .first()
+                .receive(on: scheduler)
                 .map { [unowned self] listData -> ViewState in
                     lastKnownDataState = listData
 

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -130,7 +130,6 @@ public final class GradeListViewModel: ObservableObject {
                 .first()
             }
             .receive(on: scheduler)
-            .throttle(for: .seconds(1), scheduler: scheduler, latest: true)
             .assign(to: &$state)
 
         didSelectAssignment

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -28,9 +28,11 @@ public enum GradeArrangementOptions {
 
 public final class GradeListViewModel: ObservableObject {
     typealias RefreshCompletion = (() -> Void)?
+    typealias IgnoreCache = Bool
 
     enum ViewState: Equatable {
-        case loading
+        case initialLoading
+        case refreshing(GradeListData)
         case data(GradeListData)
         case empty(GradeListData)
         case error
@@ -42,11 +44,13 @@ public final class GradeListViewModel: ObservableObject {
 
     // MARK: - Output
 
-    @Published private(set) var state: ViewState = .loading
+    @Published private(set) var state: ViewState = .initialLoading
+    @Published public var isWhatIfScoreOn = false
     public var courseID: String { interactor.courseID }
 
     // MARK: - Input
 
+    let baseOnGradedAssignment = CurrentValueRelay<Bool>(true)
     let selectedGradingPeriod = PassthroughRelay<GradingPeriod?>()
     let selectedGroupByOption = CurrentValueRelay<GradeArrangementOptions>(.groupName)
     let pullToRefreshDidTrigger = PassthroughRelay<(() -> Void)?>()
@@ -54,6 +58,7 @@ public final class GradeListViewModel: ObservableObject {
 
     // MARK: - Private properties
 
+    private var lastKnownDataState: GradeListData?
     private var subscriptions = Set<AnyCancellable>()
 
     // MARK: - Init
@@ -65,17 +70,11 @@ public final class GradeListViewModel: ObservableObject {
     ) {
         self.interactor = interactor
 
-        let triggerRefresh = PassthroughRelay<(Bool, RefreshCompletion)>()
+        let triggerRefresh = PassthroughRelay<(IgnoreCache, RefreshCompletion)>()
 
         pullToRefreshDidTrigger
             .sink {
                 triggerRefresh.accept((true, $0))
-            }
-            .store(in: &subscriptions)
-
-        selectedGroupByOption
-            .sink { _ in
-                triggerRefresh.accept((false, nil))
             }
             .store(in: &subscriptions)
 
@@ -86,14 +85,37 @@ public final class GradeListViewModel: ObservableObject {
             }
             .store(in: &subscriptions)
 
-        triggerRefresh
-            .prepend((false, nil))
-            .flatMap { [unowned selectedGroupByOption] ignoreCache, refreshCompletion in
-                interactor.getGrades(
+        selectedGroupByOption
+            .sink { _ in
+                triggerRefresh.accept((false, nil))
+            }
+            .store(in: &subscriptions)
+
+        baseOnGradedAssignment
+            .sink { _ in
+                triggerRefresh.accept((false, nil))
+            }
+            .store(in: &subscriptions)
+
+        triggerRefresh.prepend((false, nil))
+            .flatMap { [unowned self] params in
+                let ignoreCache = params.0
+                let refreshCompletion = params.1
+
+                // Changing the grading period fires an API request that takes time,
+                // so we need to show a loading indicator. 
+                if let lastKnownDataState, refreshCompletion == nil, ignoreCache {
+                    state = .refreshing(lastKnownDataState)
+                }
+
+                return interactor.getGrades(
                     arrangeBy: selectedGroupByOption.value,
+                    baseOnGradedAssignment: baseOnGradedAssignment.value,
                     ignoreCache: ignoreCache
                 )
-                .map { listData -> ViewState in
+                .map { [unowned self] listData -> ViewState in
+                    lastKnownDataState = listData
+
                     if listData.assignmentSections.count == 0 {
                         return ViewState.empty(listData)
                     } else {
@@ -108,6 +130,7 @@ public final class GradeListViewModel: ObservableObject {
                 .first()
             }
             .receive(on: scheduler)
+            .throttle(for: .seconds(1), scheduler: scheduler, latest: true)
             .assign(to: &$state)
 
         didSelectAssignment

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -27,7 +27,7 @@ public enum GradeArrangementOptions {
 }
 
 public final class GradeListViewModel: ObservableObject {
-    typealias RefreshCompletion = (() -> Void)?
+    typealias RefreshCompletion = (() -> Void)
     typealias IgnoreCache = Bool
 
     enum ViewState: Equatable {
@@ -50,7 +50,7 @@ public final class GradeListViewModel: ObservableObject {
 
     // MARK: - Input
 
-    let pullToRefreshDidTrigger = PassthroughRelay<(() -> Void)?>()
+    let pullToRefreshDidTrigger = PassthroughRelay<(RefreshCompletion)?>()
     let didSelectAssignment = PassthroughRelay<(WeakViewController, Assignment)>()
 
     // MARK: - Input / Output
@@ -73,7 +73,7 @@ public final class GradeListViewModel: ObservableObject {
     ) {
         self.interactor = interactor
 
-        let triggerRefresh = PassthroughRelay<(IgnoreCache, RefreshCompletion)>()
+        let triggerRefresh = PassthroughRelay<(IgnoreCache, RefreshCompletion?)>()
 
         pullToRefreshDidTrigger
             .sink {

--- a/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
+++ b/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
@@ -170,7 +170,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
         api.mock(GetAssignmentsByGroup(courseID: "1", gradingPeriodID: "1"), value: assignmentGroups)
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .dueDate, ignoreCache: true)
+        let subscription = testee.getGrades(arrangeBy: .dueDate, baseOnGradedAssignment: true, ignoreCache: true)
             .sink(
                 receiveCompletion: { _ in }) { data in
                     XCTAssertEqual(data.assignmentSections.count, 3)
@@ -197,7 +197,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
         api.mock(GetAssignmentsByGroup(courseID: "1", gradingPeriodID: "1"), value: assignmentGroups)
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .groupName, ignoreCache: false)
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
                     XCTAssertEqual(data.assignmentSections.count, 3)
@@ -232,10 +232,39 @@ class GradeListInteractorLiveTests: CoreTestCase {
 
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .groupName, ignoreCache: false)
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
-                    XCTAssertEqual(data.totalGradeText, "N/A")
+                    XCTAssertEqual(data.totalGradeText, nil)
+                    expectation.fulfill()
+            }
+        drainMainQueue()
+        waitForExpectations(timeout: 0.1)
+        subscription.cancel()
+    }
+
+    func testHideTotalsWithTotalsForAllGradingPeriodIsDisabled() {
+        api.mock(
+            GetCourse(courseID: "1"),
+            value: .make(enrollments: [
+                .make(
+                    id: nil,
+                    course_id: "1",
+                    enrollment_state: .active,
+                    user_id: currentSession.userID,
+                    multiple_grading_periods_enabled: true,
+                    totals_for_all_grading_periods_option: false,
+                    current_grading_period_id: nil
+                ),
+            ])
+        )
+
+        let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
+            .sink(
+                receiveCompletion: { _ in }) { data in
+                    XCTAssertEqual(data.totalGradeText, nil)
                     expectation.fulfill()
             }
         drainMainQueue()
@@ -262,10 +291,10 @@ class GradeListInteractorLiveTests: CoreTestCase {
 
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .groupName, ignoreCache: false)
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
-                    XCTAssertEqual(data.totalGradeText, "N/A")
+                    XCTAssertEqual(data.totalGradeText, nil)
                     expectation.fulfill()
             }
         drainMainQueue()
@@ -308,10 +337,103 @@ class GradeListInteractorLiveTests: CoreTestCase {
 
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .groupName, ignoreCache: false)
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
                     XCTAssertEqual(data.totalGradeText, "42% (C)")
+                    expectation.fulfill()
+            }
+        drainMainQueue()
+        waitForExpectations(timeout: 0.1)
+        subscription.cancel()
+    }
+
+    func testShowGradeLetterForGradingPeriodNotBasedOnGradedAssignment() {
+        api.mock(
+            GetCourse(courseID: "1"),
+            value: .make(enrollments: [
+                .make(
+                    id: nil,
+                    course_id: "1",
+                    enrollment_state: .active,
+                    user_id: currentSession.userID,
+                    current_grading_period_id: "1"
+                ),
+            ])
+        )
+        api.mock(
+            GetEnrollments(
+                context: .course("1"),
+                userID: currentSession.userID,
+                gradingPeriodID: "1",
+                types: ["StudentEnrollment"],
+                states: [.active]
+            ),
+            value: [
+                .make(
+                    id: "1",
+                    course_id: "1",
+                    enrollment_state: .active,
+                    type: "StudentEnrollment",
+                    user_id: currentSession.userID,
+                    grades: .make(current_grade: "C", current_score: 42, final_score: 21)
+                ),
+            ]
+        )
+
+        let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: false, ignoreCache: false)
+            .sink(
+                receiveCompletion: { _ in }) { data in
+                    XCTAssertEqual(data.totalGradeText, "21% (C)")
+                    expectation.fulfill()
+            }
+        drainMainQueue()
+        waitForExpectations(timeout: 0.1)
+        subscription.cancel()
+    }
+
+    func testShowGradeLetterForAllGradingPeriodsNotBasedOnGradedAssignment() {
+        api.mock(
+            GetCourse(courseID: "1"),
+            value: .make(enrollments: [
+                .make(
+                    id: nil,
+                    course_id: "1",
+                    enrollment_state: .active,
+                    user_id: currentSession.userID,
+                    current_grading_period_id: nil
+                ),
+            ])
+        )
+        api.mock(
+            GetEnrollments(
+                context: .course("1"),
+                userID: currentSession.userID,
+                gradingPeriodID: nil,
+                types: ["StudentEnrollment"],
+                states: [.active]
+            ),
+            value: [
+                .make(
+                    id: "1",
+                    course_id: "1",
+                    enrollment_state: .active,
+                    type: "StudentEnrollment",
+                    user_id: currentSession.userID,
+                    grades: .make(current_grade: "C", current_score: 42, final_score: 21)
+                ),
+            ]
+        )
+
+        let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
+        testee.updateGradingPeriod(id: nil)
+        let expectation = expectation(description: "Publisher sends value")
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: false, ignoreCache: false)
+            .sink(
+                receiveCompletion: { _ in }) { data in
+                    XCTAssertEqual(data.totalGradeText, "21%")
                     expectation.fulfill()
             }
         drainMainQueue()
@@ -355,7 +477,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
 
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)
         let expectation = expectation(description: "Publisher sends value")
-        let subscription = testee.getGrades(arrangeBy: .groupName, ignoreCache: false)
+        let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: true, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
                     XCTAssertEqual(data.totalGradeText, "C")

--- a/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
+++ b/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
@@ -386,7 +386,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
         let subscription = testee.getGrades(arrangeBy: .groupName, baseOnGradedAssignment: false, ignoreCache: false)
             .sink(
                 receiveCompletion: { _ in }) { data in
-                    XCTAssertEqual(data.totalGradeText, "21% (C)")
+                    XCTAssertEqual(data.totalGradeText, "21%")
                     expectation.fulfill()
             }
         drainMainQueue()

--- a/Core/CoreTests/Store/UseCaseTests.swift
+++ b/Core/CoreTests/Store/UseCaseTests.swift
@@ -184,7 +184,6 @@ class UseCaseTests: CoreTestCase {
         }
         let useCase = UseCase()
         let expectation = expectation(description: "Fetch fails.")
-        var subscription: AnyCancellable?
 
         DispatchQueue.global().async {
             useCase.fetch { _, _, error in
@@ -195,7 +194,6 @@ class UseCaseTests: CoreTestCase {
             }
         }
         waitForExpectations(timeout: 0.1)
-        subscription?.cancel()
     }
 }
 


### PR DESCRIPTION
Base on graded assignment toggle.

- Added core functionality 
- Locked state 
- Loading state when switching grading periods

refs: MBL17302
affects: Student, Parent
release note: Added the ability to show grades based on graded assignments
test plan: Compare to Android, Web

## Screenshots

<table>
<tr><th>Toggle</th><th>Locked state</th><th>Loading state</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/d0b99375-a293-4d49-b68c-ea2a305e1b83" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/6611f9da-7d85-45be-bf42-596eadc8914a" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/203e0b42-6d85-4a27-b9cc-f115e2abdaaa" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
