### PR TITLE
Hide non-functioning peer review link in hybrid discussions screen.

### DIFF
--- a/Core/Core/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussions.swift
+++ b/Core/Core/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussions.swift
@@ -22,7 +22,6 @@ private class HidePeerReviewLinkInWebDiscussions: CoreWebViewFeature {
             .discussions-peer-review {
                 display: none;
             }
-        }
         """
 
         let cssString = css.components(separatedBy: .newlines).joined()

--- a/Core/Core/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussions.swift
+++ b/Core/Core/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussions.swift
@@ -1,0 +1,48 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+private class HidePeerReviewLinkInWebDiscussions: CoreWebViewFeature {
+    private let script: String = {
+        let css = """
+            .discussions-peer-review {
+                display: none;
+            }
+        }
+        """
+
+        let cssString = css.components(separatedBy: .newlines).joined()
+        return """
+           var element = document.createElement('style');
+           element.innerHTML = '\(cssString)';
+           document.head.appendChild(element);
+        """
+    }()
+
+    public override init() {}
+
+    override func apply(on webView: CoreWebView) {
+        webView.addScript(script)
+    }
+}
+
+public extension CoreWebViewFeature {
+
+    static var hidePeerReviewLinkInWebDiscussions: CoreWebViewFeature {
+        HidePeerReviewLinkInWebDiscussions()
+    }
+}

--- a/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
+++ b/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
@@ -20,7 +20,12 @@ import SwiftUI
 
 public struct EmbeddedWebPageView<ViewModel: EmbeddedWebPageViewModel>: View {
     @ObservedObject private var viewModel: ViewModel
-    private var features: [CoreWebViewFeature] = [.disableZoom, .darkModeForWebDiscussions, .forceDisableHorizontalScroll]
+    private var features: [CoreWebViewFeature] = [
+        .disableZoom,
+        .darkModeForWebDiscussions,
+        .forceDisableHorizontalScroll,
+        .hidePeerReviewLinkInWebDiscussions,
+    ]
 
     public init(
         viewModel: ViewModel,

--- a/Core/CoreTests/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussionsTests.swift
+++ b/Core/CoreTests/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussionsTests.swift
@@ -1,0 +1,46 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import XCTest
+
+class HidePeerReviewLinkInDiscussionsTests: XCTestCase {
+
+    func testDisplayStleSetToNone() {
+        let mockLinkDelegate = MockCoreWebViewLinkDelegate()
+        let webView = CoreWebView(features: [.hidePeerReviewLinkInWebDiscussions])
+        webView.linkDelegate = mockLinkDelegate
+        webView.loadHTMLString("<span class='discussions-peer-review'>Test</span>")
+        wait(for: [mockLinkDelegate.navigationFinishedExpectation], timeout: 10)
+
+        let jsEvaluated = expectation(description: "JS evaluated")
+        webView.evaluateJavaScript(
+            """
+            const reviewSpan = document.getElementsByClassName('discussions-peer-review')[0];
+            const computedStyle = window.getComputedStyle(reviewSpan);
+            computedStyle.getPropertyValue('display');
+            """
+        ) { result, error in
+            XCTAssertEqual((result as! String), "none")
+            XCTAssertNil(error)
+            jsEvaluated.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Core/CoreTests/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussionsTests.swift
+++ b/Core/CoreTests/CoreWebView/Model/Features/HidePeerReviewLinkInDiscussionsTests.swift
@@ -21,7 +21,7 @@ import XCTest
 
 class HidePeerReviewLinkInDiscussionsTests: XCTestCase {
 
-    func testDisplayStleSetToNone() {
+    func testDisplayStyleSetToNone() {
         let mockLinkDelegate = MockCoreWebViewLinkDelegate()
         let webView = CoreWebView(features: [.hidePeerReviewLinkInWebDiscussions])
         webView.linkDelegate = mockLinkDelegate


### PR DESCRIPTION
refs: MBL-17445
affects: Student, Teacher
release note: none

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/da41febd-14d7-4ec6-8ebe-78c786253655" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/bd147fe5-8965-4573-86d2-5e635166420b" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode