### PR TITLE
Show missing tag for all submission types

### DIFF
--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -65,11 +65,9 @@ public struct GradeRowView: View {
             let submission = assignment.submissions?.first { $0.userID == userID }
             let status = submission?.status ?? .notSubmitted
 
-            if assignment.isOnline {
-                Text(status.text)
-                    .foregroundStyle(Color(status.color))
-                    .font(.regular14)
-            }
+            Text(status.text)
+                .foregroundStyle(Color(status.color))
+                .font(.regular14)
         }
     }
 

--- a/Core/Core/Models/Viewable/SubmissionViewable.swift
+++ b/Core/Core/Models/Viewable/SubmissionViewable.swift
@@ -44,7 +44,7 @@ extension SubmissionViewable {
     }
 
     public var submissionStatusIsHidden: Bool {
-        return submissionTypes.contains(.none) || submissionTypes.contains(.not_graded)
+        return submissionTypes.contains(.not_graded)
     }
 
     public var submissionStatusColor: UIColor {

--- a/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
+++ b/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
@@ -61,7 +61,6 @@ class SubmissionViewableTests: XCTestCase {
 
     func testStatusIsHidden() {
         XCTAssertFalse(Model(submissionTypes: [.online_text_entry]).submissionStatusIsHidden)
-        XCTAssertTrue(Model(submissionTypes: [.none]).submissionStatusIsHidden)
         XCTAssertTrue(Model(submissionTypes: [.not_graded]).submissionStatusIsHidden)
     }
 

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -388,12 +388,13 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         nameLabel?.text = assignment.name
         pointsLabel?.text = hideScores ? nil : assignment.pointsPossibleText
         pointsLabel?.isHidden = pointsLabel?.text == nil
+        let status = assignment.submission?.status ?? .notSubmitted
         statusIconView?.isHidden = assignment.submissionStatusIsHidden
-        statusIconView?.image = assignment.submissionStatusIcon
-        statusIconView?.tintColor = assignment.submissionStatusColor
+        statusIconView?.image = status.icon
+        statusIconView?.tintColor = status.color
         statusLabel?.isHidden = assignment.submissionStatusIsHidden
-        statusLabel?.textColor = assignment.submissionStatusColor
-        statusLabel?.text = assignment.submissionStatusText
+        statusLabel?.textColor = status.color
+        statusLabel?.text = status.text
         dueSection?.subHeader.text = assignment.dueAt.flatMap {
             $0.dateTimeString
         } ?? NSLocalizedString("No Due Date", bundle: .core, comment: "")


### PR DESCRIPTION
refs: MBL-17468
affects: Student, Parent
release note: Missing tag is visible for all submission types now.
test plan: See ticket, check web.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/4d82bbde-cf25-4710-b555-d4968acf6227" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/b62813cd-3796-4c82-af17-fcf4fbbe7cad" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/8205cf28-b8e3-465d-9701-533f23ded3a6" maxHeight=500></td>
<td></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet
