### PR TITLE
Page gets reloaded and scrolled to the top

### DIFF
--- a/Core/Core/ActAsUser/ActAsUserWindow.swift
+++ b/Core/Core/ActAsUser/ActAsUserWindow.swift
@@ -70,6 +70,17 @@ public class ActAsUserWindow: UIWindow {
             }
         }
     }
+
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
+
+        NotificationCenter.default.post(
+            name: .windowUserInterfaceStyleDidChange,
+            object: nil,
+            userInfo: ["style": traitCollection.userInterfaceStyle]
+        )
+    }
 }
 
 class ActAsUserOverlay: UIView {

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -584,9 +584,7 @@ extension CoreWebView {
 
         themeSwitcher = CoreWebViewThemeSwitcherLive(host: self)
         themeSwitcher?.pinHostAndButton(inside: parent)
-
-        let parentStyle = parent.viewController?.traitCollection.userInterfaceStyle ?? .unspecified
-        themeSwitcher?.updateUserInterfaceStyle(with: parentStyle)
+        themeSwitcher?.updateUserInterfaceStyle(with: .current)
     }
 
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {

--- a/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcher.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcher.swift
@@ -1,0 +1,161 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+protocol CoreWebViewThemeSwitcher {
+    var currentHeight: CGFloat { get }
+    var isThemeInverted: Bool { get }
+    func pinHostAndButton(inside parent: UIView, leading: CGFloat?, trailing: CGFloat?, top: CGFloat?, bottom: CGFloat?)
+    func updateUserInterfaceStyle(with style: UIUserInterfaceStyle)
+}
+
+extension CoreWebViewThemeSwitcher {
+    func pinHostAndButton(
+        inside parent: UIView,
+        leading: CGFloat? = 0,
+        trailing: CGFloat? = 0,
+        top: CGFloat? = 0,
+        bottom: CGFloat? = 0
+    ) {
+        pinHostAndButton(inside: parent, leading: leading, trailing: trailing, top: top, bottom: bottom)
+    }
+}
+
+final class CoreWebViewThemeSwitcherLive: CoreWebViewThemeSwitcher {
+    private struct Constants {
+        static let buttonHeight: CGFloat = 38
+        static let topPadding: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
+    }
+
+    private weak var host: UIView?
+
+    private var themeSwitcherButton: CoreWebViewThemeSwitcherButton?
+    private var themeSwitcherButtonHeightConstraint: NSLayoutConstraint?
+    private var themeSwitcherButtonTopConstraint: NSLayoutConstraint?
+
+    private var userInterfaceStyleDidChangeObserver: NSObjectProtocol?
+
+    private var isInverted = false
+    private var isThemeDark = false
+
+    var currentHeight: CGFloat {
+        isThemeDark ? Constants.buttonHeight + Constants.topPadding : 0
+    }
+
+    var isThemeInverted: Bool {
+        isInverted
+    }
+
+    init(host: UIView) {
+        self.host = host
+    }
+
+    /**
+     Adds a theme switcher button to parent and sets up constraints between the webview, the button and parent.
+     - parameters:
+        - leading: The leading padding between the webview and the parent view. If nil is passed then it's the caller's responsibility to add this constraint. Default is 0.
+        - trailing: The trailing padding between the webview and the parent view. If nil is passed then it's the caller's responsibility to add this constraint. Default is 0.
+        - top: The top padding between the webview and the theme switcher button. If nil is passed then it's the caller's responsibility to add this constraint. Default is 0.
+        - bottom: The bottom padding between the webview and the parent view. If nil is passed then it's the caller's responsibility to add this constraint. Default is 0.
+     */
+    func pinHostAndButton(
+        inside parent: UIView,
+        leading: CGFloat? = 0,
+        trailing: CGFloat? = 0,
+        top: CGFloat? = 0,
+        bottom: CGFloat? = 0
+    ) {
+        guard let host else { return }
+
+        let button = CoreWebViewThemeSwitcherButton { [weak self] in
+            self?.didTapThemeSwitcherButton()
+        }
+        parent.addSubview(button)
+
+        // pin button
+        let heightConstraint = button.heightAnchor.constraint(equalToConstant: 0)
+        let topConstraint = button.topAnchor.constraint(equalTo: parent.topAnchor, constant: 0)
+        NSLayoutConstraint.activate([
+            heightConstraint,
+            topConstraint,
+            button.leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: Constants.horizontalPadding),
+            button.trailingAnchor.constraint(equalTo: parent.trailingAnchor, constant: -Constants.horizontalPadding),
+            button.bottomAnchor.constraint(equalTo: host.topAnchor, constant: 0),
+        ])
+
+        // pin webView
+        NSLayoutConstraint.activate([
+            leading.map { host.leadingAnchor.constraint(equalTo: parent.leadingAnchor, constant: $0) },
+            trailing.map { parent.trailingAnchor.constraint(equalTo: host.trailingAnchor, constant: $0)},
+            top.map { host.topAnchor.constraint(equalTo: button.bottomAnchor, constant: $0) },
+            bottom.map { parent.bottomAnchor.constraint(equalTo: host.bottomAnchor, constant: $0) },
+        ].compactMap { $0 })
+
+        themeSwitcherButton = button
+        themeSwitcherButtonHeightConstraint = heightConstraint
+        themeSwitcherButtonTopConstraint = topConstraint
+    }
+
+    private func didTapThemeSwitcherButton() {
+        themeSwitcherButton?.invert()
+
+        isInverted.toggle()
+        updateOverrideUserInterfaceStyle()
+    }
+
+    private func addUserInterfaceStyleDidChangeObserver() {
+        userInterfaceStyleDidChangeObserver = NotificationCenter.default.addObserver(
+            forName: .windowUserInterfaceStyleDidChange,
+            object: nil,
+            queue: .main,
+            using: { [weak self] in
+                self?.updateUserInterfaceStyle(with: $0.userInfo?["style"] as? UIUserInterfaceStyle ?? .unspecified)
+            }
+        )
+    }
+
+    func updateUserInterfaceStyle(with style: UIUserInterfaceStyle) {
+        let definiteStyle = style == .unspecified ? .current : style
+        isThemeDark = definiteStyle == .dark
+        updateOverrideUserInterfaceStyle()
+
+        // show/hide Theme Switcher
+        themeSwitcherButton?.isHidden = !isThemeDark
+        themeSwitcherButtonHeightConstraint?.constant = isThemeDark ? Constants.buttonHeight : 0
+        themeSwitcherButtonTopConstraint?.constant = isThemeDark ? Constants.topPadding : 0
+    }
+
+    private func updateOverrideUserInterfaceStyle() {
+        let currentStyle: UIUserInterfaceStyle = isThemeDark ? (isInverted ? .light : .dark) : .light
+
+        // When `overrideUserInterfaceStyle != .unspecified` the `traitCollectionDidChange()` method is not called,
+        // so we need to observe it from the outside. This problem may go away once minimum deployment target is set to iOS17.
+        if host?.overrideUserInterfaceStyle == .unspecified && currentStyle != .unspecified {
+            addUserInterfaceStyleDidChangeObserver()
+        }
+
+        // override style, based on current settings
+        host?.overrideUserInterfaceStyle = currentStyle
+
+        // also update parent backgroundColor accordingly
+        let traitCollection = UITraitCollection(userInterfaceStyle: currentStyle)
+        themeSwitcherButton?.superview?.backgroundColor = .backgroundLightest.resolvedColor(with: traitCollection)
+    }
+}

--- a/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
@@ -55,7 +55,7 @@ final class CoreWebViewThemeSwitcherButton: UIButton {
         var config = UIButton.Configuration.borderedProminent()
         config.cornerStyle = .capsule
         config.background.strokeWidth = 1.0
-        config.image = UIImage(named: "unionLine", in: .core, with: .none)
+        config.image = .unionLine
         config.imagePadding = 9.5
         config.imagePlacement = .leading
         config.preferredSymbolConfigurationForImage = .init(scale: .medium)

--- a/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
@@ -1,0 +1,87 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+final class CoreWebViewThemeSwitcherButton: UIButton {
+    private struct Titles {
+        static let currentlyLight = String(localized: "Switch To Dark Mode")
+        static let currentlyDark = String(localized: "Switch To Light Mode")
+    }
+
+    /// Helper to simplify logic by removing `.unspecified`.
+    private enum Style: Equatable {
+        case light
+        case dark
+
+        var userInterfaceStyle: UIUserInterfaceStyle {
+            switch self {
+            case .light: .light
+            case .dark: .dark
+            }
+        }
+    }
+
+    private var style: Style = .dark
+
+    init(primaryAction: @escaping () -> Void) {
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        addAction(UIAction(title: "", handler: { _ in primaryAction() }), for: .primaryActionTriggered)
+        setupConfiguration()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupConfiguration() {
+        var config = UIButton.Configuration.borderedProminent()
+        config.cornerStyle = .capsule
+        config.background.strokeWidth = 1.0
+        config.image = UIImage(named: "unionLine", in: .core, with: .none)
+        config.imagePadding = 9.5
+        config.imagePlacement = .leading
+        config.preferredSymbolConfigurationForImage = .init(scale: .medium)
+        configuration = config
+    }
+
+    override func updateConfiguration() {
+        var config = configuration
+
+        config?.title = style == .light ? Titles.currentlyLight : Titles.currentlyDark
+
+        let traitCollection = UITraitCollection(userInterfaceStyle: style.userInterfaceStyle)
+        config?.background.backgroundColor = .backgroundLightest.resolvedColor(with: traitCollection)
+        config?.background.strokeColor = .borderDarkest.resolvedColor(with: traitCollection)
+        config?.baseForegroundColor = .textDarkest.resolvedColor(with: traitCollection)
+
+        configuration = config
+    }
+
+    func invert() {
+        switch style {
+        case .light:
+            style = .dark
+        case .dark:
+            style = .light
+        }
+        setNeedsUpdateConfiguration()
+    }
+}

--- a/Core/Core/Extensions/NotificationCenterExtensions.swift
+++ b/Core/Core/Extensions/NotificationCenterExtensions.swift
@@ -25,6 +25,7 @@ extension NSNotification.Name {
     public static let celebrateSubmission = Notification.Name("com.instructure.core.notification.celebrateSubmission")
     public static let showGradesOnDashboardDidChange = Notification.Name("com.instructure.core.notification.showGradesOnDashboardDidChange")
     public static let favoritesDidChange = Notification.Name("course-favorite-change")
+    public static let windowUserInterfaceStyleDidChange = Notification.Name("com.instructure.core.notification.windowUserInterfaceStyleDidChange")
 }
 
 extension NotificationCenter {

--- a/Core/Core/Extensions/UIColorExtensions.swift
+++ b/Core/Core/Extensions/UIColorExtensions.swift
@@ -49,7 +49,7 @@ extension UIColor {
     public var hexString: String { hexString(userInterfaceStyle: .current) }
     public var intValue: UInt32 { intValue(userInterfaceStyle: .current) }
     /** Returns the color for the current app appearance. */
-    private var interfaceStyleColor: UIColor { resolvedColor(with: .current) }
+    private var interfaceStyleColor: UIColor { resolvedColor(with: .init(userInterfaceStyle: .current)) }
 
     public convenience init(intValue value: UInt32) {
         self.init(

--- a/Core/Core/Extensions/UITraitCollectionExtensions.swift
+++ b/Core/Core/Extensions/UITraitCollectionExtensions.swift
@@ -28,10 +28,6 @@ public extension UITraitCollection {
         UITraitCollection(userInterfaceStyle: .dark)
     }
 
-    static var current: UITraitCollection {
-        UITraitCollection(userInterfaceStyle: .current)
-    }
-
     var isDarkInterface: Bool { userInterfaceStyle == .dark }
     var isLightInterface: Bool { userInterfaceStyle == .light }
 }

--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -87,9 +87,6 @@ public class RichContentEditorViewController: UIViewController {
         guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }
         getHTML { [weak self] htmlString in
             self?.html = htmlString
-            if self?.traitCollection.userInterfaceStyle != .dark {
-                self?.webView.updateHtmlContentView()
-            }
         }
     }
 


### PR DESCRIPTION
refs: [MBL-17383](https://instructure.atlassian.net/browse/MBL-17383)
affects: Student, Teacher, Parent
release note: Fixed some screens reloading and resetting videos after switching back from other apps.

test plan: See ticket + Test WebView inverting and dark/light mode changes throughout the apps.
If you encounter a related issue please compare with build from before this PR, because there are many Dark Mode related issues already, but this PR should not introduce new ones :)

## Notes
- fixed CoreWebView reloading after app is backgrounded
- fixed flickering when inverting via switcher button
- fixed switcher button remaining on screen when switched to light first and disabled dark mode after

## Screenshots
Before:
https://github.com/instructure/canvas-ios/assets/15140172/95e9acfd-87ff-42ef-92e9-1c42a9dc4460

After:
https://github.com/instructure/canvas-ios/assets/15140172/50e255bd-9fb2-4faa-b184-b2f9fdf56c77

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Tested on iOS 16
- [x] Tested on iOS 17


[MBL-17383]: https://instructure.atlassian.net/browse/MBL-17383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ