### PR TITLE
Fix offline progress behaviour

### DIFF
--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -140,7 +140,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 .getEntities(ignoreCache: true)
                 .flatMap { [filesInteractor] files -> AnyPublisher<Void, Error> in
                     guard let file = files.first, let url = file.url, let fileID = file.id, let mimeClass = file.mimeClass else {
-                        return Empty(completeImmediately: false)
+                        return Empty(completeImmediately: true)
                             .setFailureType(to: Error.self)
                             .eraseToAnyPublisher()
                     }


### PR DESCRIPTION
refs: MBL-17470
affects: Student
release note: none
test plan: Login to Judit's account. Download Canvas for teachers course.

### Problem
Offline download seemingly never finishes downloading. 

### Cause
It looks like files that have been locked, don't have urls available, which caused the file downloader stream to never emit. 

### Solution
Change the `Empty` publisher so it finished the stream. 

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product
