### PR TITLE
Bulk Publish - Disable Unpublish, Extend hit area

### DIFF
--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -29,7 +29,6 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case nativeStudentInbox = "native_student_inbox"
     case nativeTeacherInbox = "native_teacher_inbox"
     case K5Dashboard = "enable_K5_dashboard"
-    case teacherBulkPublish
     case whatIfScore = "what_if_score"
 
     public var isEnabled: Bool {

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23B2073" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -680,6 +680,7 @@
         <relationship name="itemsRaw" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ModuleItem" inverseName="module" inverseEntity="ModuleItem"/>
     </entity>
     <entity name="ModuleItem" representedClassName="Core.ModuleItem" syncable="YES">
+        <attribute name="canBeUnpublished" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="completedRaw" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="completionRequirementTypeRaw" optional="YES" attributeType="String"/>
         <attribute name="courseID" attributeType="String"/>

--- a/Core/Core/Files/Model/Entities/FileAvailability.swift
+++ b/Core/Core/Files/Model/Entities/FileAvailability.swift
@@ -23,22 +23,7 @@ public enum FileAvailability: Int, CaseIterable, Identifiable, Equatable {
     case scheduledAvailability = 3
 
     public var id: FileAvailability { self }
-    public var label: String {
-        switch self {
-        case .published: return String(localized: "Publish")
-        case .unpublished: return String(localized: "Unpublish")
-        case .hidden: return String(localized: "Only Available With Link")
-        case .scheduledAvailability: return String(localized: "Schedule Availability")
-        }
-    }
-    public var a11yLabel: String {
-        switch self {
-        case .published: return String(localized: "published")
-        case .unpublished: return String(localized: "unpublished")
-        case .hidden: return String(localized: "only available with link")
-        case .scheduledAvailability: return String(localized: "scheduled availability")
-        }
-    }
+
     public var isLastCase: Bool {
         Self.allCases.last == self
     }

--- a/Core/Core/Modules/APIModule.swift
+++ b/Core/Core/Modules/APIModule.swift
@@ -60,6 +60,8 @@ public struct APIModuleItem: Codable, Equatable {
     public let url: URL?
     /// Only present if the caller has permission to view unpublished items
     public let published: Bool?
+    /// Indicates whether the item is allowed to be unpublished. This could be false e.g. when related assignment already has submissions.
+    public let unpublishable: Bool?
     public let content_details: ContentDetails? // include[]=content_details not available in sequence call
     public var completion_requirement: CompletionRequirement? // not available in sequence call
     public let mastery_paths: APIMasteryPath? // include[]=mastery_paths
@@ -74,6 +76,7 @@ public struct APIModuleItem: Codable, Equatable {
         html_url: URL?,
         url: URL?,
         published: Bool?,
+        unpublishable: Bool?,
         content_details: ContentDetails?,
         completion_requirement: CompletionRequirement?,
         mastery_paths: APIMasteryPath?
@@ -87,6 +90,7 @@ public struct APIModuleItem: Codable, Equatable {
         self.html_url = html_url
         self.url = url
         self.published = published
+        self.unpublishable = unpublishable
         self.content_details = content_details
         self.completion_requirement = completion_requirement
         self.mastery_paths = mastery_paths
@@ -101,6 +105,7 @@ public struct APIModuleItem: Codable, Equatable {
         case html_url
         case url
         case published
+        case unpublishable
         case content
         case content_details
         case completion_requirement
@@ -117,6 +122,7 @@ public struct APIModuleItem: Codable, Equatable {
         html_url = try container.decodeIfPresent(URL.self, forKey: .html_url)
         url = try container.decodeIfPresent(URL.self, forKey: .url)
         published = try container.decodeIfPresent(Bool.self, forKey: .published)
+        unpublishable = try container.decodeIfPresent(Bool.self, forKey: .unpublishable)
         content = try ModuleItemType?(from: decoder)
         content_details = try container.decodeIfPresent(ContentDetails.self, forKey: .content_details)
         completion_requirement = try container.decodeIfPresent(CompletionRequirement.self, forKey: .completion_requirement)
@@ -218,6 +224,7 @@ extension APIModuleItem {
         html_url: URL? = URL(string: "https://canvas.example.edu/courses/222/modules/items/768"),
         url: URL? = URL(string: "https://canvas.example.edu/api/v1/courses/222/assignments/987"),
         published: Bool? = nil,
+        unpublishable: Bool? = nil,
         content_details: ContentDetails? = nil,
         completion_requirement: CompletionRequirement? = nil,
         mastery_paths: APIMasteryPath? = nil
@@ -232,6 +239,7 @@ extension APIModuleItem {
             html_url: html_url,
             url: url,
             published: published,
+            unpublishable: unpublishable,
             content_details: content_details,
             completion_requirement: completion_requirement,
             mastery_paths: mastery_paths

--- a/Core/Core/Modules/ModuleItem.swift
+++ b/Core/Core/Modules/ModuleItem.swift
@@ -32,6 +32,7 @@ public class ModuleItem: NSManagedObject {
     @NSManaged public var htmlURL: URL?
     @NSManaged public var url: URL?
     @NSManaged public var publishedRaw: NSNumber?
+    @NSManaged public var canBeUnpublished: Bool
     @NSManaged public var typeRaw: Data?
     @NSManaged public var module: Module?
     @NSManaged public var dueAt: Date?
@@ -164,6 +165,7 @@ public class ModuleItem: NSManagedObject {
         model.htmlURL = item.html_url
         model.url = item.url
         model.published = item.published
+        model.canBeUnpublished = item.unpublishable ?? true
         model.type = item.content
         model.pointsPossible = item.content_details?.points_possible
         model.dueAt = item.content_details?.due_at

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
@@ -94,7 +94,7 @@ class ModulePublishInteractorLive: ModulePublishInteractor {
     ) {
         self.courseId = courseId
         self.api = api
-        isPublishActionAvailable = app == .teacher && ExperimentalFeature.teacherBulkPublish.isEnabled
+        isPublishActionAvailable = app == .teacher
     }
 
     func changeItemPublishedState(

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
@@ -18,12 +18,14 @@
 
 import Combine
 
-protocol ModulePublishInteractor {
+protocol ModulePublishInteractor: AnyObject {
     var isPublishActionAvailable: Bool { get }
     var moduleItemsUpdating: CurrentValueSubject<Set<String>, Never> { get }
     var modulesUpdating: CurrentValueSubject<Set<String>, Never> { get }
     var statusUpdates: PassthroughSubject<String, Never> { get }
-    var isModulePublishInProgress: Bool { get }
+
+    func isModulePublishInProgress(_ module: Module) -> Bool
+    func isModuleItemPublishInProgress(_ moduleItem: ModuleItem) -> Bool
 
     func changeItemPublishedState(
         moduleId: String,
@@ -51,8 +53,14 @@ protocol ModulePublishInteractor {
 }
 
 extension ModulePublishInteractor {
-    var isModulePublishInProgress: Bool {
-        !modulesUpdating.value.isEmpty
+    func isModulePublishInProgress(_ module: Module) -> Bool {
+        modulesUpdating.value.contains(module.id)
+    }
+
+    func isModuleItemPublishInProgress(_ moduleItem: ModuleItem) -> Bool {
+        let isItemUpdating = moduleItemsUpdating.value.contains(moduleItem.id)
+        let isParentModuleUpdating = modulesUpdating.value.contains(moduleItem.moduleID)
+        return isItemUpdating || isParentModuleUpdating
     }
 }
 

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -30,6 +30,7 @@ class ModuleItemCell: UITableViewCell {
     @IBOutlet weak var indentConstraint: NSLayoutConstraint!
     @IBOutlet weak var completedStatusView: UIImageView!
     @IBOutlet weak var publishControl: ModulePublishControl!
+    @IBOutlet weak var contentStackViewTrailingConstraint: NSLayoutConstraint!
 
     private let env = AppEnvironment.shared
     private var publishStateObservers = Set<AnyCancellable>()
@@ -94,6 +95,7 @@ class ModuleItemCell: UITableViewCell {
         dueLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).dueLabel"
 
         publishControl.isHidden = !shouldShowPublishControl
+        contentStackViewTrailingConstraint.constant = shouldShowPublishControl ? 0 : 16
 
         // We have to do an instant update because the update via subscription is delayed
         updatePublishControl(item)

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -291,3 +291,14 @@ private extension ModuleItem {
         type.isFile || published == false || canBeUnpublished
     }
 }
+
+private extension FileAvailability {
+    var a11yLabel: String {
+        switch self {
+        case .published: return String(localized: "published")
+        case .unpublished: return String(localized: "unpublished")
+        case .hidden: return String(localized: "only available with link")
+        case .scheduledAvailability: return String(localized: "scheduled availability")
+        }
+    }
+}

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -29,21 +29,26 @@ class ModuleItemCell: UITableViewCell {
     @IBOutlet weak var iconView: UIImageView!
     @IBOutlet weak var indentConstraint: NSLayoutConstraint!
     @IBOutlet weak var completedStatusView: UIImageView!
-    @IBOutlet weak var publishMenuButton: UIButton!
-    @IBOutlet weak var publishIndicatorView: ModuleItemPublishIndicatorView!
+    @IBOutlet weak var publishControl: ModulePublishControl!
 
     private let env = AppEnvironment.shared
     private var publishStateObservers = Set<AnyCancellable>()
     private weak var host: UIViewController?
+
+    private var publishInteractor: ModulePublishInteractor?
+    private var shouldShowPublishControl: Bool = false
+
+    // stored IDs for FilePermissionEditor
     private var moduleItemId: String?
     private var fileId: String?
     private var moduleId: String?
     private var courseId: String?
-    private var publishInteractor: ModulePublishInteractor?
+
+    // MARK: - Update
 
     override func prepareForReuse() {
         super.prepareForReuse()
-        publishIndicatorView.prepareForReuse()
+        publishControl.prepareForReuse()
         publishStateObservers.removeAll()
     }
 
@@ -56,24 +61,48 @@ class ModuleItemCell: UITableViewCell {
     ) {
         self.host = host
         self.publishInteractor = publishInteractor
+        shouldShowPublishControl = publishInteractor.isPublishActionAvailable
         moduleId = item.moduleID
         moduleItemId = item.id
         fileId = item.type.fileId
         courseId = item.courseID
+
         backgroundColor = .backgroundLightest
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)
+
         let isLocked = item.isLocked || item.masteryPath?.locked == true
         isUserInteractionEnabled = env.app == .teacher || !isLocked
+
         nameLabel.setText(item.title, style: .textCellTitle)
         nameLabel.isEnabled = isUserInteractionEnabled
         nameLabel.textColor = nameLabel.isEnabled ? .textDarkest : .textLight
+
         iconView.image = item.masteryPath?.locked == true ? UIImage.lockLine : item.type?.icon
         contentStackView.setCustomSpacing(16, after: iconView)
         iconView.isHidden = (iconView.image == nil)
+
         completedStatusView.isHidden = env.app == .teacher || item.completionRequirement == nil
         completedStatusView.image = item.completed == true ? .checkLine : .emptyLine
         completedStatusView.tintColor = item.completed == true ? .backgroundSuccess : .borderMedium
+
         indentConstraint.constant = CGFloat(item.indent) * ModuleItemCell.IndentMultiplier
+
+        updateDueLabel(item)
+
+        accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row)"
+        nameLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).nameLabel"
+        dueLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).dueLabel"
+
+        publishControl.isHidden = !shouldShowPublishControl
+
+        // We have to do an instant update because the update via subscription is delayed
+        updatePublishControl(item)
+        updatePublishInProgressState(item, isUpdating: publishInteractor.isModuleItemPublishInProgress(item))
+
+        subscribeToPublishStateUpdates(item, publishInteractor: publishInteractor, host: host)
+    }
+
+    private func updateDueLabel(_ item: ModuleItem) {
         let dueAt = item.dueAt.flatMap { DateFormatter.localizedString(from: $0, dateStyle: .medium, timeStyle: .none) }
         let points: String? = item.pointsPossible.flatMap {
             if item.hideQuantitativeData {
@@ -97,63 +126,142 @@ class ModuleItemCell: UITableViewCell {
             accessoryView = nil
         }
         dueLabel.isHidden = dueLabel.text == nil
-        var a11yLabels = [item.type?.label, item.title, dueLabel.text]
-        if item.isLocked {
-            a11yLabels.append(NSLocalizedString("locked", bundle: .core, comment: ""))
+    }
+
+    private func updateA11yLabel(_ item: ModuleItem, isPublishing: Bool) {
+        var a11yLabels: [String?] = [
+            item.type?.label,
+            item.title,
+        ]
+
+        if shouldShowPublishControl {
+            let publishedText = {
+                if isPublishing {
+                    return String(localized: "Publish state modification in progress")
+                }
+
+                if let availability = item.fileAvailability {
+                    return availability.a11yLabel
+                } else {
+                    return item.published == true
+                        ? String(localized: "published")
+                        : String(localized: "unpublished")
+                }
+            }()
+            a11yLabels.append(publishedText)
+        } else {
+            a11yLabels.append(contentsOf: [
+                dueLabel.text,
+                item.isLocked ? String(localized: "locked") : nil,
+            ])
         }
+
         accessibilityLabel = a11yLabels.compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: ", ")
-        let isPublishing: Bool = {
-            publishInteractor.moduleItemsUpdating.value.contains(item.id) ||
-            publishInteractor.modulesUpdating.value.contains(item.moduleID)
-        }()
-        updateA11yLabelForPublishState(moduleItem: item, isPublishing: isPublishing)
+    }
 
-        accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row)"
-        nameLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).nameLabel"
-        dueLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).dueLabel"
+    // MARK: - Publish
 
-        publishMenuButton.isHidden = !publishInteractor.isPublishActionAvailable
+    private func subscribeToPublishStateUpdates(
+        _ item: ModuleItem,
+        publishInteractor: ModulePublishInteractor,
+        host: UIViewController
+    ) {
+        guard publishStateObservers.isEmpty else { return }
+
+        Publishers.CombineLatest(
+            publishInteractor.moduleItemsUpdating.map { $0.contains(item.id) },
+            publishInteractor.modulesUpdating.map { $0.contains(item.moduleID) }
+        )
+        .map { (itemUpdating, parentModuleUpdating) in
+            itemUpdating || parentModuleUpdating
+        }
+        .removeDuplicates()
+        .receive(on: RunLoop.main)
+        .sink { [weak self] isUpdating in
+            guard let self else { return }
+
+            updatePublishControl(item)
+            updatePublishInProgressState(item, isUpdating: isUpdating)
+        }
+        .store(in: &publishStateObservers)
+    }
+
+    private func updatePublishControl(_ item: ModuleItem) {
+        publishControl.isEnabled = item.shouldEnablePublishControl
+        updatePublishedState(item)
+    }
+
+    private func updatePublishedState(_ item: ModuleItem) {
+        let availability = item.fileAvailability ?? (item.published == true ? .published : .unpublished)
+        publishControl.update(availability: availability)
+    }
+
+    private func updatePublishInProgressState(_ item: ModuleItem, isUpdating: Bool) {
+        updatePublishButtonAction(item, isPublishing: isUpdating)
+        publishControl.update(isPublishInProgress: isUpdating)
+        updateA11yLabel(item, isPublishing: isUpdating)
+    }
+
+    private func updatePublishButtonAction(_ item: ModuleItem, isPublishing: Bool) {
+        guard let host else { return }
+
+        if !shouldShowPublishControl || isPublishing {
+            publishControl.setPrimaryAction(nil)
+            accessibilityCustomActions = []
+            return
+        }
+
         switch item.type {
         case .file: // files open a dedicated dialog and don't use the context menu
-            publishMenuButton.showsMenuAsPrimaryAction = false
-            accessibilityCustomActions = publishInteractor.isPublishActionAvailable ? [
+            publishControl.setPrimaryAction { [weak self] in
+                self?.presentFilePermissionEditorDialog()
+            }
+            accessibilityCustomActions = [
                 .init(
                     name: String(localized: "Edit permissions"),
                     target: self,
                     selector: #selector(presentFilePermissionEditorDialog)
                 ),
-            ] : []
-            publishMenuButton.addTarget(self, action: #selector(presentFilePermissionEditorDialog), for: .primaryActionTriggered)
+            ]
         default:
-            publishMenuButton.showsMenuAsPrimaryAction = true
-            publishMenuButton.removeTarget(self, action: #selector(presentFilePermissionEditorDialog), for: .primaryActionTriggered)
+            if item.shouldEnablePublishControl {
+                let action: ModulePublishAction = item.published == true ? .unpublish : .publish
+                let performUpdate: () -> Void = { [weak publishInteractor] in
+                    publishInteractor?.changeItemPublishedState(
+                        moduleId: item.moduleID,
+                        moduleItemId: item.id,
+                        action: action
+                    )
+                }
+
+                publishControl.setPrimaryActionToMenu(
+                    .makePublishModuleItemMenu(
+                        action: action,
+                        host: host,
+                        actionDidPerform: performUpdate
+                    )
+                )
+                accessibilityCustomActions = .makePublishModuleItemA11yActions(
+                    action: action,
+                    host: host,
+                    actionDidPerform: performUpdate
+                )
+            } else {
+                publishControl.setPrimaryAction { [weak self] in
+                    self?.showCantUnpublishSnackBar()
+                }
+                accessibilityCustomActions = []
+            }
         }
-
-        subscribeToPublishStateUpdates(item, publishInteractor: publishInteractor, host: host)
     }
 
-    private func updatePublishedState(_ item: ModuleItem) {
-        let availability = item.fileAvailability ?? (item.published == true ? .published : .unpublished)
-        publishIndicatorView.update(availability: availability)
+    @objc
+    private func showCantUnpublishSnackBar() {
+        let message = String(localized: "Can’t unpublish, if there are student submissions.")
+        host?.findSnackBarViewModel()?.showSnack(message)
     }
 
-    private func updatePublishInProgressState(
-        _ item: ModuleItem,
-        publishInteractor: ModulePublishInteractor
-    ) {
-        let isItemUpdating = publishInteractor
-            .moduleItemsUpdating
-            .value
-            .contains(item.id)
-        let isParentModuleUpdating = publishInteractor
-            .modulesUpdating
-            .value
-            .contains(item.moduleID)
-        let isUpdating = isItemUpdating || isParentModuleUpdating
-
-        publishIndicatorView.update(isPublishInProgress: isUpdating)
-        publishMenuButton.isEnabled = !isUpdating
-    }
+    // MARK: - File Permissions
 
     @objc
     private func presentFilePermissionEditorDialog() {
@@ -174,90 +282,10 @@ class ModuleItemCell: UITableViewCell {
         let hostController = CoreHostingController(editorView)
         env.router.show(hostController, from: host, options: .modal(isDismissable: false, embedInNav: true))
     }
+}
 
-    private func subscribeToPublishStateUpdates(
-        _ item: ModuleItem,
-        publishInteractor: ModulePublishInteractor,
-        host: UIViewController
-    ) {
-        guard publishStateObservers.isEmpty else { return }
-
-        // We have to do an instant update because the update via subscription is delayed
-        updatePublishedState(item)
-        updatePublishInProgressState(item, publishInteractor: publishInteractor)
-
-        Publishers.CombineLatest(
-            publishInteractor.moduleItemsUpdating.map { $0.contains(item.id) },
-            publishInteractor.modulesUpdating.map { $0.contains(item.moduleID) }
-        )
-        .map { (itemUpdating, parentModuleUpdating) in
-            itemUpdating || parentModuleUpdating
-        }
-        .removeDuplicates()
-        .receive(on: RunLoop.main)
-        .sink { [weak self, weak host] isUpdating in
-            guard let self, let host else { return }
-
-            if !item.type.isFile {
-                updatePublishMenuActions(moduleItem: item, publishInteractor: publishInteractor, isPublishing: isUpdating, host: host)
-            }
-
-            publishMenuButton.isEnabled = !isUpdating
-            updatePublishedState(item)
-            publishIndicatorView.update(isPublishInProgress: isUpdating)
-            updateA11yLabelForPublishState(moduleItem: item, isPublishing: isUpdating)
-        }
-        .store(in: &publishStateObservers)
-    }
-
-    private func updatePublishMenuActions(
-        moduleItem: ModuleItem,
-        publishInteractor: ModulePublishInteractor,
-        isPublishing: Bool,
-        host: UIViewController
-    ) {
-        let action: ModulePublishAction = moduleItem.published == true ? .unpublish : .publish
-        let performUpdate = {
-            publishInteractor.changeItemPublishedState(
-                moduleId: moduleItem.moduleID,
-                moduleItemId: moduleItem.id,
-                action: action
-            )
-        }
-        publishMenuButton.menu = .makePublishModuleItemMenu(action: action, host: host, actionDidPerform: performUpdate)
-
-        accessibilityCustomActions = {
-            if publishMenuButton.isHidden || isPublishing {
-                return []
-            }
-
-            return .makePublishModuleItemA11yActions(
-                action: action,
-                host: host,
-                actionDidPerform: performUpdate
-            )
-        }()
-    }
-
-    private func updateA11yLabelForPublishState(moduleItem: ModuleItem, isPublishing: Bool) {
-        if !publishIndicatorView.isHidden {
-            let publishedText = {
-                if isPublishing {
-                    return String(localized: "Publish state modification in progress")
-                }
-                if let availability = moduleItem.fileAvailability {
-                    return availability.a11yLabel
-                } else {
-                    return moduleItem.published == true
-                        ? String(localized: "published")
-                        : String(localized: "unpublished")
-                }
-            }()
-            accessibilityLabel = [
-                moduleItem.type?.label,
-                moduleItem.title,
-                publishedText,
-            ].compactMap { $0 }.joined(separator: ", ")
-        }
+private extension ModuleItem {
+    var shouldEnablePublishControl: Bool {
+        type.isFile || published == false || canBeUnpublished
     }
 }

--- a/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
@@ -45,6 +45,8 @@ class ModuleItemPublishIndicatorView: UIView {
     }
 
     func update(isPublishInProgress isUpdating: Bool, animationDuration: TimeInterval) {
+        publishInProgressIndicator.setRemovedOnCompletion(to: !isUpdating)
+
         if isUpdating {
             publishInProgressIndicator.startAnimating()
         }

--- a/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
@@ -20,45 +20,70 @@ import Combine
 import UIKit
 
 class ModuleItemPublishIndicatorView: UIView {
-    @IBOutlet unowned var publishedIconView: PublishedIconView!
+    @IBOutlet unowned var publishedButton: UIButton!
     @IBOutlet unowned var publishInProgressIndicator: CircleProgressView!
-
-    private var isFirstUpdate = true
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         loadFromXib()
     }
 
+    init() {
+        super.init(frame: .zero)
+        loadFromXib()
+    }
+
     func prepareForReuse() {
-        publishedIconView.alpha = 1
+        publishedButton.alpha = 1
         publishInProgressIndicator.alpha = 0
         publishInProgressIndicator.stopAnimating()
-        isFirstUpdate = true
+        isHidden = false
     }
 
-    func update(availability: FileAvailability) {
-        publishedIconView.setupState(with: availability)
+    func update(availability: FileAvailability?) {
+        setupState(with: availability)
     }
 
-    func update(isPublishInProgress: Bool) {
-        let animated = !isFirstUpdate
-        isFirstUpdate = false
-        updatePublishedUIState(isUpdating: isPublishInProgress, animated: animated)
-    }
-
-    private func updatePublishedUIState(isUpdating: Bool, animated: Bool) {
+    func update(isPublishInProgress isUpdating: Bool, animationDuration: TimeInterval) {
         if isUpdating {
             publishInProgressIndicator.startAnimating()
         }
 
-        UIView.animate(withDuration: animated ? 0.3 : 0.0) { [weak publishInProgressIndicator, weak publishedIconView] in
+        UIView.animate(withDuration: animationDuration) { [weak publishInProgressIndicator, weak publishedButton] in
             publishInProgressIndicator?.alpha = isUpdating ? 1 : 0
-            publishedIconView?.alpha = isUpdating ? 0 : 1
+            publishedButton?.alpha = isUpdating ? 0 : 1
         } completion: { [weak publishInProgressIndicator] _ in
             if !isUpdating {
                 publishInProgressIndicator?.stopAnimating()
             }
         }
+    }
+
+    private func setupState(with fileAvilability: FileAvailability?) {
+        guard let fileAvilability else {
+            isHidden = true
+            return
+        }
+
+        let image: UIImage
+        let tintColor: UIColor
+        switch fileAvilability {
+        case .published:
+            image = .publishSolid
+            tintColor = UIColor.backgroundSuccess
+        case .unpublished:
+            image = .noSolid
+            tintColor = UIColor.ash
+        case .hidden:
+            image = .offLine
+            tintColor = UIColor.textWarning
+        case .scheduledAvailability:
+            image = .calendarMonthLine
+            tintColor = UIColor.textWarning
+        }
+
+        publishedButton.setImage(image, for: .normal)
+        publishedButton.tintColor = tintColor
+        isHidden = false
     }
 }

--- a/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.swift
@@ -45,8 +45,6 @@ class ModuleItemPublishIndicatorView: UIView {
     }
 
     func update(isPublishInProgress isUpdating: Bool, animationDuration: TimeInterval) {
-        publishInProgressIndicator.setRemovedOnCompletion(to: !isUpdating)
-
         if isUpdating {
             publishInProgressIndicator.startAnimating()
         }

--- a/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.xib
+++ b/Core/Core/Modules/ModuleList/ModuleItemPublishIndicatorView.xib
@@ -11,7 +11,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ModuleItemPublishIndicatorView" customModule="Core" customModuleProvider="target">
             <connections>
                 <outlet property="publishInProgressIndicator" destination="PWJ-HK-XQS" id="5KN-HD-8dy"/>
-                <outlet property="publishedIconView" destination="7jg-vX-1ld" id="dWa-Tx-UGP"/>
+                <outlet property="publishedButton" destination="k4b-9c-him" id="2Jr-3f-aiT"/>
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
@@ -19,14 +19,15 @@
             <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="publishSolid" translatesAutoresizingMaskIntoConstraints="NO" id="7jg-vX-1ld" customClass="PublishedIconView" customModule="Core">
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k4b-9c-him">
                     <rect key="frame" x="0.0" y="0.0" width="24" height="24"/>
-                    <color key="tintColor" red="0.0" green="0.67450980390000004" blue="0.094117647060000004" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="24" id="Xaf-KE-Hni"/>
-                        <constraint firstAttribute="height" constant="24" id="Y28-KT-TCd"/>
+                        <constraint firstAttribute="height" constant="24" id="m7E-9V-g2j"/>
+                        <constraint firstAttribute="width" constant="24" id="q1Y-Rr-3LM"/>
                     </constraints>
-                </imageView>
+                    <state key="normal" title="Button"/>
+                    <buttonConfiguration key="configuration" style="plain"/>
+                </button>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="PWJ-HK-XQS" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
                     <rect key="frame" x="2" y="2" width="20" height="20"/>
                     <viewLayoutGuide key="safeArea" id="AyZ-QF-WLa"/>
@@ -46,15 +47,12 @@
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             <constraints>
                 <constraint firstItem="PWJ-HK-XQS" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="8oF-Ae-3nE"/>
-                <constraint firstItem="7jg-vX-1ld" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="Ear-5W-fXg"/>
-                <constraint firstItem="7jg-vX-1ld" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="JGK-xy-uYV"/>
                 <constraint firstItem="PWJ-HK-XQS" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="MJc-uX-U3y"/>
+                <constraint firstItem="k4b-9c-him" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="centerY" id="UVI-ly-CFo"/>
+                <constraint firstItem="k4b-9c-him" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="lZo-pN-Xsr"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <point key="canvasLocation" x="120" y="42"/>
         </view>
     </objects>
-    <resources>
-        <image name="publishSolid" width="24" height="24"/>
-    </resources>
 </document>

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
@@ -5,6 +5,7 @@
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -102,10 +103,10 @@
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="big-gi-hFf">
-                                                            <rect key="frame" x="28" y="7" width="229" height="36.5"/>
+                                                            <rect key="frame" x="28" y="7" width="209" height="36.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Module Item" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="idp-ZT-sKj" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="229" height="19.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="209" height="19.5"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                                     <color key="textColor" red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -114,7 +115,7 @@
                                                                     </userDefinedRuntimeAttributes>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Due Apr 15 at 10:48 AM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SK2-Ab-F0Z" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="19.5" width="229" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="19.5" width="209" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                                                     <color key="textColor" red="0.54509803921568623" green="0.58823529411764708" blue="0.61960784313725492" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -124,39 +125,26 @@
                                                                 </label>
                                                             </subviews>
                                                         </stackView>
-                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="z4A-b1-T89" customClass="ModuleItemPublishIndicatorView" customModule="Core" customModuleProvider="target">
-                                                            <rect key="frame" x="261" y="13" width="24" height="24"/>
-                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" constant="24" id="BBs-Lw-5lE"/>
-                                                                <constraint firstAttribute="height" constant="24" id="loI-bU-1Br"/>
-                                                            </constraints>
-                                                        </view>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="L9I-ND-fkY">
-                                                            <rect key="frame" x="289" y="13" width="24" height="24"/>
+                                                            <rect key="frame" x="241" y="13" width="24" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="24" id="H3n-PE-mCB"/>
                                                                 <constraint firstAttribute="width" constant="24" id="UiW-UD-5Ho"/>
                                                             </constraints>
                                                         </imageView>
-                                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TY1-wH-TOK">
-                                                            <rect key="frame" x="317" y="13" width="24" height="24"/>
-                                                            <accessibility key="accessibilityConfiguration">
-                                                                <bool key="isElement" value="NO"/>
-                                                            </accessibility>
+                                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VJK-jg-cka" userLabel="Publish Control" customClass="ModulePublishControl" customModule="Core" customModuleProvider="target">
+                                                            <rect key="frame" x="269" y="13" width="72" height="24"/>
+                                                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="24" id="c21-iO-u6y"/>
-                                                                <constraint firstAttribute="width" constant="24" id="fHH-IK-aP5"/>
+                                                                <constraint firstAttribute="height" constant="24" id="f03-1C-MeL"/>
+                                                                <constraint firstAttribute="width" constant="72" id="uFQ-Za-4b3"/>
                                                             </constraints>
-                                                            <state key="normal" title="Button"/>
-                                                            <buttonConfiguration key="configuration" style="plain" image="moreLine">
-                                                                <color key="baseForegroundColor" name="textDarkest"/>
-                                                            </buttonConfiguration>
-                                                        </button>
+                                                        </view>
                                                     </subviews>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="WCl-X7-vQ8"/>
                                                         <constraint firstItem="lwl-X5-mNS" firstAttribute="leading" secondItem="rv6-mL-EtC" secondAttribute="leading" id="gj0-Xh-gMC"/>
+                                                        <constraint firstAttribute="trailing" secondItem="VJK-jg-cka" secondAttribute="trailing" id="nDf-fA-g3V"/>
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
@@ -177,8 +165,7 @@
                                             <outlet property="iconView" destination="lwl-X5-mNS" id="bgO-sR-lZK"/>
                                             <outlet property="indentConstraint" destination="gj0-Xh-gMC" id="81H-PG-FGS"/>
                                             <outlet property="nameLabel" destination="idp-ZT-sKj" id="xXf-gg-CFl"/>
-                                            <outlet property="publishIndicatorView" destination="z4A-b1-T89" id="SuE-P6-2NS"/>
-                                            <outlet property="publishMenuButton" destination="TY1-wH-TOK" id="W6J-Vi-IQF"/>
+                                            <outlet property="publishControl" destination="VJK-jg-cka" id="YjT-yC-6xh"/>
                                         </connections>
                                     </tableViewCell>
                                 </prototypes>
@@ -222,10 +209,10 @@
     </scenes>
     <designables>
         <designable name="ECd-PX-fxS">
-            <size key="intrinsicContentSize" width="263" height="19.5"/>
+            <size key="intrinsicContentSize" width="250" height="19.5"/>
         </designable>
         <designable name="GQS-7c-kQa">
-            <size key="intrinsicContentSize" width="111.5" height="24"/>
+            <size key="intrinsicContentSize" width="108" height="24"/>
         </designable>
         <designable name="SK2-Ab-F0Z">
             <size key="intrinsicContentSize" width="156.5" height="17"/>
@@ -239,9 +226,8 @@
     </designables>
     <resources>
         <image name="PandaBlocks" width="157" height="169"/>
-        <image name="moreLine" width="24" height="24"/>
-        <namedColor name="textDarkest">
-            <color red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.storyboard
@@ -94,19 +94,19 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="rv6-mL-EtC">
-                                                    <rect key="frame" x="18" y="8" width="341" height="50"/>
+                                                    <rect key="frame" x="18" y="0.0" width="341" height="66"/>
                                                     <subviews>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="lwl-X5-mNS">
-                                                            <rect key="frame" x="0.0" y="0.0" width="24" height="50"/>
+                                                            <rect key="frame" x="0.0" y="8" width="24" height="50"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="24" id="jTw-KY-W6y"/>
                                                             </constraints>
                                                         </imageView>
                                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="big-gi-hFf">
-                                                            <rect key="frame" x="28" y="7" width="209" height="36.5"/>
+                                                            <rect key="frame" x="28" y="15" width="193" height="36.5"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Module Item" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="idp-ZT-sKj" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="209" height="19.5"/>
+                                                                    <rect key="frame" x="0.0" y="0.0" width="193" height="19.5"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="16"/>
                                                                     <color key="textColor" red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -115,7 +115,7 @@
                                                                     </userDefinedRuntimeAttributes>
                                                                 </label>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="749" text="Due Apr 15 at 10:48 AM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SK2-Ab-F0Z" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="19.5" width="209" height="17"/>
+                                                                    <rect key="frame" x="0.0" y="19.5" width="193" height="17"/>
                                                                     <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
                                                                     <color key="textColor" red="0.54509803921568623" green="0.58823529411764708" blue="0.61960784313725492" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -126,31 +126,36 @@
                                                             </subviews>
                                                         </stackView>
                                                         <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="L9I-ND-fkY">
-                                                            <rect key="frame" x="241" y="13" width="24" height="24"/>
+                                                            <rect key="frame" x="225" y="21" width="24" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="24" id="H3n-PE-mCB"/>
                                                                 <constraint firstAttribute="width" constant="24" id="UiW-UD-5Ho"/>
                                                             </constraints>
                                                         </imageView>
                                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VJK-jg-cka" userLabel="Publish Control" customClass="ModulePublishControl" customModule="Core" customModuleProvider="target">
-                                                            <rect key="frame" x="269" y="13" width="72" height="24"/>
+                                                            <rect key="frame" x="253" y="0.0" width="88" height="66"/>
                                                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="24" id="f03-1C-MeL"/>
-                                                                <constraint firstAttribute="width" constant="72" id="uFQ-Za-4b3"/>
+                                                                <constraint firstAttribute="width" constant="88" id="uFQ-Za-4b3"/>
                                                             </constraints>
                                                         </view>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="WCl-X7-vQ8"/>
+                                                        <constraint firstItem="VJK-jg-cka" firstAttribute="top" secondItem="rv6-mL-EtC" secondAttribute="top" id="Duh-qo-Fg9"/>
+                                                        <constraint firstItem="big-gi-hFf" firstAttribute="top" relation="greaterThanOrEqual" secondItem="rv6-mL-EtC" secondAttribute="top" constant="8" id="K5V-GY-fyG"/>
+                                                        <constraint firstAttribute="bottom" secondItem="VJK-jg-cka" secondAttribute="bottom" id="Oso-sn-iKD"/>
+                                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="lwl-X5-mNS" secondAttribute="bottom" constant="8" id="RxN-Cw-M7x"/>
+                                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="big-gi-hFf" secondAttribute="bottom" constant="8" id="Ubc-pq-y2O"/>
+                                                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="56" id="WCl-X7-vQ8"/>
                                                         <constraint firstItem="lwl-X5-mNS" firstAttribute="leading" secondItem="rv6-mL-EtC" secondAttribute="leading" id="gj0-Xh-gMC"/>
                                                         <constraint firstAttribute="trailing" secondItem="VJK-jg-cka" secondAttribute="trailing" id="nDf-fA-g3V"/>
+                                                        <constraint firstItem="lwl-X5-mNS" firstAttribute="top" relation="greaterThanOrEqual" secondItem="rv6-mL-EtC" secondAttribute="top" constant="8" id="suw-8e-wWF"/>
                                                     </constraints>
                                                 </stackView>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="rv6-mL-EtC" secondAttribute="bottom" constant="8" id="SBy-2l-S0z"/>
-                                                <constraint firstItem="rv6-mL-EtC" firstAttribute="top" secondItem="UBc-rt-n2v" secondAttribute="top" constant="8" id="fHZ-Tc-lue"/>
+                                                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="rv6-mL-EtC" secondAttribute="bottom" id="SBy-2l-S0z"/>
+                                                <constraint firstItem="rv6-mL-EtC" firstAttribute="top" secondItem="UBc-rt-n2v" secondAttribute="top" id="fHZ-Tc-lue"/>
                                                 <constraint firstItem="rv6-mL-EtC" firstAttribute="leading" secondItem="UBc-rt-n2v" secondAttribute="leading" constant="18" id="hq8-pz-Yww"/>
                                                 <constraint firstAttribute="trailing" secondItem="rv6-mL-EtC" secondAttribute="trailing" constant="16" id="kW2-bP-Zeh"/>
                                             </constraints>
@@ -161,6 +166,7 @@
                                         <connections>
                                             <outlet property="completedStatusView" destination="L9I-ND-fkY" id="KIE-5U-6j3"/>
                                             <outlet property="contentStackView" destination="rv6-mL-EtC" id="2oC-TW-uxC"/>
+                                            <outlet property="contentStackViewTrailingConstraint" destination="kW2-bP-Zeh" id="l8z-HK-Lqy"/>
                                             <outlet property="dueLabel" destination="SK2-Ab-F0Z" id="vEC-W0-b2n"/>
                                             <outlet property="iconView" destination="lwl-X5-mNS" id="bgO-sR-lZK"/>
                                             <outlet property="indentConstraint" destination="gj0-Xh-gMC" id="81H-PG-FGS"/>
@@ -209,10 +215,10 @@
     </scenes>
     <designables>
         <designable name="ECd-PX-fxS">
-            <size key="intrinsicContentSize" width="250" height="19.5"/>
+            <size key="intrinsicContentSize" width="263" height="19.5"/>
         </designable>
         <designable name="GQS-7c-kQa">
-            <size key="intrinsicContentSize" width="108" height="24"/>
+            <size key="intrinsicContentSize" width="111.5" height="24"/>
         </designable>
         <designable name="SK2-Ab-F0Z">
             <size key="intrinsicContentSize" width="156.5" height="17"/>

--- a/Core/Core/Modules/ModuleList/ModulePublishControl.swift
+++ b/Core/Core/Modules/ModuleList/ModulePublishControl.swift
@@ -32,7 +32,7 @@ final class ModulePublishControl: UIView {
     private var publishedView: ModuleItemPublishIndicatorView!
     private var publishButton: UIButton!
     private var clearButton: ClearButton!
-    
+
     private var stackView: UIStackView!
     private var topBottomStackViewConstraints: [NSLayoutConstraint] = []
     private var centerStackViewConstraint: NSLayoutConstraint?

--- a/Core/Core/Modules/ModuleList/ModulePublishControl.swift
+++ b/Core/Core/Modules/ModuleList/ModulePublishControl.swift
@@ -117,7 +117,7 @@ final class ModulePublishControl: UIView {
         clearButton.accessibilityElementsHidden = true
     }
 
-    func constraintIconsCenterTo(_ guide: UIView) {
+    func constrainIconsCenterTo(_ guide: UIView) {
         guide.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.deactivate(topBottomStackViewConstraints)

--- a/Core/Core/Modules/ModuleList/ModulePublishControl.swift
+++ b/Core/Core/Modules/ModuleList/ModulePublishControl.swift
@@ -1,0 +1,201 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+final class ModulePublishControl: UIView {
+
+    private var publishedView: ModuleItemPublishIndicatorView!
+    private var publishButton: UIButton!
+    private var clearButton: ClearButton!
+
+    private(set) var menu: UIMenu?
+    private var primaryAction: (() -> Void)?
+    private var isFirstUpdate = true
+
+    var isEnabled: Bool = true {
+        didSet {
+            publishedView.publishedButton.isEnabled = isEnabled
+            publishButton.isEnabled = isEnabled
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupView()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    private func setupView() {
+        translatesAutoresizingMaskIntoConstraints = false
+        backgroundColor = .clear
+
+        publishedView = .init()
+        publishedView.translatesAutoresizingMaskIntoConstraints = false
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .textDarkest
+        configuration.image = .moreLine
+        publishButton = .init(configuration: configuration)
+        publishButton.translatesAutoresizingMaskIntoConstraints = false
+
+        let stackView = UIStackView(arrangedSubviews: [publishedView, publishButton])
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 4
+        stackView.distribution = .equalSpacing
+
+        NSLayoutConstraint.activate([
+            publishedView.widthAnchor.constraint(equalToConstant: 24),
+            publishButton.widthAnchor.constraint(equalToConstant: 24),
+            publishButton.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+        ])
+
+        addSubview(stackView)
+        NSLayoutConstraint.activate([
+            stackView.topAnchor.constraint(equalTo: topAnchor),
+            stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        clearButton = ClearButton()
+        clearButton.subButtons = [publishedView.publishedButton, publishButton]
+        clearButton.setClearImage(size: CGSize(width: 72, height: 24))
+
+        addSubview(clearButton)
+        NSLayoutConstraint.activate([
+            clearButton.topAnchor.constraint(equalTo: topAnchor),
+            clearButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+            clearButton.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
+            clearButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+        ])
+
+        publishedView.accessibilityElementsHidden = true
+        publishButton.accessibilityElementsHidden = true
+        clearButton.accessibilityElementsHidden = true
+    }
+
+    func prepareForReuse() {
+        isFirstUpdate = true
+        isEnabled = true
+        publishedView.prepareForReuse()
+        setPrimaryAction(nil)
+    }
+
+    func update(availability: FileAvailability?) {
+        publishedView.update(availability: availability)
+    }
+
+    func update(isPublishInProgress: Bool) {
+        let animationDuration: TimeInterval = isFirstUpdate ? 0.0 : 0.3
+        isFirstUpdate = false
+
+        publishedView.update(isPublishInProgress: isPublishInProgress, animationDuration: animationDuration)
+        UIView.animate(withDuration: animationDuration) { [weak self] in
+            guard let self else { return }
+            publishButton.isEnabled = !isPublishInProgress && isEnabled
+        }
+    }
+
+    func setPrimaryAction(_ action: (() -> Void)?) {
+        self.menu = nil
+        clearButton.menu = nil
+        clearButton.showsMenuAsPrimaryAction = false
+        primaryAction = action
+
+        clearButton.removeTarget(self, action: nil, for: .primaryActionTriggered)
+        if action != nil {
+            clearButton.addTarget(self, action: #selector(callPrimaryAction), for: .primaryActionTriggered)
+        }
+    }
+
+    func setPrimaryActionToMenu(_ menu: UIMenu) {
+        self.menu = menu
+        clearButton.menu = menu
+        clearButton.showsMenuAsPrimaryAction = true
+        primaryAction = nil
+
+        clearButton.removeTarget(self, action: nil, for: .primaryActionTriggered)
+    }
+
+    @objc
+    private func callPrimaryAction() {
+        primaryAction?()
+    }
+}
+
+private final class ClearButton: UIButton {
+
+    var subButtons: [UIButton] = []
+
+    override var isSelected: Bool {
+        didSet {
+            subButtons.forEach {
+                $0.isHighlighted = isHighlighted
+            }
+        }
+    }
+
+    override var isHighlighted: Bool {
+        didSet {
+            subButtons.forEach {
+                $0.isHighlighted = isHighlighted
+            }
+        }
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+        setupView()
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    init() {
+        super.init(frame: .zero)
+        setupView()
+    }
+
+    private func setupView() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        configuration = UIButton.Configuration.plain()
+    }
+
+    func setClearImage(size: CGSize) {
+        let image = UIGraphicsImageRenderer(size: size).image { rendererContext in
+            UIColor.clear.setFill()
+            rendererContext.fill(CGRect(origin: .zero, size: size))
+        }
+        configuration?.image = image
+    }
+}

--- a/Core/Core/Modules/ModuleList/ModulePublishControl.swift
+++ b/Core/Core/Modules/ModuleList/ModulePublishControl.swift
@@ -20,9 +20,22 @@ import UIKit
 
 final class ModulePublishControl: UIView {
 
+    private enum Size {
+        static let iconWidth: CGFloat = 24
+        static let iconHeight: CGFloat = 24
+        static let iconSpacing: CGFloat = 4
+        static let paddingTrailing: CGFloat = 16
+        static let hitAreaWidth: CGFloat = 88
+        static let hitAreaMinHeight: CGFloat = 24
+    }
+
     private var publishedView: ModuleItemPublishIndicatorView!
     private var publishButton: UIButton!
     private var clearButton: ClearButton!
+    
+    private var stackView: UIStackView!
+    private var topBottomStackViewConstraints: [NSLayoutConstraint] = []
+    private var centerStackViewConstraint: NSLayoutConstraint?
 
     private(set) var menu: UIMenu?
     private var primaryAction: (() -> Void)?
@@ -63,7 +76,7 @@ final class ModulePublishControl: UIView {
         publishButton = .init(configuration: configuration)
         publishButton.translatesAutoresizingMaskIntoConstraints = false
 
-        let stackView = UIStackView(arrangedSubviews: [publishedView, publishButton])
+        stackView = UIStackView(arrangedSubviews: [publishedView, publishButton])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .horizontal
         stackView.alignment = .center
@@ -71,22 +84,25 @@ final class ModulePublishControl: UIView {
         stackView.distribution = .equalSpacing
 
         NSLayoutConstraint.activate([
-            publishedView.widthAnchor.constraint(equalToConstant: 24),
-            publishButton.widthAnchor.constraint(equalToConstant: 24),
+            publishedView.widthAnchor.constraint(equalToConstant: Size.iconWidth),
+            publishButton.widthAnchor.constraint(equalToConstant: Size.iconWidth),
             publishButton.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
         ])
 
         addSubview(stackView)
-        NSLayoutConstraint.activate([
+        topBottomStackViewConstraints = [
             stackView.topAnchor.constraint(equalTo: topAnchor),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ]
+        NSLayoutConstraint.activate(topBottomStackViewConstraints)
+        NSLayoutConstraint.activate([
             stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -Size.paddingTrailing),
         ])
 
         clearButton = ClearButton()
         clearButton.subButtons = [publishedView.publishedButton, publishButton]
-        clearButton.setClearImage(size: CGSize(width: 72, height: 24))
+        clearButton.setClearImage(size: CGSize(width: Size.hitAreaWidth, height: Size.hitAreaMinHeight))
 
         addSubview(clearButton)
         NSLayoutConstraint.activate([
@@ -99,6 +115,16 @@ final class ModulePublishControl: UIView {
         publishedView.accessibilityElementsHidden = true
         publishButton.accessibilityElementsHidden = true
         clearButton.accessibilityElementsHidden = true
+    }
+
+    func constraintIconsCenterTo(_ guide: UIView) {
+        guide.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.deactivate(topBottomStackViewConstraints)
+        centerStackViewConstraint?.isActive = false
+
+        centerStackViewConstraint = stackView.centerYAnchor.constraint(equalTo: guide.centerYAnchor)
+        centerStackViewConstraint?.isActive = true
     }
 
     func prepareForReuse() {
@@ -189,6 +215,8 @@ private final class ClearButton: UIButton {
         translatesAutoresizingMaskIntoConstraints = false
 
         configuration = UIButton.Configuration.plain()
+        configuration?.contentInsets.leading = 0
+        configuration?.contentInsets.trailing = 0
     }
 
     func setClearImage(size: CGSize) {

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -77,7 +77,7 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         publishControl.isHidden = !shouldShowPublishControl
         publishControlGuide.isHidden = !shouldShowPublishControl
         contentStackViewTrailingConstraint.constant = shouldShowPublishControl ? 0 : 16
-        publishControl.constraintIconsCenterTo(publishControlGuide)
+        publishControl.constrainIconsCenterTo(publishControlGuide)
         updatePublishedState(module)
 
         // Do an instant update because the subscription is delayed

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -23,6 +23,8 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
     @IBOutlet weak var collapsableIndicator: UIImageView!
     @IBOutlet weak var lockedButton: UIButton!
     @IBOutlet weak var publishControl: ModulePublishControl!
+    @IBOutlet weak var publishControlGuide: UIView!
+    @IBOutlet weak var contentStackViewTrailingConstraint: NSLayoutConstraint!
 
     var isExpanded = true
     var onTap: (() -> Void)?
@@ -73,6 +75,9 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
         accessibilityIdentifier = "ModuleList.\(section)"
 
         publishControl.isHidden = !shouldShowPublishControl
+        publishControlGuide.isHidden = !shouldShowPublishControl
+        contentStackViewTrailingConstraint.constant = shouldShowPublishControl ? 0 : 16
+        publishControl.constraintIconsCenterTo(publishControlGuide)
         updatePublishedState(module)
 
         // Do an instant update because the subscription is delayed

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.xib
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.xib
@@ -13,8 +13,10 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="ModuleSectionHeaderView" customModule="Core" customModuleProvider="target">
             <connections>
                 <outlet property="collapsableIndicator" destination="Cc0-w5-zrP" id="WP6-7I-9g1"/>
+                <outlet property="contentStackViewTrailingConstraint" destination="nFM-eU-9Nx" id="M3P-lE-nqn"/>
                 <outlet property="lockedButton" destination="x61-b5-ndv" id="RUM-F9-hDo"/>
-                <outlet property="publishControl" destination="VG6-pE-JNB" id="HaO-55-4Ak"/>
+                <outlet property="publishControl" destination="cZ1-fe-hKS" id="y7w-I9-d0u"/>
+                <outlet property="publishControlGuide" destination="gas-xK-oxU" id="iqn-60-N5u"/>
                 <outlet property="titleLabel" destination="4NE-AM-KWx" id="rib-Ss-7wW"/>
             </connections>
         </placeholder>
@@ -48,7 +50,7 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Module Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4NE-AM-KWx" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="28" y="0.5" width="211" height="24"/>
+                            <rect key="frame" x="28" y="0.5" width="195" height="24"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                             <color key="textColor" red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -58,7 +60,7 @@
                             </userDefinedRuntimeAttributes>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x61-b5-ndv" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="243" y="0.5" width="24" height="24"/>
+                            <rect key="frame" x="227" y="0.5" width="24" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="24" id="BdE-LF-Z1J"/>
                                 <constraint firstAttribute="height" constant="24" id="yh7-8k-Y2A"/>
@@ -70,15 +72,17 @@
                                 <action selector="lockTapped" destination="-1" eventType="primaryActionTriggered" id="krv-OU-TIo"/>
                             </connections>
                         </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VG6-pE-JNB" userLabel="Publish Control" customClass="ModulePublishControl" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="271" y="0.5" width="72" height="24"/>
-                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gas-xK-oxU" userLabel="Publish Control Guide">
+                            <rect key="frame" x="255" y="0.5" width="88" height="24"/>
                             <constraints>
-                                <constraint firstAttribute="height" constant="24" id="NEG-Xs-mfs"/>
-                                <constraint firstAttribute="width" constant="72" id="cul-sg-wBI"/>
+                                <constraint firstAttribute="width" constant="88" id="Rjk-ol-baj"/>
+                                <constraint firstAttribute="height" constant="24" id="kDI-hE-cNw"/>
                             </constraints>
                         </view>
                     </subviews>
+                    <constraints>
+                        <constraint firstAttribute="trailing" secondItem="gas-xK-oxU" secondAttribute="trailing" id="Q8t-4g-vph"/>
+                    </constraints>
                 </stackView>
                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JmO-Tg-r8P" customClass="DividerView" customModule="Core" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="86" width="375" height="1"/>
@@ -89,21 +93,29 @@
                         <userDefinedRuntimeAttribute type="string" keyPath="tintColorName" value="borderMedium"/>
                     </userDefinedRuntimeAttributes>
                 </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="cZ1-fe-hKS" userLabel="Publish Control" customClass="ModulePublishControl" customModule="Core" customModuleProvider="target">
+                    <rect key="frame" x="271" y="20" width="88" height="67"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                </view>
             </subviews>
             <viewLayoutGuide key="safeArea" id="vUN-kp-3ea"/>
             <color key="backgroundColor" name="backgroundLight"/>
             <gestureRecognizers/>
             <constraints>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="Xwa-uh-Uxh" secondAttribute="trailing" id="1k3-Wb-XTv"/>
+                <constraint firstItem="cZ1-fe-hKS" firstAttribute="trailing" secondItem="gas-xK-oxU" secondAttribute="trailing" id="1vo-dg-gvc"/>
                 <constraint firstItem="JmO-Tg-r8P" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="B1I-Ez-3Yy"/>
                 <constraint firstItem="Xwa-uh-Uxh" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" id="Eez-pp-hJa"/>
+                <constraint firstItem="cZ1-fe-hKS" firstAttribute="top" secondItem="Xwa-uh-Uxh" secondAttribute="top" id="FCz-df-UM2"/>
                 <constraint firstItem="587-C5-WKa" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" constant="16" id="HZe-Na-ctb"/>
                 <constraint firstItem="Xwa-uh-Uxh" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="L4y-Rd-H59"/>
                 <constraint firstItem="JmO-Tg-r8P" firstAttribute="top" secondItem="587-C5-WKa" secondAttribute="bottom" constant="8" id="UOG-kQ-6Xa"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="JmO-Tg-r8P" secondAttribute="trailing" id="VVy-cY-GLL"/>
+                <constraint firstItem="JmO-Tg-r8P" firstAttribute="bottom" secondItem="cZ1-fe-hKS" secondAttribute="bottom" id="fto-Yq-H3n"/>
                 <constraint firstItem="587-C5-WKa" firstAttribute="top" secondItem="Xwa-uh-Uxh" secondAttribute="bottom" constant="32" id="gxG-cl-yzl"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="587-C5-WKa" secondAttribute="trailing" constant="16" id="nFM-eU-9Nx"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="JmO-Tg-r8P" secondAttribute="bottom" id="typ-sy-jo8"/>
+                <constraint firstItem="cZ1-fe-hKS" firstAttribute="leading" secondItem="gas-xK-oxU" secondAttribute="leading" id="zxO-IB-6uN"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
@@ -119,13 +131,13 @@
     </objects>
     <designables>
         <designable name="4NE-AM-KWx">
-            <size key="intrinsicContentSize" width="126" height="24"/>
+            <size key="intrinsicContentSize" width="129.5" height="24"/>
         </designable>
         <designable name="Cc0-w5-zrP">
             <size key="intrinsicContentSize" width="24" height="24"/>
         </designable>
         <designable name="x61-b5-ndv">
-            <size key="intrinsicContentSize" width="24" height="24"/>
+            <size key="intrinsicContentSize" width="30" height="30"/>
         </designable>
     </designables>
     <resources>

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.xib
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.xib
@@ -6,6 +6,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -13,8 +14,7 @@
             <connections>
                 <outlet property="collapsableIndicator" destination="Cc0-w5-zrP" id="WP6-7I-9g1"/>
                 <outlet property="lockedButton" destination="x61-b5-ndv" id="RUM-F9-hDo"/>
-                <outlet property="publishIndicatorView" destination="aaS-Cs-4pH" id="sWv-rZ-Ry8"/>
-                <outlet property="publishMenuButton" destination="qoD-av-3pS" id="AzC-BO-a5K"/>
+                <outlet property="publishControl" destination="VG6-pE-JNB" id="HaO-55-4Ak"/>
                 <outlet property="titleLabel" destination="4NE-AM-KWx" id="rib-Ss-7wW"/>
             </connections>
         </placeholder>
@@ -48,7 +48,7 @@
                             </userDefinedRuntimeAttributes>
                         </imageView>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Module Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="4NE-AM-KWx" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="28" y="0.5" width="231" height="24"/>
+                            <rect key="frame" x="28" y="0.5" width="211" height="24"/>
                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                             <color key="textColor" red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
@@ -58,7 +58,7 @@
                             </userDefinedRuntimeAttributes>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x61-b5-ndv" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="263" y="0.5" width="24" height="24"/>
+                            <rect key="frame" x="243" y="0.5" width="24" height="24"/>
                             <constraints>
                                 <constraint firstAttribute="width" constant="24" id="BdE-LF-Z1J"/>
                                 <constraint firstAttribute="height" constant="24" id="yh7-8k-Y2A"/>
@@ -70,25 +70,14 @@
                                 <action selector="lockTapped" destination="-1" eventType="primaryActionTriggered" id="krv-OU-TIo"/>
                             </connections>
                         </button>
-                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="aaS-Cs-4pH" customClass="ModuleItemPublishIndicatorView" customModule="Core" customModuleProvider="target">
-                            <rect key="frame" x="291" y="0.5" width="24" height="24"/>
-                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VG6-pE-JNB" userLabel="Publish Control" customClass="ModulePublishControl" customModule="Core" customModuleProvider="target">
+                            <rect key="frame" x="271" y="0.5" width="72" height="24"/>
+                            <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                             <constraints>
-                                <constraint firstAttribute="width" constant="24" id="7LC-8C-zkS"/>
-                                <constraint firstAttribute="height" constant="24" id="hNd-ut-4Ze"/>
+                                <constraint firstAttribute="height" constant="24" id="NEG-Xs-mfs"/>
+                                <constraint firstAttribute="width" constant="72" id="cul-sg-wBI"/>
                             </constraints>
                         </view>
-                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qoD-av-3pS">
-                            <rect key="frame" x="319" y="0.5" width="24" height="24"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="24" id="88a-uo-K9W"/>
-                                <constraint firstAttribute="width" constant="24" id="Zfl-gn-YS3"/>
-                            </constraints>
-                            <state key="normal" title="Button"/>
-                            <buttonConfiguration key="configuration" style="plain" image="moreLine">
-                                <color key="baseForegroundColor" name="textDarkest"/>
-                            </buttonConfiguration>
-                        </button>
                     </subviews>
                 </stackView>
                 <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JmO-Tg-r8P" customClass="DividerView" customModule="Core" customModuleProvider="target">
@@ -130,23 +119,22 @@
     </objects>
     <designables>
         <designable name="4NE-AM-KWx">
-            <size key="intrinsicContentSize" width="129.5" height="24"/>
+            <size key="intrinsicContentSize" width="126" height="24"/>
         </designable>
         <designable name="Cc0-w5-zrP">
             <size key="intrinsicContentSize" width="24" height="24"/>
         </designable>
         <designable name="x61-b5-ndv">
-            <size key="intrinsicContentSize" width="30" height="30"/>
+            <size key="intrinsicContentSize" width="24" height="24"/>
         </designable>
     </designables>
     <resources>
         <image name="miniArrowUpSolid" width="24" height="24"/>
-        <image name="moreLine" width="24" height="24"/>
         <namedColor name="backgroundLight">
             <color red="0.96078431372549022" green="0.96078431372549022" blue="0.96078431372549022" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
-        <namedColor name="textDarkest">
-            <color red="0.17647058823529413" green="0.23137254901960785" blue="0.27058823529411763" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
@@ -139,6 +139,17 @@ struct ModuleFilePermissionEditorView: View {
     }
 }
 
+private extension FileAvailability {
+    var label: String {
+        switch self {
+        case .published: return String(localized: "Publish")
+        case .unpublished: return String(localized: "Unpublish")
+        case .hidden: return String(localized: "Only Available With Link")
+        case .scheduledAvailability: return String(localized: "Schedule Availability")
+        }
+    }
+}
+
 #if DEBUG
 
 struct ModuleFilePermissionEditorView_Previews: PreviewProvider {

--- a/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
@@ -69,6 +69,7 @@ struct ModulePublishProgressView: View {
             viewModel.didTapDismiss.send(viewController)
         } label: {
             Image.xLine.navigationBarButtonStyle()
+                .accessibilityLabel(Text("Dismiss"))
         }
     }
 
@@ -104,7 +105,7 @@ struct ModulePublishProgressView: View {
     @ViewBuilder
     private var progressViewArea: some View {
         VStack(spacing: 8) {
-            progressText
+            Text(progressTitle())
                 .font(.regular14).foregroundStyle(Color.textDarkest)
             ProgressView(value: viewModel.progress)
                 .progressViewStyle(.determinateBar(color: viewModel.progressViewColor))
@@ -112,26 +113,32 @@ struct ModulePublishProgressView: View {
                 .animation(.default, value: viewModel.progress)
         }
         .padding(.horizontal, 16)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(Text(progressTitle(forAccessibility: true)))
     }
 
-    @ViewBuilder
-    private var progressText: some View {
+    private func progressTitle(forAccessibility: Bool = false) -> String {
+        let percentage = Int(viewModel.progress * 100)
+
         switch viewModel.state {
         case .inProgress:
-            let percentage = Int(viewModel.progress * 100)
             if viewModel.isPublish {
-                Text("Publishing \(percentage)%")
+                return String(localized: "Publishing \(percentage)%")
             } else {
-                Text("Unpublishing \(percentage)%")
+                return String(localized: "Unpublishing \(percentage)%")
             }
         case .completed:
             if viewModel.isPublish {
-                Text("Published 100%")
+                return String(localized: "Published 100%")
             } else {
-                Text("Unpublished 100%")
+                return String(localized: "Unpublished 100%")
             }
         case .error:
-            Text("Update failed")
+            if forAccessibility {
+                return String(localized: "Update failed at \(percentage)%")
+            } else {
+                return String(localized: "Update failed")
+            }
         }
     }
 

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -113,6 +113,11 @@ public class CircleProgressView: UIView {
         updateProgress()
     }
 
+    public func setRemovedOnCompletion(to value: Bool) {
+        morph.isRemovedOnCompletion = value
+        rotate.isRemovedOnCompletion = value
+    }
+
     func ring(_ thickness: CGFloat) -> CGPath {
         return UIBezierPath(
             arcCenter: CGPoint(x: bounds.width / 2, y: bounds.height / 2),

--- a/Core/Core/UIViews/CircleProgressView.swift
+++ b/Core/Core/UIViews/CircleProgressView.swift
@@ -113,11 +113,6 @@ public class CircleProgressView: UIView {
         updateProgress()
     }
 
-    public func setRemovedOnCompletion(to value: Bool) {
-        morph.isRemovedOnCompletion = value
-        rotate.isRemovedOnCompletion = value
-    }
-
     func ring(_ thickness: CGFloat) -> CGPath {
         return UIBezierPath(
             arcCenter: CGPoint(x: bounds.width / 2, y: bounds.height / 2),
@@ -135,10 +130,14 @@ public class CircleProgressView: UIView {
     }
 
     public func startAnimating() {
+        setRemovedOnCompletion(to: false)
+
         progress = nil
     }
 
     public func stopAnimating() {
+        setRemovedOnCompletion(to: true)
+
         clearAnimation()
     }
 
@@ -146,5 +145,10 @@ public class CircleProgressView: UIView {
         fill.removeAnimation(forKey: morphKey)
         layer.removeAnimation(forKey: rotateKey)
         fill.strokeEnd = 0
+    }
+
+    private func setRemovedOnCompletion(to value: Bool) {
+        morph.isRemovedOnCompletion = value
+        rotate.isRemovedOnCompletion = value
     }
 }

--- a/Core/CoreTests/Modules/ModuleItemTests.swift
+++ b/Core/CoreTests/Modules/ModuleItemTests.swift
@@ -61,6 +61,17 @@ class ModuleItemTests: CoreTestCase {
         XCTAssertNil(ModuleItem.save(empty, forCourse: "1", in: databaseClient).published)
     }
 
+    func testSaveCanBeUnpublished() {
+        let unpublishable = APIModuleItem.make(unpublishable: true)
+        XCTAssertEqual(ModuleItem.save(unpublishable, forCourse: "1", in: databaseClient).canBeUnpublished, true)
+
+        let notUnpublishable = APIModuleItem.make(unpublishable: false)
+        XCTAssertEqual(ModuleItem.save(notUnpublishable, forCourse: "1", in: databaseClient).canBeUnpublished, false)
+
+        let empty = APIModuleItem.make(unpublishable: nil)
+        XCTAssertEqual(ModuleItem.save(empty, forCourse: "1", in: databaseClient).canBeUnpublished, true)
+    }
+
     func testVisibleWhenLocked() {
         let assignment = ModuleItem.make(from: .make(content: .assignment("1")))
         XCTAssertTrue(assignment.visibleWhenLocked)

--- a/Core/CoreTests/Modules/ModuleList/Model/ModulePublishInteractorTests.swift
+++ b/Core/CoreTests/Modules/ModuleList/Model/ModulePublishInteractorTests.swift
@@ -23,25 +23,14 @@ import XCTest
 class ModulePublishInteractorTests: CoreTestCase {
 
     func testPublishAvailability() {
-        ExperimentalFeature.teacherBulkPublish.isEnabled = false
         var testee = ModulePublishInteractorLive(app: nil, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
+        XCTAssertEqual(testee.isPublishActionAvailable, false)
         testee = ModulePublishInteractorLive(app: .parent, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
+        XCTAssertEqual(testee.isPublishActionAvailable, false)
         testee = ModulePublishInteractorLive(app: .student, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
+        XCTAssertEqual(testee.isPublishActionAvailable, false)
         testee = ModulePublishInteractorLive(app: .teacher, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
-
-        ExperimentalFeature.teacherBulkPublish.isEnabled = true
-        testee = ModulePublishInteractorLive(app: nil, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
-        testee = ModulePublishInteractorLive(app: .parent, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
-        testee = ModulePublishInteractorLive(app: .student, courseId: "")
-        XCTAssertFalse(testee.isPublishActionAvailable)
-        testee = ModulePublishInteractorLive(app: .teacher, courseId: "")
-        XCTAssertTrue(testee.isPublishActionAvailable)
+        XCTAssertEqual(testee.isPublishActionAvailable, true)
     }
 
     func testUpdatesItemPublishState() {

--- a/Core/CoreTests/Modules/ModuleList/ModuleListViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleList/ModuleListViewControllerTests.swift
@@ -175,18 +175,17 @@ class ModuleListViewControllerTests: CoreTestCase {
             .make(id: "3", position: 3, title: "A1", published: false),
         ])
         loadView()
+        // published/unpublished is not included because dependency is not injected
         XCTAssertEqual(header(forSection: 0).titleLabel.text, "A")
-        XCTAssertEqual(header(forSection: 0).publishIndicatorView.publishedIconView.published, false)
-        XCTAssertEqual(header(forSection: 0).accessibilityLabel, "A, unpublished, expanded")
+        XCTAssertEqual(header(forSection: 0).accessibilityLabel, "A, expanded")
         XCTAssert(header(forSection: 0).accessibilityTraits.contains(.button))
         XCTAssertEqual(moduleItemCell(at: IndexPath(row: 0, section: 0)).nameLabel.text, "A1")
-        XCTAssertEqual(moduleItemCell(at: IndexPath(row: 0, section: 0)).accessibilityLabel, "assignment, A1, unpublished")
+        XCTAssertEqual(moduleItemCell(at: IndexPath(row: 0, section: 0)).accessibilityLabel, "assignment, A1")
         XCTAssertEqual(header(forSection: 1).titleLabel.text, "B")
-        XCTAssertEqual(header(forSection: 1).publishIndicatorView.publishedIconView.published, true)
-        XCTAssertEqual(header(forSection: 1).accessibilityLabel, "B, published, expanded")
+        XCTAssertEqual(header(forSection: 1).accessibilityLabel, "B, expanded")
         XCTAssertEqual(moduleItemCell(at: IndexPath(row: 0, section: 1)).nameLabel.text, "B1")
         XCTAssertEqual(moduleItemCell(at: IndexPath(row: 1, section: 1)).nameLabel.text, "B2")
-        XCTAssertEqual(moduleItemCell(at: IndexPath(row: 1, section: 1)).accessibilityLabel, "assignment, B2, published")
+        XCTAssertEqual(moduleItemCell(at: IndexPath(row: 1, section: 1)).accessibilityLabel, "assignment, B2")
     }
 
     func testEmptyItems() {
@@ -310,11 +309,11 @@ class ModuleListViewControllerTests: CoreTestCase {
         drainMainQueue()
         let before = header(forSection: 0)
         XCTAssertTrue(before.isExpanded)
-        XCTAssertEqual(before.accessibilityLabel, "Module 1, published, expanded")
+        XCTAssertEqual(before.accessibilityLabel, "Module 1, expanded")
         before.handleTap()
         let after = header(forSection: 0)
         XCTAssertFalse(after.isExpanded)
-        XCTAssertEqual(before.accessibilityLabel, "Module 1, published, expanded")
+        XCTAssertEqual(before.accessibilityLabel, "Module 1, expanded")
 
         let viewController = ModuleListViewController.create(courseID: "1")
         viewController.view.layoutIfNeeded()
@@ -344,14 +343,14 @@ class ModuleListViewControllerTests: CoreTestCase {
             ),
         ])
         loadView()
+        // published/unpublished is not included because dependency is not injected
         let cell = try XCTUnwrap(viewController.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? ModuleItemCell)
         XCTAssertEqual(cell.nameLabel.text, "I am a sub header")
         XCTAssertEqual(cell.indentConstraint.constant, 20)
-        XCTAssertEqual(cell.publishIndicatorView.publishedIconView.published, true)
         XCTAssertTrue(cell.isUserInteractionEnabled)
-        XCTAssertEqual(cell.accessibilityLabel, "I am a sub header, published")
+        XCTAssertEqual(cell.accessibilityLabel, "I am a sub header")
         let other = try XCTUnwrap(viewController.tableView.cellForRow(at: IndexPath(row: 1, section: 0)) as? ModuleItemCell)
-        XCTAssertEqual(other.accessibilityLabel, "other subheader, unpublished")
+        XCTAssertEqual(other.accessibilityLabel, "other subheader")
 
     }
 


### PR DESCRIPTION
refs: [MBL-17347](https://instructure.atlassian.net/browse/MBL-17347), [MBL-17456](https://instructure.atlassian.net/browse/MBL-17456)
affects: Teacher, Student
release note: none

## What's new
- added support to disable action for Items which are not unpublishable
- reworked Publish Button to include the Published icon and an extended hit area
- improved Bulk Publish Progress Screen accessibility
- fixed freezing Progress Animation when navigating forward and back or backgrounding and back

### Details
- added `unpublishable` to`APIModuleItem`
- added `ModulePublishControl` to replace the individual Publish icons/buttons
- refactored & rearranged `ModuleItemCell` and to a lesser extent `ModuleSectionHeaderView`
- added a11y label to ProgressView (X) button & added unified a11y label for progress title and bar

## Test plan
- Teacher app: Enable experimental feature flag in Developer Menu
- Verify Publish action is disabled when API returns `unpublishable=true` for an item
  - to reproduce this: submit something to an assignment
- Verify Publish action is temporarily disabled when publish is in progress
- Verify Publish action for Files works as before
- Verify hit area matches the extended one in [Figma](https://www.figma.com/file/znAwsM8ipGulMfbGYCd83j/%E2%9C%85-%5BDelivered%5D-(Canvas-Teacher)-Modules-V1.1---Marci?type=design&node-id=1993-6510&mode=design&t=B1juuEIMUnZbENuR-4) (also see screenshot)
- Verify Student app is not affected and no Publish icon/button is visible there
- Verify publish spinner animation stays in progress when
  - going to background and back
  - pushing a Details screen and coming back
- Verify the same for PullToRefresh spinner

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/94677982-2b9f-4633-9055-7b1b104835c8" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/406324a3-f793-4aab-9e4f-091f27705f6c" maxHeight=500></td>
</tr>
<tr>
<tr><th>HitArea</th></tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/dae15e9a-4bd8-42f6-8bf2-16dfb8a09a1e" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode

[MBL-17347]: https://instructure.atlassian.net/browse/MBL-17347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MBL-17456]: https://instructure.atlassian.net/browse/MBL-17456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ