### PR TITLE
Large GIF course image causes app to crash

### DIFF
--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsHeaderView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsHeaderView.swift
@@ -31,7 +31,7 @@ struct CourseDetailsHeaderView: View {
         ZStack {
             Color(viewModel.courseColor.resolvedColor(with: .light).darkenToEnsureContrast(against: .textLightest)).frame(width: width, height: viewModel.height)
             if let url = viewModel.imageURL {
-                RemoteImage(url, width: width, height: viewModel.height)
+                RemoteImage(url, width: width, height: viewModel.height, shouldHandleAnimatedGif: true)
                     .opacity(viewModel.imageOpacity)
                     .accessibility(hidden: true)
             }

--- a/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
@@ -70,7 +70,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
             ZStack {
                 Color(viewModel.courseColor ?? .ash).frame(width: width, height: height)
                 if let url = viewModel.imageURL {
-                    RemoteImage(url, width: width, height: height)
+                    RemoteImage(url, width: width, height: height, shouldHandleAnimatedGif: true)
                         .opacity(viewModel.hideColorOverlay == true ? 1 : 0.4)
                         .accessibility(hidden: true)
                 }

--- a/Core/Core/Courses/K5/View/Subject/K5SubjectHeaderView.swift
+++ b/Core/Core/Courses/K5/View/Subject/K5SubjectHeaderView.swift
@@ -28,7 +28,7 @@ struct K5SubjectHeaderView: View {
             backgroundColor
             if let imageUrl {
                 GeometryReader { geometry in
-                    RemoteImage(imageUrl, width: geometry.size.width, height: 113)
+                    RemoteImage(imageUrl, width: geometry.size.width, height: 113, shouldHandleAnimatedGif: true)
                         .clipped()
                         .contentShape(Path(CGRect(x: 0, y: 0, width: geometry.size.width, height: geometry.size.height)))
                 }

--- a/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
@@ -64,7 +64,7 @@ struct CustomizeCourseView: View {
             ZStack {
                 Color(color).frame(width: width, height: height)
                 if let url = imageDownloadURL {
-                    RemoteImage(url, width: width, height: height)
+                    RemoteImage(url, width: width, height: height, shouldHandleAnimatedGif: true)
                         .opacity(hideColorOverlay ? 1 : 0.4)
                 }
             }

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -87,7 +87,7 @@ struct DashboardCourseCardView: View {
     private func courseImage(width: CGFloat, height: CGFloat = 80) -> some View {
         ZStack(alignment: .topLeading) {
             Color(courseCard.color).frame(width: width, height: height)
-            courseCard.imageURL.map { RemoteImage($0, width: width, height: height) }?
+            courseCard.imageURL.map { RemoteImage($0, width: width, height: height, shouldHandleAnimatedGif: true) }?
                 .opacity(hideColorOverlay ? 1 : 0.4)
                 .clipped()
                 // Fix big course image consuming tap events.

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -87,7 +87,8 @@ struct DashboardCourseCardView: View {
     private func courseImage(width: CGFloat, height: CGFloat = 80) -> some View {
         ZStack(alignment: .topLeading) {
             Color(courseCard.color).frame(width: width, height: height)
-            courseCard.imageURL.map { RemoteImage($0, width: width, height: height, shouldHandleAnimatedGif: true) }?
+            // disable animated GIFs to avoid creating multiple WebViews
+            courseCard.imageURL.map { RemoteImage($0, width: width, height: height, shouldHandleAnimatedGif: false) }?
                 .opacity(hideColorOverlay ? 1 : 0.4)
                 .clipped()
                 // Fix big course image consuming tap events.

--- a/Core/Core/Extensions/ResultExtensions.swift
+++ b/Core/Core/Extensions/ResultExtensions.swift
@@ -20,10 +20,31 @@ import Foundation
 
 public extension Result {
 
+    var value: Success? {
+        if case .success(let value) = self {
+            return value
+        }
+        return nil
+    }
+
     var error: Failure? {
         if case .failure(let error) = self {
             return error
         }
         return nil
+    }
+
+    var isSuccess: Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+
+    var isFailure: Bool {
+        if case .failure = self {
+            return true
+        }
+        return false
     }
 }

--- a/Core/Core/Extensions/UIImageViewExtensions.swift
+++ b/Core/Core/Extensions/UIImageViewExtensions.swift
@@ -104,9 +104,10 @@ public class ImageLoader {
     init(url: URL, frame: CGRect, callback: @escaping (Result<LoadedImage, Error>) -> Void) {
         self.callback = callback
         self.frame = frame
+        let keyBase = url.absoluteStringWithoutTokenQuery
         self.key = url.pathExtension == "svg"
-            ? "\(url.absoluteString)@\(frame.width)x\(frame.height)"
-            : url.absoluteString
+            ? "\(keyBase)@\(frame.width)x\(frame.height)"
+            : keyBase
         self.url = url
     }
 
@@ -253,4 +254,18 @@ public func greatestCommonFactor(_ a: Int, _ b: Int) -> Int {
         (a, b) = (b, a % b)
     }
     return a
+}
+
+private extension URL {
+    var absoluteStringWithoutTokenQuery: String {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false),
+              let tokenIndex = components.queryItems?.firstIndex(where: { $0.name == "token" })
+        else {
+            return absoluteString
+        }
+
+        components.queryItems?.remove(at: tokenIndex)
+
+        return components.url?.absoluteString ?? absoluteString
+    }
 }

--- a/Core/Core/Extensions/UIImageViewExtensions.swift
+++ b/Core/Core/Extensions/UIImageViewExtensions.swift
@@ -160,11 +160,12 @@ public class ImageLoader {
             result = .failure(error ?? NSError.internalError())
         }
 
-        for loader in ImageLoader.loading[key] ?? [] {
+        let activeLoaders = ImageLoader.loading[key] ?? []
+        ImageLoader.loading[key] = nil
+
+        for loader in activeLoaders {
             loader.callback(result)
         }
-
-        ImageLoader.loading[key] = nil
     }
 
     // MARK: - SVG snapshot

--- a/Core/Core/Extensions/UIImageViewExtensions.swift
+++ b/Core/Core/Extensions/UIImageViewExtensions.swift
@@ -51,6 +51,7 @@ extension UIImageView {
     @discardableResult
     public func load(url: URL?) -> APITask? {
         guard self.url != url else { return nil }
+
         self.url = url
         loader = nil
         image = nil
@@ -59,14 +60,17 @@ extension UIImageView {
                 self?.load(url: url, result: result)
             }
         }
+
         return loader?.load()
     }
 
-    private func load(url: URL, result: Result<UIImage, Error>) {
+    func load(url: URL, result: Result<UIImage, Error>) {
         guard self.url == url else { return }
-        if case .success(let image) = result {
+
+        if let image = result.value {
             self.image = image
         }
+
         loader = nil
     }
 }
@@ -92,6 +96,7 @@ public class ImageLoader {
 
     static func reset() {
         rendered = [:]
+        isAnimated = [:]
         loading = [:]
     }
 
@@ -185,7 +190,7 @@ public class ImageLoader {
 
     // MARK: - SVG snapshot
 
-    func svgFrom(data: Data) {
+    private func svgFrom(data: Data) {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()
         let view = WKWebView(frame: frame, configuration: config)
@@ -213,7 +218,7 @@ public class ImageLoader {
 
     // MARK: - GIF
 
-    func isAnimatedGif(data: Data) -> Bool {
+    private func isAnimatedGif(data: Data) -> Bool {
         guard let source = CGImageSourceCreateWithData(data as CFData, nil) else { return false }
         let count = CGImageSourceGetCount(source)
         return count > 1

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -391,7 +391,7 @@ extension FileDetailsViewController: URLSessionDownloadDelegate, LocalFileURLCre
 extension FileDetailsViewController: UIScrollViewDelegate {
     func embedImageOrWebView(for url: URL) {
         imageLoader = ImageLoader(url: url, frame: .zero, shouldFailForAnimatedGif: true) { [weak self] result in
-            if case .failure(LoadedImage.Error.animatedGifFound) = result {
+            if case .failure(ImageLoaderError.animatedGifFound) = result {
                 self?.embedWebView(for: url, handleDarkMode: false)
                 self?.imageLoader = nil
             } else {

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -198,13 +198,13 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         doneLoading()
     }
 
-    func embedWebView(for url: URL, isLocalURL: Bool = true, handleDarkMode: Bool = true) {
-        let webView = CoreWebView(features: handleDarkMode ? [.invertColorsInDarkMode] : [])
+    func embedWebView(for url: URL, isLocalURL: Bool = true, isImageWrapper: Bool = false) {
+        let webView = CoreWebView(features: isImageWrapper ? [] : [.invertColorsInDarkMode])
         contentView.addSubview(webView)
-        if handleDarkMode {
-            webView.pinWithThemeSwitchButton(inside: contentView)
-        } else {
+        if isImageWrapper {
             webView.pin(inside: contentView)
+        } else {
+            webView.pinWithThemeSwitchButton(inside: contentView)
         }
         webView.linkDelegate = self
         webView.accessibilityLabel = "FileDetails.webView"
@@ -392,7 +392,7 @@ extension FileDetailsViewController: UIScrollViewDelegate {
     func embedImageOrWebView(for url: URL) {
         imageLoader = ImageLoader(url: url, frame: .zero, shouldFailForAnimatedGif: true) { [weak self] result in
             if case .failure(ImageLoaderError.animatedGifFound) = result {
-                self?.embedWebView(for: url, handleDarkMode: false)
+                self?.embedWebView(for: url, isImageWrapper: true)
                 self?.imageLoader = nil
             } else {
                 self?.embedImageView(for: url)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -402,7 +402,7 @@ extension FileDetailsViewController: URLSessionDownloadDelegate, LocalFileURLCre
 extension FileDetailsViewController: UIScrollViewDelegate {
     private func embedImageOrWebView(for url: URL) {
         imageLoader = ImageLoader(url: url, frame: .zero, shouldFailForAnimatedGif: true) { [weak self] result in
-            if case .failure(ImageLoaderError.animatedGifFound) = result {
+            if result.error as? ImageLoaderError == .animatedGifFound {
                 self?.embedImageWrappedInWebView(for: url)
                 self?.imageLoader = nil
             } else {

--- a/Core/Core/SwiftUIViews/ImageWrapperWebView.swift
+++ b/Core/Core/SwiftUIViews/ImageWrapperWebView.swift
@@ -1,0 +1,136 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import SwiftUI
+import WebKit
+
+public struct ImageWrapperWebView: UIViewRepresentable {
+    @Environment(\.appEnvironment) private var env
+    @Environment(\.viewController) private var controller
+
+    private let url: URL?
+
+    // MARK: - Initializers
+
+    public init(url: URL?) {
+        self.url = url
+    }
+
+    // MARK: - UIViewRepresentable Protocol
+
+    public func makeUIView(context: Self.Context) -> UIView {
+        let webViewContainer = UIView()
+        let webView = ImageWrapperUIKitWebView()
+        webViewContainer.addSubview(webView)
+        webView.pin(inside: webViewContainer)
+
+        webView.isUserInteractionEnabled = false
+
+        return webViewContainer
+    }
+
+    public func updateUIView(_ uiView: UIView, context: Self.Context) {
+        guard let webView = uiView.subviews.first(where: { $0 is ImageWrapperUIKitWebView }) as? ImageWrapperUIKitWebView else { return }
+
+        if context.coordinator.loaded != url {
+            context.coordinator.loaded = url
+            if let url {
+                webView.loadImageURL(url, fill: true, restrictZoom: true)
+            }
+        }
+    }
+
+    public func makeCoordinator() -> Coordinator {
+        Coordinator(view: self)
+    }
+}
+
+// MARK: - Inner Types
+
+extension ImageWrapperWebView {
+    public class Coordinator {
+        var loaded: URL?
+        private let view: ImageWrapperWebView
+
+        init(view: ImageWrapperWebView) {
+            self.view = view
+        }
+    }
+}
+
+#if DEBUG
+
+struct ImageWrapperWebView_Previews: PreviewProvider {
+    static var previews: some View {
+        ImageWrapperWebView(url: nil)
+            .border(Color.red, width: 1)
+    }
+}
+
+#endif
+
+public final class ImageWrapperUIKitWebView: WKWebView {
+    public required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setup()
+    }
+
+    public init() {
+        super.init(frame: .zero, configuration: .defaultConfiguration)
+        setup()
+    }
+
+    private func setup() {
+        isOpaque = false
+        backgroundColor = UIColor.clear
+        translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    public func loadImageURL(
+        _ imageURL: URL,
+        baseURL: URL? = AppEnvironment.shared.currentSession?.baseURL,
+        fill: Bool,
+        restrictZoom: Bool
+    ) {
+        var html = ""
+
+        if restrictZoom {
+            html += """
+                <meta name="viewport" content="initial-scale=1, minimum-scale=1, maximum-scale=1" />
+            """
+        }
+
+        html += """
+            <body style="
+                margin: 0px; height: 100%; \
+                -webkit-user-select: none; \
+                ">\
+                <img src="\(imageURL)" style="
+                    margin: auto; padding: 0px; height: 100%; width: 100%; display: block; \
+                    object-fit: \(fill ? "cover" : "contain"); \
+                    -webkit-user-select: none; \
+                    -webkit-user-drag: none; \
+                    -webkit-touch-callout: none; \
+                    ">\
+            </body>
+        """
+
+        loadHTMLString(html, baseURL: baseURL)
+    }
+}

--- a/Core/Core/SwiftUIViews/RemoteImage.swift
+++ b/Core/Core/SwiftUIViews/RemoteImage.swift
@@ -51,7 +51,8 @@ public struct RemoteImage: View {
                 .resizable().scaledToFill()
                 .frame(width: width, height: height)
         } else if animated {
-            WebView(url: url)
+            ImageWrapperWebView(url: url)
+                .frame(width: width, height: height)
         } else {
             emptyState.onAppear {
                 load()

--- a/Core/Core/SwiftUIViews/RemoteImage.swift
+++ b/Core/Core/SwiftUIViews/RemoteImage.swift
@@ -79,23 +79,21 @@ public struct RemoteImage: View {
         let localURL = url // Create a local copy in case it changes while the previous image is still loading
         let frame = CGRect(x: 0, y: 0, width: width, height: height)
 
-        loader = ImageLoader(url: localURL, frame: frame, shouldFailForAnimatedGif: shouldHandleAnimatedGif) { result in
+        executeLoad(localURL: localURL, frame: frame, handleAnimatedGif: shouldHandleAnimatedGif)
+    }
+
+    private func executeLoad(localURL: URL, frame: CGRect, handleAnimatedGif: Bool) {
+        loader = ImageLoader(url: localURL, frame: frame, shouldFailForAnimatedGif: handleAnimatedGif) { result in
             loader = nil
 
-            if shouldHandleAnimatedGif {
+            if handleAnimatedGif {
                 if case .failure(ImageLoaderError.animatedGifFound) = result {
                     animated = true
                     image = nil
                     loadedURL = localURL
                 } else {
-                    animated = false
-                    loader = ImageLoader(url: localURL, frame: frame, shouldFailForAnimatedGif: shouldHandleAnimatedGif) { result in
-                        loader = nil
-                        guard case .success(let image) = result else { return }
-                        self.image = image
-                        self.loadedURL = localURL
-                    }
-                    loader?.load()
+                    // load already cached UIImage
+                    executeLoad(localURL: localURL, frame: frame, handleAnimatedGif: false)
                 }
             } else {
                 animated = false

--- a/Core/Core/SwiftUIViews/RemoteImage.swift
+++ b/Core/Core/SwiftUIViews/RemoteImage.swift
@@ -88,7 +88,7 @@ public struct RemoteImage: View {
             loader = nil
 
             if handleAnimatedGif {
-                if case .failure(ImageLoaderError.animatedGifFound) = result {
+                if result.error as? ImageLoaderError == .animatedGifFound {
                     animated = true
                     image = nil
                     loadedURL = localURL
@@ -98,7 +98,7 @@ public struct RemoteImage: View {
                 }
             } else {
                 animated = false
-                guard case .success(let image) = result else { return }
+                guard let image = result.value else { return }
                 self.image = image
                 self.loadedURL = localURL
             }

--- a/Core/CoreTests/Extensions/ResultExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ResultExtensionsTests.swift
@@ -21,13 +21,25 @@ import XCTest
 
 class ResultExtensionsTests: XCTestCase {
 
-    func testError() {
-        let testee: Result<Void, NSError> = .failure(NSError.instructureError("TestError"))
-        XCTAssertEqual(testee.error, NSError.instructureError("TestError"))
+    private enum TestConstants {
+        static let error = NSError.instructureError("TestError")
     }
 
-    func testErrorOnSuccess() {
-        let testee: Result<Void, NSError> = .success(())
-        XCTAssertNil(testee.error)
+    func testSuccess() {
+        let testee: Result<Int, NSError> = .success(42)
+
+        XCTAssertEqual(testee.value, 42)
+        XCTAssertEqual(testee.error, nil)
+        XCTAssertEqual(testee.isSuccess, true)
+        XCTAssertEqual(testee.isFailure, false)
+    }
+
+    func testFailure() {
+        let testee: Result<Int, NSError> = .failure(TestConstants.error)
+
+        XCTAssertEqual(testee.value, nil)
+        XCTAssertEqual(testee.error, TestConstants.error)
+        XCTAssertEqual(testee.isSuccess, false)
+        XCTAssertEqual(testee.isFailure, true)
     }
 }


### PR DESCRIPTION
refs: [MBL-17453](https://instructure.atlassian.net/browse/MBL-17453)
affects: Teacher, Student
release note: Optimized memory and bandwidth usage for Course Image and uploaded files.

## Problem
- Animated GIFs were loaded as bitmaps frame by frame, which eats up a lot of memory.
- Image caching was based on the full image URLs, which included token in the query as well. Because it changes slighly in each request, this resulted in each Course Image downloaded and loaded into memory multiple times.
- In-memory image cache was never reseted.

## What's new
- Animated GIFs are displayed and animating in WebViews, where deemed important:
  - Course Details screen
  - Customize Course screen
  - Course Settings screen
  - Files
  - K5 Subject Details screen
- Animated GIFs are showing only the first frame, without animating in all other places, including:
  - Dashboard
  - K5 Homeroom screen
- Image caching now ignores token

## What's not changed
- Animated GIFs may still be downloaded multiple times, but this is no longer a noticeable issue.
- In-memory image cache is still not reseted, because it is hard to guess when it's no longer needed.

## Test plan
See ticket and use already setup account described there.
- Verify GIFs are animating and apps doesn't crash in places listed above.
- Verify non-animated Course Images load instantly in Course Details screen if it was already loaded & displayed on Dashboard.
- Verify Animated GIFs are zoomable and scrollable in Files.
- Verify Animated GIFs are not zoomable or scrollable in all other places.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product

[MBL-17453]: https://instructure.atlassian.net/browse/MBL-17453?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ