### PR TITLE
Improve support for larger text sizes in Assignment Details

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.storyboard
@@ -287,7 +287,7 @@
                                                                                     <constraint firstAttribute="height" constant="24" id="xaN-fk-PHp"/>
                                                                                 </constraints>
                                                                             </imageView>
-                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Successfully submitted!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x12-ry-KqJ" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
+                                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="750" text="Successfully submitted!" textAlignment="natural" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x12-ry-KqJ" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="221" height="0.0"/>
                                                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                                                 <accessibility key="accessibilityConfiguration" identifier="AssignmentDetails.submittedText"/>
@@ -321,8 +321,8 @@
                                                                             <action selector="viewFileSubmission" destination="dvz-Jp-ehK" eventType="primaryActionTriggered" id="F1Q-an-sZu"/>
                                                                         </connections>
                                                                     </button>
-                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Your submission is now waiting to be graded" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ePD-c3-2H7" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
-                                                                        <rect key="frame" x="12" y="28" width="287" height="0.0"/>
+                                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Your submission is now waiting to be graded" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ePD-c3-2H7" customClass="DynamicLabel" customModule="Student" customModuleProvider="target">
+                                                                        <rect key="frame" x="0.0" y="28" width="311" height="0.0"/>
                                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                         <nil key="textColor"/>
                                                                         <nil key="highlightedColor"/>
@@ -335,15 +335,22 @@
                                                                 <constraints>
                                                                     <constraint firstItem="4TE-cB-TlA" firstAttribute="leading" secondItem="A1G-mN-QCX" secondAttribute="leading" id="6oC-8k-h5Z"/>
                                                                     <constraint firstAttribute="trailing" secondItem="4TE-cB-TlA" secondAttribute="trailing" id="BE6-bh-MVm"/>
+                                                                    <constraint firstItem="ePD-c3-2H7" firstAttribute="leading" secondItem="A1G-mN-QCX" secondAttribute="leading" id="G4r-G7-SOg"/>
                                                                     <constraint firstAttribute="bottom" secondItem="ePD-c3-2H7" secondAttribute="bottom" id="Gvg-vX-znb"/>
-                                                                    <constraint firstItem="aEs-0G-CDt" firstAttribute="centerX" secondItem="A1G-mN-QCX" secondAttribute="centerX" id="UiM-56-9gA"/>
-                                                                    <constraint firstItem="ePD-c3-2H7" firstAttribute="centerX" secondItem="A1G-mN-QCX" secondAttribute="centerX" id="Xjn-JH-Okv"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="ePD-c3-2H7" secondAttribute="trailing" id="MAB-20-MIH"/>
+                                                                    <constraint firstItem="aEs-0G-CDt" firstAttribute="centerX" secondItem="A1G-mN-QCX" secondAttribute="centerX" id="Nrs-zK-Kqd"/>
+                                                                    <constraint firstItem="aEs-0G-CDt" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="A1G-mN-QCX" secondAttribute="leading" id="Rpx-wr-ZwY"/>
+                                                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="aEs-0G-CDt" secondAttribute="trailing" id="VqP-Sx-AXD"/>
                                                                     <constraint firstItem="ePD-c3-2H7" firstAttribute="top" secondItem="aEs-0G-CDt" secondAttribute="bottom" constant="8" id="dN9-FF-oXa"/>
                                                                     <constraint firstItem="4TE-cB-TlA" firstAttribute="top" secondItem="aEs-0G-CDt" secondAttribute="bottom" constant="8" id="kZp-p0-8aw"/>
                                                                     <constraint firstItem="aEs-0G-CDt" firstAttribute="top" secondItem="A1G-mN-QCX" secondAttribute="top" constant="20" id="zNR-8z-0ge"/>
                                                                 </constraints>
                                                             </view>
                                                         </subviews>
+                                                        <constraints>
+                                                            <constraint firstAttribute="trailing" secondItem="A1G-mN-QCX" secondAttribute="trailing" constant="16" id="Hpt-DA-sc2"/>
+                                                            <constraint firstItem="A1G-mN-QCX" firstAttribute="leading" secondItem="uqK-cv-6c4" secondAttribute="leading" constant="16" id="Rmh-nZ-cKM"/>
+                                                        </constraints>
                                                         <edgeInsets key="layoutMargins" top="16" left="16" bottom="40" right="16"/>
                                                     </stackView>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2dw-BH-GAc" userLabel="Spacer - 32pt">


### PR DESCRIPTION
refs: MBL-17442
affects: Student
release note: Improved support for larger text sizes in Assignment Details.

## What's new
Submitted title & description layout is fixed

## What's not changed
Rest of the issues will be done in a followup task

## Test plan
- Verify Submitted title & description is displayed inside card and truncated
- Verify screen layouts properly in other scenarios

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/a10d1cb9-7c05-4f0e-8eff-0d48782977b7" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/13c4d1cb-0237-43de-9129-096f3c4348bc" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode