### PR TITLE
Fix Calendar ToDo items added by Student not displaying full details

### DIFF
--- a/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
+++ b/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oav-uz-31f" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="60" width="382" height="21"/>
+                                <rect key="frame" x="16" y="64" width="382" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="MaF-Pb-aoH"/>
                                 </constraints>
@@ -30,7 +31,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QAB-9f-VoY" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="97" width="382" height="21"/>
+                                <rect key="frame" x="16" y="101" width="382" height="21"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="21" id="UTQ-qM-fNH"/>
                                 </constraints>
@@ -42,33 +43,50 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WzI-Qy-NaQ" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="134" width="382" height="21"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hT3-Dz-abl">
+                                <rect key="frame" x="16" y="138" width="398" height="724"/>
+                                <subviews>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WzI-Qy-NaQ" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="0.0" width="52" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                        <userDefinedRuntimeAttributes>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
+                                            <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular14"/>
+                                        </userDefinedRuntimeAttributes>
+                                    </label>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="UDb-nt-rJK"/>
+                                    <constraint firstItem="oHY-Ug-fUz" firstAttribute="trailing" secondItem="WzI-Qy-NaQ" secondAttribute="trailing" id="C86-em-Eff"/>
+                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="height" secondItem="oHY-Ug-fUz" secondAttribute="height" id="Veg-s4-Sun"/>
+                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="leading" secondItem="oHY-Ug-fUz" secondAttribute="leading" id="cT1-bI-vDn"/>
+                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="top" secondItem="oHY-Ug-fUz" secondAttribute="top" id="fcw-K7-Xby"/>
+                                    <constraint firstItem="oHY-Ug-fUz" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="WzI-Qy-NaQ" secondAttribute="bottom" id="gUz-yp-nF4"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular14"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
+                                <viewLayoutGuide key="contentLayoutGuide" id="oHY-Ug-fUz"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="TJG-cB-fHo"/>
+                                <variation key="default">
+                                    <mask key="constraints">
+                                        <exclude reference="gUz-yp-nF4"/>
+                                    </mask>
+                                </variation>
+                            </scrollView>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="294-WC-frm"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="oav-uz-31f" firstAttribute="top" secondItem="294-WC-frm" secondAttribute="top" constant="16" id="7FF-ih-mqv"/>
                             <constraint firstItem="oav-uz-31f" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="Ag2-uG-jdW"/>
-                            <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="WzI-Qy-NaQ" secondAttribute="trailing" constant="16" id="F8w-yU-9XJ"/>
+                            <constraint firstItem="hT3-Dz-abl" firstAttribute="top" secondItem="QAB-9f-VoY" secondAttribute="bottom" constant="16" id="CuU-zv-3bh"/>
                             <constraint firstItem="QAB-9f-VoY" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="M9n-Po-flZ"/>
                             <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="QAB-9f-VoY" secondAttribute="trailing" constant="16" id="Zaf-rf-4uP"/>
                             <constraint firstItem="QAB-9f-VoY" firstAttribute="top" secondItem="oav-uz-31f" secondAttribute="bottom" constant="16" id="bte-sF-wPk"/>
-                            <constraint firstItem="WzI-Qy-NaQ" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="djr-b7-LtF"/>
-                            <constraint firstItem="WzI-Qy-NaQ" firstAttribute="top" secondItem="QAB-9f-VoY" secondAttribute="bottom" constant="16" id="ntX-Uk-gMC"/>
+                            <constraint firstItem="hT3-Dz-abl" firstAttribute="leading" secondItem="Jyj-Fn-tab" secondAttribute="leading" constant="16" id="qYW-Mf-7w6"/>
+                            <constraint firstItem="294-WC-frm" firstAttribute="bottom" secondItem="hT3-Dz-abl" secondAttribute="bottom" id="qzm-Ht-Sw3"/>
                             <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="oav-uz-31f" secondAttribute="trailing" constant="16" id="vam-pE-WTV"/>
+                            <constraint firstAttribute="trailing" secondItem="hT3-Dz-abl" secondAttribute="trailing" id="zM5-CK-H6o"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="294-WC-frm"/>
                     </view>
                     <connections>
                         <outlet property="dateLabel" destination="QAB-9f-VoY" id="lKb-Bc-7nx"/>
@@ -81,4 +99,20 @@
             <point key="canvasLocation" x="139" y="86"/>
         </scene>
     </scenes>
+    <designables>
+        <designable name="QAB-9f-VoY">
+            <size key="intrinsicContentSize" width="36" height="20.5"/>
+        </designable>
+        <designable name="WzI-Qy-NaQ">
+            <size key="intrinsicContentSize" width="52" height="20.5"/>
+        </designable>
+        <designable name="oav-uz-31f">
+            <size key="intrinsicContentSize" width="33" height="20.5"/>
+        </designable>
+    </designables>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
+++ b/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
@@ -47,7 +47,7 @@
                                 <rect key="frame" x="16" y="138" width="398" height="724"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WzI-Qy-NaQ" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="0.0" width="52" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
@@ -58,19 +58,13 @@
                                     </label>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="oHY-Ug-fUz" firstAttribute="trailing" secondItem="WzI-Qy-NaQ" secondAttribute="trailing" id="C86-em-Eff"/>
-                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="height" secondItem="oHY-Ug-fUz" secondAttribute="height" id="Veg-s4-Sun"/>
+                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="width" secondItem="oHY-Ug-fUz" secondAttribute="width" priority="750" constant="-16" id="2Wl-di-wXO"/>
+                                    <constraint firstItem="WzI-Qy-NaQ" firstAttribute="height" secondItem="oHY-Ug-fUz" secondAttribute="height" priority="750" constant="-16" id="Veg-s4-Sun"/>
                                     <constraint firstItem="WzI-Qy-NaQ" firstAttribute="leading" secondItem="oHY-Ug-fUz" secondAttribute="leading" id="cT1-bI-vDn"/>
                                     <constraint firstItem="WzI-Qy-NaQ" firstAttribute="top" secondItem="oHY-Ug-fUz" secondAttribute="top" id="fcw-K7-Xby"/>
-                                    <constraint firstItem="oHY-Ug-fUz" firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="WzI-Qy-NaQ" secondAttribute="bottom" id="gUz-yp-nF4"/>
                                 </constraints>
                                 <viewLayoutGuide key="contentLayoutGuide" id="oHY-Ug-fUz"/>
                                 <viewLayoutGuide key="frameLayoutGuide" id="TJG-cB-fHo"/>
-                                <variation key="default">
-                                    <mask key="constraints">
-                                        <exclude reference="gUz-yp-nF4"/>
-                                    </mask>
-                                </variation>
                             </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="294-WC-frm"/>
@@ -80,12 +74,13 @@
                             <constraint firstItem="oav-uz-31f" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="Ag2-uG-jdW"/>
                             <constraint firstItem="hT3-Dz-abl" firstAttribute="top" secondItem="QAB-9f-VoY" secondAttribute="bottom" constant="16" id="CuU-zv-3bh"/>
                             <constraint firstItem="QAB-9f-VoY" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="M9n-Po-flZ"/>
+                            <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="WzI-Qy-NaQ" secondAttribute="trailing" constant="16" id="NCv-1B-ZRb"/>
                             <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="QAB-9f-VoY" secondAttribute="trailing" constant="16" id="Zaf-rf-4uP"/>
                             <constraint firstItem="QAB-9f-VoY" firstAttribute="top" secondItem="oav-uz-31f" secondAttribute="bottom" constant="16" id="bte-sF-wPk"/>
-                            <constraint firstItem="hT3-Dz-abl" firstAttribute="leading" secondItem="Jyj-Fn-tab" secondAttribute="leading" constant="16" id="qYW-Mf-7w6"/>
+                            <constraint firstItem="hT3-Dz-abl" firstAttribute="leading" secondItem="294-WC-frm" secondAttribute="leading" constant="16" id="qYW-Mf-7w6"/>
                             <constraint firstItem="294-WC-frm" firstAttribute="bottom" secondItem="hT3-Dz-abl" secondAttribute="bottom" id="qzm-Ht-Sw3"/>
                             <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="oav-uz-31f" secondAttribute="trailing" constant="16" id="vam-pE-WTV"/>
-                            <constraint firstAttribute="trailing" secondItem="hT3-Dz-abl" secondAttribute="trailing" id="zM5-CK-H6o"/>
+                            <constraint firstItem="294-WC-frm" firstAttribute="trailing" secondItem="hT3-Dz-abl" secondAttribute="trailing" id="zM5-CK-H6o"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
+++ b/Core/Core/Planner/PlannerNoteDetailViewController.storyboard
@@ -18,10 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Title" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oav-uz-31f" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="64" width="382" height="21"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="MaF-Pb-aoH"/>
-                                </constraints>
+                                <rect key="frame" x="16" y="64" width="382" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -30,11 +27,8 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QAB-9f-VoY" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="101" width="382" height="21"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="21" id="UTQ-qM-fNH"/>
-                                </constraints>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="QAB-9f-VoY" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                <rect key="frame" x="16" y="100.5" width="382" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -44,7 +38,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="hT3-Dz-abl">
-                                <rect key="frame" x="16" y="138" width="398" height="724"/>
+                                <rect key="frame" x="16" y="137" width="398" height="725"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Details" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WzI-Qy-NaQ" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="382" height="20.5"/>

--- a/Core/Core/Planner/PlannerNoteDetailViewController.swift
+++ b/Core/Core/Planner/PlannerNoteDetailViewController.swift
@@ -33,8 +33,12 @@ public class PlannerNoteDetailViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+
         navigationController?.setNavigationBarHidden(false, animated: false)
-        title = NSLocalizedString("To Do", bundle: .core, comment: "")
+        title = String(localized: "To Do")
+
+        view.backgroundColor = .backgroundLightest
+
         titleLabel.text = plannable.title
         dateLabel.text = plannable.date?.dateTimeString
         detailsLabel.text = plannable.details

--- a/Core/Core/Planner/PlannerNoteDetailViewController.swift
+++ b/Core/Core/Planner/PlannerNoteDetailViewController.swift
@@ -38,5 +38,6 @@ public class PlannerNoteDetailViewController: UIViewController {
         titleLabel.text = plannable.title
         dateLabel.text = plannable.date?.dateTimeString
         detailsLabel.text = plannable.details
+        detailsLabel.sizeToFit()
     }
 }


### PR DESCRIPTION
refs: [MBL-17395](https://instructure.atlassian.net/browse/MBL-17395)
affects: Student
release note: Fixed Calendar ToDo items added by Student not displaying full details

Also fixed
- accessibility issues with Title & Date labels
  - removed hardcoded heights
  - changed Date to wrap instead of truncating
- changed background color to `backgroundLightest`

test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/dc9fc30f-249a-4941-8360-0833d922e105" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/cdfdf0b4-e6d5-4741-b51d-88d92579b26a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet

[MBL-17395]: https://instructure.atlassian.net/browse/MBL-17395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ