### PR TITLE
Fix crash

### DIFF
--- a/Core/Core/Extensions/UIViewControllerExtensions.swift
+++ b/Core/Core/Extensions/UIViewControllerExtensions.swift
@@ -154,10 +154,10 @@ extension UIViewController {
                 self?.navigationItem.titleView = item.titleView
             },
             viewController.navigationItem.observe(\.rightBarButtonItems) { [weak self] item, _ in
-                self?.navigationItem.rightBarButtonItems = (item.rightBarButtonItems ?? []) + right
+                self?.navigationItem.rightBarButtonItems = ((item.rightBarButtonItems ?? []) + right).removeDuplicates()
             },
             viewController.navigationItem.observe(\.leftBarButtonItems) { [weak self] item, _ in
-                self?.navigationItem.leftBarButtonItems = (item.leftBarButtonItems ?? []) + left
+                self?.navigationItem.leftBarButtonItems = ((item.leftBarButtonItems ?? []) + left).removeDuplicates()
             },
             viewController.navigationItem.observe(\.leftItemsSupplementBackButton) { [weak self] item, _ in
                 self?.navigationItem.leftItemsSupplementBackButton = item.leftItemsSupplementBackButton || leftItemsSupplementBackButton

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -292,7 +292,7 @@ public struct GradeListView: View, ScreenViewTrackable {
     private func togglesView() -> some View {
         VStack(spacing: 0) {
             Toggle(isOn: $viewModel.baseOnGradedAssignment) {
-                Text("Base on graded assignments", bundle: .core)
+                Text("Based on graded assignments", bundle: .core)
                     .foregroundStyle(Color.textDarkest)
                     .font(.regular16)
                     .multilineTextAlignment(.leading)

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -74,13 +74,6 @@ public final class ModuleItemSequenceViewController: UIViewController {
         store.refresh(force: true)
     }
 
-    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-        if let viewController = pages.currentPage {
-            observations = syncNavigationBar(with: viewController)
-        }
-    }
-
     private func update(embed: Bool) {
         if store.requested, store.pending {
             return

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
@@ -77,7 +77,7 @@ class ModuleItemSequenceViewControllerTests: CoreTestCase {
         XCTAssertTrue(controller.nextButton.isHidden)
         XCTAssertFalse(controller.previousButton.isHidden)
 
-        let leftButton = UIBarButtonItem()
+        let leftButton = UIBarButtonItemWithCompletion(title: "", actionHandler: {})
         let rightButton = UIBarButtonItem()
         details.title = "Title 1"
         details.navigationItem.title = "Title 2"


### PR DESCRIPTION
### What's new?
- Fixed a crash related to nav bar items.
- Also fixed an issue that caused nav bar items to duplicate.
- Fixed a typo on the grade screen.

refs: MBL-17467
affects: Student, Teacher
release note: none

test plan:
- Create an announcement with a linked file.
- Start the app on a split view capable iphone.
- Open announcement.
- Tap on the file's link, it should open in a popup.
- Rotate the phone.
- App shouldn't crash.

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet