### PR TITLE
Teacher Bulk Publish Progress screen UI

### DIFF
--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressInfoView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressInfoView.swift
@@ -43,13 +43,11 @@ struct CourseSyncProgressInfoView: View {
                 SwiftUI.EmptyView()
             case .downloadStarting:
                 ProgressView(value: progress)
-                    .progressViewStyle(.indeterminateBar(foregroundColor: progressColor,
-                                                         backgroundColor: progressColor.opacity(0.24)))
+                    .progressViewStyle(.indeterminateBar(color: progressColor))
             case let .finishedSuccessfully(_, progress),
                  let .downloadInProgress(_, progress):
                 ProgressView(value: progress)
-                    .progressViewStyle(.determinateBar(foregroundColor: progressColor,
-                                                       backgroundColor: progressColor.opacity(0.24)))
+                    .progressViewStyle(.determinateBar(color: progressColor))
 
             }
         }

--- a/Core/Core/Dashboard/FileUploadNotification/View/FileUploadNotificationCard.swift
+++ b/Core/Core/Dashboard/FileUploadNotification/View/FileUploadNotificationCard.swift
@@ -112,10 +112,7 @@ struct FileUploadNotificationCard: View {
     private var progressView: some View {
         ProgressView()
             .progressViewStyle(
-                .indeterminateBar(
-                    foregroundColor: .electric,
-                    backgroundColor: .electric.opacity(0.2)
-                )
+                .indeterminateBar(color: .electric)
             )
             .padding(.top, 8)
     }

--- a/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
+++ b/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
@@ -108,8 +108,7 @@ struct DashboardOfflineSyncProgressCardView: View {
     private func progressBar(progress: Float) -> some View {
         ProgressView(value: progress)
             .progressViewStyle(
-                .determinateBar(foregroundColor: .textLightest,
-                                backgroundColor: .textLightest.opacity(0.2))
+                .determinateBar(color: .textLightest)
             )
             .animation(.default, value: progress)
     }

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
@@ -34,7 +34,7 @@ class ModulePublishInteractor {
     func changeItemPublishedState(
         moduleId: String,
         moduleItemId: String,
-        action: PutModuleItemPublishRequest.Action
+        action: ModulePublishAction
     ) {
         moduleItemsUpdating.value.insert(moduleItemId)
         let useCase = PutModuleItemPublishState(
@@ -60,7 +60,7 @@ class ModulePublishInteractor {
 
 extension Subscribers.Completion<Error> {
 
-    func moduleItemStatusUpdateText(for action: PutModuleItemPublishRequest.Action) -> String {
+    func moduleItemStatusUpdateText(for action: ModulePublishAction) -> String {
         switch self {
         case .finished:
             switch action {

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishItem.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishItem.swift
@@ -18,11 +18,37 @@
 
 import Foundation
 
+enum ModulePublishAction {
+    enum Subject: Equatable {
+        case modulesAndItems
+        case onlyModules
+    }
+
+    case publish(Subject?)
+    case unpublish(Subject?)
+
+    var isPublish: Bool {
+        switch self {
+        case .publish: true
+        case .unpublish: false
+        }
+    }
+
+    var subject: Subject? {
+        switch self {
+        case .publish(let actionSubject): actionSubject
+        case .unpublish(let actionSubject): actionSubject
+        }
+    }
+
+    static let publish = Self.publish(nil)
+    static let unpublish = Self.unpublish(nil)
+}
+
 struct ModulePublishItem {
     let title: String
     let confirmMessage: String
-    let action: PutModuleItemPublishRequest.Action
-    let actionSubject: PutModuleItemPublishRequest.ActionSubject
+    let action: ModulePublishAction
 
     var icon: UIImage {
         switch action {

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishItem.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishItem.swift
@@ -22,6 +22,8 @@ struct ModulePublishItem {
     let title: String
     let confirmMessage: String
     let action: PutModuleItemPublishRequest.Action
+    let actionSubject: PutModuleItemPublishRequest.ActionSubject
+
     var icon: UIImage {
         switch action {
         case .publish: return .completeLine

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -141,7 +141,7 @@ class ModuleItemCell: UITableViewCell {
         publishInteractor: ModulePublishInteractor,
         host: UIViewController
     ) {
-        let action: PutModuleItemPublishRequest.Action = moduleItem.published == true ? .unpublish : .publish
+        let action: ModulePublishAction = moduleItem.published == true ? .unpublish : .publish
         let performUpdate = {
             publishInteractor.changeItemPublishedState(
                 moduleId: moduleItem.moduleID,
@@ -156,7 +156,7 @@ class ModuleItemCell: UITableViewCell {
                 return []
             }
 
-            return .moduleItemPublishA11yActions(
+            return .makePublishModuleItemA11yActions(
                 action: action,
                 host: host,
                 actionDidPerform: performUpdate

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -141,7 +141,10 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         else { return }
 
         let button = UIBarButtonItem(image: .moreLine)
-        button.menu = .makePublishModulesMenu(host: self)
+        button.menu = .makePublishAllModulesMenu(host: self) { action, subject in
+            print("⚠️ isPublished: \(action.isPublished ? "✅" : "❌")")
+            print("⚠️ isModulesAndItems: \(subject == .modulesAndItems ? "✅" : "❌")")
+        }
         button.accessibilityLabel = String(localized: "Publish options")
         navigationItem.setRightBarButton(button, animated: true)
     }

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -141,9 +141,8 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         else { return }
 
         let button = UIBarButtonItem(image: .moreLine)
-        button.menu = .makePublishAllModulesMenu(host: self) { action in
-            print("⚠️ isPublished: \(action.isPublish ? "✅" : "❌")")
-            print("⚠️ isModulesAndItems: \(action.subject == .modulesAndItems ? "✅" : "❌")")
+        button.menu = .makePublishAllModulesMenu(host: self) { [weak self] action in
+            self?.didPerformPublishAction(action: action)
         }
         button.accessibilityLabel = String(localized: "Publish options")
         navigationItem.setRightBarButton(button, animated: true)
@@ -158,6 +157,12 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
             .sink(receiveValue: { [weak self] update in
                 self?.findSnackBarViewModel()?.showSnack(update)
             })
+    }
+
+    private func didPerformPublishAction(action: ModulePublishAction) {
+        let viewModel = ModulePublishProgressViewModel(action: action, allModules: true, router: env.router)
+        let viewController = CoreHostingController(ModulePublishProgressView(viewModel: viewModel))
+        env.router.show(viewController, from: self, options: .modal(isDismissable: true, embedInNav: true))
     }
 
     private func reloadCourse() {

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -141,9 +141,9 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         else { return }
 
         let button = UIBarButtonItem(image: .moreLine)
-        button.menu = .makePublishAllModulesMenu(host: self) { action, subject in
-            print("⚠️ isPublished: \(action.isPublished ? "✅" : "❌")")
-            print("⚠️ isModulesAndItems: \(subject == .modulesAndItems ? "✅" : "❌")")
+        button.menu = .makePublishAllModulesMenu(host: self) { action in
+            print("⚠️ isPublished: \(action.isPublish ? "✅" : "❌")")
+            print("⚠️ isModulesAndItems: \(action.subject == .modulesAndItems ? "✅" : "❌")")
         }
         button.accessibilityLabel = String(localized: "Publish options")
         navigationItem.setRightBarButton(button, animated: true)

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -68,15 +68,15 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         accessibilityIdentifier = "ModuleList.\(section)"
 
         if publishMenuButton.menu == nil {
-            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action, subject in
-                self?.didPerformPublishAction(action: action, subject: subject)
+            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action in
+                self?.didPerformPublishAction(action: action)
             }
             publishMenuButton.showsMenuAsPrimaryAction = true
         }
 
         publishMenuButton.isHidden = !publishInteractor.isPublishActionAvailable
-        accessibilityCustomActions = publishMenuButton.isHidden ? [] : .modulePublishA11yActions(host: host) { [weak self] action, subject in
-            self?.didPerformPublishAction(action: action, subject: subject)
+        accessibilityCustomActions = publishMenuButton.isHidden ? [] : .makePublishModuleA11yActions(host: host) { [weak self] action in
+            self?.didPerformPublishAction(action: action)
         }
     }
 
@@ -98,8 +98,8 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         publishInteractor: ModulePublishInteractor
     ) {
         if publishMenuButton.menu == nil {
-            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action, subject in
-                self?.didPerformPublishAction(action: action, subject: subject)
+            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action in
+                self?.didPerformPublishAction(action: action)
             }
             publishMenuButton.showsMenuAsPrimaryAction = true
         }
@@ -107,8 +107,8 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         publishMenuButton.isHidden = !publishInteractor.isPublishActionAvailable
     }
 
-    private func didPerformPublishAction(action: PutModuleItemPublishRequest.Action, subject: PutModuleItemPublishRequest.ActionSubject) {
-        print("⚠️ isPublished: \(action.isPublished ? "✅" : "❌")")
-        print("⚠️ isModulesAndItems: \(subject == .modulesAndItems ? "✅" : "❌")")
+    private func didPerformPublishAction(action: ModulePublishAction) {
+        print("⚠️ isPublished: \(action.isPublish ? "✅" : "❌")")
+        print("⚠️ isModulesAndItems: \(action.subject == .modulesAndItems ? "✅" : "❌")")
     }
 }

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -108,7 +108,11 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
     }
 
     private func didPerformPublishAction(action: ModulePublishAction) {
-        print("⚠️ isPublished: \(action.isPublish ? "✅" : "❌")")
-        print("⚠️ isModulesAndItems: \(action.subject == .modulesAndItems ? "✅" : "❌")")
+        guard let sourceViewController = viewController else { return }
+
+        let router = AppEnvironment.shared.router
+        let viewModel = ModulePublishProgressViewModel(action: action, allModules: false, router: router)
+        let viewController = CoreHostingController(ModulePublishProgressView(viewModel: viewModel))
+        router.show(viewController, from: sourceViewController, options: .modal(isDismissable: true, embedInNav: true))
     }
 }

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -68,12 +68,16 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         accessibilityIdentifier = "ModuleList.\(section)"
 
         if publishMenuButton.menu == nil {
-            publishMenuButton.menu = .makePublishModuleMenu(host: host)
+            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action, subject in
+                self?.didPerformPublishAction(action: action, subject: subject)
+            }
             publishMenuButton.showsMenuAsPrimaryAction = true
         }
 
         publishMenuButton.isHidden = !publishInteractor.isPublishActionAvailable
-        accessibilityCustomActions = publishMenuButton.isHidden ? [] : .modulePublishA11yActions(host: host)
+        accessibilityCustomActions = publishMenuButton.isHidden ? [] : .modulePublishA11yActions(host: host) { [weak self] action, subject in
+            self?.didPerformPublishAction(action: action, subject: subject)
+        }
     }
 
     @IBAction func handleTap() {
@@ -94,10 +98,17 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         publishInteractor: ModulePublishInteractor
     ) {
         if publishMenuButton.menu == nil {
-            publishMenuButton.menu = .makePublishModuleMenu(host: host)
+            publishMenuButton.menu = .makePublishModuleMenu(host: host) { [weak self] action, subject in
+                self?.didPerformPublishAction(action: action, subject: subject)
+            }
             publishMenuButton.showsMenuAsPrimaryAction = true
         }
 
         publishMenuButton.isHidden = !publishInteractor.isPublishActionAvailable
+    }
+
+    private func didPerformPublishAction(action: PutModuleItemPublishRequest.Action, subject: PutModuleItemPublishRequest.ActionSubject) {
+        print("⚠️ isPublished: \(action.isPublished ? "✅" : "❌")")
+        print("⚠️ isModulesAndItems: \(subject == .modulesAndItems ? "✅" : "❌")")
     }
 }

--- a/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
@@ -1,0 +1,175 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+struct ModulePublishProgressView: View {
+    @Environment(\.sizeCategory) private var sizeCategory
+    @Environment(\.viewController) private var viewController
+    @ObservedObject private var viewModel: ModulePublishProgressViewModel
+
+    init(viewModel: ModulePublishProgressViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        content
+            .navigationTitleStyled(titleText.navigationBarTitleStyle())
+            .navigationBarItems(leading: dismissButton, trailing: trailingBarButton)
+            .navigationBarStyle(.modal)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        VStack(spacing: 0) {
+            progressViewArea
+                .padding(.vertical, 24)
+            Divider()
+            ScrollView {
+                textArea
+                    .padding(.vertical, 24)
+            }
+            Spacer()
+        }
+    }
+
+    // MARK: - Navigation Bar
+
+    private var titleText: Text {
+        switch viewModel.title {
+        case .allModulesAndItems:
+            Text("All Modules and Items")
+        case .allModules:
+            Text("All Modules")
+        case .selectedModuleAndItems:
+            Text("Selected Module and Items")
+        case .selectedModule:
+            Text("Selected Module")
+        }
+    }
+
+    @ViewBuilder
+    private var dismissButton: some View {
+        Button {
+            viewModel.didTapDismiss.send(viewController)
+        } label: {
+            Image.xLine.navigationBarButtonStyle()
+        }
+    }
+
+    @ViewBuilder
+    private var cancelButton: some View {
+        Button {
+            viewModel.didTapCancel.send(viewController)
+        } label: {
+            Text("Cancel").navigationBarButtonStyle()
+        }
+    }
+
+    @ViewBuilder
+    private var doneButton: some View {
+        Button {
+            viewModel.didTapDone.send(viewController)
+        } label: {
+            Text("Done").navigationBarButtonStyle()
+        }
+    }
+
+    @ViewBuilder
+    private var trailingBarButton: some View {
+        switch viewModel.trailingBarButton {
+        case .cancel: cancelButton
+        case .done: doneButton
+        }
+    }
+
+    // MARK: - Progress View area
+
+    @ViewBuilder
+    private var progressViewArea: some View {
+        VStack(spacing: 8) {
+            progressText
+                .font(.regular14).foregroundStyle(Color.textDarkest)
+            ProgressView(value: viewModel.progress)
+                .progressViewStyle(.determinateBar(color: viewModel.progressViewColor))
+                .padding(.bottom, 8)
+        }
+        .padding(.horizontal, 16)
+    }
+
+    @ViewBuilder
+    private var progressText: some View {
+        switch viewModel.state {
+        case .inProgress:
+            let percentage = Int(viewModel.progress * 100)
+            if viewModel.isPublish {
+                Text("Publishing \(percentage)%")
+            } else {
+                Text("Unpublishing \(percentage)%")
+            }
+        case .completed:
+            if viewModel.isPublish {
+                Text("Published 100%")
+            } else {
+                Text("Unpublished 100%")
+            }
+        case .error:
+            Text("Update failed")
+        }
+    }
+
+    // MARK: - Text area
+
+    @ViewBuilder
+    private var textArea: some View {
+        VStack(spacing: 0) {
+            Text("This process could take a few minutes. You may close the modal or navigate away from the page during this process.")
+                .font(.regular16).foregroundStyle(Color.textDarkest)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 24)
+            Text("Note")
+                .font(.regular14).foregroundStyle(Color.textDark)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.bottom, 4)
+            Text("Modules and items that have already been processed will not be reverted to their previous state when the process is discontinued.")
+                .font(.regular16).foregroundStyle(Color.textDarkest)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 16)
+    }
+}
+
+// MARK: - Helpers
+
+private extension View {
+    func navigationBarTitleStyle() -> some View {
+        self
+            .font(.semibold16)
+            .foregroundStyle(Color.textDarkest)
+    }
+
+    func navigationBarButtonStyle() -> some View {
+        self
+            .font(.semibold16)
+            .foregroundStyle(Color.textDarkest)
+    }
+}
+
+#Preview {
+    ModulePublishProgressView(viewModel: .init(action: .publish(.onlyModules), allModules: true, router: AppEnvironment.shared.router))
+}

--- a/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
@@ -74,8 +74,9 @@ struct ModulePublishProgressView: View {
 
     @ViewBuilder
     private var cancelButton: some View {
+        let snackBarTitle = String(localized: "Update cancelled")
         Button {
-            viewModel.didTapCancel.send(viewController)
+            viewModel.didTapCancel.send((viewController, snackBarTitle))
         } label: {
             Text("Cancel").navigationBarButtonStyle()
         }

--- a/Core/Core/Modules/ModuleList/ViewModel/ModulePublishProgressViewModel.swift
+++ b/Core/Core/Modules/ModuleList/ViewModel/ModulePublishProgressViewModel.swift
@@ -1,0 +1,172 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import SwiftUI
+
+// TODO: remove
+extension ModulePublishProgressViewModel {
+    final class DummyInteractor {
+        typealias State = ModulePublishProgressViewModel.ViewState
+        let state = CurrentValueSubject<State, Never>(.inProgress)
+        let progress = CurrentValueSubject<Double, Never>(0)
+
+        func start(shouldFail: Bool) {
+            let total = 7
+            let errorTreshold = 3
+            let interval = 0.5
+            for i in 0...total {
+                guard !shouldFail || i <= errorTreshold else { break }
+                DispatchQueue.main.asyncAfter(deadline: .now() + Double(i) * interval) { [weak self] in
+                    let stateValue: State = switch i {
+                    case total: .completed
+                    case errorTreshold: shouldFail ? .error : .inProgress
+                    default: .inProgress
+                    }
+                    self?.state.send(stateValue)
+                    self?.progress.send(Double(i) / Double(total))
+                }
+            }
+        }
+    }
+}
+
+final class ModulePublishProgressViewModel: ObservableObject {
+
+    enum ViewState {
+        case inProgress
+        case completed
+        case error
+    }
+
+    enum Title {
+        case allModulesAndItems
+        case allModules
+        case selectedModuleAndItems
+        case selectedModule
+    }
+
+    enum TrailingBarButton {
+        case cancel
+        case done
+    }
+
+    // MARK: - Output
+
+    @Published private(set) var state: ViewState = .inProgress
+    @Published private(set) var progress: Double = 0
+    @Published private(set) var progressViewColor: Color = .clear
+    @Published private(set) var trailingBarButton: TrailingBarButton = .cancel
+
+    var title: Title {
+        guard let subject = action.subject else {
+            assertionFailure("Subject should never be nil for this view")
+            return .selectedModuleAndItems
+        }
+
+        switch subject {
+        case .modulesAndItems:
+            return allModules ? .allModulesAndItems : .selectedModuleAndItems
+        case .onlyModules:
+            return allModules ? .allModules : .selectedModule
+        }
+    }
+
+    var isPublish: Bool {
+        action.isPublish
+    }
+
+    // MARK: - Input
+
+    let didTapDismiss = PassthroughSubject<WeakViewController, Never>()
+    let didTapCancel = PassthroughSubject<WeakViewController, Never>()
+    let didTapDone = PassthroughSubject<WeakViewController, Never>()
+
+    // MARK: - Private
+
+    private let action: ModulePublishAction
+    private let allModules: Bool
+
+    private let interactor: DummyInteractor
+    private var subscriptions = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(
+        action: ModulePublishAction,
+        allModules: Bool,
+        interactor: DummyInteractor = .init(),
+        router: Router
+    ) {
+        self.action = action
+        self.allModules = allModules
+        self.interactor = interactor
+
+        interactor.state
+            .assign(to: &$state)
+
+        interactor.state
+            .map {
+                switch $0 {
+                case .inProgress:
+                        .accentColor
+                case .completed:
+                        .backgroundSuccess
+                case .error:
+                        .backgroundDanger
+                }
+            }
+            .assign(to: &$progressViewColor)
+
+        interactor.state
+            .map {
+                switch $0 {
+                case .inProgress:
+                        .cancel
+                case .completed:
+                        .done
+                case .error:
+                        .done
+                }
+            }
+            .assign(to: &$trailingBarButton)
+
+        interactor.progress
+            .assign(to: &$progress)
+
+        // TODO: remove
+        interactor.start(shouldFail: !allModules)
+
+        didTapDismiss
+            .sink { router.dismiss($0) }
+            .store(in: &subscriptions)
+
+        didTapCancel
+            .sink {
+                print("⚠️ ❌ Did tap cancel")
+                // TODO: send cancel request silently: no spinner, no errors
+                router.dismiss($0)
+                // TODO: show snackbar ""
+            }
+            .store(in: &subscriptions)
+
+        didTapDone
+            .sink { router.dismiss($0) }
+            .store(in: &subscriptions)
+    }
+}

--- a/Core/Core/Modules/ModuleList/ViewModel/ModulePublishProgressViewModel.swift
+++ b/Core/Core/Modules/ModuleList/ViewModel/ModulePublishProgressViewModel.swift
@@ -28,7 +28,7 @@ extension ModulePublishProgressViewModel {
 
         func start(shouldFail: Bool) {
             let total = 7
-            let errorTreshold = 3
+            let errorTreshold = 5
             let interval = 0.5
             for i in 0...total {
                 guard !shouldFail || i <= errorTreshold else { break }
@@ -94,7 +94,7 @@ final class ModulePublishProgressViewModel: ObservableObject {
     // MARK: - Input
 
     let didTapDismiss = PassthroughSubject<WeakViewController, Never>()
-    let didTapCancel = PassthroughSubject<WeakViewController, Never>()
+    let didTapCancel = PassthroughSubject<(WeakViewController, String), Never>()
     let didTapDone = PassthroughSubject<WeakViewController, Never>()
 
     // MARK: - Private
@@ -157,11 +157,12 @@ final class ModulePublishProgressViewModel: ObservableObject {
             .store(in: &subscriptions)
 
         didTapCancel
-            .sink {
-                print("⚠️ ❌ Did tap cancel")
+            .sink { weakVC, snackBarTitle in
                 // TODO: send cancel request silently: no spinner, no errors
-                router.dismiss($0)
-                // TODO: show snackbar ""
+                let snackBarViewModel = weakVC.value.findSnackBarViewModel()
+                router.dismiss(weakVC) {
+                    snackBarViewModel?.showSnack(snackBarTitle)
+                }
             }
             .store(in: &subscriptions)
 

--- a/Core/Core/Modules/PutModuleItemPublishRequest.swift
+++ b/Core/Core/Modules/PutModuleItemPublishRequest.swift
@@ -32,6 +32,10 @@ struct PutModuleItemPublishRequest: APIRequestable {
 
         var isPublished: Bool { self == .publish ? true : false }
     }
+    enum ActionSubject: Equatable {
+        case modulesAndItems
+        case onlyModules
+    }
 
     let path: String
     let body: Body?

--- a/Core/Core/Modules/PutModuleItemPublishRequest.swift
+++ b/Core/Core/Modules/PutModuleItemPublishRequest.swift
@@ -26,16 +26,6 @@ struct PutModuleItemPublishRequest: APIRequestable {
         }
         let module_item: ModuleItem
     }
-    enum Action: Equatable {
-        case publish
-        case unpublish
-
-        var isPublished: Bool { self == .publish ? true : false }
-    }
-    enum ActionSubject: Equatable {
-        case modulesAndItems
-        case onlyModules
-    }
 
     let path: String
     let body: Body?
@@ -48,12 +38,12 @@ struct PutModuleItemPublishRequest: APIRequestable {
         courseId: String,
         moduleId: String,
         moduleItemId: String,
-        action: Action
+        action: ModulePublishAction
     ) {
         self.courseId = courseId
         self.moduleItemId = moduleItemId
         path = "courses/\(courseId)/modules/\(moduleId)/items/\(moduleItemId)"
-        body = Body(module_item: .init(published: action.isPublished))
+        body = Body(module_item: .init(published: action.isPublish))
     }
 }
 
@@ -64,14 +54,14 @@ struct PutModuleItemPublishState: APIUseCase {
     let request: PutModuleItemPublishRequest
     var scope: Scope { Scope(predicate: predicate, order: []) }
 
-    private let action: PutModuleItemPublishRequest.Action
+    private let action: ModulePublishAction
     private let predicate: NSPredicate
 
     init(
         courseId: String,
         moduleId: String,
         moduleItemId: String,
-        action: PutModuleItemPublishRequest.Action
+        action: ModulePublishAction
     ) {
         self.action = action
         predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
@@ -96,6 +86,6 @@ struct PutModuleItemPublishState: APIUseCase {
             return
         }
 
-        model.published = action.isPublished
+        model.published = action.isPublish
     }
 }

--- a/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
+++ b/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
@@ -29,7 +29,7 @@ public extension UIViewController {
             presentingViewController,
             presentingViewController?.tabBarController,
         ]
-        
+
         let provider = possibleProviders
             .compactMap { $0 as? SnackBarProvider }
             .first

--- a/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
+++ b/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
@@ -23,7 +23,17 @@ public protocol SnackBarProvider {
 public extension UIViewController {
 
     func findSnackBarViewModel() -> SnackBarViewModel? {
-        (tabBarController as? SnackBarProvider)?.snackBarViewModel
+        let possibleProviders = [
+            self,
+            tabBarController,
+            presentingViewController,
+            presentingViewController?.tabBarController,
+        ]
+        
+        let provider = possibleProviders
+            .compactMap { $0 as? SnackBarProvider }
+            .first
+        return provider?.snackBarViewModel
     }
 }
 

--- a/Core/Core/SwiftUIViews/ProgressViewStyle/DeterminateBarProgressViewStyle.swift
+++ b/Core/Core/SwiftUIViews/ProgressViewStyle/DeterminateBarProgressViewStyle.swift
@@ -57,10 +57,14 @@ public struct DeterminateBarProgressViewStyle: ProgressViewStyle {
 }
 
 extension ProgressViewStyle where Self == DeterminateBarProgressViewStyle {
-    static func determinateBar(
-        foregroundColor: Color = .accentColor,
-        backgroundColor: Color = .accentColor.opacity(0.2)
-    ) -> DeterminateBarProgressViewStyle {
+    static func determinateBar(color: Color = .accentColor) -> DeterminateBarProgressViewStyle {
+        .init(
+            foregroundColor: color,
+            backgroundColor: color.opacity(ProgressViewStyleConstants.backgroundOpacity)
+        )
+    }
+
+    static func determinateBar(foregroundColor: Color, backgroundColor: Color) -> DeterminateBarProgressViewStyle {
         DeterminateBarProgressViewStyle(
             foregroundColor: foregroundColor,
             backgroundColor: backgroundColor
@@ -76,7 +80,7 @@ struct DeterminateBarProgressViewStyle_Previews: PreviewProvider {
             .previewLayout(.sizeThatFits)
 
         ProgressView(value: 0.75)
-            .progressViewStyle(.determinateBar())
+            .progressViewStyle(.determinateBar(color: .red))
             .preferredColorScheme(.light)
             .previewLayout(.sizeThatFits)
 

--- a/Core/Core/SwiftUIViews/ProgressViewStyle/DeterminateCircleProgressViewStyle.swift
+++ b/Core/Core/SwiftUIViews/ProgressViewStyle/DeterminateCircleProgressViewStyle.swift
@@ -45,7 +45,7 @@ struct DeterminateCircleProgressViewStyle: ProgressViewStyle {
                     color,
                     lineWidth: lineWidth
                 )
-                .opacity(0.2)
+                .opacity(ProgressViewStyleConstants.backgroundOpacity)
             Circle()
                 .trim(from: 0, to: progress)
                 .stroke(

--- a/Core/Core/SwiftUIViews/ProgressViewStyle/IndeterminateBarProgressViewStyle.swift
+++ b/Core/Core/SwiftUIViews/ProgressViewStyle/IndeterminateBarProgressViewStyle.swift
@@ -64,10 +64,14 @@ public struct IndeterminateBarProgressViewStyle: ProgressViewStyle {
 }
 
 extension ProgressViewStyle where Self == IndeterminateBarProgressViewStyle {
-    static func indeterminateBar(
-        foregroundColor: Color = .accentColor,
-        backgroundColor: Color = .accentColor.opacity(0.2)
-    ) -> IndeterminateBarProgressViewStyle {
+    static func indeterminateBar(color: Color = .accentColor) -> IndeterminateBarProgressViewStyle {
+        .init(
+            foregroundColor: color,
+            backgroundColor: color.opacity(ProgressViewStyleConstants.backgroundOpacity)
+        )
+    }
+
+    static func indeterminateBar(foregroundColor: Color, backgroundColor: Color) -> IndeterminateBarProgressViewStyle {
         IndeterminateBarProgressViewStyle(
             foregroundColor: foregroundColor,
             backgroundColor: backgroundColor

--- a/Core/Core/SwiftUIViews/ProgressViewStyle/IndeterminateCircleProgressViewStyle.swift
+++ b/Core/Core/SwiftUIViews/ProgressViewStyle/IndeterminateCircleProgressViewStyle.swift
@@ -60,7 +60,7 @@ public struct IndeterminateCircleProgressViewStyle: ProgressViewStyle {
                     color,
                     lineWidth: lineWidth
                 )
-                .opacity(0.2)
+                .opacity(ProgressViewStyleConstants.backgroundOpacity)
             Circle()
                 .trim(from: 0, to: fillWidth)
                 .stroke(

--- a/Core/Core/SwiftUIViews/ProgressViewStyle/ProgressViewStyleConstants.swift
+++ b/Core/Core/SwiftUIViews/ProgressViewStyle/ProgressViewStyleConstants.swift
@@ -1,0 +1,23 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+enum ProgressViewStyleConstants {
+    static let backgroundOpacity: Double = 0.2
+}

--- a/Core/CoreTests/Modules/ModuleList/ViewModel/ModulePublishMenuTests.swift
+++ b/Core/CoreTests/Modules/ModuleList/ViewModel/ModulePublishMenuTests.swift
@@ -34,7 +34,7 @@ class ModulePublishMenuTests: XCTestCase {
     // MARK: - All Modules Actions
 
     func testPublishAllModulesAndItems() {
-        let testee = UIMenu.makePublishModulesMenu(host: hostView, router: router)
+        let testee = UIMenu.makePublishAllModulesMenu(host: hostView, router: router) { _ in }
         let publishMenu = testee.children[0] as! UIMenu
         let publishAll = publishMenu.children[0] as! UIAction
 
@@ -47,8 +47,8 @@ class ModulePublishMenuTests: XCTestCase {
                    defaultActionTitle: "Publish")
     }
 
-    func testPublishModulesOnly() {
-        let testee = UIMenu.makePublishModulesMenu(host: hostView, router: router)
+    func testPublishAllModulesOnly() {
+        let testee = UIMenu.makePublishAllModulesMenu(host: hostView, router: router) { _ in }
         let publishMenu = testee.children[0] as! UIMenu
         let publishModules = publishMenu.children[1] as! UIAction
 
@@ -62,7 +62,7 @@ class ModulePublishMenuTests: XCTestCase {
     }
 
     func testUnpublishAllModulesAndItems() {
-        let testee = UIMenu.makePublishModulesMenu(host: hostView, router: router)
+        let testee = UIMenu.makePublishAllModulesMenu(host: hostView, router: router) { _ in }
         let unpublishMenu = testee.children[1] as! UIMenu
         let unpublishAll = unpublishMenu.children[0] as! UIAction
 
@@ -78,7 +78,7 @@ class ModulePublishMenuTests: XCTestCase {
     // MARK: - Module Actions
 
     func testPublishModuleAndAllItems() {
-        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router)
+        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router) { _ in }
         let publishMenu = testee.children[0] as! UIMenu
         let publishModule = publishMenu.children[0] as! UIAction
 
@@ -92,19 +92,19 @@ class ModulePublishMenuTests: XCTestCase {
     }
 
     func testPublishModuleAndAllItemsA11yAction() {
-        let testee = [UIAccessibilityCustomAction].modulePublishA11yActions(host: hostView,
-                                                                            router: router)[0]
+        let testee = [UIAccessibilityCustomAction].makePublishModuleA11yActions(host: hostView, router: router) { _ in }
+        let action = testee[0]
 
-        _ = testee.actionHandler!(testee)
+        _ = action.actionHandler!(action)
 
-        XCTAssertEqual(testee.name, "Publish Module And All Items")
+        XCTAssertEqual(action.name, "Publish Module And All Items")
         checkAlert(title: "Publish?",
                    message: "This will make the module and all items visible to students.",
                    defaultActionTitle: "Publish")
     }
 
     func testPublishModuleOnly() {
-        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router)
+        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router) { _ in }
         let publishMenu = testee.children[0] as! UIMenu
         let publishModule = publishMenu.children[1] as! UIAction
 
@@ -118,19 +118,19 @@ class ModulePublishMenuTests: XCTestCase {
     }
 
     func testPublishModuleOnlyA11yAction() {
-        let testee = [UIAccessibilityCustomAction].modulePublishA11yActions(host: hostView,
-                                                                            router: router)[1]
+        let testee = [UIAccessibilityCustomAction].makePublishModuleA11yActions(host: hostView, router: router) { _ in }
+        let action = testee[1]
 
-        _ = testee.actionHandler!(testee)
+        _ = action.actionHandler!(action)
 
-        XCTAssertEqual(testee.name, "Publish Module Only")
+        XCTAssertEqual(action.name, "Publish Module Only")
         checkAlert(title: "Publish?",
                    message: "This will make only the module visible to students.",
                    defaultActionTitle: "Publish")
     }
 
     func testUnpublishModule() {
-        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router)
+        let testee = UIMenu.makePublishModuleMenu(host: hostView, router: router) { _ in }
         let publishMenu = testee.children[1] as! UIMenu
         let publishModule = publishMenu.children[0] as! UIAction
 
@@ -144,12 +144,12 @@ class ModulePublishMenuTests: XCTestCase {
     }
 
     func testUnpublishModuleA11yAction() {
-        let testee = [UIAccessibilityCustomAction].modulePublishA11yActions(host: hostView,
-                                                                            router: router)[2]
+        let testee = [UIAccessibilityCustomAction].makePublishModuleA11yActions(host: hostView, router: router) { _ in }
+        let action = testee[2]
 
-        _ = testee.actionHandler!(testee)
+        _ = action.actionHandler!(action)
 
-        XCTAssertEqual(testee.name, "Unpublish Module And All Items")
+        XCTAssertEqual(action.name, "Unpublish Module And All Items")
         checkAlert(title: "Unpublish?",
                    message: "This will make the module and all items invisible to students.",
                    defaultActionTitle: "Unpublish")
@@ -177,10 +177,10 @@ class ModulePublishMenuTests: XCTestCase {
 
     func testPublishItemA11yAction() {
         let actionExpectation = expectation(description: "Action performed")
-        let testee = [UIAccessibilityCustomAction].moduleItemPublishA11yActions(action: .publish,
-                                                                                host: hostView,
-                                                                                router: router,
-                                                                                actionDidPerform: { actionExpectation.fulfill() })[0]
+        let testee = [UIAccessibilityCustomAction].makePublishModuleItemA11yActions(action: .publish,
+                                                                                    host: hostView,
+                                                                                    router: router,
+                                                                                    actionDidPerform: { actionExpectation.fulfill() })[0]
 
         _ = testee.actionHandler!(testee)
 
@@ -211,10 +211,10 @@ class ModulePublishMenuTests: XCTestCase {
 
     func testUnpublishItemA11yAction() {
         let actionExpectation = expectation(description: "Action performed")
-        let testee = [UIAccessibilityCustomAction].moduleItemPublishA11yActions(action: .unpublish,
-                                                                                host: hostView,
-                                                                                router: router,
-                                                                                actionDidPerform: { actionExpectation.fulfill() })[0]
+        let testee = [UIAccessibilityCustomAction].makePublishModuleItemA11yActions(action: .unpublish,
+                                                                                    host: hostView,
+                                                                                    router: router,
+                                                                                    actionDidPerform: { actionExpectation.fulfill() })[0]
 
         _ = testee.actionHandler!(testee)
 
@@ -232,7 +232,11 @@ class ModulePublishMenuTests: XCTestCase {
         message: String,
         defaultActionTitle: String
     ) {
-        let alert = router.lastViewController as! UIAlertController
+        guard let alert = router.lastViewController as? UIAlertController else {
+            XCTFail("Alert not found")
+            return
+        }
+
         let routerCall = router.viewControllerCalls.last!
         XCTAssertEqual(routerCall.0, alert)
         XCTAssertEqual(routerCall.1, hostView)

--- a/Core/CoreTests/Modules/ModuleList/ViewModel/ModulePublishProgressViewModelTests.swift
+++ b/Core/CoreTests/Modules/ModuleList/ViewModel/ModulePublishProgressViewModelTests.swift
@@ -1,0 +1,99 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+@testable import Core
+import TestsFoundation
+
+final class ModulePublishProgressViewModelTests: CoreTestCase {
+
+    func testTitle() {
+        var testee = makeViewModel(action: .publish(.modulesAndItems), allModules: true)
+        XCTAssertEqual(testee.title, .allModulesAndItems)
+        testee = makeViewModel(action: .unpublish(.modulesAndItems), allModules: true)
+        XCTAssertEqual(testee.title, .allModulesAndItems)
+
+        testee = makeViewModel(action: .publish(.onlyModules), allModules: true)
+        XCTAssertEqual(testee.title, .allModules)
+        testee = makeViewModel(action: .unpublish(.onlyModules), allModules: true)
+        XCTAssertEqual(testee.title, .allModules)
+
+        testee = makeViewModel(action: .publish(.modulesAndItems), allModules: false)
+        XCTAssertEqual(testee.title, .selectedModuleAndItems)
+        testee = makeViewModel(action: .unpublish(.modulesAndItems), allModules: false)
+        XCTAssertEqual(testee.title, .selectedModuleAndItems)
+
+        testee = makeViewModel(action: .publish(.onlyModules), allModules: false)
+        XCTAssertEqual(testee.title, .selectedModule)
+        testee = makeViewModel(action: .unpublish(.onlyModules), allModules: false)
+        XCTAssertEqual(testee.title, .selectedModule)
+    }
+
+    func testIsPublish() {
+        var action: ModulePublishAction
+
+        action = .publish
+        var testee = makeViewModel(action: action)
+        XCTAssertEqual(testee.isPublish, action.isPublish)
+
+        action = .unpublish
+        testee = makeViewModel(action: action)
+        XCTAssertEqual(testee.isPublish, action.isPublish)
+    }
+
+    func testDidTapDismiss() {
+        let vc = UIViewController()
+        let testee = makeViewModel()
+
+        testee.didTapDismiss.send(.init(vc))
+
+        XCTAssertEqual(router.dismissed, vc)
+    }
+
+    func testDidTapCancel() {
+        let vc = SnackBarProviderMock()
+        let testee = makeViewModel()
+
+        testee.didTapCancel.send((.init(vc), "some snack"))
+
+        XCTAssertEqual(router.dismissed, vc)
+        XCTAssertEqual(vc.snackBarViewModel.visibleSnack, "some snack")
+    }
+
+    func testDidTapDone() {
+        let vc = UIViewController()
+        let testee = makeViewModel()
+
+        testee.didTapDone.send(.init(vc))
+
+        XCTAssertEqual(router.dismissed, vc)
+    }
+}
+
+private extension ModulePublishProgressViewModelTests {
+    func makeViewModel(
+        action: ModulePublishAction = .publish(.onlyModules),
+        allModules: Bool = false
+    ) -> ModulePublishProgressViewModel {
+        .init(action: action, allModules: allModules, router: router)
+    }
+
+    final class SnackBarProviderMock: UIViewController, SnackBarProvider {
+        var snackBarViewModel = SnackBarViewModel()
+    }
+}


### PR DESCRIPTION
refs: [MBL-17305](https://instructure.atlassian.net/browse/MBL-17305)
affects: Teacher
release note: none

## What's new
- added Progress screen for All Modules or single Module bulk publish
- added Cancel snackbar
- integrated them into ModuleList

### Details
- added view & viewmodel
- added temporary dummy interactor for QA purposes
- refactored publish action enum to `ModulePublishAction` to include `subject`
- updated `findSnackBarViewModel()` to handle more cases
- unified ProgressViewStyle coloring

## Test plan
- Enable experimental feature flag in Developer Menu
- To reproduce success case: publish/unpublish All Modules (in navBar)
- To reproduce failure case: publish/unpublish a Module (in Module section header)
  - update should fail after a few seconds
- See ticket for expectations

## Screenshots

<table>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/d1e22968-a2e8-459b-94e9-10c102cff37e" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/112d163d-8411-4ed2-a9dc-29719fb935f4" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/618ee676-42f3-450b-a0b3-0998ae15282a" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/9cc0d986-639b-4be6-97a5-6184f610a02b" maxHeight=500></td>
</tr>
</table>


## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode

[MBL-17305]: https://instructure.atlassian.net/browse/MBL-17305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ