### PR TITLE
Hide student names in anonymous ungraded surveys

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="23B2073" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -863,6 +863,7 @@
     <entity name="Quiz" representedClassName="Core.Quiz" syncable="YES">
         <attribute name="accessCode" optional="YES" attributeType="String"/>
         <attribute name="allowedAttempts" optional="YES" attributeType="Integer 64" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="anonymousSubmissions" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="assignmentID" optional="YES" attributeType="String"/>
         <attribute name="cantGoBack" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="courseID" attributeType="String"/>

--- a/Core/Core/Quizzes/APIQuiz.swift
+++ b/Core/Core/Quizzes/APIQuiz.swift
@@ -60,7 +60,7 @@ public struct APIQuiz: Codable, Equatable {
     let title: String
     let unlock_at: Date?
     let unpublishable: Bool?
-    // let anonymous_submissions: Bool?
+    let anonymous_submissions: Bool?
     // let assignment_group_id: String?
     // let lock_info: LockInfoModel?
     // let one_time_results: Bool
@@ -203,7 +203,8 @@ extension APIQuiz {
         time_limit: Double? = nil,
         title: String = "What kind of pokemon are you?",
         unlock_at: Date? = nil,
-        unpublishable: Bool = false
+        unpublishable: Bool = false,
+        anonymous_submissions: Bool? = false
     ) -> APIQuiz {
         APIQuiz(
             access_code: access_code,
@@ -239,7 +240,8 @@ extension APIQuiz {
             time_limit: time_limit,
             title: title,
             unlock_at: unlock_at,
-            unpublishable: unpublishable
+            unpublishable: unpublishable,
+            anonymous_submissions: anonymous_submissions
         )
     }
 }

--- a/Core/Core/Quizzes/Quiz.swift
+++ b/Core/Core/Quizzes/Quiz.swift
@@ -58,6 +58,7 @@ public class Quiz: NSManagedObject {
     @NSManaged public var title: String
     @NSManaged public var unlockAt: Date?
     @NSManaged public var unpublishable: Bool
+    @NSManaged public var anonymousSubmissions: Bool
 
     public var course: Course? {
         managedObjectContext?.first(where: #keyPath(Course.id), equals: courseID)
@@ -205,6 +206,7 @@ extension Quiz {
         model.unpublishable = item.unpublishable == true
         let orderDate = (item.quiz_type == .assignment ? item.due_at : item.lock_at) ?? Date.distantFuture
         model.order = orderDate.isoString()
+        model.anonymousSubmissions = item.anonymous_submissions ?? false
         return model
     }
 }

--- a/Core/Core/SwiftUIViews/Avatar.swift
+++ b/Core/Core/SwiftUIViews/Avatar.swift
@@ -19,13 +19,17 @@
 import SwiftUI
 
 public struct Avatar: View {
-    public let initials: String
+    public let initials: String?
     public let url: URL?
     public let size: CGFloat
     private let isAccessible: Bool
 
     public init(name: String?, url: URL?, size: CGFloat = 40, isAccessible: Bool = false) {
-        initials = Avatar.initials(for: name ?? "")
+        if let name {
+            initials = Avatar.initials(for: name)
+        } else {
+            initials = nil
+        }
         self.url = Avatar.scrubbedURL(url)
         self.size = size
         self.isAccessible = isAccessible
@@ -39,7 +43,7 @@ public struct Avatar: View {
                 .background(Color.backgroundLight)
                 .cornerRadius(size / 2)
                 .testID("Avatar.imageView")
-        } else {
+        } else if let initials {
             Text(initials)
                 .accessibility(hidden: !isAccessible)
                 .allowsTightening(true)
@@ -52,6 +56,18 @@ public struct Avatar: View {
                     .stroke(Color.borderMedium, lineWidth: 1)
                 )
                 .testID("Avatar.initialsLabel")
+        } else {
+            Image.userLine
+                .aspectRatio(contentMode: .fill)
+                .frame(width: size, height: size)
+                .accessibility(hidden: !isAccessible)
+                .foregroundColor(.textDark)
+                .background(Color.backgroundLightest)
+                .cornerRadius(size / 2)
+                .overlay(Circle()
+                    .stroke(Color.borderMedium, lineWidth: 1)
+                )
+                .testID("Avatar.anonymousUser")
         }
     }
 

--- a/rn/Teacher/ios/Teacher/Localizable.xcstrings
+++ b/rn/Teacher/ios/Teacher/Localizable.xcstrings
@@ -16421,6 +16421,9 @@
         }
       }
     },
+    "Group %lld" : {
+
+    },
     "Hide Grades" : {
       "localizations" : {
         "ar" : {
@@ -27401,6 +27404,9 @@
           }
         }
       }
+    },
+    "Student %lld" : {
+
     },
     "Submissions" : {
       "localizations" : {

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
@@ -26,24 +26,40 @@ public struct QuizSubmissionListItem: Equatable {
     public let score: String?
     public let avatarURL: URL?
 
-    public static func make(users: [QuizSubmissionUser], submissions: [QuizSubmission]) -> [QuizSubmissionListItem] {
-        users.map { user in
+    public static func make(
+        users: [QuizSubmissionUser],
+        submissions: [QuizSubmission],
+        isAnonymous: Bool
+    ) -> [QuizSubmissionListItem] {
+        users.enumerated().map { index, user in
             var status: QuizSubmissionWorkflowState = .untaken
             var score: String?
-            if let submission = submissions.first(where: {$0.userID == user.id}) {
+            if let submission = submissions.first(where: { $0.userID == user.id }) {
                 status = submission.workflowState
                 if let submissionScore = submission.score {
                     let truncated = GradeFormatter.truncate(submissionScore)
                     score = String(truncated.stringValue)
                 }
             }
+
+            let displayName: String
+            let avatarURL: URL?
+
+            if isAnonymous {
+                displayName = String(localized: "Student \(index + 1)", bundle: .core)
+                avatarURL = nil
+            } else {
+                displayName = User.displayName(user.name, pronouns: user.pronouns)
+                avatarURL = user.avatarURL
+            }
+
             return QuizSubmissionListItem(
                 id: user.id,
-                displayName: User.displayName(user.name, pronouns: user.pronouns),
+                displayName: displayName,
                 name: user.name,
                 status: status,
                 score: score,
-                avatarURL: user.avatarURL
+                avatarURL: avatarURL
             )
         }
     }
@@ -52,20 +68,19 @@ public struct QuizSubmissionListItem: Equatable {
 #if DEBUG
 
 public extension QuizSubmissionListItem {
-    static func make(id: String = "0")
-    -> QuizSubmissionListItem {
+    static func make(id _: String = "0")
+        -> QuizSubmissionListItem {
         let mockObject = QuizSubmissionListItem(id: "1", displayName: "Student", name: "Student", status: .complete, score: "5", avatarURL: nil)
         return mockObject
     }
 }
 
 public extension Array where Element == QuizSubmissionListItem {
-
     static func make(count: Int)
-    -> [QuizSubmissionListItem] {
-        (0..<count).reduce(into: [], { partialResult, index in
+        -> [QuizSubmissionListItem] {
+        (0 ..< count).reduce(into: []) { partialResult, index in
             partialResult.append(.make(id: "\(index)"))
-        })
+        }
     }
 }
 

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
@@ -21,7 +21,7 @@ import Core
 public struct QuizSubmissionListItem: Equatable {
     public let id: String
     public let displayName: String
-    public let name: String
+    public let name: String?
     public let status: QuizSubmissionWorkflowState
     public let score: String?
     public let avatarURL: URL?
@@ -44,19 +44,22 @@ public struct QuizSubmissionListItem: Equatable {
 
             let displayName: String
             let avatarURL: URL?
+            let name: String?
 
             if isAnonymous {
                 displayName = String(localized: "Student \(index + 1)", bundle: .core)
                 avatarURL = nil
+                name = nil
             } else {
                 displayName = User.displayName(user.name, pronouns: user.pronouns)
                 avatarURL = user.avatarURL
+                name = user.name
             }
 
             return QuizSubmissionListItem(
                 id: user.id,
                 displayName: displayName,
-                name: user.name,
+                name: name,
                 status: status,
                 score: score,
                 avatarURL: avatarURL

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
@@ -47,7 +47,7 @@ public struct QuizSubmissionListItem: Equatable {
             let name: String?
 
             if isAnonymous {
-                displayName = String(localized: "Student \(index + 1)", bundle: .core)
+                displayName = String(localized: "Student \(index + 1)")
                 avatarURL = nil
                 name = nil
             } else {

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/QuizSubmissionListInteractorLive.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/QuizSubmissionListInteractorLive.swift
@@ -50,7 +50,11 @@ public class QuizSubmissionListInteractorLive: QuizSubmissionListInteractor {
         self.quizID = quizID
 
         Publishers
-            .CombineLatest3(usersStore.allObjects, submissionsStore.allObjects, quizStore.allObjects.compactMap { $0.first } )
+            .CombineLatest3(
+                usersStore.allObjects,
+                submissionsStore.allObjects,
+                quizStore.allObjects.compactMap { $0.first }
+            )
             .map {
                 QuizSubmissionListItem.make(users: $0.0, submissions: $0.1, isAnonymous: $0.2.anonymousSubmissions)
             }

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/QuizSubmissionListInteractorLive.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/QuizSubmissionListInteractorLive.swift
@@ -50,9 +50,9 @@ public class QuizSubmissionListInteractorLive: QuizSubmissionListInteractor {
         self.quizID = quizID
 
         Publishers
-            .CombineLatest(usersStore.allObjects, submissionsStore.allObjects)
+            .CombineLatest3(usersStore.allObjects, submissionsStore.allObjects, quizStore.allObjects.compactMap { $0.first } )
             .map {
-                QuizSubmissionListItem.make(users: $0.0, submissions: $0.1)
+                QuizSubmissionListItem.make(users: $0.0, submissions: $0.1, isAnonymous: $0.2.anonymousSubmissions)
             }
             .combineLatest(filter) {
                 $0.applyFilter(filter: $1)

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListItemViewModel.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListItemViewModel.swift
@@ -21,7 +21,7 @@ import SwiftUI
 public struct QuizSubmissionListItemViewModel: Identifiable, Equatable {
     public let id: String
     public let displayName: String
-    public let name: String
+    public let name: String?
     public let status: String
     public let statusColor: Color
     public let score: String?

--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
@@ -238,10 +238,10 @@ class SubmissionListCell: UITableViewCell {
         if assignment?.anonymizeStudents != false {
             if submission?.groupID != nil {
                 avatarView.icon = .groupLine
-                nameLabel.text = String(localized: "Group \(row)", comment: "")
+                nameLabel.text = String(localized: "Group \(row)")
             } else {
                 avatarView.icon = .userLine
-                nameLabel.text = String(localized: "Student \(row)", comment: "")
+                nameLabel.text = String(localized: "Student \(row)")
             }
         } else if let name = submission?.groupName {
             avatarView.name = name

--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
@@ -199,7 +199,7 @@ extension SubmissionListViewController: UITableViewDataSource, UITableViewDelega
 
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: SubmissionListCell = tableView.dequeue(for: indexPath)
-        cell.update(assignment.first, submission: submissions[indexPath])
+        cell.update(assignment.first, submission: submissions[indexPath], row: indexPath.row + 1)
         return cell
     }
 
@@ -232,16 +232,16 @@ class SubmissionListCell: UITableViewCell {
         needsGradingView.layer.cornerRadius = needsGradingView.frame.height / 2
     }
 
-    func update(_ assignment: Assignment?, submission: Submission?) {
+    func update(_ assignment: Assignment?, submission: Submission?, row: Int) {
         accessibilityIdentifier = "SubmissionListCell.\(submission?.userID ?? "")"
         backgroundColor = .backgroundLightest
         if assignment?.anonymizeStudents != false {
             if submission?.groupID != nil {
                 avatarView.icon = .groupLine
-                nameLabel.text = NSLocalizedString("Group", comment: "")
+                nameLabel.text = String(localized: "Group \(row)", comment: "")
             } else {
                 avatarView.icon = .userLine
-                nameLabel.text = NSLocalizedString("Student", comment: "")
+                nameLabel.text = String(localized: "Student \(row)", comment: "")
             }
         } else if let name = submission?.groupName {
             avatarView.name = name

--- a/rn/Teacher/ios/TeacherTests/Submissions/QuizSubmissionList/QuizSubmissionListItemTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/QuizSubmissionList/QuizSubmissionListItemTests.swift
@@ -26,7 +26,7 @@ class QuizSubmissionListItemTests: TeacherTestCase {
         let user = QuizSubmissionUser.save(APIUser.make(id: 1, name: "John", avatar_url: URL(string: "https://example.com/avatar1"), pronouns: "he/him"), in: databaseClient)
         let users = [user, QuizSubmissionUser.make(in: databaseClient)]
         let submissions: [QuizSubmission] = [.make()]
-        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions)
+        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions, isAnonymous: false)
 
         XCTAssertEqual(testee.count, 2)
         XCTAssertEqual(testee[0].id, "1")
@@ -35,13 +35,27 @@ class QuizSubmissionListItemTests: TeacherTestCase {
         XCTAssertEqual(testee[0].status, .untaken)
         XCTAssertNil(testee[0].score)
         XCTAssertEqual(testee[0].avatarURL, user.avatarURL)
+    }
 
+    func testAnonymizedStudent() {
+        let user = QuizSubmissionUser.save(APIUser.make(id: 1, name: "John", avatar_url: URL(string: "https://example.com/avatar1"), pronouns: "he/him"), in: databaseClient)
+        let users = [user, QuizSubmissionUser.make(in: databaseClient)]
+        let submissions: [QuizSubmission] = [.make()]
+        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions, isAnonymous: true)
+
+        XCTAssertEqual(testee.count, 2)
+        XCTAssertEqual(testee[0].id, "1")
+        XCTAssertEqual(testee[0].displayName, "Student 1")
+        XCTAssertEqual(testee[0].name, "John")
+        XCTAssertEqual(testee[0].status, .untaken)
+        XCTAssertNil(testee[0].score)
+        XCTAssertEqual(testee[0].avatarURL, nil)
     }
 
     func testConnectSubmissions() {
         let users = [QuizSubmissionUser.make(id: "1", in: databaseClient), QuizSubmissionUser.make(id: "2", in: databaseClient)]
         let submissions = [QuizSubmission.make(from: .make(score: 99, user_id: "1", workflow_state: .complete))]
-        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions)
+        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions, isAnonymous: false)
 
         XCTAssertEqual(testee[0].status, .complete)
         XCTAssertEqual(testee[0].score, "99")
@@ -67,7 +81,7 @@ class QuizSubmissionListItemTests: TeacherTestCase {
             QuizSubmission.make(from: .make(id: "1", score: 2.66667, user_id: "1", workflow_state: .complete)),
             QuizSubmission.make(from: .make(id: "2", score: 1.00001, user_id: "2", workflow_state: .complete)),
         ]
-        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions)
+        let testee = QuizSubmissionListItem.make(users: users, submissions: submissions, isAnonymous: false)
 
         XCTAssertEqual(testee[0].score, "2.67")
         XCTAssertEqual(testee[1].score, "1")

--- a/rn/Teacher/ios/TeacherTests/Submissions/QuizSubmissionList/QuizSubmissionListItemTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/QuizSubmissionList/QuizSubmissionListItemTests.swift
@@ -46,7 +46,7 @@ class QuizSubmissionListItemTests: TeacherTestCase {
         XCTAssertEqual(testee.count, 2)
         XCTAssertEqual(testee[0].id, "1")
         XCTAssertEqual(testee[0].displayName, "Student 1")
-        XCTAssertEqual(testee[0].name, "John")
+        XCTAssertEqual(testee[0].name, nil)
         XCTAssertEqual(testee[0].status, .untaken)
         XCTAssertNil(testee[0].score)
         XCTAssertEqual(testee[0].avatarURL, nil)

--- a/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -130,25 +130,26 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         let assigment = controller.assignment.first
         let submission = controller.submissions.first
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? SubmissionListCell
+        let row = 1
 
         assigment?.anonymizeStudents = true
-        cell?.update(assigment, submission: submission, row: <#Int#>)
-        XCTAssertEqual(cell?.nameLabel.text, "Student")
+        cell?.update(assigment, submission: submission, row: row)
+        XCTAssertEqual(cell?.nameLabel.text, "Student 1")
 
         submission?.groupID = "1"
-        cell?.update(assigment, submission: submission, row: <#Int#>)
-        XCTAssertEqual(cell?.nameLabel.text, "Group")
+        cell?.update(assigment, submission: submission, row: row)
+        XCTAssertEqual(cell?.nameLabel.text, "Group 1")
 
         assigment?.anonymizeStudents = false
         submission?.groupName = "Group One"
-        cell?.update(assigment, submission: submission, row: <#Int#>)
+        cell?.update(assigment, submission: submission, row: row)
         XCTAssertEqual(cell?.nameLabel.text, "Group One")
 
         submission?.groupID = nil
         submission?.groupName = nil
         submission?.user?.name = "Alice"
         submission?.user?.pronouns = "She/Her"
-        cell?.update(assigment, submission: submission, row: <#Int#>)
+        cell?.update(assigment, submission: submission, row: row)
         XCTAssertEqual(cell?.nameLabel.text, "Alice (She/Her)")
     }
 }

--- a/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/rn/Teacher/ios/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -132,23 +132,23 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? SubmissionListCell
 
         assigment?.anonymizeStudents = true
-        cell?.update(assigment, submission: submission)
+        cell?.update(assigment, submission: submission, row: <#Int#>)
         XCTAssertEqual(cell?.nameLabel.text, "Student")
 
         submission?.groupID = "1"
-        cell?.update(assigment, submission: submission)
+        cell?.update(assigment, submission: submission, row: <#Int#>)
         XCTAssertEqual(cell?.nameLabel.text, "Group")
 
         assigment?.anonymizeStudents = false
         submission?.groupName = "Group One"
-        cell?.update(assigment, submission: submission)
+        cell?.update(assigment, submission: submission, row: <#Int#>)
         XCTAssertEqual(cell?.nameLabel.text, "Group One")
 
         submission?.groupID = nil
         submission?.groupName = nil
         submission?.user?.name = "Alice"
         submission?.user?.pronouns = "She/Her"
-        cell?.update(assigment, submission: submission)
+        cell?.update(assigment, submission: submission, row: <#Int#>)
         XCTAssertEqual(cell?.nameLabel.text, "Alice (She/Her)")
     }
 }


### PR DESCRIPTION
refs: MBL-17458
affects: Teacher
release note: Anonymous ungraded surveys now hide student names. Anonymous submissions show a numbered list of students instead of showing student multiple times. 
test plan: See ticket and test other anonymized submission formats. 

### What's new
- Anonymous ungraded surveys now hide Student names and avatars and use a numbered anynomized list. (Student 1, Student 2, etc..)
- Other anonymous submissions are displayed with the same logic as above instead of simply showing (Student, Student) 

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/f569cbbe-5b1d-4902-830b-8f6e6c77e275" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/91e59df8-7ded-478b-a2b0-0a6eb2d60e07" maxHeight=500></td>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/c751f920-b577-4f95-b7e5-f872f535e383" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/2a2991fa-2f94-48c4-ab84-8b3a4ad1cf2c" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
