### PR TITLE
Check course's published state when determining if a group is active.

### DIFF
--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -51,11 +51,11 @@ public final class Group: NSManagedObject, WriteableModel {
 
     public var isActive: Bool {
         if courseID == nil { return true }
-        guard let course = course, let enrollments = course.enrollments else {
+        guard let course, let enrollments = course.enrollments else {
             return false
         }
 
-        return enrollments.contains(where: {$0.state == .active}) && !course.isPastEnrollment
+        return enrollments.contains(where: {$0.state == .active}) && !course.isPastEnrollment && course.isPublished
     }
 
     @discardableResult

--- a/Core/CoreTests/Groups/GroupTests.swift
+++ b/Core/CoreTests/Groups/GroupTests.swift
@@ -47,11 +47,15 @@ class GroupTests: CoreTestCase {
         group = Group.make(from: .make(course_id: nil))
         XCTAssertTrue(group.isActive)
 
-        Course.make()
+        Course.make(from: .make(workflow_state: .available))
         group = Group.save(.make(course_id: "1"), in: databaseClient)
         XCTAssertTrue(group.isActive)
 
         Course.make(from: .make(end_at: Date.distantPast), in: databaseClient)
+        group = Group.save(.make(course_id: "1"), in: databaseClient)
+        XCTAssertFalse(group.isActive)
+
+        Course.make(from: .make(workflow_state: .unpublished))
         group = Group.save(.make(course_id: "1"), in: databaseClient)
         XCTAssertFalse(group.isActive)
     }


### PR DESCRIPTION
refs: MBL-17444
affects: Student
release note: Fixed groups from unpublished courses showing up on dashboard.

test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet