### PR TITLE
Fix Submissions mixing up Student and Group names and therefore ordering

### DIFF
--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -331,7 +331,7 @@ public struct GetSubmissionRequest: APIRequestable {
     }
 
     public var query: [APIQueryItem] {
-        return [ .array("include", [ "submission_comments", "submission_history", "user", "rubric_assessment"]) ]
+        return [ .array("include", [ "submission_comments", "submission_history", "user", "rubric_assessment", "group"]) ]
     }
 }
 

--- a/Core/CoreTests/Submissions/APISubmissionTests.swift
+++ b/Core/CoreTests/Submissions/APISubmissionTests.swift
@@ -28,6 +28,7 @@ class APISubmissionTests: CoreTestCase {
             "submission_history",
             "user",
             "rubric_assessment",
+            "group",
         ]), ])
     }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -73,7 +73,14 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
     }
 
     func update() {
-        guard assignment.requested && !assignment.pending && submissions.requested && !submissions.pending && !submissions.hasNextPage else { return }
+        guard assignment.requested && !assignment.pending
+                && submissions.requested && !submissions.pending
+                && !submissions.hasNextPage
+                && enrollments.requested && !enrollments.pending
+                && !enrollments.hasNextPage
+        else {
+            return
+        }
 
         if !submissions.useCase.shuffled, assignment.first?.anonymizeStudents == true {
             submissions.useCase.shuffled = true


### PR DESCRIPTION
refs: [MBL-17464](https://instructure.atlassian.net/browse/MBL-17464)
affects: Teacher
release note: Fixed Submissions List showing Students instead of Groups. Fixed SpeedGrader presenting a different Submission from the list then the one selected.

## Test plan
See ticket and use already setup account described there.

## Problem
The problem was that `GetSubmissionsRequest` (plural) included `"group"` but `GetSubmissionRequest` (singular) did not, and the later request got called by `GetSubmissionComments` usecase whenever CoreDate didn't have it, clearing out the group `id` and `name`.
This resulted in Student names displayed instead of Group names.
Also since these also drive the sort ordering, SpeedGrader showed the submissions in weird order.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet

[MBL-17464]: https://instructure.atlassian.net/browse/MBL-17464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ