### PR TITLE
Fix act as user url param not getting appended to requests without query items

### DIFF
--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -226,6 +226,8 @@ extension APIRequestable {
             } else {
                 components.queryItems = (components.queryItems ?? []) + self.queryItems + actAsUserQueryItem
             }
+        } else if !actAsUserQueryItem.isEmpty {
+            components.queryItems = actAsUserQueryItem
         }
 
         // The conditional path prefixing *should* have made this impossible to fail

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -174,6 +174,11 @@ class APIRequestableTests: XCTestCase {
         XCTAssertEqual(try GetQueryItems().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: "78"), expected)
     }
 
+    func testActAsUserIDWhenThereAreNoURLParams() {
+        let expected = expectedUrlRequest(path: "api/v1/date?as_user_id=78")
+        XCTAssertEqual(try GetDate().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: "78"), expected)
+    }
+
     func testUrlRequest() {
         var expected = expectedUrlRequest(path: "api/v1/post")
         expected.httpMethod = "POST"


### PR DESCRIPTION
refs: MBL-17410
affects: Student, Teacher
release note: Fixed act as user not loading the impersonated user's dashboard.

test plan: See ticket.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet