### PR TITLE
Support anonymous discussion when redesign is enabled

### DIFF
--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -54,7 +54,9 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
         self?.update()
     }
     /** This is required for the router to help decide if the hybrid discussion details or the native one should be launched. */
-    private lazy var featureFlags = env.subscribe(GetEnabledFeatureFlags(context: context))
+    private lazy var featureFlags = env.subscribe(GetEnabledFeatureFlags(context: context)) { [weak self] in
+        self?.update()
+    }
     private var offlineModeInteractor: OfflineModeInteractor?
 
     public static func create(context: Context, offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()) -> DiscussionListViewController {
@@ -226,7 +228,7 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
         let cell: DiscussionListCell = tableView.dequeue(for: indexPath)
         let topic = topics[indexPath]
         cell.update(topic: topic, isTeacher: course?.first?.hasTeacherEnrollment == true, color: color)
-        if topic?.anonymousState != nil {
+        if topic?.anonymousState != nil && !featureFlags.isFeatureFlagEnabled(.discussionRedesign) {
             cell.selectionStyle = .none
             cell.contentView.alpha = 0.5
             cell.statusLabel.text = NSLocalizedString("Not supported", bundle: .core, comment: "")


### PR DESCRIPTION
refs: MBL-17439
affects: Student, Teacher
release note: Anonymous discussions can be opened when it's enabled on course level.
test plan: Enable Discussion Redesign flag and check discussion list

### What's new
- When Discussion Redesign is enabled on course level, anonymous discussions are not greyed out/disabled anymore, they can be opened. 

### What's not included
- Creating anonymous discussion is not possible on mobile yet. 

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/85e4fec0-cca8-49f0-bfed-edfd57d39d8d" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/de56e79f-b400-4f7a-9640-19e10e95eef9" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
