### PR TITLE
Fix Grade screen crash

### DIFF
--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -115,9 +115,7 @@ public final class GradeListViewModel: ObservableObject {
             .receive(on: scheduler)
             .flatMapLatest { [weak self] params -> AnyPublisher<ViewState, Never> in
                 guard let self = self else {
-                    return Empty(completeImmediately: false)
-                        .setFailureType(to: Never.self)
-                        .eraseToAnyPublisher()
+                    return Empty(completeImmediately: false).eraseToAnyPublisher()
                 }
                 let ignoreCache = params.0
                 let refreshCompletion = params.1
@@ -137,9 +135,7 @@ public final class GradeListViewModel: ObservableObject {
                 .receive(on: scheduler)
                 .flatMap { [weak self] listData -> AnyPublisher<ViewState, Never> in
                     guard let self = self else {
-                        return Empty(completeImmediately: false)
-                            .setFailureType(to: Never.self)
-                            .eraseToAnyPublisher()
+                        return Empty(completeImmediately: false).eraseToAnyPublisher()
                     }
                     lastKnownDataState = listData
 

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -113,7 +113,12 @@ public final class GradeListViewModel: ObservableObject {
 
         triggerRefresh.prepend((false, nil))
             .receive(on: scheduler)
-            .flatMapLatest { [unowned self] params in
+            .flatMapLatest { [weak self] params -> AnyPublisher<ViewState, Never> in
+                guard let self = self else {
+                    return Empty(completeImmediately: false)
+                        .setFailureType(to: Never.self)
+                        .eraseToAnyPublisher()
+                }
                 let ignoreCache = params.0
                 let refreshCompletion = params.1
 
@@ -130,13 +135,18 @@ public final class GradeListViewModel: ObservableObject {
                 )
                 .first()
                 .receive(on: scheduler)
-                .map { [unowned self] listData -> ViewState in
+                .flatMap { [weak self] listData -> AnyPublisher<ViewState, Never> in
+                    guard let self = self else {
+                        return Empty(completeImmediately: false)
+                            .setFailureType(to: Never.self)
+                            .eraseToAnyPublisher()
+                    }
                     lastKnownDataState = listData
 
                     if listData.assignmentSections.count == 0 {
-                        return ViewState.empty(listData)
+                        return Just(ViewState.empty(listData)).eraseToAnyPublisher()
                     } else {
-                        return ViewState.data(listData)
+                        return Just(ViewState.data(listData)).eraseToAnyPublisher()
                     }
                 }
                 .replaceError(with: .error)
@@ -145,6 +155,7 @@ public final class GradeListViewModel: ObservableObject {
                     return $0
                 }
                 .first()
+                .eraseToAnyPublisher()
             }
             .receive(on: scheduler)
             .assign(to: &$state)

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -114,8 +114,8 @@ public final class GradeListViewModel: ObservableObject {
         triggerRefresh.prepend((false, nil))
             .receive(on: scheduler)
             .flatMapLatest { [weak self] params -> AnyPublisher<ViewState, Never> in
-                guard let self = self else {
-                    return Empty(completeImmediately: false).eraseToAnyPublisher()
+                guard let self else {
+                    return Empty(completeImmediately: true).eraseToAnyPublisher()
                 }
                 let ignoreCache = params.0
                 let refreshCompletion = params.1
@@ -134,8 +134,8 @@ public final class GradeListViewModel: ObservableObject {
                 .first()
                 .receive(on: scheduler)
                 .flatMap { [weak self] listData -> AnyPublisher<ViewState, Never> in
-                    guard let self = self else {
-                        return Empty(completeImmediately: false).eraseToAnyPublisher()
+                    guard let self else {
+                        return Empty(completeImmediately: true).eraseToAnyPublisher()
                     }
                     lastKnownDataState = listData
 


### PR DESCRIPTION
refs: MBL-17450
affects: Student, Parent
release note: Fixed an issue that caused an occasional crash on Grades Screen.
test plan: Wasn't able to reproduce, check if everything still works.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
