### PR TITLE
Missing translations

### DIFF
--- a/CanvasCore/CanvasCore/Helm/Helm.swift
+++ b/CanvasCore/CanvasCore/Helm/Helm.swift
@@ -212,8 +212,8 @@ open class HelmManager: NSObject {
                 if (viewCanExpandCollapse) {
                     viewController.navigationItem.leftBarButtonItem = splitViewController.prettyDisplayModeButtonItem(splitViewController.displayMode)
                     viewController.navigationItem.leftItemsSupplementBackButton = true
-                    let backButton = UIBarButtonItem(title: NSLocalizedString("Back", comment: ""), style: .plain, target: nil, action: nil)
-                    backButton.accessibilityLabel = NSLocalizedString("Back on detailed view", comment: "")
+                    let backButton = UIBarButtonItem(title: String(localized: "Back", bundle: .canvas), style: .plain, target: nil, action: nil)
+                    backButton.accessibilityLabel = String(localized: "Back on detailed view", bundle: .canvas)
                     viewController.navigationItem.backBarButtonItem = backButton
                 }
                 

--- a/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmSplitViewController.swift
@@ -72,8 +72,8 @@ public class HelmSplitViewController: UISplitViewController {
         let icon: UIImage = collapse ? .exitFullScreenLine : .fullScreenLine
         let prettyButton = UIBarButtonItem(image: icon, style: .plain, target: defaultButton.target, action: defaultButton.action)
         prettyButton.accessibilityLabel = collapse ?
-            NSLocalizedString("Collapse detail view", bundle: .canvas, comment: "") :
-            NSLocalizedString("Expand detail view", bundle: .canvas, comment: "")
+            String(localized: "Collapse detail view", bundle: .canvas) :
+            String(localized: "Expand detail view", bundle: .canvas)
         return prettyButton
     }
 }

--- a/CanvasCore/CanvasCore/Helm/HelmViewController.swift
+++ b/CanvasCore/CanvasCore/Helm/HelmViewController.swift
@@ -396,7 +396,7 @@ public final class HelmViewController: ScreenViewTrackableViewController, HelmSc
         // show the dismiss button when view controller is shown modally
         let navigatorOptions = props[PropKeys.navigatorOptions] as? [String: Any]
         if screenConfig[PropKeys.dismissButtonTitle] != nil || (navigatorOptions?["modal"] as? Bool == true && screenConfig[PropKeys.showDismissButton] as? Bool == true) {
-            let dismissTitle = screenConfig[PropKeys.dismissButtonTitle] as? String ?? NSLocalizedString("Done", bundle: .canvas, comment: "")
+            let dismissTitle = screenConfig[PropKeys.dismissButtonTitle] as? String ?? String(localized: "Done", bundle: .canvas)
             addModalDismissButton(buttonTitle: dismissTitle)
         }
 
@@ -453,7 +453,7 @@ fileprivate struct Associated {
 
 extension UIViewController {
     @objc public func addModalDismissButton(buttonTitle: String?) {
-        var dismissTitle = NSLocalizedString("Done", bundle: .canvas, comment: "")
+        var dismissTitle = String(localized: "Done", bundle: .canvas)
         if let buttonTitle = buttonTitle {
             dismissTitle = buttonTitle
         }

--- a/CanvasCore/CanvasCore/ReactNativeModules/SiriShortcutManager.swift
+++ b/CanvasCore/CanvasCore/ReactNativeModules/SiriShortcutManager.swift
@@ -27,7 +27,7 @@ public class SiriShortcutManager: NSObject {
             switch self {
             case ShortcutType.grades:
                 guard let name = userInfo["name"] as? String else { return "" }
-                let title = NSLocalizedString("Get Grades for", bundle: .canvas, comment: "")
+                let title = String(localized: "Get Grades for", bundle: .canvas)
                 return "\(title) \(name)"
             }
         }

--- a/Core/Core/API/APIError.swift
+++ b/Core/Core/API/APIError.swift
@@ -32,7 +32,7 @@ public enum APIError: LocalizedError {
             let message = extractMessage(from: json)
 
             if response?.isUnauthorized == true {
-                let defaultMessage = NSLocalizedString("You are not authorized to perform this action", bundle: .core, comment: "User is missing a necessary permission")
+                let defaultMessage = String(localized: "You are not authorized to perform this action", bundle: .core, comment: "User is missing a necessary permission")
                 return unauthorized(localizedMessage: message ?? defaultMessage)
             }
 
@@ -41,7 +41,7 @@ public enum APIError: LocalizedError {
             }
         }
         if let status = (response as? HTTPURLResponse)?.statusCode, status >= 400 {
-            return NSError.instructureError(NSLocalizedString("There was an unexpected error. Please try again.", bundle: .core, comment: ""))
+            return NSError.instructureError(String(localized: "There was an unexpected error. Please try again.", bundle: .core))
         }
         return error
     }

--- a/Core/Core/API/DownloadTaskPublisher.swift
+++ b/Core/Core/API/DownloadTaskPublisher.swift
@@ -117,10 +117,7 @@ final class DownloadTaskSubscription<SubscriberType: Subscriber>: NSObject,
         } catch {
             _ = subscriber?.receive(completion: .failure(
                 NSError.instructureError(
-                    NSLocalizedString(
-                        "Couldn't save the file.",
-                        comment: ""
-                    )
+                    NSLocalizedString("Couldn't save the file.", bundle: .core, comment: "")
                 )
             ))
             return

--- a/Core/Core/API/DownloadTaskPublisher.swift
+++ b/Core/Core/API/DownloadTaskPublisher.swift
@@ -117,7 +117,7 @@ final class DownloadTaskSubscription<SubscriberType: Subscriber>: NSObject,
         } catch {
             _ = subscriber?.receive(completion: .failure(
                 NSError.instructureError(
-                    NSLocalizedString("Couldn't save the file.", bundle: .core, comment: "")
+                    String(localized: "Couldn't save the file.", bundle: .core)
                 )
             ))
             return

--- a/Core/Core/About/Model/AboutInfoEntry.swift
+++ b/Core/Core/About/Model/AboutInfoEntry.swift
@@ -28,7 +28,7 @@ public struct AboutInfoEntry: Identifiable, Equatable {
 
     public init(title: String, label: String) {
         self.id = title
-        self.a11yLabel = "\(title),\(label == Self.UnknownLabel ? NSLocalizedString("Unknown", comment: "") : label)"
+        self.a11yLabel = "\(title),\(label == Self.UnknownLabel ? NSLocalizedString("Unknown", bundle: .core, comment: "") : label)"
         self.title = title
         self.label = label
     }
@@ -42,28 +42,28 @@ public extension AboutInfoEntry {
             appName = "Canvas \(app.rawValue.capitalized)"
         }
 
-        return Self(title: NSLocalizedString("App", comment: ""),
+        return Self(title: NSLocalizedString("App", bundle: .core, comment: ""),
                     label: appName)
     }
 }
 
 public extension AboutInfoEntry {
     static func domain(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Domain", comment: ""),
+        Self(title: NSLocalizedString("Domain", bundle: .core, comment: ""),
                     label: session?.baseURL.absoluteString ?? UnknownLabel)
     }
 }
 
 public extension AboutInfoEntry {
     static func loginID(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Login ID", comment: ""),
+        Self(title: NSLocalizedString("Login ID", bundle: .core, comment: ""),
                     label: session?.userID ?? UnknownLabel)
     }
 }
 
 public extension AboutInfoEntry {
     static func email(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Email", comment: ""),
+        Self(title: NSLocalizedString("Email", bundle: .core, comment: ""),
              label: session?.userEmail ?? UnknownLabel)
     }
 }
@@ -71,7 +71,7 @@ public extension AboutInfoEntry {
 public extension AboutInfoEntry {
     static func version(_ bundle: Bundle = Bundle.main) -> Self {
         let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? UnknownLabel
-        return Self(title: NSLocalizedString("Version", comment: ""),
+        return Self(title: NSLocalizedString("Version", bundle: .core, comment: ""),
                     label: version)
     }
 }

--- a/Core/Core/About/Model/AboutInfoEntry.swift
+++ b/Core/Core/About/Model/AboutInfoEntry.swift
@@ -28,7 +28,7 @@ public struct AboutInfoEntry: Identifiable, Equatable {
 
     public init(title: String, label: String) {
         self.id = title
-        self.a11yLabel = "\(title),\(label == Self.UnknownLabel ? NSLocalizedString("Unknown", bundle: .core, comment: "") : label)"
+        self.a11yLabel = "\(title),\(label == Self.UnknownLabel ? String(localized: "Unknown", bundle: .core) : label)"
         self.title = title
         self.label = label
     }
@@ -42,28 +42,28 @@ public extension AboutInfoEntry {
             appName = "Canvas \(app.rawValue.capitalized)"
         }
 
-        return Self(title: NSLocalizedString("App", bundle: .core, comment: ""),
+        return Self(title: String(localized: "App", bundle: .core),
                     label: appName)
     }
 }
 
 public extension AboutInfoEntry {
     static func domain(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Domain", bundle: .core, comment: ""),
+        Self(title: String(localized: "Domain", bundle: .core),
                     label: session?.baseURL.absoluteString ?? UnknownLabel)
     }
 }
 
 public extension AboutInfoEntry {
     static func loginID(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Login ID", bundle: .core, comment: ""),
+        Self(title: String(localized: "Login ID", bundle: .core),
                     label: session?.userID ?? UnknownLabel)
     }
 }
 
 public extension AboutInfoEntry {
     static func email(_ session: LoginSession? = AppEnvironment.shared.currentSession) -> Self {
-        Self(title: NSLocalizedString("Email", bundle: .core, comment: ""),
+        Self(title: String(localized: "Email", bundle: .core),
              label: session?.userEmail ?? UnknownLabel)
     }
 }
@@ -71,7 +71,7 @@ public extension AboutInfoEntry {
 public extension AboutInfoEntry {
     static func version(_ bundle: Bundle = Bundle.main) -> Self {
         let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? UnknownLabel
-        return Self(title: NSLocalizedString("Version", bundle: .core, comment: ""),
+        return Self(title: String(localized: "Version", bundle: .core),
                     label: version)
     }
 }

--- a/Core/Core/About/ViewModel/AboutViewModel.swift
+++ b/Core/Core/About/ViewModel/AboutViewModel.swift
@@ -26,7 +26,7 @@ public class AboutViewModel: ObservableObject {
         .email(),
         .version(),
     ]
-    public let title = NSLocalizedString("About", comment: "")
+    public let title = NSLocalizedString("About", bundle: .core, comment: "")
     public let entries: [AboutInfoEntry]
 
     public init(entries: [AboutInfoEntry] = DefaultEntries) {

--- a/Core/Core/About/ViewModel/AboutViewModel.swift
+++ b/Core/Core/About/ViewModel/AboutViewModel.swift
@@ -26,7 +26,7 @@ public class AboutViewModel: ObservableObject {
         .email(),
         .version(),
     ]
-    public let title = NSLocalizedString("About", bundle: .core, comment: "")
+    public let title = String(localized: "About", bundle: .core)
     public let entries: [AboutInfoEntry]
 
     public init(entries: [AboutInfoEntry] = DefaultEntries) {

--- a/Core/Core/ActAsUser/ActAsUserViewController.swift
+++ b/Core/Core/ActAsUser/ActAsUserViewController.swift
@@ -43,13 +43,13 @@ public class ActAsUserViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         addCancelButton(side: .left)
-        title = NSLocalizedString("Act as User", bundle: .core, comment: "")
+        title = String(localized: "Act as User", bundle: .core)
         navigationItem.rightBarButtonItem = nil // remove Done added by Helm
         // swiftlint:disable:next line_length
-        actAsUserDescription.text = NSLocalizedString("\"Act as\" is essentially logging in as this user without a password. You will be able to take any action as if you were this user, and from other users' points of view, as if this user performed them. However, audit logs record that you were the one who performed the actions on behalf of this user.", bundle: .core, comment: "")
-        domainTextField.placeholder = NSLocalizedString("Domain", bundle: .core, comment: "")
-        userIDTextField.placeholder = NSLocalizedString("User ID", bundle: .core, comment: "")
-        actAsUserButton.titleLabel?.text = NSLocalizedString("Act as User", bundle: .core, comment: "")
+        actAsUserDescription.text = String(localized: "\"Act as\" is essentially logging in as this user without a password. You will be able to take any action as if you were this user, and from other users' points of view, as if this user performed them. However, audit logs record that you were the one who performed the actions on behalf of this user.", bundle: .core)
+        domainTextField.placeholder = String(localized: "Domain", bundle: .core)
+        userIDTextField.placeholder = String(localized: "User ID", bundle: .core)
+        actAsUserButton.titleLabel?.text = String(localized: "Act as User", bundle: .core)
         domainTextField.text = env.currentSession?.baseURL.absoluteString
         userIDTextField.text = initialUserID
         updateActAsUserButtonDisabledStatus()
@@ -149,11 +149,11 @@ public class ActAsUserViewController: UIViewController {
 
     func showMasqueradingError() {
         let alert = UIAlertController(
-            title: NSLocalizedString("Error", bundle: .core, comment: ""),
-            message: NSLocalizedString("There was an error with Act as User. Please try again later.", bundle: .core, comment: ""),
+            title: String(localized: "Error", bundle: .core),
+            message: String(localized: "There was an error with Act as User. Please try again later.", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
     }
 }

--- a/Core/Core/ActAsUser/ActAsUserWindow.swift
+++ b/Core/Core/ActAsUser/ActAsUserWindow.swift
@@ -100,7 +100,7 @@ class ActAsUserOverlay: UIView {
         let button = UIButton(type: .custom)
         button.addTarget(self, action: #selector(stopActing), for: .primaryActionTriggered)
         button.accessibilityIdentifier = "ActAsUser.endActAsUserButton"
-        button.accessibilityLabel = NSLocalizedString("End Act as User", bundle: .core, comment: "")
+        button.accessibilityLabel = String(localized: "End Act as User", bundle: .core)
         return button
     }()
 
@@ -153,23 +153,23 @@ class ActAsUserOverlay: UIView {
     @objc func stopActing() {
         guard let viewController = window?.rootViewController?.topMostViewController() else { return }
         let session = AppEnvironment.shared.currentSession
-        var message: String? = NSLocalizedString("You will stop acting as this user and return to your account.", bundle: .core, comment: "")
+        var message: String? = String(localized: "You will stop acting as this user and return to your account.", bundle: .core)
         if let name = session?.userName, session?.isFakeStudent != true {
-            let template = NSLocalizedString("You will stop acting as %@ and return to your account.", bundle: .core, comment: "")
+            let template = String(localized: "You will stop acting as %@ and return to your account.", bundle: .core)
             message = String.localizedStringWithFormat(template, name)
         }
-        var title = NSLocalizedString("Stop acting as...", bundle: .core, comment: "")
+        var title = String(localized: "Stop acting as...", bundle: .core)
         if session?.isFakeStudent == true {
-            title = NSLocalizedString("Leave Student View", bundle: .core, comment: "")
-            message = NSLocalizedString("Are you sure you want to exit Student View?", bundle: .core, comment: "")
+            title = String(localized: "Leave Student View", bundle: .core)
+            message = String(localized: "Are you sure you want to exit Student View?", bundle: .core)
         }
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let ok = UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
+        let ok = UIAlertAction(title: String(localized: "OK", bundle: .core), style: .default) { _ in
             if let loginDelegate = self.loginDelegate, let session = AppEnvironment.shared.currentSession {
                 loginDelegate.stopActing(as: session)
             }
         }
-        let cancelTitle = NSLocalizedString("Cancel", bundle: .core, comment: "")
+        let cancelTitle = String(localized: "Cancel", bundle: .core)
         let cancel = UIAlertAction(title: cancelTitle, style: .cancel, handler: nil)
         alert.addAction(ok)
         alert.addAction(cancel)

--- a/Core/Core/AppEnvironment/LocalizationManager.swift
+++ b/Core/Core/AppEnvironment/LocalizationManager.swift
@@ -57,11 +57,11 @@ public class LocalizationManager {
         let env = AppEnvironment.shared
         guard needsRestart, let root = env.window?.rootViewController else { return then() }
         let alert = UIAlertController(
-            title: NSLocalizedString("Updated Language Settings", bundle: .core, comment: ""),
-            message: NSLocalizedString("The app needs to restart to use the new language settings. Please relaunch the app.", bundle: .core, comment: ""),
+            title: String(localized: "Updated Language Settings", bundle: .core),
+            message: String(localized: "The app needs to restart to use the new language settings. Please relaunch the app.", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Close App", bundle: .core, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "Close App", bundle: .core), style: .default) { _ in
             UIControl().sendAction(suspend, to: app, for: nil)
         })
         if let presented = root.presentedViewController { // QR login alert

--- a/Core/Core/Assignments/APIAssignmentList.swift
+++ b/Core/Core/Assignments/APIAssignmentList.swift
@@ -180,19 +180,19 @@ public struct APIAssignmentListAssignment: Codable, Equatable, Hashable {
 extension APIAssignmentListAssignment {
     public var formattedDueDate: String? {
         if let lockAt = lockAt, Clock.now > lockAt {
-            return NSLocalizedString("Availability: Closed", bundle: .core, comment: "")
+            return String(localized: "Availability: Closed", bundle: .core)
         }
 
         if let lockAt = lockAt, Clock.now > lockAt {
-            return NSLocalizedString("Closed", bundle: .core, comment: "")
+            return String(localized: "Closed", bundle: .core)
         }
 
         if let dueAt = dueAt {
-            let format = NSLocalizedString("Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
+            let format = String(localized: "Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
             return String.localizedStringWithFormat(format, dueAt.relativeDateTimeString)
         }
 
-        return NSLocalizedString("No Due Date", bundle: .core, comment: "")
+        return String(localized: "No Due Date", bundle: .core)
     }
 
     public var icon: UIImage? {

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -458,17 +458,17 @@ public enum GradingType: String, Codable, CaseIterable {
     var string: String {
         switch self {
         case .percent:
-            return NSLocalizedString("Percentage", comment: "")
+            return NSLocalizedString("Percentage", bundle: .core, comment: "")
         case .pass_fail:
-            return NSLocalizedString("Complete/Incomplete", comment: "")
+            return NSLocalizedString("Complete/Incomplete", bundle: .core, comment: "")
         case .points:
-            return NSLocalizedString("Points", comment: "")
+            return NSLocalizedString("Points", bundle: .core, comment: "")
         case .letter_grade:
-            return NSLocalizedString("Letter Grade", comment: "")
+            return NSLocalizedString("Letter Grade", bundle: .core, comment: "")
         case .gpa_scale:
-            return NSLocalizedString("GPA Scale", comment: "")
+            return NSLocalizedString("GPA Scale", bundle: .core, comment: "")
         case .not_graded:
-            return NSLocalizedString("Not Graded", comment: "")
+            return NSLocalizedString("Not Graded", bundle: .core, comment: "")
         }
     }
 }

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -360,7 +360,7 @@ extension Assignment: DueViewable, GradeViewable, SubmissionViewable {
     }
 
     public var descriptionHTML: String {
-        let fallback = "<i>\(NSLocalizedString("No Content", bundle: .core, comment: ""))</i>"
+        let fallback = "<i>\(String(localized: "No Content", bundle: .core))</i>"
         if isDiscussion {
             return discussionTopic.map { DiscussionHTML.string(for: $0) } ?? fallback
         }
@@ -458,17 +458,17 @@ public enum GradingType: String, Codable, CaseIterable {
     var string: String {
         switch self {
         case .percent:
-            return NSLocalizedString("Percentage", bundle: .core, comment: "")
+            return String(localized: "Percentage", bundle: .core)
         case .pass_fail:
-            return NSLocalizedString("Complete/Incomplete", bundle: .core, comment: "")
+            return String(localized: "Complete/Incomplete", bundle: .core)
         case .points:
-            return NSLocalizedString("Points", bundle: .core, comment: "")
+            return String(localized: "Points", bundle: .core)
         case .letter_grade:
-            return NSLocalizedString("Letter Grade", bundle: .core, comment: "")
+            return String(localized: "Letter Grade", bundle: .core)
         case .gpa_scale:
-            return NSLocalizedString("GPA Scale", bundle: .core, comment: "")
+            return String(localized: "GPA Scale", bundle: .core)
         case .not_graded:
-            return NSLocalizedString("Not Graded", bundle: .core, comment: "")
+            return String(localized: "Not Graded", bundle: .core)
         }
     }
 }

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDateSectionViewModel.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDateSectionViewModel.swift
@@ -47,7 +47,7 @@ public class AssignmentDateSectionViewModel: DateSectionViewModelProtocol {
 
     public var forText: String {
         if allDatesDate?.base == true {
-            return NSLocalizedString("Everyone", bundle: .core, comment: "")
+            return String(localized: "Everyone", bundle: .core)
         } else {
             return allDatesDate?.title ?? "-"
         }

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -49,7 +49,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
         states
             .background(Color.backgroundLightest)
             .navigationBarStyle(.color(course.first?.color))
-            .navigationTitle(NSLocalizedString("Assignment Details", comment: ""), subtitle: course.first?.name)
+            .navigationTitle(NSLocalizedString("Assignment Details", bundle: .core, comment: ""), subtitle: course.first?.name)
             .rightBarButtonItems(editButton)
             .onAppear {
                 refreshAssignments()
@@ -221,16 +221,16 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
      */
     private func editButton() -> [UIBarButtonItemWithCompletion] {
         [
-            UIBarButtonItemWithCompletion(title: NSLocalizedString("Edit", comment: "")) { [_isTeacherEnrollment] in
+            UIBarButtonItemWithCompletion(title: NSLocalizedString("Edit", bundle: .core, comment: "")) { [_isTeacherEnrollment] in
                 if _isTeacherEnrollment.wrappedValue {
                     env.router.route(to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
                                      from: controller,
                                      options: .modal(isDismissable: false, embedInNav: true))
                 } else {
                     let alert = UIAlertController(title: NSLocalizedString("Error", bundle: .core, comment: ""),
-                                                  message: NSLocalizedString("You are not authorized to perform this action", comment: ""),
+                                                  message: NSLocalizedString("You are not authorized to perform this action", bundle: .core, comment: ""),
                                                   preferredStyle: .alert)
-                    alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default))
+                    alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default))
                     env.router.show(alert, from: controller, options: .modal())
                 }
             },

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -49,7 +49,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
         states
             .background(Color.backgroundLightest)
             .navigationBarStyle(.color(course.first?.color))
-            .navigationTitle(NSLocalizedString("Assignment Details", bundle: .core, comment: ""), subtitle: course.first?.name)
+            .navigationTitle(String(localized: "Assignment Details", bundle: .core), subtitle: course.first?.name)
             .rightBarButtonItems(editButton)
             .onAppear {
                 refreshAssignments()
@@ -221,16 +221,16 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
      */
     private func editButton() -> [UIBarButtonItemWithCompletion] {
         [
-            UIBarButtonItemWithCompletion(title: NSLocalizedString("Edit", bundle: .core, comment: "")) { [_isTeacherEnrollment] in
+            UIBarButtonItemWithCompletion(title: String(localized: "Edit", bundle: .core)) { [_isTeacherEnrollment] in
                 if _isTeacherEnrollment.wrappedValue {
                     env.router.route(to: "courses/\(courseID)/assignments/\(assignmentID)/edit",
                                      from: controller,
                                      options: .modal(isDismissable: false, embedInNav: true))
                 } else {
-                    let alert = UIAlertController(title: NSLocalizedString("Error", bundle: .core, comment: ""),
-                                                  message: NSLocalizedString("You are not authorized to perform this action", bundle: .core, comment: ""),
+                    let alert = UIAlertController(title: String(localized: "Error", bundle: .core),
+                                                  message: String(localized: "You are not authorized to perform this action", bundle: .core),
                                                   preferredStyle: .alert)
-                    alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default))
+                    alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default))
                     env.router.show(alert, from: controller, options: .modal())
                 }
             },

--- a/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDateItemViewModel.swift
+++ b/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDateItemViewModel.swift
@@ -37,7 +37,7 @@ public struct AssignmentDueDateItemViewModel: Identifiable, Equatable {
             self.title = NSLocalizedString("No Due Date", bundle: .core, comment: "")
         }
 
-        self.assignee = item.title ?? NSLocalizedString("Everyone", comment: "")
+        self.assignee = item.title ?? NSLocalizedString("Everyone", bundle: .core, comment: "")
 
         if let unlockAt = item.unlockAt?.dateTimeString {
             self.from = unlockAt

--- a/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDateItemViewModel.swift
+++ b/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDateItemViewModel.swift
@@ -31,24 +31,24 @@ public struct AssignmentDueDateItemViewModel: Identifiable, Equatable {
         self.id = item.id
 
         if let dueAt = item.dueAt {
-            let format = NSLocalizedString("Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
+            let format = String(localized: "Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
             self.title = String.localizedStringWithFormat(format, dueAt.dateTimeString)
         } else {
-            self.title = NSLocalizedString("No Due Date", bundle: .core, comment: "")
+            self.title = String(localized: "No Due Date", bundle: .core)
         }
 
-        self.assignee = item.title ?? NSLocalizedString("Everyone", bundle: .core, comment: "")
+        self.assignee = item.title ?? String(localized: "Everyone", bundle: .core)
 
         if let unlockAt = item.unlockAt?.dateTimeString {
             self.from = unlockAt
         } else {
-            self.fromEmptyAccessibility = NSLocalizedString("No available from date set.", bundle: .core, comment: "")
+            self.fromEmptyAccessibility = String(localized: "No available from date set.", bundle: .core)
         }
 
         if let lockAt = item.lockAt?.dateTimeString {
             self.until = lockAt
         } else {
-            self.untilEmptyAccessibility = NSLocalizedString("No available until date set.", bundle: .core, comment: "")
+            self.untilEmptyAccessibility = String(localized: "No available until date set.", bundle: .core)
         }
     }
 }

--- a/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDatesViewModel.swift
+++ b/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDatesViewModel.swift
@@ -23,7 +23,7 @@ class AssignmentDueDatesViewModel: ObservableObject {
     // MARK: - Outputs
     @Published public private(set) var state: StoreState = .loading
     @Published public private(set) var dueDates: [AssignmentDueDateItemViewModel] = []
-    public let title = NSLocalizedString("Due Dates", comment: "")
+    public let title = NSLocalizedString("Due Dates", bundle: .core, comment: "")
 
     // MARK: - Private
     private var subscriptions = Set<AnyCancellable>()

--- a/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDatesViewModel.swift
+++ b/Core/Core/Assignments/AssignmentDueDates/ViewModel/AssignmentDueDatesViewModel.swift
@@ -23,7 +23,7 @@ class AssignmentDueDatesViewModel: ObservableObject {
     // MARK: - Outputs
     @Published public private(set) var state: StoreState = .loading
     @Published public private(set) var dueDates: [AssignmentDueDateItemViewModel] = []
-    public let title = NSLocalizedString("Due Dates", bundle: .core, comment: "")
+    public let title = String(localized: "Due Dates", bundle: .core)
 
     // MARK: - Private
     private var subscriptions = Set<AnyCancellable>()

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneeList.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneeList.swift
@@ -30,7 +30,7 @@ struct AssigmentAssigneeList: View {
 
     @Binding var selection: [Assignee]
 
-    let everyone = NSLocalizedString("Everyone", bundle: .core, comment: "")
+    let everyone = String(localized: "Everyone", bundle: .core)
     @State var search: String = ""
 
     var isEveryoneMatching: Bool {
@@ -53,7 +53,7 @@ struct AssigmentAssigneeList: View {
         GeometryReader { geometry in VStack(spacing: 0) {
             SearchBar(
                 text: Binding(get: { search }, set: { updateSearch($0) }),
-                placeholder: NSLocalizedString("Search", bundle: .core, comment: "")
+                placeholder: String(localized: "Search", bundle: .core)
             )
             ScrollView {
                 if isEmpty {

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneeList.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneeList.swift
@@ -30,7 +30,7 @@ struct AssigmentAssigneeList: View {
 
     @Binding var selection: [Assignee]
 
-    let everyone = NSLocalizedString("Everyone", comment: "")
+    let everyone = NSLocalizedString("Everyone", bundle: .core, comment: "")
     @State var search: String = ""
 
     var isEveryoneMatching: Bool {
@@ -53,7 +53,7 @@ struct AssigmentAssigneeList: View {
         GeometryReader { geometry in VStack(spacing: 0) {
             SearchBar(
                 text: Binding(get: { search }, set: { updateSearch($0) }),
-                placeholder: NSLocalizedString("Search", comment: "")
+                placeholder: NSLocalizedString("Search", bundle: .core, comment: "")
             )
             ScrollView {
                 if isEmpty {

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneePicker.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentAssigneePicker.swift
@@ -76,7 +76,7 @@ struct AssignmentAssigneePicker: View {
             EditorSection { ButtonRow(action: add, content: {
                 Image.addSolid.size(18)
                     .padding(.trailing, 12)
-                Text("Add Assignee")
+                Text("Add Assignee", bundle: .core)
                 Spacer()
                 DisclosureIndicator()
             }) }

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -116,8 +116,8 @@ public struct AssignmentEditorView: View, ScreenViewTrackable {
     private var descriptionEditorSection: some View {
         EditorSection(label: Text("Description", bundle: .core)) {
             RichContentEditor(
-                placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
-                a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
+                placeholder: String(localized: "Add description", bundle: .core),
+                a11yLabel: String(localized: "Description", bundle: .core),
                 html: $description,
                 context: .course(courseID),
                 uploadTo: .context(.course(courseID)),
@@ -146,7 +146,7 @@ public struct AssignmentEditorView: View, ScreenViewTrackable {
             ButtonRow(action: {
                 let options: [GradingType] = GradingType.allCases
                 self.env.router.show(ItemPickerViewController.create(
-                    title: NSLocalizedString("Display Grade as", bundle: .core, comment: ""),
+                    title: String(localized: "Display Grade as", bundle: .core),
                     sections: [
                         ItemPickerSection(
                             items: options.map {

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -116,8 +116,8 @@ public struct AssignmentEditorView: View, ScreenViewTrackable {
     private var descriptionEditorSection: some View {
         EditorSection(label: Text("Description", bundle: .core)) {
             RichContentEditor(
-                placeholder: NSLocalizedString("Add description", comment: ""),
-                a11yLabel: NSLocalizedString("Description", comment: ""),
+                placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
+                a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
                 html: $description,
                 context: .course(courseID),
                 uploadTo: .context(.course(courseID)),
@@ -146,7 +146,7 @@ public struct AssignmentEditorView: View, ScreenViewTrackable {
             ButtonRow(action: {
                 let options: [GradingType] = GradingType.allCases
                 self.env.router.show(ItemPickerViewController.create(
-                    title: NSLocalizedString("Display Grade as", comment: ""),
+                    title: NSLocalizedString("Display Grade as", bundle: .core, comment: ""),
                     sections: [
                         ItemPickerSection(
                             items: options.map {

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
@@ -91,7 +91,7 @@ public struct AssignmentOverridesEditor: View {
     }
 
     var everyone: String {
-        overrides.count <= 1 ? NSLocalizedString("Everyone", comment: "") : NSLocalizedString("Everyone else", comment: "")
+        overrides.count <= 1 ? NSLocalizedString("Everyone", bundle: .core, comment: "") : NSLocalizedString("Everyone else", bundle: .core, comment: "")
     }
 
     func add() {
@@ -204,7 +204,7 @@ public struct AssignmentOverridesEditor: View {
         var isEveryone: Bool { groupID == nil && sectionID == nil && studentIDs == nil }
 
         static func studentsString(_ count: Int) -> String {
-            return String.localizedStringWithFormat(NSLocalizedString("%d students", comment: ""), count)
+            return String.localizedStringWithFormat(NSLocalizedString("%d students", bundle: .core, comment: ""), count)
         }
     }
 }

--- a/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentOverridesEditor.swift
@@ -91,7 +91,7 @@ public struct AssignmentOverridesEditor: View {
     }
 
     var everyone: String {
-        overrides.count <= 1 ? NSLocalizedString("Everyone", bundle: .core, comment: "") : NSLocalizedString("Everyone else", bundle: .core, comment: "")
+        overrides.count <= 1 ? String(localized: "Everyone", bundle: .core) : String(localized: "Everyone else", bundle: .core)
     }
 
     func add() {
@@ -204,7 +204,7 @@ public struct AssignmentOverridesEditor: View {
         var isEveryone: Bool { groupID == nil && sectionID == nil && studentIDs == nil }
 
         static func studentsString(_ count: Int) -> String {
-            return String.localizedStringWithFormat(NSLocalizedString("%d students", bundle: .core, comment: ""), count)
+            return String.localizedStringWithFormat(String(localized: "%d students", bundle: .core), count)
         }
     }
 }

--- a/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
+++ b/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
@@ -55,7 +55,7 @@ public struct AssignmentListView: View, ScreenViewTrackable {
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
         .navigationBarStyle(.color(viewModel.courseColor))
-        .navigationTitle(NSLocalizedString("Assignments", comment: ""), subtitle: viewModel.courseName)
+        .navigationTitle(NSLocalizedString("Assignments", bundle: .core, comment: ""), subtitle: viewModel.courseName)
         .navigationBarGenericBackButton()
         .onAppear(perform: viewModel.viewDidAppear)
         .onReceive(viewModel.$defaultDetailViewRoute, perform: setupDefaultSplitDetailView)

--- a/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
+++ b/Core/Core/Assignments/AssignmentList/View/AssignmentListView.swift
@@ -55,7 +55,7 @@ public struct AssignmentListView: View, ScreenViewTrackable {
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
         .navigationBarStyle(.color(viewModel.courseColor))
-        .navigationTitle(NSLocalizedString("Assignments", bundle: .core, comment: ""), subtitle: viewModel.courseName)
+        .navigationTitle(String(localized: "Assignments", bundle: .core), subtitle: viewModel.courseName)
         .navigationBarGenericBackButton()
         .onAppear(perform: viewModel.viewDidAppear)
         .onReceive(viewModel.$defaultDetailViewRoute, perform: setupDefaultSplitDetailView)

--- a/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
+++ b/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
@@ -59,25 +59,25 @@ public class AssignmentCellViewModel: ObservableObject {
             return nil
         }
 
-        let format = NSLocalizedString("d_needs_grading", bundle: .core, comment: "")
+        let format = String(localized: "d_needs_grading", bundle: .core)
         return String.localizedStringWithFormat(format, assignment.needsGradingCount).localizedUppercase
     }
 
     public var formattedDueDate: String {
         if let lockAt = assignment.lockAt, Clock.now > lockAt {
-            return NSLocalizedString("Availability: Closed", bundle: .core, comment: "")
+            return String(localized: "Availability: Closed", bundle: .core)
         }
 
         if assignment.hasMultipleDueDates {
-            return NSLocalizedString("Multiple Due Dates", bundle: .core, comment: "")
+            return String(localized: "Multiple Due Dates", bundle: .core)
         }
 
         if let dueAt = assignment.dueAt {
-            let format = NSLocalizedString("Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
+            let format = String(localized: "Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
             return String.localizedStringWithFormat(format, dueAt.relativeDateTimeString)
         }
 
-        return NSLocalizedString("No Due Date", bundle: .core, comment: "")
+        return String(localized: "No Due Date", bundle: .core)
     }
 
     private var isTeacher: Bool {

--- a/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
+++ b/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
@@ -59,7 +59,7 @@ public class AssignmentCellViewModel: ObservableObject {
             return nil
         }
 
-        let format = NSLocalizedString("d_needs_grading", comment: "")
+        let format = NSLocalizedString("d_needs_grading", bundle: .core, comment: "")
         return String.localizedStringWithFormat(format, assignment.needsGradingCount).localizedUppercase
     }
 
@@ -69,7 +69,7 @@ public class AssignmentCellViewModel: ObservableObject {
         }
 
         if assignment.hasMultipleDueDates {
-            return NSLocalizedString("Multiple Due Dates", comment: "")
+            return NSLocalizedString("Multiple Due Dates", bundle: .core, comment: "")
         }
 
         if let dueAt = assignment.dueAt {

--- a/Core/Core/AudioVideo/AudioPlayerViewController.swift
+++ b/Core/Core/AudioVideo/AudioPlayerViewController.swift
@@ -79,12 +79,12 @@ public class AudioPlayerViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
         backgroundColor = .backgroundDarkest
-        playPauseButton?.accessibilityLabel = NSLocalizedString("Play", bundle: .core, comment: "")
-        currentTimeLabel?.accessibilityLabel = NSLocalizedString("Time elapsed", bundle: .core, comment: "")
+        playPauseButton?.accessibilityLabel = String(localized: "Play", bundle: .core)
+        currentTimeLabel?.accessibilityLabel = String(localized: "Time elapsed", bundle: .core)
         loadingView?.accessibilityIdentifier = "AudioPlayer.loadingView"
         loadingView?.color = color
-        remainingTimeLabel?.accessibilityLabel = NSLocalizedString("Total time", bundle: .core, comment: "")
-        timeSlider?.accessibilityLabel = NSLocalizedString("Current position", bundle: .core, comment: "")
+        remainingTimeLabel?.accessibilityLabel = String(localized: "Total time", bundle: .core)
+        timeSlider?.accessibilityLabel = String(localized: "Current position", bundle: .core)
     }
 
     public override func viewWillDisappear(_ animated: Bool) {
@@ -94,8 +94,8 @@ public class AudioPlayerViewController: UIViewController {
 
     public func load(url: URL?) {
         self.url = url
-        currentTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
-        remainingTimeLabel?.text = NSLocalizedString("--:--", bundle: .core, comment: "Unknown time duration")
+        currentTimeLabel?.text = String(localized: "--:--", bundle: .core, comment: "Unknown time duration")
+        remainingTimeLabel?.text = String(localized: "--:--", bundle: .core, comment: "Unknown time duration")
         loadingView?.startAnimating()
         playPauseButton?.alpha = 0
         playPauseButton?.isEnabled = false
@@ -135,7 +135,7 @@ public class AudioPlayerViewController: UIViewController {
             try session.setActive(true)
             if player.play() {
                 playPauseButton?.setImage(.pauseSolid, for: .normal)
-                playPauseButton?.accessibilityLabel = NSLocalizedString("Pause", bundle: .core, comment: "")
+                playPauseButton?.accessibilityLabel = String(localized: "Pause", bundle: .core)
                 timer = CADisplayLink(target: self, selector: #selector(tick))
                 timer?.add(to: RunLoop.main, forMode: RunLoop.Mode.common)
             }
@@ -166,7 +166,7 @@ public class AudioPlayerViewController: UIViewController {
         timer = nil
         player.stop()
         playPauseButton?.setImage(.playSolid, for: .normal)
-        playPauseButton?.accessibilityLabel = NSLocalizedString("Play", bundle: .core, comment: "")
+        playPauseButton?.accessibilityLabel = String(localized: "Play", bundle: .core)
         try? AVAudioSession.sharedInstance().setActive(false)
     }
 

--- a/Core/Core/AudioVideo/AudioRecorderViewController.swift
+++ b/Core/Core/AudioVideo/AudioRecorderViewController.swift
@@ -55,13 +55,13 @@ public class AudioRecorderViewController: UIViewController, ErrorViewController 
     public override func viewDidLoad() {
         super.viewDidLoad()
         borderView?.layer.borderColor = UIColor.borderMedium.cgColor
-        cancelButton?.accessibilityLabel = NSLocalizedString("Cancel", bundle: .core, comment: "")
-        clearButton?.accessibilityLabel = NSLocalizedString("Clear recording", bundle: .core, comment: "")
+        cancelButton?.accessibilityLabel = String(localized: "Cancel", bundle: .core)
+        clearButton?.accessibilityLabel = String(localized: "Clear recording", bundle: .core)
         player.accessibilityPrefix = "AudioRecorder."
         if let view = playerView { embed(player, in: view) }
-        recordButton?.accessibilityLabel = NSLocalizedString("Start recording", bundle: .core, comment: "")
-        sendButton?.setTitle(NSLocalizedString("Send", bundle: .core, comment: ""), for: .normal)
-        stopButton?.accessibilityLabel = NSLocalizedString("Stop recording", bundle: .core, comment: "")
+        recordButton?.accessibilityLabel = String(localized: "Start recording", bundle: .core)
+        sendButton?.setTitle(String(localized: "Send", bundle: .core), for: .normal)
+        stopButton?.accessibilityLabel = String(localized: "Stop recording", bundle: .core)
     }
 
     @IBAction func record(_ sender: UIButton) {

--- a/Core/Core/Conferences/Conference.swift
+++ b/Core/Core/Conferences/Conference.swift
@@ -56,14 +56,14 @@ public final class Conference: NSManagedObject {
     var statusText: String {
         if let date = endedAt {
             return String.localizedStringWithFormat(
-                NSLocalizedString("Concluded %@", bundle: .core, comment: "concluded datetime"),
+                String(localized: "Concluded %@", bundle: .core, comment: "concluded datetime"),
                 date.dateTimeString
             )
         }
         if startedAt != nil {
-            return NSLocalizedString("In Progress", bundle: .core, comment: "")
+            return String(localized: "In Progress", bundle: .core)
         }
-        return NSLocalizedString("Not Started", bundle: .core, comment: "")
+        return String(localized: "Not Started", bundle: .core)
     }
 
     var statusLongText: NSAttributedString {
@@ -72,7 +72,7 @@ public final class Conference: NSManagedObject {
             status.append(NSAttributedString(string: statusText, attributes: [.foregroundColor: statusColor]))
             status.append(NSAttributedString(string: " | "))
             status.append(NSAttributedString(string: String.localizedStringWithFormat(
-                NSLocalizedString("Started %@", bundle: .core, comment: "started datetime"),
+                String(localized: "Started %@", bundle: .core, comment: "started datetime"),
                 date.dateTimeString
             )))
             return status

--- a/Core/Core/Conferences/ConferenceDetailsViewController.swift
+++ b/Core/Core/Conferences/ConferenceDetailsViewController.swift
@@ -72,15 +72,15 @@ public class ConferenceDetailsViewController: ScreenViewTrackableViewController,
         view.backgroundColor = .backgroundLightest
         tableView.backgroundColor = .backgroundLightest
 
-        setupTitleViewInNavbar(title: NSLocalizedString("Conference Details", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Conference Details", bundle: .core))
 
-        detailsHeadingLabel.text = NSLocalizedString("Description", bundle: .core, comment: "")
+        detailsHeadingLabel.text = String(localized: "Description", bundle: .core)
 
-        joinButton.setTitle(NSLocalizedString("Join", bundle: .core, comment: ""), for: .normal)
+        joinButton.setTitle(String(localized: "Join", bundle: .core), for: .normal)
         joinButton.isHidden = true
         joinButton.makeUnavailableInOfflineMode()
 
-        recordingsHeadingLabel.text = NSLocalizedString("Recordings", bundle: .core, comment: "")
+        recordingsHeadingLabel.text = String(localized: "Recordings", bundle: .core)
         recordingsView.isHidden = true
 
         refreshControl.addTarget(self, action: #selector(refresh(_:)), for: .primaryActionTriggered)
@@ -120,7 +120,7 @@ public class ConferenceDetailsViewController: ScreenViewTrackableViewController,
         if let description = conference?.details, !description.isEmpty {
             detailsLabel.text = description
         } else {
-            detailsLabel.text = NSLocalizedString("No description", bundle: .core, comment: "")
+            detailsLabel.text = String(localized: "No description", bundle: .core)
         }
         joinButton.isHidden = !(conference?.startedAt != nil && conference?.endedAt == nil)
         recordingsView.isHidden = conference?.recordings?.isEmpty != false

--- a/Core/Core/Conferences/ConferenceListViewController.swift
+++ b/Core/Core/Conferences/ConferenceListViewController.swift
@@ -57,11 +57,11 @@ public class ConferenceListViewController: ScreenViewTrackableViewController, Co
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Conferences", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Conferences", bundle: .core))
 
-        emptyMessageLabel.text = NSLocalizedString("There are no conferences to display yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Conferences", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading conferences. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "There are no conferences to display yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Conferences", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading conferences. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         tableView.backgroundColor = .backgroundLightest
@@ -130,8 +130,8 @@ extension ConferenceListViewController: UITableViewDataSource, UITableViewDelega
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let view = tableView.dequeueHeaderFooter(SectionHeaderView.self)
         view.titleLabel?.text = conferences[IndexPath(row: 0, section: section)]?.isConcluded == true
-            ? NSLocalizedString("Concluded Conferences", bundle: .core, comment: "")
-            : NSLocalizedString("New Conferences", bundle: .core, comment: "")
+            ? String(localized: "Concluded Conferences", bundle: .core)
+            : String(localized: "New Conferences", bundle: .core)
         view.titleLabel?.accessibilityIdentifier = "ConferencesList.header-\(section)"
         return view
     }

--- a/Core/Core/Conversations/AttachmentCardsViewController.swift
+++ b/Core/Core/Conversations/AttachmentCardsViewController.swift
@@ -59,7 +59,7 @@ public class AttachmentCardsViewController: UIViewController {
         for (index, a) in self.attachments.enumerated() {
             let card = getCard(cardIndex)
             if a.uploadError != nil {
-                card.updateFile(name: NSLocalizedString("Failed. Tap for options", bundle: .core, comment: ""), icon: .warningLine)
+                card.updateFile(name: String(localized: "Failed. Tap for options", bundle: .core), icon: .warningLine)
                 card.iconView?.tintColor = .textDanger
             } else if a.isUploading, a.size > 0 {
                 card.updateProgress(name: a.displayName ?? a.localFileURL?.lastPathComponent, sent: a.bytesSent, of: a.size)
@@ -247,8 +247,8 @@ class AttachmentCardView: UIView {
         }()
         let progress = Double(sent) / Double(total)
         button.accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("Uploading %@ is at %@", bundle: .core, comment: ""),
-            name ?? NSLocalizedString("File", bundle: .core, comment: ""),
+            String(localized: "Uploading %@ is at %@", bundle: .core),
+            name ?? String(localized: "File", bundle: .core),
             NumberFormatter.localizedString(from: NSNumber(value: progress), number: .percent)
         )
         progressView.isHidden = false

--- a/Core/Core/Conversations/ComposeRecipientsView.swift
+++ b/Core/Core/Conversations/ComposeRecipientsView.swift
@@ -60,7 +60,7 @@ class ComposeRecipientsView: UIView {
         editButton.setImage(.addressBookLine, for: .normal)
         editButton.tintColor = .textDark
         editButton.translatesAutoresizingMaskIntoConstraints = false
-        editButton.accessibilityLabel = NSLocalizedString("Edit Recipients", comment: "")
+        editButton.accessibilityLabel = NSLocalizedString("Edit Recipients", bundle: .core, comment: "")
         addSubview(editButton)
         NSLayoutConstraint.activate([
             editButton.heightAnchor.constraint(equalToConstant: 44),
@@ -73,7 +73,7 @@ class ComposeRecipientsView: UIView {
     func addPlaceholder() {
         placeholder = UILabel()
         placeholder.translatesAutoresizingMaskIntoConstraints = false
-        placeholder.text = NSLocalizedString("To", comment: "")
+        placeholder.text = NSLocalizedString("To", bundle: .core, comment: "")
         placeholder.textColor = .ash
         placeholder.font = .scaledNamedFont(.medium16)
         addSubview(placeholder)

--- a/Core/Core/Conversations/ComposeRecipientsView.swift
+++ b/Core/Core/Conversations/ComposeRecipientsView.swift
@@ -60,7 +60,7 @@ class ComposeRecipientsView: UIView {
         editButton.setImage(.addressBookLine, for: .normal)
         editButton.tintColor = .textDark
         editButton.translatesAutoresizingMaskIntoConstraints = false
-        editButton.accessibilityLabel = NSLocalizedString("Edit Recipients", bundle: .core, comment: "")
+        editButton.accessibilityLabel = String(localized: "Edit Recipients", bundle: .core)
         addSubview(editButton)
         NSLayoutConstraint.activate([
             editButton.heightAnchor.constraint(equalToConstant: 44),
@@ -73,7 +73,7 @@ class ComposeRecipientsView: UIView {
     func addPlaceholder() {
         placeholder = UILabel()
         placeholder.translatesAutoresizingMaskIntoConstraints = false
-        placeholder.text = NSLocalizedString("To", bundle: .core, comment: "")
+        placeholder.text = String(localized: "To", bundle: .core)
         placeholder.textColor = .ash
         placeholder.font = .scaledNamedFont(.medium16)
         addSubview(placeholder)
@@ -103,7 +103,7 @@ class ComposeRecipientsView: UIView {
     }
 
     func updatePills() {
-        additionalRecipients.text = String.localizedStringWithFormat(NSLocalizedString("+%d", bundle: .core, comment: ""), recipients.count - 1)
+        additionalRecipients.text = String.localizedStringWithFormat(String(localized: "+%d", bundle: .core), recipients.count - 1)
         additionalRecipients.isHidden = recipients.count <= 1 || isExpanded
 
         pills.forEach { $0.removeFromSuperview() }

--- a/Core/Core/Conversations/ComposeReplyViewController.swift
+++ b/Core/Core/Conversations/ComposeReplyViewController.swift
@@ -35,7 +35,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var toLabel: UILabel!
 
     lazy var attachButton = UIBarButtonItem(image: .paperclipLine, style: .plain, target: self, action: #selector(attach))
-    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", comment: ""), style: .done, target: self, action: #selector(send))
+    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done, target: self, action: #selector(send))
 
     let batchID = UUID.string
     lazy var attachments = UploadManager.shared.subscribe(batchID: batchID) { [weak self] in
@@ -71,7 +71,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
         view.backgroundColor = .backgroundLightest
 
         addCancelButton(side: .left)
-        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", comment: "")
+        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", bundle: .core, comment: "")
         attachButton.accessibilityIdentifier = "ComposeReply.attachButton"
         sendButton.isEnabled = false
         sendButton.accessibilityIdentifier = "ComposeReply.sendButton"
@@ -81,12 +81,12 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
         attachmentsContainer.isHidden = true
         attachmentsController.showOptions = { [weak self] in self?.showOptions(for: $0) }
 
-        bodyView.placeholder = NSLocalizedString("Message", comment: "")
+        bodyView.placeholder = NSLocalizedString("Message", bundle: .core, comment: "")
         bodyView.placeholderColor = UIColor.textDark
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .textDarkest
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
-        bodyView.accessibilityLabel = NSLocalizedString("Message", comment: "")
+        bodyView.accessibilityLabel = NSLocalizedString("Message", bundle: .core, comment: "")
         if env.app == .parent {
             students.refresh()
         }
@@ -108,8 +108,8 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
 
     func update() {
         title = all
-            ? NSLocalizedString("Reply All", comment: "")
-            : NSLocalizedString("Reply", comment: "")
+            ? NSLocalizedString("Reply All", bundle: .core, comment: "")
+            : NSLocalizedString("Reply", bundle: .core, comment: "")
 
         guard let conversation = conversation,
             let message = message,

--- a/Core/Core/Conversations/ComposeReplyViewController.swift
+++ b/Core/Core/Conversations/ComposeReplyViewController.swift
@@ -35,7 +35,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var toLabel: UILabel!
 
     lazy var attachButton = UIBarButtonItem(image: .paperclipLine, style: .plain, target: self, action: #selector(attach))
-    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done, target: self, action: #selector(send))
+    lazy var sendButton = UIBarButtonItem(title: String(localized: "Send", bundle: .core), style: .done, target: self, action: #selector(send))
 
     let batchID = UUID.string
     lazy var attachments = UploadManager.shared.subscribe(batchID: batchID) { [weak self] in
@@ -71,7 +71,7 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
         view.backgroundColor = .backgroundLightest
 
         addCancelButton(side: .left)
-        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", bundle: .core, comment: "")
+        attachButton.accessibilityLabel = String(localized: "Add Attachments", bundle: .core)
         attachButton.accessibilityIdentifier = "ComposeReply.attachButton"
         sendButton.isEnabled = false
         sendButton.accessibilityIdentifier = "ComposeReply.sendButton"
@@ -81,12 +81,12 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
         attachmentsContainer.isHidden = true
         attachmentsController.showOptions = { [weak self] in self?.showOptions(for: $0) }
 
-        bodyView.placeholder = NSLocalizedString("Message", bundle: .core, comment: "")
+        bodyView.placeholder = String(localized: "Message", bundle: .core)
         bodyView.placeholderColor = UIColor.textDark
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .textDarkest
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
-        bodyView.accessibilityLabel = NSLocalizedString("Message", bundle: .core, comment: "")
+        bodyView.accessibilityLabel = String(localized: "Message", bundle: .core)
         if env.app == .parent {
             students.refresh()
         }
@@ -108,8 +108,8 @@ class ComposeReplyViewController: UIViewController, ErrorViewController {
 
     func update() {
         title = all
-            ? NSLocalizedString("Reply All", bundle: .core, comment: "")
-            : NSLocalizedString("Reply", bundle: .core, comment: "")
+            ? String(localized: "Reply All", bundle: .core)
+            : String(localized: "Reply", bundle: .core)
 
         guard let conversation = conversation,
             let message = message,

--- a/Core/Core/Conversations/ComposeViewController.swift
+++ b/Core/Core/Conversations/ComposeViewController.swift
@@ -30,7 +30,7 @@ public class ComposeViewController: UIViewController, ErrorViewController {
     let titleSubtitleView = TitleSubtitleView.create()
 
     lazy var attachButton = UIBarButtonItem(image: .paperclipLine, style: .plain, target: self, action: #selector(attach))
-    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", comment: ""), style: .done, target: self, action: #selector(send))
+    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done, target: self, action: #selector(send))
 
     let batchID = UUID.string
     lazy var attachments = UploadManager.shared.subscribe(batchID: batchID) { [weak self] in
@@ -83,10 +83,10 @@ public class ComposeViewController: UIViewController, ErrorViewController {
         titleSubtitleView.titleLabel?.textColor = .textDarkest
         titleSubtitleView.subtitleLabel?.textColor = .textDark
         navigationItem.titleView = titleSubtitleView
-        titleSubtitleView.title = NSLocalizedString("New Message", comment: "")
+        titleSubtitleView.title = NSLocalizedString("New Message", bundle: .core, comment: "")
 
         addCancelButton(side: .left)
-        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", comment: "")
+        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", bundle: .core, comment: "")
         sendButton.isEnabled = false
         navigationItem.rightBarButtonItems = [ sendButton, attachButton ]
 
@@ -95,18 +95,18 @@ public class ComposeViewController: UIViewController, ErrorViewController {
         attachmentsController.showOptions = { [weak self] in self?.showOptions(for: $0) }
 
         bodyMinHeight.isActive = true
-        bodyView.placeholder = NSLocalizedString("Message", comment: "")
+        bodyView.placeholder = NSLocalizedString("Message", bundle: .core, comment: "")
         bodyView.placeholderColor = UIColor.textDark
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .textDarkest
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
-        bodyView.accessibilityLabel = NSLocalizedString("Message", comment: "")
+        bodyView.accessibilityLabel = NSLocalizedString("Message", bundle: .core, comment: "")
 
         subjectField.attributedPlaceholder = NSAttributedString(
-            string: NSLocalizedString("Subject", comment: ""),
+            string: NSLocalizedString("Subject", bundle: .core, comment: ""),
             attributes: [ .foregroundColor: UIColor.textDark ]
         )
-        subjectField.accessibilityLabel = NSLocalizedString("Subject", comment: "")
+        subjectField.accessibilityLabel = NSLocalizedString("Subject", bundle: .core, comment: "")
 
         recipientsView.editButton.addTarget(self, action: #selector(editRecipients), for: .primaryActionTriggered)
         course?.refresh()

--- a/Core/Core/Conversations/ComposeViewController.swift
+++ b/Core/Core/Conversations/ComposeViewController.swift
@@ -30,7 +30,7 @@ public class ComposeViewController: UIViewController, ErrorViewController {
     let titleSubtitleView = TitleSubtitleView.create()
 
     lazy var attachButton = UIBarButtonItem(image: .paperclipLine, style: .plain, target: self, action: #selector(attach))
-    lazy var sendButton = UIBarButtonItem(title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done, target: self, action: #selector(send))
+    lazy var sendButton = UIBarButtonItem(title: String(localized: "Send", bundle: .core), style: .done, target: self, action: #selector(send))
 
     let batchID = UUID.string
     lazy var attachments = UploadManager.shared.subscribe(batchID: batchID) { [weak self] in
@@ -83,10 +83,10 @@ public class ComposeViewController: UIViewController, ErrorViewController {
         titleSubtitleView.titleLabel?.textColor = .textDarkest
         titleSubtitleView.subtitleLabel?.textColor = .textDark
         navigationItem.titleView = titleSubtitleView
-        titleSubtitleView.title = NSLocalizedString("New Message", bundle: .core, comment: "")
+        titleSubtitleView.title = String(localized: "New Message", bundle: .core)
 
         addCancelButton(side: .left)
-        attachButton.accessibilityLabel = NSLocalizedString("Add Attachments", bundle: .core, comment: "")
+        attachButton.accessibilityLabel = String(localized: "Add Attachments", bundle: .core)
         sendButton.isEnabled = false
         navigationItem.rightBarButtonItems = [ sendButton, attachButton ]
 
@@ -95,18 +95,18 @@ public class ComposeViewController: UIViewController, ErrorViewController {
         attachmentsController.showOptions = { [weak self] in self?.showOptions(for: $0) }
 
         bodyMinHeight.isActive = true
-        bodyView.placeholder = NSLocalizedString("Message", bundle: .core, comment: "")
+        bodyView.placeholder = String(localized: "Message", bundle: .core)
         bodyView.placeholderColor = UIColor.textDark
         bodyView.font = .scaledNamedFont(.medium16)
         bodyView.textColor = .textDarkest
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
-        bodyView.accessibilityLabel = NSLocalizedString("Message", bundle: .core, comment: "")
+        bodyView.accessibilityLabel = String(localized: "Message", bundle: .core)
 
         subjectField.attributedPlaceholder = NSAttributedString(
-            string: NSLocalizedString("Subject", bundle: .core, comment: ""),
+            string: String(localized: "Subject", bundle: .core),
             attributes: [ .foregroundColor: UIColor.textDark ]
         )
-        subjectField.accessibilityLabel = NSLocalizedString("Subject", bundle: .core, comment: "")
+        subjectField.accessibilityLabel = String(localized: "Subject", bundle: .core)
 
         recipientsView.editButton.addTarget(self, action: #selector(editRecipients), for: .primaryActionTriggered)
         course?.refresh()

--- a/Core/Core/Conversations/ConversationCoursesActionSheet.swift
+++ b/Core/Core/Conversations/ConversationCoursesActionSheet.swift
@@ -50,7 +50,7 @@ public class ConversationCoursesActionSheet: UIViewController, ErrorViewControll
         view.frame.size.height = 294
 
         let titleLabel = UILabel()
-        titleLabel.text = NSLocalizedString("Choose a course to message", bundle: .core, comment: "")
+        titleLabel.text = String(localized: "Choose a course to message", bundle: .core)
         titleLabel.textColor = .textDark
         titleLabel.font = .scaledNamedFont(.semibold14)
         view.addSubview(titleLabel)
@@ -97,7 +97,7 @@ extension ConversationCoursesActionSheet: UITableViewDataSource, UITableViewDele
         let cell: SubtitleTableViewCell = tableView.dequeue(for: indexPath)
         cell.textLabel?.text = enrollment?.course?.name
         let userName = enrollment?.observedUser.flatMap { User.displayName($0.shortName, pronouns: $0.pronouns) } ?? ""
-        cell.detailTextLabel?.text = String.localizedStringWithFormat(NSLocalizedString("for %@", bundle: .core, comment: ""), userName)
+        cell.detailTextLabel?.text = String.localizedStringWithFormat(String(localized: "for %@", bundle: .core), userName)
         return cell
     }
 

--- a/Core/Core/Conversations/ConversationDetailCell.swift
+++ b/Core/Core/Conversations/ConversationDetailCell.swift
@@ -55,7 +55,7 @@ class ConversationDetailCell: UITableViewCell {
         attachmentsController.updateAttachments(m.attachments, mediaComment: m.mediaComment)
         attachmentCardsContainer.isHidden = m.mediaComment == nil && m.attachments.isEmpty
 
-        let template = NSLocalizedString("Message from %@, %@, on %@, %@", bundle: .core, comment: "")
+        let template = String(localized: "Message from %@, %@, on %@, %@", bundle: .core)
         accessibilityLabel = String.localizedStringWithFormat(template, fromLabel.text ?? "", toLabel.text ?? "", dateLabel.text ?? "", m.body)
         accessibilityIdentifier = "ConversationDetailCell.\(m.id)"
     }

--- a/Core/Core/Conversations/ConversationDetailCell.swift
+++ b/Core/Core/Conversations/ConversationDetailCell.swift
@@ -55,7 +55,7 @@ class ConversationDetailCell: UITableViewCell {
         attachmentsController.updateAttachments(m.attachments, mediaComment: m.mediaComment)
         attachmentCardsContainer.isHidden = m.mediaComment == nil && m.attachments.isEmpty
 
-        let template = NSLocalizedString("Message from %@, %@, on %@, %@", comment: "")
+        let template = NSLocalizedString("Message from %@, %@, on %@, %@", bundle: .core, comment: "")
         accessibilityLabel = String.localizedStringWithFormat(template, fromLabel.text ?? "", toLabel.text ?? "", dateLabel.text ?? "", m.body)
         accessibilityIdentifier = "ConversationDetailCell.\(m.id)"
     }

--- a/Core/Core/Conversations/ConversationDetailViewController.swift
+++ b/Core/Core/Conversations/ConversationDetailViewController.swift
@@ -66,15 +66,15 @@ public class ConversationDetailViewController: UIViewController {
             mapUsers(conversation: conversations.first)
             if refreshControl.isRefreshing { refreshControl.endRefreshing() }
             tableView?.reloadData()
-            title = conversations.first?.subject.isEmpty ?? true ? NSLocalizedString("No Subject", comment: "") : conversations.first?.subject
+            title = conversations.first?.subject.isEmpty ?? true ? NSLocalizedString("No Subject", bundle: .core, comment: "") : conversations.first?.subject
             let lastMessage = conversations.first?.messages.first
             let lastParticipantCount = lastMessage?.participantIDs.count ?? 0
             if lastMessage?.authorID == myID || lastParticipantCount > 2 {
                 replyButton.setImage(.replyAllSolid, for: .normal)
-                replyButton.accessibilityLabel = NSLocalizedString("Reply All", comment: "")
+                replyButton.accessibilityLabel = NSLocalizedString("Reply All", bundle: .core, comment: "")
             } else {
                 replyButton.setImage(.replySolid, for: .normal)
-                replyButton.accessibilityLabel = NSLocalizedString("Reply", comment: "")
+                replyButton.accessibilityLabel = NSLocalizedString("Reply", bundle: .core, comment: "")
             }
         }
     }
@@ -116,7 +116,7 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
         var actions: [UIContextualAction] = []
 
         if msg.authorID != myID {
-            let reply = UIContextualAction(style: .normal, title: NSLocalizedString("Reply", comment: "")) { [weak self] _, _, success in
+            let reply = UIContextualAction(style: .normal, title: NSLocalizedString("Reply", bundle: .core, comment: "")) { [weak self] _, _, success in
                 self?.showReplyFor(indexPath, all: false)
                 success(true)
             }
@@ -126,7 +126,7 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
         }
 
         if msg.authorID == myID || msg.participantIDs.count > 2 {
-            let replyAll = UIContextualAction(style: .normal, title: NSLocalizedString("Reply All", comment: "")) { [weak self] _, _, success in
+            let replyAll = UIContextualAction(style: .normal, title: NSLocalizedString("Reply All", bundle: .core, comment: "")) { [weak self] _, _, success in
                 self?.showReplyFor(indexPath, all: true)
                 success(true)
             }

--- a/Core/Core/Conversations/ConversationDetailViewController.swift
+++ b/Core/Core/Conversations/ConversationDetailViewController.swift
@@ -66,15 +66,15 @@ public class ConversationDetailViewController: UIViewController {
             mapUsers(conversation: conversations.first)
             if refreshControl.isRefreshing { refreshControl.endRefreshing() }
             tableView?.reloadData()
-            title = conversations.first?.subject.isEmpty ?? true ? NSLocalizedString("No Subject", bundle: .core, comment: "") : conversations.first?.subject
+            title = conversations.first?.subject.isEmpty ?? true ? String(localized: "No Subject", bundle: .core) : conversations.first?.subject
             let lastMessage = conversations.first?.messages.first
             let lastParticipantCount = lastMessage?.participantIDs.count ?? 0
             if lastMessage?.authorID == myID || lastParticipantCount > 2 {
                 replyButton.setImage(.replyAllSolid, for: .normal)
-                replyButton.accessibilityLabel = NSLocalizedString("Reply All", bundle: .core, comment: "")
+                replyButton.accessibilityLabel = String(localized: "Reply All", bundle: .core)
             } else {
                 replyButton.setImage(.replySolid, for: .normal)
-                replyButton.accessibilityLabel = NSLocalizedString("Reply", bundle: .core, comment: "")
+                replyButton.accessibilityLabel = String(localized: "Reply", bundle: .core)
             }
         }
     }
@@ -116,7 +116,7 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
         var actions: [UIContextualAction] = []
 
         if msg.authorID != myID {
-            let reply = UIContextualAction(style: .normal, title: NSLocalizedString("Reply", bundle: .core, comment: "")) { [weak self] _, _, success in
+            let reply = UIContextualAction(style: .normal, title: String(localized: "Reply", bundle: .core)) { [weak self] _, _, success in
                 self?.showReplyFor(indexPath, all: false)
                 success(true)
             }
@@ -126,7 +126,7 @@ extension ConversationDetailViewController: UITableViewDataSource, UITableViewDe
         }
 
         if msg.authorID == myID || msg.participantIDs.count > 2 {
-            let replyAll = UIContextualAction(style: .normal, title: NSLocalizedString("Reply All", bundle: .core, comment: "")) { [weak self] _, _, success in
+            let replyAll = UIContextualAction(style: .normal, title: String(localized: "Reply All", bundle: .core)) { [weak self] _, _, success in
                 self?.showReplyFor(indexPath, all: true)
                 success(true)
             }

--- a/Core/Core/Conversations/ConversationListCell.swift
+++ b/Core/Core/Conversations/ConversationListCell.swift
@@ -34,7 +34,7 @@ public  class ConversationListCell: UITableViewCell {
         unreadView.isHidden = conversation.workflowState != .unread
         let subject = !conversation.subject.isEmpty
             ? conversation.subject
-            : NSLocalizedString("(No subject)", bundle: .core, comment: "")
+            : String(localized: "(No subject)", bundle: .core)
         subjectLabel.text = subject
         dateLabel.text = conversation.lastMessageAt?.relativeDateTimeString ?? ""
         contextLabel.text = conversation.contextName
@@ -42,7 +42,7 @@ public  class ConversationListCell: UITableViewCell {
 
         accessibilityIdentifier = "ConversationListCell.\(conversation.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("%@, in %@, the last message was on %@ %@", bundle: .core, comment: "label for conversation row with context, subject, & last message date & text"),
+            String(localized: "%@, in %@, the last message was on %@ %@", bundle: .core, comment: "label for conversation row with context, subject, & last message date & text"),
             subject,
             conversation.contextName ?? "",
             conversation.lastMessageAt?.dateTimeString ?? "",
@@ -50,7 +50,7 @@ public  class ConversationListCell: UITableViewCell {
         )
         if conversation.workflowState == .unread {
             accessibilityLabel = String.localizedStringWithFormat(
-                NSLocalizedString("%@, unread", bundle: .core, comment: "added to conversation label when unread"),
+                String(localized: "%@, unread", bundle: .core, comment: "added to conversation label when unread"),
                 accessibilityLabel!
             )
         }

--- a/Core/Core/Conversations/ConversationListCell.swift
+++ b/Core/Core/Conversations/ConversationListCell.swift
@@ -34,7 +34,7 @@ public  class ConversationListCell: UITableViewCell {
         unreadView.isHidden = conversation.workflowState != .unread
         let subject = !conversation.subject.isEmpty
             ? conversation.subject
-            : NSLocalizedString("(No subject)", comment: "")
+            : NSLocalizedString("(No subject)", bundle: .core, comment: "")
         subjectLabel.text = subject
         dateLabel.text = conversation.lastMessageAt?.relativeDateTimeString ?? ""
         contextLabel.text = conversation.contextName
@@ -42,7 +42,7 @@ public  class ConversationListCell: UITableViewCell {
 
         accessibilityIdentifier = "ConversationListCell.\(conversation.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("%@, in %@, the last message was on %@ %@", comment: "label for conversation row with context, subject, & last message date & text"),
+            NSLocalizedString("%@, in %@, the last message was on %@ %@", bundle: .core, comment: "label for conversation row with context, subject, & last message date & text"),
             subject,
             conversation.contextName ?? "",
             conversation.lastMessageAt?.dateTimeString ?? "",
@@ -50,7 +50,7 @@ public  class ConversationListCell: UITableViewCell {
         )
         if conversation.workflowState == .unread {
             accessibilityLabel = String.localizedStringWithFormat(
-                NSLocalizedString("%@, unread", comment: "added to conversation label when unread"),
+                NSLocalizedString("%@, unread", bundle: .core, comment: "added to conversation label when unread"),
                 accessibilityLabel!
             )
         }

--- a/Core/Core/Conversations/ConversationMessage.swift
+++ b/Core/Core/Conversations/ConversationMessage.swift
@@ -75,15 +75,15 @@ extension ConversationMessage {
         let containsMe = audience.contains(myID)
 
         if audience.count == 1 {
-            user =  containsMe ? NSLocalizedString("me", bundle: .core, comment: "") : userMap[ audience[0] ]?.displayName
+            user =  containsMe ? String(localized: "me", bundle: .core) : userMap[ audience[0] ]?.displayName
         } else if audience.count > 1 {
             let cnt = containsMe ? audience.count - 1 : audience.count
-            let pluralFormat = NSLocalizedString("conversation_recipients_to", bundle: .core, comment: "")
+            let pluralFormat = String(localized: "conversation_recipients_to", bundle: .core)
             let othersText = String.localizedStringWithFormat(pluralFormat, cnt)
-            user = containsMe ? String.localizedStringWithFormat( NSLocalizedString("me & %@", bundle: .core, comment: ""), othersText) : othersText
+            user = containsMe ? String.localizedStringWithFormat( String(localized: "me & %@", bundle: .core), othersText) : othersText
         }
 
-        let template = NSLocalizedString("to %@", bundle: .core, comment: "")
+        let template = String(localized: "to %@", bundle: .core)
         return String.localizedStringWithFormat(template, user ?? "")
     }
 }

--- a/Core/Core/Conversations/EditComposeRecipientsViewController.swift
+++ b/Core/Core/Conversations/EditComposeRecipientsViewController.swift
@@ -57,7 +57,7 @@ class EditComposeRecipientsViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         view.frame.size.height = 304
-        titleLabel.text = NSLocalizedString("Recipients", bundle: .core, comment: "")
+        titleLabel.text = String(localized: "Recipients", bundle: .core)
         teachers.exhaust(force: false)
         tas.exhaust(force: false)
     }

--- a/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
+++ b/Core/Core/CoreWebView/Model/CoreWebViewJSInjections.swift
@@ -83,7 +83,7 @@ extension CoreWebView {
      Replaces all LTI tool iframes with a button that opens the tool in a popup.
      */
     public static var LTIToolButtonJS: String {
-        let buttonText = NSLocalizedString("Launch External Tool", bundle: .core, comment: "")
+        let buttonText = String(localized: "Launch External Tool", bundle: .core)
         return """
         function fixLTITools() {
             // Replace all iframes with a button to launch in SFSafariViewController

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -410,7 +410,7 @@ extension CoreWebView: WKUIDelegate {
     ) {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(false) }
         let alert = UIAlertController(title: frame.request.url?.host, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { _ in
             completionHandler(true)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())
@@ -424,10 +424,10 @@ extension CoreWebView: WKUIDelegate {
     ) {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(false) }
         let alert = UIAlertController(title: frame.request.url?.host, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) { _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel) { _ in
             completionHandler(false)
         })
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { _ in
             completionHandler(true)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())
@@ -443,10 +443,10 @@ extension CoreWebView: WKUIDelegate {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(defaultText) }
         let alert = UIAlertController(title: frame.request.url?.host, message: prompt, preferredStyle: .alert)
         alert.addTextField()
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) { _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel) { _ in
             completionHandler(nil)
         })
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { _ in
             completionHandler(alert.textFields?[0].text)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -410,7 +410,7 @@ extension CoreWebView: WKUIDelegate {
     ) {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(false) }
         let alert = UIAlertController(title: frame.request.url?.host, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
             completionHandler(true)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())
@@ -424,10 +424,10 @@ extension CoreWebView: WKUIDelegate {
     ) {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(false) }
         let alert = UIAlertController(title: frame.request.url?.host, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) { _ in
             completionHandler(false)
         })
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
             completionHandler(true)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())
@@ -443,10 +443,10 @@ extension CoreWebView: WKUIDelegate {
         guard let from = linkDelegate?.routeLinksFrom else { return completionHandler(defaultText) }
         let alert = UIAlertController(title: frame.request.url?.host, message: prompt, preferredStyle: .alert)
         alert.addTextField()
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) { _ in
             completionHandler(nil)
         })
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
             completionHandler(alert.textFields?[0].text)
         })
         AppEnvironment.shared.router.show(alert, from: from, options: .modal())

--- a/Core/Core/CoreWebView/View/CoreWebViewController.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewController.swift
@@ -56,7 +56,7 @@ public class CoreWebViewController: UIViewController, CoreWebViewLinkDelegate {
 
     func setupLimitedInteractionNotification() {
         let n = NotificationView()
-        n.messageLabel.text = NSLocalizedString("Interactions on this page are limited by your institution.", bundle: .core, comment: "")
+        n.messageLabel.text = String(localized: "Interactions on this page are limited by your institution.", bundle: .core)
         n.showDismiss = true
         n.dismissHandler = { [weak self] in
             self?.limitedInteractionView?.removeFromSuperview()

--- a/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewThemeSwitcherButton.swift
@@ -20,8 +20,8 @@ import UIKit
 
 final class CoreWebViewThemeSwitcherButton: UIButton {
     private struct Titles {
-        static let currentlyLight = String(localized: "Switch To Dark Mode")
-        static let currentlyDark = String(localized: "Switch To Light Mode")
+        static let currentlyLight = String(localized: "Switch To Dark Mode", bundle: .core)
+        static let currentlyDark = String(localized: "Switch To Light Mode", bundle: .core)
     }
 
     /// Helper to simplify logic by removing `.unspecified`.

--- a/Core/Core/CoreWebView/ViewModel/CoreWebViewContentErrorViewModel.swift
+++ b/Core/Core/CoreWebView/ViewModel/CoreWebViewContentErrorViewModel.swift
@@ -27,11 +27,11 @@ class CoreWebViewContentErrorViewModel: ObservableObject {
         let url = urlToOpenInBrowser.flatMap { URLComponents.parse($0) }
         let displayBrowserButton = (url != nil)
         let subtitle = {
-            var result = NSLocalizedString("Something went wrong beyond our control.", comment: "")
+            var result = NSLocalizedString("Something went wrong beyond our control.", bundle: .core, comment: "")
 
             if displayBrowserButton {
                 result.append("\n")
-                result.append(NSLocalizedString("You can try to open the page in a browser.", comment: ""))
+                result.append(NSLocalizedString("You can try to open the page in a browser.", bundle: .core, comment: ""))
             }
 
             return result

--- a/Core/Core/CoreWebView/ViewModel/CoreWebViewContentErrorViewModel.swift
+++ b/Core/Core/CoreWebView/ViewModel/CoreWebViewContentErrorViewModel.swift
@@ -27,11 +27,11 @@ class CoreWebViewContentErrorViewModel: ObservableObject {
         let url = urlToOpenInBrowser.flatMap { URLComponents.parse($0) }
         let displayBrowserButton = (url != nil)
         let subtitle = {
-            var result = NSLocalizedString("Something went wrong beyond our control.", bundle: .core, comment: "")
+            var result = String(localized: "Something went wrong beyond our control.", bundle: .core)
 
             if displayBrowserButton {
                 result.append("\n")
-                result.append(NSLocalizedString("You can try to open the page in a browser.", bundle: .core, comment: ""))
+                result.append(String(localized: "You can try to open the page in a browser.", bundle: .core))
             }
 
             return result

--- a/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
@@ -52,7 +52,7 @@ public final class CourseSyncEntryComposerInteractorLive: CourseSyncEntryCompose
                     files.map {
                         CourseSyncEntry.File(
                             id: "courses/\(course.courseId)/files/\($0.id ?? Foundation.UUID().uuidString)",
-                            displayName: $0.displayName ?? NSLocalizedString("Unknown file", bundle: .core, comment: ""),
+                            displayName: $0.displayName ?? String(localized: "Unknown file", bundle: .core),
                             fileName: $0.filename,
                             url: $0.url!,
                             mimeClass: $0.mimeClass!,

--- a/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncEntryComposerInteractor.swift
@@ -52,7 +52,7 @@ public final class CourseSyncEntryComposerInteractorLive: CourseSyncEntryCompose
                     files.map {
                         CourseSyncEntry.File(
                             id: "courses/\(course.courseId)/files/\($0.id ?? Foundation.UUID().uuidString)",
-                            displayName: $0.displayName ?? NSLocalizedString("Unknown file", comment: ""),
+                            displayName: $0.displayName ?? NSLocalizedString("Unknown file", bundle: .core, comment: ""),
                             fileName: $0.filename,
                             url: $0.url!,
                             mimeClass: $0.mimeClass!,

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -50,7 +50,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
         label: "com.instructure.icanvas.core.course-sync-utility",
         attributes: .concurrent
     )
-    private let fileErrorMessage = NSLocalizedString("File download failed.", comment: "")
+    private let fileErrorMessage = NSLocalizedString("File download failed.", bundle: .core, comment: "")
     private let notificationInteractor: CourseSyncNotificationInteractor
     internal private(set) var downloadSubscription: AnyCancellable?
     private var subscriptions = Set<AnyCancellable>()
@@ -499,7 +499,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
         downloadSubscription = nil
         progressWriterInteractor.markInProgressDownloadsAsFailed()
         progressWriterInteractor.saveDownloadResult(isFinished: true,
-                                                    error: NSLocalizedString("Offline sync was interrupted by the operating system", comment: ""))
+                                                    error: NSLocalizedString("Offline sync was interrupted by the operating system", bundle: .core, comment: ""))
         notificationInteractor.sendFailedNotification()
     }
 }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -50,7 +50,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
         label: "com.instructure.icanvas.core.course-sync-utility",
         attributes: .concurrent
     )
-    private let fileErrorMessage = NSLocalizedString("File download failed.", bundle: .core, comment: "")
+    private let fileErrorMessage = String(localized: "File download failed.", bundle: .core)
     private let notificationInteractor: CourseSyncNotificationInteractor
     internal private(set) var downloadSubscription: AnyCancellable?
     private var subscriptions = Set<AnyCancellable>()
@@ -499,7 +499,7 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
         downloadSubscription = nil
         progressWriterInteractor.markInProgressDownloadsAsFailed()
         progressWriterInteractor.saveDownloadResult(isFinished: true,
-                                                    error: NSLocalizedString("Offline sync was interrupted by the operating system", bundle: .core, comment: ""))
+                                                    error: String(localized: "Offline sync was interrupted by the operating system", bundle: .core))
         notificationInteractor.sendFailedNotification()
     }
 }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncFilesInteractor.swift
@@ -170,11 +170,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
         guard let sessionID = env.currentSession?.uniqueID else {
             return Fail(error:
                 NSError.instructureError(
-                    NSLocalizedString(
-                        "There was an unexpected error. Please try again.",
-                        bundle: .core,
-                        comment: ""
-                    )
+                    String(localized: "There was an unexpected error. Please try again.", bundle: .core)
                 )
             )
             .eraseToAnyPublisher()
@@ -221,11 +217,7 @@ public final class CourseSyncFilesInteractorLive: CourseSyncFilesInteractor, Loc
         guard let sessionID = env.currentSession?.uniqueID else {
             return Fail(error:
                 NSError.instructureError(
-                    NSLocalizedString(
-                        "There was an unexpected error. Please try again.",
-                        bundle: .core,
-                        comment: ""
-                    )
+                    String(localized: "There was an unexpected error. Please try again.", bundle: .core)
                 )
             )
             .eraseToAnyPublisher()

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/HTMLParser/HTMLDownloadInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/HTMLParser/HTMLDownloadInteractor.swift
@@ -54,7 +54,7 @@ class HTMLDownloadInteractorLive: HTMLDownloadInteractor {
                 .receive(on: scheduler)
                 .eraseToAnyPublisher()
         } else {
-            return Fail(error: NSError.instructureError(String(localized: "Failed to construct request"))).eraseToAnyPublisher()
+            return Fail(error: NSError.instructureError(String(localized: "Failed to construct request", bundle: .core))).eraseToAnyPublisher()
         }
     }
 
@@ -78,7 +78,7 @@ class HTMLDownloadInteractorLive: HTMLDownloadInteractor {
             try fileManager.moveItem(at: tempURL, to: saveURL)
             return Result.Publisher(saveURL).eraseToAnyPublisher()
         } catch {
-            return Result.Publisher(.failure(NSError.instructureError(String(localized: "Failed to save image")))).eraseToAnyPublisher()
+            return Result.Publisher(.failure(NSError.instructureError(String(localized: "Failed to save image", bundle: .core)))).eraseToAnyPublisher()
         }
     }
 
@@ -89,7 +89,7 @@ class HTMLDownloadInteractorLive: HTMLDownloadInteractor {
             fileManager.createFile(atPath: saveURL.path, contents: nil)
             try content.write(to: saveURL, atomically: true, encoding: .utf8)
         } catch {
-            return Result.Publisher(.failure(NSError.instructureError(String(localized: "Failed to save base content")))).eraseToAnyPublisher()
+            return Result.Publisher(.failure(NSError.instructureError(String(localized: "Failed to save base content", bundle: .core)))).eraseToAnyPublisher()
         }
         return Result.Publisher(content).eraseToAnyPublisher()
     }

--- a/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/View/CourseSyncProgressView.swift
@@ -161,7 +161,7 @@ struct CourseSyncProgressView: View {
                                                isCollapsed: item.isCollapsed,
                                                collapseDidToggle: item.collapseDidToggle,
                                                removeItemPressed: item.removeItemPressed,
-                                               state: .error(NSLocalizedString("Sync Failed", bundle: .core, comment: ""))))
+                                               state: .error(String(localized: "Sync Failed", bundle: .core))))
             }
             Divider().padding(.leading, item.cellStyle == .listItem ? 16 : 0)
         }.padding(.leading, item.cellStyle == .listItem ? 24 : 0)

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
@@ -40,17 +40,17 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
             .map { progress in
                 if progress.isFinished {
                     if progress.error != nil {
-                        return .finishedWithError(title: NSLocalizedString("Offline Content Sync Failed", bundle: .core, comment: ""),
-                                                  subtitle: NSLocalizedString("One or more files failed to sync. Check your internet connection and retry to submit.", bundle: .core, comment: ""))
+                        return .finishedWithError(title: String(localized: "Offline Content Sync Failed", bundle: .core),
+                                                  subtitle: String(localized: "One or more files failed to sync. Check your internet connection and retry to submit.", bundle: .core))
                     } else {
-                        let format = NSLocalizedString("Success! Downloaded %@ of %@", bundle: .core, comment: "")
+                        let format = String(localized: "Success! Downloaded %@ of %@", bundle: .core)
                         let message = String.localizedStringWithFormat(format,
                                                                        progress.bytesDownloaded.humanReadableFileSize,
                                                                        progress.bytesToDownload.humanReadableFileSize)
                         return .finishedSuccessfully(message: message, progress: 1)
                     }
                 } else {
-                    let format = NSLocalizedString("Downloading %@ of %@", bundle: .core, comment: "Downloading 42 GB of 64 GB")
+                    let format = String(localized: "Downloading %@ of %@", bundle: .core, comment: "Downloading 42 GB of 64 GB")
                     let message = String.localizedStringWithFormat(format,
                                                                    progress.bytesDownloaded.humanReadableFileSize,
                                                                    progress.bytesToDownload.humanReadableFileSize)

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressInfoViewModel.swift
@@ -40,10 +40,10 @@ class CourseSyncProgressInfoViewModel: ObservableObject {
             .map { progress in
                 if progress.isFinished {
                     if progress.error != nil {
-                        return .finishedWithError(title: NSLocalizedString("Offline Content Sync Failed", comment: ""),
-                                                  subtitle: NSLocalizedString("One or more files failed to sync. Check your internet connection and retry to submit.", comment: ""))
+                        return .finishedWithError(title: NSLocalizedString("Offline Content Sync Failed", bundle: .core, comment: ""),
+                                                  subtitle: NSLocalizedString("One or more files failed to sync. Check your internet connection and retry to submit.", bundle: .core, comment: ""))
                     } else {
-                        let format = NSLocalizedString("Success! Downloaded %@ of %@", comment: "")
+                        let format = NSLocalizedString("Success! Downloaded %@ of %@", bundle: .core, comment: "")
                         let message = String.localizedStringWithFormat(format,
                                                                        progress.bytesDownloaded.humanReadableFileSize,
                                                                        progress.bytesToDownload.humanReadableFileSize)

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -38,27 +38,24 @@ class CourseSyncProgressViewModel: ObservableObject {
 
     public let labels = (
         noCourses: (
-            title: NSLocalizedString("No Courses", bundle: .core, comment: ""),
-            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
+            title: String(localized: "No Courses", bundle: .core),
+            message: String(localized: "Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core)
         ),
         noItems: (
-            title: NSLocalizedString("No Course Content", bundle: .core, comment: ""),
-            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
+            title: String(localized: "No Course Content", bundle: .core),
+            message: String(localized: "The course content will be listed here, and then you can make them available for offline usage.", bundle: .core)
         ),
         error: (
-            title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
-            message: NSLocalizedString("There was an unexpected error.", bundle: .core, comment: "")
+            title: String(localized: "Something went wrong", bundle: .core),
+            message: String(localized: "There was an unexpected error.", bundle: .core)
         )
     )
 
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Cancel Sync?", bundle: .core, comment: ""),
-        message: NSLocalizedString(
-           """
-           It will stop offline content sync. You can do it again later.
-           """, bundle: .core, comment: ""),
-        cancelButtonTitle: NSLocalizedString("No", bundle: .core, comment: ""),
-        confirmButtonTitle: NSLocalizedString("Yes", bundle: .core, comment: ""),
+        title: String(localized: "Cancel Sync?", bundle: .core),
+        message: String(localized: "It will stop offline content sync. You can do it again later.", bundle: .core),
+        cancelButtonTitle: String(localized: "No", bundle: .core),
+        confirmButtonTitle: String(localized: "Yes", bundle: .core),
         isDestructive: false
     )
 

--- a/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncProgress/ViewModel/CourseSyncProgressViewModel.swift
@@ -38,27 +38,27 @@ class CourseSyncProgressViewModel: ObservableObject {
 
     public let labels = (
         noCourses: (
-            title: NSLocalizedString("No Courses", comment: ""),
-            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", comment: "")
+            title: NSLocalizedString("No Courses", bundle: .core, comment: ""),
+            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
         ),
         noItems: (
-            title: NSLocalizedString("No Course Content", comment: ""),
-            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", comment: "")
+            title: NSLocalizedString("No Course Content", bundle: .core, comment: ""),
+            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
         ),
         error: (
-            title: NSLocalizedString("Something went wrong", comment: ""),
-            message: NSLocalizedString("There was an unexpected error.", comment: "")
+            title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
+            message: NSLocalizedString("There was an unexpected error.", bundle: .core, comment: "")
         )
     )
 
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Cancel Sync?", comment: ""),
+        title: NSLocalizedString("Cancel Sync?", bundle: .core, comment: ""),
         message: NSLocalizedString(
            """
            It will stop offline content sync. You can do it again later.
-           """, comment: ""),
-        cancelButtonTitle: NSLocalizedString("No", comment: ""),
-        confirmButtonTitle: NSLocalizedString("Yes", comment: ""),
+           """, bundle: .core, comment: ""),
+        cancelButtonTitle: NSLocalizedString("No", bundle: .core, comment: ""),
+        confirmButtonTitle: NSLocalizedString("Yes", bundle: .core, comment: ""),
         isDestructive: false
     )
 

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -186,7 +186,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
 
     func getCourseName() -> AnyPublisher<String, Never> {
         guard let courseID else {
-            return Just(NSLocalizedString("All Courses", comment: "")).eraseToAnyPublisher()
+            return Just(NSLocalizedString("All Courses", bundle: .core, comment: "")).eraseToAnyPublisher()
         }
 
         return courseSyncEntries

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -186,7 +186,7 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
 
     func getCourseName() -> AnyPublisher<String, Never> {
         guard let courseID else {
-            return Just(NSLocalizedString("All Courses", bundle: .core, comment: "")).eraseToAnyPublisher()
+            return Just(String(localized: "All Courses", bundle: .core)).eraseToAnyPublisher()
         }
 
         return courseSyncEntries

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncDiskSpaceInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncDiskSpaceInfoViewModel.swift
@@ -43,11 +43,11 @@ class CourseSyncDiskSpaceInfoViewModel: ObservableObject {
         self.appName = appName
 
         a11yLabel = [
-            NSLocalizedString("Storage Info", comment: ""),
+            NSLocalizedString("Storage Info", bundle: .core, comment: ""),
             diskUsage,
-            NSLocalizedString("Other Apps", comment: "") + String(format: " %.1f%%", 100 * chart.other),
+            NSLocalizedString("Other Apps", bundle: .core, comment: "") + String(format: " %.1f%%", 100 * chart.other),
             appName + String(format: " %.1f%%", 100 * chart.app),
-            NSLocalizedString("Remaining", comment: "") + String(format: " %.1f%%", 100 * chart.free),
+            NSLocalizedString("Remaining", bundle: .core, comment: "") + String(format: " %.1f%%", 100 * chart.free),
         ].joined(separator: ",")
     }
 }

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncDiskSpaceInfoViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncDiskSpaceInfoViewModel.swift
@@ -26,7 +26,7 @@ class CourseSyncDiskSpaceInfoViewModel: ObservableObject {
 
     init(interactor: DiskSpaceInteractor, app: AppEnvironment.App) {
         let diskSpace = interactor.getDiskSpace()
-        let format = NSLocalizedString("%@ of %@ Used", bundle: .core, comment: "42 GB of 64 GB Used")
+        let format = String(localized: "%@ of %@ Used", bundle: .core, comment: "42 GB of 64 GB Used")
         let diskUsage = String.localizedStringWithFormat(format,
                                                          diskSpace.used.humanReadableFileSize,
                                                          diskSpace.total.humanReadableFileSize)
@@ -43,11 +43,11 @@ class CourseSyncDiskSpaceInfoViewModel: ObservableObject {
         self.appName = appName
 
         a11yLabel = [
-            NSLocalizedString("Storage Info", bundle: .core, comment: ""),
+            String(localized: "Storage Info", bundle: .core),
             diskUsage,
-            NSLocalizedString("Other Apps", bundle: .core, comment: "") + String(format: " %.1f%%", 100 * chart.other),
+            String(localized: "Other Apps", bundle: .core) + String(format: " %.1f%%", 100 * chart.other),
             appName + String(format: " %.1f%%", 100 * chart.app),
-            NSLocalizedString("Remaining", bundle: .core, comment: "") + String(format: " %.1f%%", 100 * chart.free),
+            String(localized: "Remaining", bundle: .core) + String(format: " %.1f%%", 100 * chart.free),
         ].joined(separator: ",")
     }
 }

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -38,25 +38,25 @@ class CourseSyncSelectorViewModel: ObservableObject {
     @Published public var isShowingConfirmationDialog = false
 
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Sync Offline Content?", bundle: .core, comment: ""),
+        title: String(localized: "Sync Offline Content?", bundle: .core),
         message: "", // Updated when selected item count changes
-        cancelButtonTitle: NSLocalizedString("Cancel", bundle: .core, comment: ""),
-        confirmButtonTitle: NSLocalizedString("Sync", bundle: .core, comment: ""),
+        cancelButtonTitle: String(localized: "Cancel", bundle: .core),
+        confirmButtonTitle: String(localized: "Sync", bundle: .core),
         isDestructive: false
     )
 
     public let labels = (
         noCourses: (
-            title: NSLocalizedString("No Courses", bundle: .core, comment: ""),
-            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
+            title: String(localized: "No Courses", bundle: .core),
+            message: String(localized: "Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core)
         ),
         noItems: (
-            title: NSLocalizedString("No Course Content", bundle: .core, comment: ""),
-            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
+            title: String(localized: "No Course Content", bundle: .core),
+            message: String(localized: "The course content will be listed here, and then you can make them available for offline usage.", bundle: .core)
         ),
         error: (
-            title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
-            message: NSLocalizedString("There was an unexpected error.", bundle: .core, comment: "")
+            title: String(localized: "Something went wrong", bundle: .core),
+            message: String(localized: "There was an unexpected error.", bundle: .core)
         )
     )
 
@@ -121,8 +121,8 @@ class CourseSyncSelectorViewModel: ObservableObject {
         interactor
             .observeIsEverythingSelected()
             .map { $0
-                ? NSLocalizedString("Deselect All", bundle: .core, comment: "")
-                : NSLocalizedString("Select All", bundle: .core, comment: "")
+                ? String(localized: "Deselect All", bundle: .core)
+                : String(localized: "Select All", bundle: .core)
             }
             .assign(to: &$leftNavBarTitle)
     }
@@ -131,8 +131,8 @@ class CourseSyncSelectorViewModel: ObservableObject {
         interactor
             .observeSelectedSize()
             .map {
-                let template = NSLocalizedString(
-                    "This will sync ~%@ content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.", bundle: .core, comment: ""
+                let template = String(localized:
+                    "This will sync ~%@ content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.", bundle: .core
                 )
                 return String.localizedStringWithFormat(template, $0.humanReadableFileSize)
             }

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -38,25 +38,25 @@ class CourseSyncSelectorViewModel: ObservableObject {
     @Published public var isShowingConfirmationDialog = false
 
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Sync Offline Content?", comment: ""),
+        title: NSLocalizedString("Sync Offline Content?", bundle: .core, comment: ""),
         message: "", // Updated when selected item count changes
-        cancelButtonTitle: NSLocalizedString("Cancel", comment: ""),
-        confirmButtonTitle: NSLocalizedString("Sync", comment: ""),
+        cancelButtonTitle: NSLocalizedString("Cancel", bundle: .core, comment: ""),
+        confirmButtonTitle: NSLocalizedString("Sync", bundle: .core, comment: ""),
         isDestructive: false
     )
 
     public let labels = (
         noCourses: (
-            title: NSLocalizedString("No Courses", comment: ""),
-            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", comment: "")
+            title: NSLocalizedString("No Courses", bundle: .core, comment: ""),
+            message: NSLocalizedString("Your courses will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
         ),
         noItems: (
-            title: NSLocalizedString("No Course Content", comment: ""),
-            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", comment: "")
+            title: NSLocalizedString("No Course Content", bundle: .core, comment: ""),
+            message: NSLocalizedString("The course content will be listed here, and then you can make them available for offline usage.", bundle: .core, comment: "")
         ),
         error: (
-            title: NSLocalizedString("Something went wrong", comment: ""),
-            message: NSLocalizedString("There was an unexpected error.", comment: "")
+            title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
+            message: NSLocalizedString("There was an unexpected error.", bundle: .core, comment: "")
         )
     )
 
@@ -121,8 +121,8 @@ class CourseSyncSelectorViewModel: ObservableObject {
         interactor
             .observeIsEverythingSelected()
             .map { $0
-                ? NSLocalizedString("Deselect All", comment: "")
-                : NSLocalizedString("Select All", comment: "")
+                ? NSLocalizedString("Deselect All", bundle: .core, comment: "")
+                : NSLocalizedString("Select All", bundle: .core, comment: "")
             }
             .assign(to: &$leftNavBarTitle)
     }
@@ -132,8 +132,7 @@ class CourseSyncSelectorViewModel: ObservableObject {
             .observeSelectedSize()
             .map {
                 let template = NSLocalizedString(
-                    "This will sync ~%@ content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.",
-                    comment: ""
+                    "This will sync ~%@ content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.", bundle: .core, comment: ""
                 )
                 return String.localizedStringWithFormat(template, $0.humanReadableFileSize)
             }

--- a/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
@@ -28,8 +28,8 @@ public enum CourseSyncFrequency: Int, CaseIterable {
         #if DEBUG
         case .osBased: return "As frequent as the OS allows (DEBUG)"
         #endif
-        case .daily: return NSLocalizedString("Daily", bundle: .core, comment: "")
-        case .weekly: return NSLocalizedString("Weekly", bundle: .core, comment: "")
+        case .daily: return String(localized: "Daily", bundle: .core)
+        case .weekly: return String(localized: "Weekly", bundle: .core)
         }
     }
 

--- a/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
@@ -28,8 +28,8 @@ public enum CourseSyncFrequency: Int, CaseIterable {
         #if DEBUG
         case .osBased: return "As frequent as the OS allows (DEBUG)"
         #endif
-        case .daily: return NSLocalizedString("Daily", comment: "")
-        case .weekly: return NSLocalizedString("Weekly", comment: "")
+        case .daily: return NSLocalizedString("Daily", bundle: .core, comment: "")
+        case .weekly: return NSLocalizedString("Weekly", bundle: .core, comment: "")
         }
     }
 

--- a/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractor.swift
@@ -39,10 +39,10 @@ class CourseSyncSettingsInteractorLive: CourseSyncSettingsInteractor {
         let settings = storedSettings
 
         guard settings.isAutoSyncEnabled else {
-            return NSLocalizedString("Manual", bundle: .core, comment: "")
+            return String(localized: "Manual", bundle: .core)
         }
 
-        let format = NSLocalizedString("%@ Auto", bundle: .core, comment: "Weekly Auto / Daily Auto Synchronization Frequency")
+        let format = String(localized: "%@ Auto", bundle: .core, comment: "Weekly Auto / Daily Auto Synchronization Frequency")
         return String.localizedStringWithFormat(format, settings.syncFrequency.stringValue)
     }
 

--- a/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/Model/CourseSyncSettingsInteractor.swift
@@ -39,11 +39,10 @@ class CourseSyncSettingsInteractorLive: CourseSyncSettingsInteractor {
         let settings = storedSettings
 
         guard settings.isAutoSyncEnabled else {
-            return NSLocalizedString("Manual", comment: "")
+            return NSLocalizedString("Manual", bundle: .core, comment: "")
         }
 
-        let format = NSLocalizedString("%@ Auto",
-                                       comment: "Weekly Auto / Daily Auto Synchronization Frequency")
+        let format = NSLocalizedString("%@ Auto", bundle: .core, comment: "Weekly Auto / Daily Auto Synchronization Frequency")
         return String.localizedStringWithFormat(format, settings.syncFrequency.stringValue)
     }
 

--- a/Core/Core/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
@@ -29,13 +29,13 @@ class CourseSyncSettingsViewModel: ObservableObject {
     @Published public var isShowingConfirmationDialog = false
     @Published public var syncFrequencyLabel = ""
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Turn Off Wi-Fi Only Sync?", comment: ""),
+        title: NSLocalizedString("Turn Off Wi-Fi Only Sync?", bundle: .core, comment: ""),
         message: NSLocalizedString(
            """
            Content sync might use cellular data which may result in extra fees from your data provider.
-           """, comment: ""),
-        cancelButtonTitle: NSLocalizedString("Cancel", comment: ""),
-        confirmButtonTitle: NSLocalizedString("Turn Off", comment: ""),
+           """, bundle: .core, comment: ""),
+        cancelButtonTitle: NSLocalizedString("Cancel", bundle: .core, comment: ""),
+        confirmButtonTitle: NSLocalizedString("Turn Off", bundle: .core, comment: ""),
         isDestructive: false)
     public let labels = (
         autoContentSync: NSLocalizedString(
@@ -43,13 +43,14 @@ class CourseSyncSettingsViewModel: ObservableObject {
             Enabling the Auto Content Sync will take care of downloading the selected content based on the below \
             settings. The content synchronization will happen even if the application is not running. If the setting is \
             switched off then no synchronization will happen. The already downloaded content will not be deleted.
-            """, comment: ""),
-        syncFrequency: NSLocalizedString("Specify the recurrence of the content synchronization. The system will download the selected content based on the frequency specified here.", comment: ""),
+            """, bundle: .core, comment: ""),
+        syncFrequency: NSLocalizedString("Specify the recurrence of the content synchronization. The system will download the selected content based on the frequency specified here.",
+                                         bundle: .core, comment: ""),
         wifiOnlySync: NSLocalizedString(
             """
             If this setting is enabled the content synchronization will only happen if the device connects \
             to a Wi-Fi network, otherwise it will be postponed until a Wi-Fi network is available.
-            """, comment: "")
+            """, bundle: .core, comment: "")
     )
 
     // MARK: - Input
@@ -174,7 +175,7 @@ class CourseSyncSettingsViewModel: ObservableObject {
                 promise(.success(newFrequency))
             }
             let picker = ItemPickerViewController
-                .create(title: NSLocalizedString("Sync Frequency", comment: ""),
+                .create(title: NSLocalizedString("Sync Frequency", bundle: .core, comment: ""),
                         sections: CourseSyncFrequency.itemPickerData,
                         selected: selection,
                         didSelect: handleNewSelection)

--- a/Core/Core/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
@@ -29,28 +29,30 @@ class CourseSyncSettingsViewModel: ObservableObject {
     @Published public var isShowingConfirmationDialog = false
     @Published public var syncFrequencyLabel = ""
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Turn Off Wi-Fi Only Sync?", bundle: .core, comment: ""),
-        message: NSLocalizedString(
+        title: String(localized: "Turn Off Wi-Fi Only Sync?", bundle: .core),
+        message: String(localized:
            """
            Content sync might use cellular data which may result in extra fees from your data provider.
-           """, bundle: .core, comment: ""),
-        cancelButtonTitle: NSLocalizedString("Cancel", bundle: .core, comment: ""),
-        confirmButtonTitle: NSLocalizedString("Turn Off", bundle: .core, comment: ""),
+           """, bundle: .core),
+        cancelButtonTitle: String(localized: "Cancel", bundle: .core),
+        confirmButtonTitle: String(localized: "Turn Off", bundle: .core),
         isDestructive: false)
     public let labels = (
-        autoContentSync: NSLocalizedString(
+        autoContentSync: String(localized:
             """
             Enabling the Auto Content Sync will take care of downloading the selected content based on the below \
             settings. The content synchronization will happen even if the application is not running. If the setting is \
             switched off then no synchronization will happen. The already downloaded content will not be deleted.
-            """, bundle: .core, comment: ""),
-        syncFrequency: NSLocalizedString("Specify the recurrence of the content synchronization. The system will download the selected content based on the frequency specified here.",
-                                         bundle: .core, comment: ""),
-        wifiOnlySync: NSLocalizedString(
+            """, bundle: .core),
+        syncFrequency: String(localized:
+            """
+            Specify the recurrence of the content synchronization. The system will download the selected content based on the frequency specified here.
+            """, bundle: .core),
+        wifiOnlySync: String(localized:
             """
             If this setting is enabled the content synchronization will only happen if the device connects \
             to a Wi-Fi network, otherwise it will be postponed until a Wi-Fi network is available.
-            """, bundle: .core, comment: "")
+            """, bundle: .core)
     )
 
     // MARK: - Input
@@ -175,7 +177,7 @@ class CourseSyncSettingsViewModel: ObservableObject {
                 promise(.success(newFrequency))
             }
             let picker = ItemPickerViewController
-                .create(title: NSLocalizedString("Sync Frequency", bundle: .core, comment: ""),
+                .create(title: String(localized: "Sync Frequency", bundle: .core),
                         sections: CourseSyncFrequency.itemPickerData,
                         selected: selection,
                         didSelect: handleNewSelection)

--- a/Core/Core/Courses/APICourse.swift
+++ b/Core/Core/Courses/APICourse.swift
@@ -114,15 +114,15 @@ public enum CourseDefaultView: String, Codable, CaseIterable {
     var string: String {
         switch self {
         case .assignments:
-            return NSLocalizedString("Assignments List", comment: "")
+            return NSLocalizedString("Assignments List", bundle: .core, comment: "")
         case .feed:
-            return NSLocalizedString("Course Activity Stream", comment: "")
+            return NSLocalizedString("Course Activity Stream", bundle: .core, comment: "")
         case .modules:
-            return NSLocalizedString("Course Modules", comment: "")
+            return NSLocalizedString("Course Modules", bundle: .core, comment: "")
         case .syllabus:
-            return NSLocalizedString("Syllabus", comment: "")
+            return NSLocalizedString("Syllabus", bundle: .core, comment: "")
         case .wiki:
-            return NSLocalizedString("Pages Front Page", comment: "")
+            return NSLocalizedString("Pages Front Page", bundle: .core, comment: "")
         }
     }
 }

--- a/Core/Core/Courses/APICourse.swift
+++ b/Core/Core/Courses/APICourse.swift
@@ -114,15 +114,15 @@ public enum CourseDefaultView: String, Codable, CaseIterable {
     var string: String {
         switch self {
         case .assignments:
-            return NSLocalizedString("Assignments List", bundle: .core, comment: "")
+            return String(localized: "Assignments List", bundle: .core)
         case .feed:
-            return NSLocalizedString("Course Activity Stream", bundle: .core, comment: "")
+            return String(localized: "Course Activity Stream", bundle: .core)
         case .modules:
-            return NSLocalizedString("Course Modules", bundle: .core, comment: "")
+            return String(localized: "Course Modules", bundle: .core)
         case .syllabus:
-            return NSLocalizedString("Syllabus", bundle: .core, comment: "")
+            return String(localized: "Syllabus", bundle: .core)
         case .wiki:
-            return NSLocalizedString("Pages Front Page", bundle: .core, comment: "")
+            return String(localized: "Pages Front Page", bundle: .core)
         }
     }
 }

--- a/Core/Core/Courses/AllCourses/View/AllCoursesView.swift
+++ b/Core/Core/Courses/AllCourses/View/AllCoursesView.swift
@@ -51,7 +51,7 @@ public struct AllCoursesView: View, ScreenViewTrackable {
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
         .navigationBarStyle(.global)
-        .navigationTitle(NSLocalizedString("All Courses", comment: ""), subtitle: nil)
+        .navigationTitle(NSLocalizedString("All Courses", bundle: .core, comment: ""), subtitle: nil)
     }
 
     @ViewBuilder
@@ -75,7 +75,7 @@ public struct AllCoursesView: View, ScreenViewTrackable {
 
                 SearchBar(
                     text: binding,
-                    placeholder: NSLocalizedString("Search", comment: ""),
+                    placeholder: NSLocalizedString("Search", bundle: .core, comment: ""),
                     onCancel: { withAnimation { scrollView.scrollTo(0, anchor: .top) } }
                 )
 

--- a/Core/Core/Courses/AllCourses/View/AllCoursesView.swift
+++ b/Core/Core/Courses/AllCourses/View/AllCoursesView.swift
@@ -51,7 +51,7 @@ public struct AllCoursesView: View, ScreenViewTrackable {
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
         .navigationBarStyle(.global)
-        .navigationTitle(NSLocalizedString("All Courses", bundle: .core, comment: ""), subtitle: nil)
+        .navigationTitle(String(localized: "All Courses", bundle: .core), subtitle: nil)
     }
 
     @ViewBuilder
@@ -75,7 +75,7 @@ public struct AllCoursesView: View, ScreenViewTrackable {
 
                 SearchBar(
                     text: binding,
-                    placeholder: NSLocalizedString("Search", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Search", bundle: .core),
                     onCancel: { withAnimation { scrollView.scrollTo(0, anchor: .top) } }
                 )
 

--- a/Core/Core/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
+++ b/Core/Core/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
@@ -88,10 +88,10 @@ public class AllCoursesCellViewModel: ObservableObject {
         isOfflineIndicatorVisible = isItemAvailableOffline
         isFavoriteStarDisabled = offlineModeInteractor.isOfflineModeEnabled()
 
-        let offlineText = isOfflineIndicatorVisible ? NSLocalizedString("Available offline", comment: "") : nil
+        let offlineText = isOfflineIndicatorVisible ? NSLocalizedString("Available offline", bundle: .core, comment: "") : nil
         let publishedText = !(app == .teacher) ? nil : item.isPublished ?
-            NSLocalizedString("published", comment: "") :
-            NSLocalizedString("unpublished", comment: "")
+            NSLocalizedString("published", bundle: .core, comment: "") :
+            NSLocalizedString("unpublished", bundle: .core, comment: "")
         cellAccessibilityLabelText = [
             item.name,
             item.termName,
@@ -101,7 +101,7 @@ public class AllCoursesCellViewModel: ObservableObject {
         ]
         .compactMap { $0 }.joined(separator: ", ")
 
-        favoriteButtonAccessibilityText = pending ? NSLocalizedString("Updating", comment: "") : NSLocalizedString("Favorite", comment: "")
+        favoriteButtonAccessibilityText = pending ? NSLocalizedString("Updating", bundle: .core, comment: "") : NSLocalizedString("Favorite", bundle: .core, comment: "")
         favoriteButtonTraits = (item.isFavourite && !pending) ? .isSelected : []
     }
 

--- a/Core/Core/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
+++ b/Core/Core/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
@@ -88,10 +88,10 @@ public class AllCoursesCellViewModel: ObservableObject {
         isOfflineIndicatorVisible = isItemAvailableOffline
         isFavoriteStarDisabled = offlineModeInteractor.isOfflineModeEnabled()
 
-        let offlineText = isOfflineIndicatorVisible ? NSLocalizedString("Available offline", bundle: .core, comment: "") : nil
+        let offlineText = isOfflineIndicatorVisible ? String(localized: "Available offline", bundle: .core) : nil
         let publishedText = !(app == .teacher) ? nil : item.isPublished ?
-            NSLocalizedString("published", bundle: .core, comment: "") :
-            NSLocalizedString("unpublished", bundle: .core, comment: "")
+            String(localized: "published", bundle: .core) :
+            String(localized: "unpublished", bundle: .core)
         cellAccessibilityLabelText = [
             item.name,
             item.termName,
@@ -101,7 +101,7 @@ public class AllCoursesCellViewModel: ObservableObject {
         ]
         .compactMap { $0 }.joined(separator: ", ")
 
-        favoriteButtonAccessibilityText = pending ? NSLocalizedString("Updating", bundle: .core, comment: "") : NSLocalizedString("Favorite", bundle: .core, comment: "")
+        favoriteButtonAccessibilityText = pending ? String(localized: "Updating", bundle: .core) : String(localized: "Favorite", bundle: .core)
         favoriteButtonTraits = (item.isFavourite && !pending) ? .isSelected : []
     }
 

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -189,15 +189,15 @@ extension Course {
             grade = enrollment.computedCurrentGrade
             score = enrollment.computedCurrentScore
         } else if enrollment.multipleGradingPeriodsEnabled && enrollment.totalsForAllGradingPeriodsOption == false {
-            return NSLocalizedString("N/A", bundle: .core, comment: "")
+            return String(localized: "N/A", bundle: .core)
         }
 
         if hideQuantitativeData == true {
-            return grade ?? enrollment.computedCurrentLetterGrade ?? NSLocalizedString("N/A", bundle: .core, comment: "")
+            return grade ?? enrollment.computedCurrentLetterGrade ?? String(localized: "N/A", bundle: .core)
         }
 
         guard let scoreNotNil = score, let scoreString = Course.scoreFormatter.string(from: NSNumber(value: scoreNotNil)) else {
-            return grade ?? NSLocalizedString("N/A", bundle: .core, comment: "")
+            return grade ?? String(localized: "N/A", bundle: .core)
         }
 
         if let grade = grade {

--- a/Core/Core/Courses/CourseDetails/Model/CourseHomeProperties.swift
+++ b/Core/Core/Courses/CourseDetails/Model/CourseHomeProperties.swift
@@ -21,15 +21,15 @@ extension CourseDefaultView {
     var homeSubLabel: String? {
         switch self {
         case .assignments:
-            return NSLocalizedString("Assignments", comment: "")
+            return NSLocalizedString("Assignments", bundle: .core, comment: "")
         case .feed:
-            return NSLocalizedString("Recent Activity", comment: "")
+            return NSLocalizedString("Recent Activity", bundle: .core, comment: "")
         case .modules:
-            return NSLocalizedString("Course Modules", comment: "")
+            return NSLocalizedString("Course Modules", bundle: .core, comment: "")
         case .syllabus:
-            return NSLocalizedString("Syllabus", comment: "")
+            return NSLocalizedString("Syllabus", bundle: .core, comment: "")
         case .wiki:
-            return NSLocalizedString("Front Page", comment: "")
+            return NSLocalizedString("Front Page", bundle: .core, comment: "")
         }
     }
 

--- a/Core/Core/Courses/CourseDetails/Model/CourseHomeProperties.swift
+++ b/Core/Core/Courses/CourseDetails/Model/CourseHomeProperties.swift
@@ -21,15 +21,15 @@ extension CourseDefaultView {
     var homeSubLabel: String? {
         switch self {
         case .assignments:
-            return NSLocalizedString("Assignments", bundle: .core, comment: "")
+            return String(localized: "Assignments", bundle: .core)
         case .feed:
-            return NSLocalizedString("Recent Activity", bundle: .core, comment: "")
+            return String(localized: "Recent Activity", bundle: .core)
         case .modules:
-            return NSLocalizedString("Course Modules", bundle: .core, comment: "")
+            return String(localized: "Course Modules", bundle: .core)
         case .syllabus:
-            return NSLocalizedString("Syllabus", bundle: .core, comment: "")
+            return String(localized: "Syllabus", bundle: .core)
         case .wiki:
-            return NSLocalizedString("Front Page", bundle: .core, comment: "")
+            return String(localized: "Front Page", bundle: .core)
         }
     }
 

--- a/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
@@ -44,7 +44,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
                 editor(width: geometry.size.width)
             }
         }
-        .navigationTitle(NSLocalizedString("Customize Course", comment: ""), subtitle: viewModel.courseName)
+        .navigationTitle(NSLocalizedString("Customize Course", bundle: .core, comment: ""), subtitle: viewModel.courseName)
         .navBarItems(
             leading: {
                 Button(action: cancelTapped) {
@@ -60,7 +60,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
         )
         .onAppear(perform: viewModel.viewDidAppear)
         .alert(isPresented: $viewModel.showError) {
-            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", comment: "")))
+            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")))
         }
     }
 
@@ -87,7 +87,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
     private var nameRow: some View {
         TextFieldRow(
             label: Text("Name", bundle: .core),
-            placeholder: NSLocalizedString("Add Course Name", comment: ""),
+            placeholder: NSLocalizedString("Add Course Name", bundle: .core, comment: ""),
             text: $viewModel.newName
         )
     }

--- a/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseSettingsView.swift
@@ -44,7 +44,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
                 editor(width: geometry.size.width)
             }
         }
-        .navigationTitle(NSLocalizedString("Customize Course", bundle: .core, comment: ""), subtitle: viewModel.courseName)
+        .navigationTitle(String(localized: "Customize Course", bundle: .core), subtitle: viewModel.courseName)
         .navBarItems(
             leading: {
                 Button(action: cancelTapped) {
@@ -60,7 +60,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
         )
         .onAppear(perform: viewModel.viewDidAppear)
         .alert(isPresented: $viewModel.showError) {
-            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")))
+            Alert(title: Text(viewModel.errorText ?? String(localized: "Something went wrong", bundle: .core)))
         }
     }
 
@@ -87,7 +87,7 @@ public struct CourseSettingsView: View, ScreenViewTrackable {
     private var nameRow: some View {
         TextFieldRow(
             label: Text("Name", bundle: .core),
-            placeholder: NSLocalizedString("Add Course Name", bundle: .core, comment: ""),
+            placeholder: String(localized: "Add Course Name", bundle: .core),
             text: $viewModel.newName
         )
     }

--- a/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
@@ -27,8 +27,8 @@ class StudentViewCellViewModel: CourseDetailsCellViewModel {
         self.courseID = course.id
         super.init(courseColor: course.color,
                    iconImage: .userLine,
-                   label: NSLocalizedString("Student View", comment: ""),
-                   subtitle: NSLocalizedString("Opens in Canvas Student", comment: ""),
+                   label: NSLocalizedString("Student View", bundle: .core, comment: ""),
+                   subtitle: NSLocalizedString("Opens in Canvas Student", bundle: .core, comment: ""),
                    accessoryIconType: .externalLink,
                    tabID: "student_view",
                    selectedCallback: nil)

--- a/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModel.swift
@@ -27,8 +27,8 @@ class StudentViewCellViewModel: CourseDetailsCellViewModel {
         self.courseID = course.id
         super.init(courseColor: course.color,
                    iconImage: .userLine,
-                   label: NSLocalizedString("Student View", bundle: .core, comment: ""),
-                   subtitle: NSLocalizedString("Opens in Canvas Student", bundle: .core, comment: ""),
+                   label: String(localized: "Student View", bundle: .core),
+                   subtitle: String(localized: "Opens in Canvas Student", bundle: .core),
                    accessoryIconType: .externalLink,
                    tabID: "student_view",
                    selectedCallback: nil)

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -203,7 +203,10 @@ public class CourseDetailsViewModel: ObservableObject {
         guard let course = course.first, tabs.requested, !tabs.pending, !tabs.hasNextPage, permissions.requested, !permissions.pending, attendanceToolRequest == nil else { return }
 
         if tabs.error != nil {
-            state = .empty(title: NSLocalizedString("Something went wrong", comment: ""), message: NSLocalizedString("There was an unexpected error. Please try again.", comment: ""))
+            state = .empty(
+                title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
+                message: NSLocalizedString("There was an unexpected error. Please try again.", bundle: .core, comment: "")
+            )
             return
         }
 

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -204,8 +204,8 @@ public class CourseDetailsViewModel: ObservableObject {
 
         if tabs.error != nil {
             state = .empty(
-                title: NSLocalizedString("Something went wrong", bundle: .core, comment: ""),
-                message: NSLocalizedString("There was an unexpected error. Please try again.", bundle: .core, comment: "")
+                title: String(localized: "Something went wrong", bundle: .core),
+                message: String(localized: "There was an unexpected error. Please try again.", bundle: .core)
             )
             return
         }

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
@@ -70,7 +70,7 @@ public class CourseSettingsViewModel: ObservableObject {
 
         let selected: IndexPath? = options.firstIndex(of: newDefaultView).flatMap { IndexPath(row: $0, section: 0) }
         let itemPicker = ItemPickerViewController.create(
-            title: NSLocalizedString("Set \"Home\" to...", bundle: .core, comment: ""),
+            title: String(localized: "Set \"Home\" to...", bundle: .core),
             sections: sections,
             selected: selected,
             didSelect: {

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseSettingsViewModel.swift
@@ -70,7 +70,7 @@ public class CourseSettingsViewModel: ObservableObject {
 
         let selected: IndexPath? = options.firstIndex(of: newDefaultView).flatMap { IndexPath(row: $0, section: 0) }
         let itemPicker = ItemPickerViewController.create(
-            title: NSLocalizedString("Set \"Home\" to...", comment: ""),
+            title: NSLocalizedString("Set \"Home\" to...", bundle: .core, comment: ""),
             sections: sections,
             selected: selected,
             didSelect: {

--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -302,7 +302,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
                 .padding(.bottom, 50 - verticalSpacing) // group header already has a top padding
         case .error:
             ZStack {
-                Text("Something went wrong")
+                Text("Something went wrong", bundle: .core)
                     .font(.regular16).foregroundColor(.textDanger)
                     .multilineTextAlignment(.center)
             }

--- a/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
@@ -72,7 +72,7 @@ struct CustomizeCourseView: View {
                 .clipped()
             TextFieldRow(
                 label: Text("Nickname", bundle: .core),
-                placeholder: NSLocalizedString("Add Course Nickname", comment: ""),
+                placeholder: NSLocalizedString("Add Course Nickname", bundle: .core, comment: ""),
                 text: $name
             )
             Divider()
@@ -106,7 +106,7 @@ struct CustomizeCourseView: View {
             } }
             Divider()
         }
-            .navigationTitle(NSLocalizedString("Customize Course", comment: ""), subtitle: name)
+            .navigationTitle(NSLocalizedString("Customize Course", bundle: .core, comment: ""), subtitle: name)
             .navigationBarItems(
                 leading: Button(action: cancel, label: {
                     Text("Cancel", bundle: .core).fontWeight(.regular)

--- a/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
@@ -72,7 +72,7 @@ struct CustomizeCourseView: View {
                 .clipped()
             TextFieldRow(
                 label: Text("Nickname", bundle: .core),
-                placeholder: NSLocalizedString("Add Course Nickname", bundle: .core, comment: ""),
+                placeholder: String(localized: "Add Course Nickname", bundle: .core),
                 text: $name
             )
             Divider()
@@ -106,7 +106,7 @@ struct CustomizeCourseView: View {
             } }
             Divider()
         }
-            .navigationTitle(NSLocalizedString("Customize Course", bundle: .core, comment: ""), subtitle: name)
+            .navigationTitle(String(localized: "Customize Course", bundle: .core), subtitle: name)
             .navigationBarItems(
                 leading: Button(action: cancel, label: {
                     Text("Cancel", bundle: .core).fontWeight(.regular)

--- a/Core/Core/Dashboard/FileUploadNotification/ViewModel/FileUploadNotificationCardItemViewModel.swift
+++ b/Core/Core/Dashboard/FileUploadNotification/ViewModel/FileUploadNotificationCardItemViewModel.swift
@@ -26,9 +26,9 @@ final class FileUploadNotificationCardItemViewModel: ObservableObject, Identifia
 
         var text: String {
             switch self {
-            case .uploading: return NSLocalizedString("Uploading Submission", bundle: .core, comment: "")
-            case .success: return NSLocalizedString("Submission Uploaded", bundle: .core, comment: "")
-            case .failure: return NSLocalizedString("Submission Failed", bundle: .core, comment: "")
+            case .uploading: return String(localized: "Uploading Submission", bundle: .core)
+            case .success: return String(localized: "Submission Uploaded", bundle: .core)
+            case .failure: return String(localized: "Submission Failed", bundle: .core)
             }
         }
 

--- a/Core/Core/Dashboard/FileUploadNotification/ViewModel/FileUploadNotificationCardItemViewModel.swift
+++ b/Core/Core/Dashboard/FileUploadNotification/ViewModel/FileUploadNotificationCardItemViewModel.swift
@@ -26,9 +26,9 @@ final class FileUploadNotificationCardItemViewModel: ObservableObject, Identifia
 
         var text: String {
             switch self {
-            case .uploading: return NSLocalizedString("Uploading Submission", comment: "")
-            case .success: return NSLocalizedString("Submission Uploaded", comment: "")
-            case .failure: return NSLocalizedString("Submission Failed", comment: "")
+            case .uploading: return NSLocalizedString("Uploading Submission", bundle: .core, comment: "")
+            case .success: return NSLocalizedString("Submission Uploaded", bundle: .core, comment: "")
+            case .failure: return NSLocalizedString("Submission Failed", bundle: .core, comment: "")
             }
         }
 

--- a/Core/Core/Dashboard/Group/View/GroupCard.swift
+++ b/Core/Core/Dashboard/Group/View/GroupCard.swift
@@ -37,7 +37,7 @@ struct GroupCard: View {
                     Text(group.name)
                         .font(.semibold18).foregroundColor(.textDarkest)
                         .lineLimit(2).fixedSize(horizontal: false, vertical: true)
-                    Text(course?.name ?? NSLocalizedString("Account Group", comment: ""))
+                    Text(course?.name ?? NSLocalizedString("Account Group", bundle: .core, comment: ""))
                         .font(.semibold16).foregroundColor(group.dashboardCardColor)
                         .lineLimit(2).fixedSize(horizontal: false, vertical: true)
                     course?.termName.map { Text($0.localizedUppercase) }

--- a/Core/Core/Dashboard/Group/View/GroupCard.swift
+++ b/Core/Core/Dashboard/Group/View/GroupCard.swift
@@ -37,7 +37,7 @@ struct GroupCard: View {
                     Text(group.name)
                         .font(.semibold18).foregroundColor(.textDarkest)
                         .lineLimit(2).fixedSize(horizontal: false, vertical: true)
-                    Text(course?.name ?? NSLocalizedString("Account Group", bundle: .core, comment: ""))
+                    Text(course?.name ?? String(localized: "Account Group", bundle: .core))
                         .font(.semibold16).foregroundColor(group.dashboardCardColor)
                         .lineLimit(2).fixedSize(horizontal: false, vertical: true)
                     course?.termName.map { Text($0.localizedUppercase) }

--- a/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
+++ b/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
@@ -47,7 +47,7 @@ public extension APIPlannable {
 
     var k5ScheduleDueText: String {
         if self.plannable?.all_day == true {
-            return NSLocalizedString("All Day", comment: "")
+            return NSLocalizedString("All Day", bundle: .core, comment: "")
         } else if let start = self.plannable?.start_at, let end = self.plannable?.end_at {
             return start.timeIntervalString(to: end)
         } else if plannableType == .announcement {
@@ -63,22 +63,22 @@ public extension APIPlannable {
         var labels: [(text: String, color: Color)] = []
 
         if submissionStates.graded == true {
-            labels.append((text: NSLocalizedString("Graded", comment: ""), color: .ash))
+            labels.append((text: NSLocalizedString("Graded", bundle: .core, comment: ""), color: .ash))
         }
         if submissionStates.late == true {
-            labels.append((text: NSLocalizedString("Late", comment: ""), color: .crimson))
+            labels.append((text: NSLocalizedString("Late", bundle: .core, comment: ""), color: .crimson))
         }
         if submissionStates.has_feedback == true {
-            labels.append((text: NSLocalizedString("Feedback", comment: ""), color: .ash))
+            labels.append((text: NSLocalizedString("Feedback", bundle: .core, comment: ""), color: .ash))
         }
         if submissionStates.redo_request == true {
-            labels.append((text: NSLocalizedString("Redo", comment: ""), color: .crimson))
+            labels.append((text: NSLocalizedString("Redo", bundle: .core, comment: ""), color: .crimson))
         }
         if submissionStates.missing == true {
-            labels.append((text: NSLocalizedString("Missing", comment: ""), color: .crimson))
+            labels.append((text: NSLocalizedString("Missing", bundle: .core, comment: ""), color: .crimson))
         }
         if submissionStates.submitted == true && submissionStates.late == false {
-            labels.append((text: NSLocalizedString("Submitted", comment: ""), color: .ash))
+            labels.append((text: NSLocalizedString("Submitted", bundle: .core, comment: ""), color: .ash))
         }
 
         return labels
@@ -87,9 +87,9 @@ public extension APIPlannable {
     func k5ScheduleSubject(courseInfoByCourseIDs: [String: (color: Color, image: URL?, isHomeroom: Bool, shouldHideQuantitativeData: Bool)]) -> K5ScheduleSubject {
         let name: String = {
             if plannableType == .calendar_event {
-                return NSLocalizedString("To Do", comment: "")
+                return NSLocalizedString("To Do", bundle: .core, comment: "")
             } else {
-                return context_name ?? NSLocalizedString("To Do", comment: "")
+                return context_name ?? NSLocalizedString("To Do", bundle: .core, comment: "")
             }
         }()
         let color: Color = {

--- a/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
+++ b/Core/Core/Dashboard/K5/Model/Schedule/K5ScheduleItemInfo.swift
@@ -41,19 +41,19 @@ public extension APIPlannable {
 
     static func k5SchedulePoints(from points: Double?) -> String? {
         guard let points = points else { return nil }
-        let pointsTemplate = NSLocalizedString("g_pts", bundle: .core, comment: "")
+        let pointsTemplate = String(localized: "g_pts", bundle: .core)
         return String.localizedStringWithFormat(pointsTemplate, points)
     }
 
     var k5ScheduleDueText: String {
         if self.plannable?.all_day == true {
-            return NSLocalizedString("All Day", bundle: .core, comment: "")
+            return String(localized: "All Day", bundle: .core)
         } else if let start = self.plannable?.start_at, let end = self.plannable?.end_at {
             return start.timeIntervalString(to: end)
         } else if plannableType == .announcement {
             return plannable_date.timeString
         } else {
-            let dueTemplate = NSLocalizedString("Due: %@", bundle: .core, comment: "")
+            let dueTemplate = String(localized: "Due: %@", bundle: .core)
             return String.localizedStringWithFormat(dueTemplate, plannable_date.timeString)
         }
     }
@@ -63,22 +63,22 @@ public extension APIPlannable {
         var labels: [(text: String, color: Color)] = []
 
         if submissionStates.graded == true {
-            labels.append((text: NSLocalizedString("Graded", bundle: .core, comment: ""), color: .ash))
+            labels.append((text: String(localized: "Graded", bundle: .core), color: .ash))
         }
         if submissionStates.late == true {
-            labels.append((text: NSLocalizedString("Late", bundle: .core, comment: ""), color: .crimson))
+            labels.append((text: String(localized: "Late", bundle: .core), color: .crimson))
         }
         if submissionStates.has_feedback == true {
-            labels.append((text: NSLocalizedString("Feedback", bundle: .core, comment: ""), color: .ash))
+            labels.append((text: String(localized: "Feedback", bundle: .core), color: .ash))
         }
         if submissionStates.redo_request == true {
-            labels.append((text: NSLocalizedString("Redo", bundle: .core, comment: ""), color: .crimson))
+            labels.append((text: String(localized: "Redo", bundle: .core), color: .crimson))
         }
         if submissionStates.missing == true {
-            labels.append((text: NSLocalizedString("Missing", bundle: .core, comment: ""), color: .crimson))
+            labels.append((text: String(localized: "Missing", bundle: .core), color: .crimson))
         }
         if submissionStates.submitted == true && submissionStates.late == false {
-            labels.append((text: NSLocalizedString("Submitted", bundle: .core, comment: ""), color: .ash))
+            labels.append((text: String(localized: "Submitted", bundle: .core), color: .ash))
         }
 
         return labels
@@ -87,9 +87,9 @@ public extension APIPlannable {
     func k5ScheduleSubject(courseInfoByCourseIDs: [String: (color: Color, image: URL?, isHomeroom: Bool, shouldHideQuantitativeData: Bool)]) -> K5ScheduleSubject {
         let name: String = {
             if plannableType == .calendar_event {
-                return NSLocalizedString("To Do", bundle: .core, comment: "")
+                return String(localized: "To Do", bundle: .core)
             } else {
-                return context_name ?? NSLocalizedString("To Do", bundle: .core, comment: "")
+                return context_name ?? String(localized: "To Do", bundle: .core)
             }
         }()
         let color: Color = {

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleMissingItemsView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleMissingItemsView.swift
@@ -69,7 +69,7 @@ public struct K5ScheduleMissingItemsView: View {
     }
 
     private var missingItemsText: String {
-        let format = isOpened ? NSLocalizedString("hide_%d_missing_items", bundle: .core, comment: "") : NSLocalizedString("show_%d_missing_items", bundle: .core, comment: "")
+        let format = isOpened ? String(localized: "hide_%d_missing_items", bundle: .core) : String(localized: "show_%d_missing_items", bundle: .core)
         return String.localizedStringWithFormat(format, missingItems.count)
     }
 }

--- a/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleMissingItemsView.swift
+++ b/Core/Core/Dashboard/K5/View/Schedule/K5ScheduleMissingItemsView.swift
@@ -69,7 +69,7 @@ public struct K5ScheduleMissingItemsView: View {
     }
 
     private var missingItemsText: String {
-        let format = isOpened ? NSLocalizedString("hide_%d_missing_items", comment: "") : NSLocalizedString("show_%d_missing_items", comment: "")
+        let format = isOpened ? NSLocalizedString("hide_%d_missing_items", bundle: .core, comment: "") : NSLocalizedString("show_%d_missing_items", bundle: .core, comment: "")
         return String.localizedStringWithFormat(format, missingItems.count)
     }
 }

--- a/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradesViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Grades/K5GradesViewModel.swift
@@ -27,7 +27,7 @@ public class K5GradesViewModel: ObservableObject {
     private lazy var courses = env.subscribe(GetUserCourses(userID: studentID)) { [weak self] in
         self?.coursesUpdated()
     }
-    private let defaultCurrentGradingPeriod = K5GradingPeriod(periodID: nil, title: NSLocalizedString("Current Grading Period", bundle: .core, comment: ""))
+    private let defaultCurrentGradingPeriod = K5GradingPeriod(periodID: nil, title: String(localized: "Current Grading Period", bundle: .core))
 
     // MARK: Refresh
     private var refreshCompletion: (() -> Void)?

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
@@ -66,15 +66,15 @@ extension K5HomeroomSubjectCardViewModel {
             var highlightedText = ""
 
             if dueToday > 0 {
-                text = String(format: NSLocalizedString("%d due today", bundle: .core, comment: "Number of assignments due today"), dueToday)
+                text = String(format: String(localized: "%d due today", bundle: .core, comment: "Number of assignments due today"), dueToday)
             }
 
             if missing > 0 {
-                highlightedText = String(format: NSLocalizedString("%d missing", bundle: .core, comment: "Number of missing submissions"), missing)
+                highlightedText = String(format: String(localized: "%d missing", bundle: .core, comment: "Number of missing submissions"), missing)
             }
 
             if text.isEmpty && highlightedText.isEmpty {
-                text = NSLocalizedString("Nothing Due Today", bundle: .core, comment: "No due assignments for today")
+                text = String(localized: "Nothing Due Today", bundle: .core, comment: "No due assignments for today")
             } else if !text.isEmpty && !highlightedText.isEmpty {
                 text += " | "
             }

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomSubjectCardViewModel.swift
@@ -66,15 +66,15 @@ extension K5HomeroomSubjectCardViewModel {
             var highlightedText = ""
 
             if dueToday > 0 {
-                text = String(format: NSLocalizedString("%d due today", comment: "Number of assignments due today"), dueToday)
+                text = String(format: NSLocalizedString("%d due today", bundle: .core, comment: "Number of assignments due today"), dueToday)
             }
 
             if missing > 0 {
-                highlightedText = String(format: NSLocalizedString("%d missing", comment: "Number of missing submissions"), missing)
+                highlightedText = String(format: NSLocalizedString("%d missing", bundle: .core, comment: "Number of missing submissions"), missing)
             }
 
             if text.isEmpty && highlightedText.isEmpty {
-                text = NSLocalizedString("Nothing Due Today", comment: "No due assignments for today")
+                text = NSLocalizedString("Nothing Due Today", bundle: .core, comment: "No due assignments for today")
             } else if !text.isEmpty && !highlightedText.isEmpty {
                 text += " | "
             }

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -69,9 +69,9 @@ public class K5HomeroomViewModel: ObservableObject {
         let newWelcomeText: String
 
         if let userName = profile.first?.name {
-            newWelcomeText = NSLocalizedString("Welcome, \(userName)!", bundle: .core, comment: "Welcome, username!")
+            newWelcomeText = String(localized: "Welcome, \(userName)!", bundle: .core, comment: "Welcome, username!")
         } else {
-            newWelcomeText = NSLocalizedString("Welcome!", bundle: .core, comment: "")
+            newWelcomeText = String(localized: "Welcome!", bundle: .core)
         }
 
         if newWelcomeText != welcomeText {

--- a/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Homeroom/K5HomeroomViewModel.swift
@@ -69,9 +69,9 @@ public class K5HomeroomViewModel: ObservableObject {
         let newWelcomeText: String
 
         if let userName = profile.first?.name {
-            newWelcomeText = NSLocalizedString("Welcome, \(userName)!", comment: "Welcome, username!")
+            newWelcomeText = NSLocalizedString("Welcome, \(userName)!", bundle: .core, comment: "Welcome, username!")
         } else {
-            newWelcomeText = NSLocalizedString("Welcome!", comment: "")
+            newWelcomeText = NSLocalizedString("Welcome!", bundle: .core, comment: "")
         }
 
         if newWelcomeText != welcomeText {

--- a/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesContactViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesContactViewModel.swift
@@ -43,7 +43,7 @@ public struct K5ResourcesContactViewModel {
     public init(_ user: APIUser, courses: [Course]) {
         let firstActiveEnrollment = user.enrollments?.first { $0.enrollment_state == .active }
         let firstActiveRole = firstActiveEnrollment?.role
-        let role = firstActiveRole == Role.teacher.rawValue ? NSLocalizedString("Teacher", bundle: .core, comment: "") : NSLocalizedString("Teacher's Assistant", bundle: .core, comment: "")
+        let role = firstActiveRole == Role.teacher.rawValue ? String(localized: "Teacher", bundle: .core) : String(localized: "Teacher's Assistant", bundle: .core)
         let courseCode: String = {
             if let courseId = firstActiveEnrollment?.course_id {
                 return "course_\(courseId)"

--- a/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesContactViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Resources/K5ResourcesContactViewModel.swift
@@ -43,7 +43,7 @@ public struct K5ResourcesContactViewModel {
     public init(_ user: APIUser, courses: [Course]) {
         let firstActiveEnrollment = user.enrollments?.first { $0.enrollment_state == .active }
         let firstActiveRole = firstActiveEnrollment?.role
-        let role = firstActiveRole == Role.teacher.rawValue ? NSLocalizedString("Teacher", comment: "") : NSLocalizedString("Teacher's Assistant", comment: "")
+        let role = firstActiveRole == Role.teacher.rawValue ? NSLocalizedString("Teacher", bundle: .core, comment: "") : NSLocalizedString("Teacher's Assistant", bundle: .core, comment: "")
         let courseCode: String = {
             if let courseId = firstActiveEnrollment?.course_id {
                 return "course_\(courseId)"

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleDayViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleDayViewModel.swift
@@ -33,9 +33,9 @@ public class K5ScheduleDayViewModel: Identifiable, ObservableObject {
 
     public init(range: Range<Date>, calendar: Calendar) {
         if calendar.isDateInToday(range.lowerBound) {
-            self.weekday = NSLocalizedString("Today", comment: "")
+            self.weekday = NSLocalizedString("Today", bundle: .core, comment: "")
         } else if calendar.isDateInTomorrow(range.lowerBound) {
-            self.weekday = NSLocalizedString("Tomorrow", comment: "")
+            self.weekday = NSLocalizedString("Tomorrow", bundle: .core, comment: "")
         } else {
             self.weekday = range.lowerBound.weekdayName
         }

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleDayViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleDayViewModel.swift
@@ -33,9 +33,9 @@ public class K5ScheduleDayViewModel: Identifiable, ObservableObject {
 
     public init(range: Range<Date>, calendar: Calendar) {
         if calendar.isDateInToday(range.lowerBound) {
-            self.weekday = NSLocalizedString("Today", bundle: .core, comment: "")
+            self.weekday = String(localized: "Today", bundle: .core)
         } else if calendar.isDateInTomorrow(range.lowerBound) {
-            self.weekday = NSLocalizedString("Tomorrow", bundle: .core, comment: "")
+            self.weekday = String(localized: "Tomorrow", bundle: .core)
         } else {
             self.weekday = range.lowerBound.weekdayName
         }

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleEntryViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleEntryViewModel.swift
@@ -86,7 +86,7 @@ public class K5ScheduleEntryViewModel: ObservableObject, Identifiable {
 
     private func updateSubtitle() {
         guard case .checkbox(let isChecked) = leading else { return }
-        subtitle = isChecked ? SubtitleViewModel(text: NSLocalizedString("You've marked it as done.", comment: ""), color: .ash, font: .regular12) : nil
+        subtitle = isChecked ? SubtitleViewModel(text: NSLocalizedString("You've marked it as done.", bundle: .core, comment: ""), color: .ash, font: .regular12) : nil
     }
 }
 

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleEntryViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleEntryViewModel.swift
@@ -86,7 +86,7 @@ public class K5ScheduleEntryViewModel: ObservableObject, Identifiable {
 
     private func updateSubtitle() {
         guard case .checkbox(let isChecked) = leading else { return }
-        subtitle = isChecked ? SubtitleViewModel(text: NSLocalizedString("You've marked it as done.", bundle: .core, comment: ""), color: .ash, font: .regular12) : nil
+        subtitle = isChecked ? SubtitleViewModel(text: String(localized: "You've marked it as done.", bundle: .core), color: .ash, font: .regular12) : nil
     }
 }
 

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 
 public class K5ScheduleWeekViewModel: ObservableObject {
-    public let todayViewId = NSLocalizedString("Today", comment: "")
+    public let todayViewId = NSLocalizedString("Today", bundle: .core, comment: "")
 
     public let weekRange: Range<Date>
     public let isTodayButtonAvailable: Bool

--- a/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
+++ b/Core/Core/Dashboard/K5/ViewModel/Schedule/K5ScheduleWeekViewModel.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 
 public class K5ScheduleWeekViewModel: ObservableObject {
-    public let todayViewId = NSLocalizedString("Today", bundle: .core, comment: "")
+    public let todayViewId = String(localized: "Today", bundle: .core)
 
     public let weekRange: Range<Date>
     public let isTodayButtonAvailable: Bool

--- a/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
+++ b/Core/Core/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
@@ -98,7 +98,7 @@ struct DashboardOfflineSyncProgressCardView: View {
                 .font(.semibold16, lineHeight: .fit)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 2)
-            Text("One or more files failed to sync. Check your internet connection and retry to submit.")
+            Text("One or more files failed to sync. Check your internet connection and retry to submit.", bundle: .core)
                 .font(.regular14, lineHeight: .fit)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .multilineTextAlignment(.leading)

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -113,7 +113,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
             if downloadProgress.isFinished, downloadProgress.error != nil {
                 return Just(.error).eraseToAnyPublisher()
             } else {
-                let format = NSLocalizedString("d_courses_syncing", bundle: .core, comment: "")
+                let format = String(localized: "d_courses_syncing", bundle: .core)
                 let formattedText = String.localizedStringWithFormat(format, stateProgress.count)
                 return Just(.progress(downloadProgress.progress, formattedText)).eraseToAnyPublisher()
             }

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -113,7 +113,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
             if downloadProgress.isFinished, downloadProgress.error != nil {
                 return Just(.error).eraseToAnyPublisher()
             } else {
-                let format = NSLocalizedString("d_courses_syncing", comment: "")
+                let format = NSLocalizedString("d_courses_syncing", bundle: .core, comment: "")
                 let formattedText = String.localizedStringWithFormat(format, stateProgress.count)
                 return Just(.progress(downloadProgress.progress, formattedText)).eraseToAnyPublisher()
             }

--- a/Core/Core/DeveloperMenu/ExperimentalFeaturesViewController.swift
+++ b/Core/Core/DeveloperMenu/ExperimentalFeaturesViewController.swift
@@ -30,7 +30,7 @@ public class ExperimentalFeaturesViewController: UITableViewController {
             navigationItem.rightBarButtonItem = barButtonItem
         }
 
-        title = NSLocalizedString("Experimental Features", bundle: .core, comment: "")
+        title = String(localized: "Experimental Features", bundle: .core)
         tableView?.registerCell(SwitchTableViewCell.self)
     }
 

--- a/Core/Core/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Discussions/AnnouncementListViewController.swift
@@ -59,13 +59,13 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Announcements", comment: ""))
+        setupTitleViewInNavbar(title: NSLocalizedString("Announcements", bundle: .core, comment: ""))
 
-        addButton.accessibilityLabel = NSLocalizedString("Create Announcement", comment: "")
+        addButton.accessibilityLabel = NSLocalizedString("Create Announcement", bundle: .core, comment: "")
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like announcements haven’t been created in this space yet.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Announcements", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading announcements. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = NSLocalizedString("It looks like announcements haven’t been created in this space yet.", bundle: .core, comment: "")
+        emptyTitleLabel.text = NSLocalizedString("No Announcements", bundle: .core, comment: "")
+        errorView.messageLabel.text = NSLocalizedString("There was an error loading announcements. Pull to refresh to try again.", bundle: .core, comment: "")
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil
@@ -144,17 +144,17 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
     func deleteTopic(at indexPath: IndexPath, completionHandler: @escaping (Bool) -> Void) {
         guard let topicID = topics[indexPath]?.id else { return completionHandler(false) }
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Announcement", comment: ""),
-            message: NSLocalizedString("Are you sure you would like to delete this announcement?", comment: ""),
+            title: NSLocalizedString("Delete Announcement", bundle: .core, comment: ""),
+            message: NSLocalizedString("Are you sure you would like to delete this announcement?", bundle: .core, comment: ""),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Delete", comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { _ in
             let useCase = DeleteDiscussionTopic(context: self.context, topicID: topicID)
             useCase.fetch { [weak self] _, _, error in performUIUpdate {
                 if let error = error { self?.showError(error) }
             } }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
         completionHandler(true)
     }
@@ -180,7 +180,7 @@ extension AnnouncementListViewController: UITableViewDataSource, UITableViewDele
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         var actions: [UIContextualAction] = []
         if topics[indexPath]?.canDelete == true {
-            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", comment: "")) { [weak self] (_, _, handler) in
+            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] (_, _, handler) in
                 self?.deleteTopic(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundDanger
@@ -214,9 +214,9 @@ class AnnouncementListCell: UITableViewCell {
         if let delayed = topic?.delayedPostAt, delayed > Clock.now {
             iconImageView.icon = .calendarClockLine
             iconImageView.state = nil
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Delayed until %@", comment: ""), delayed.dateTimeString)
+            dateText = String.localizedStringWithFormat(NSLocalizedString("Delayed until %@", bundle: .core, comment: ""), delayed.dateTimeString)
         } else if let replyAt = topic?.lastReplyAt {
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", comment: ""), replyAt.dateTimeString)
+            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", bundle: .core, comment: ""), replyAt.dateTimeString)
         } else {
             dateText = topic?.postedAt?.dateTimeString
         }

--- a/Core/Core/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Discussions/AnnouncementListViewController.swift
@@ -59,13 +59,13 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Announcements", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Announcements", bundle: .core))
 
-        addButton.accessibilityLabel = NSLocalizedString("Create Announcement", bundle: .core, comment: "")
+        addButton.accessibilityLabel = String(localized: "Create Announcement", bundle: .core)
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like announcements haven’t been created in this space yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Announcements", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading announcements. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "It looks like announcements haven’t been created in this space yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Announcements", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading announcements. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil
@@ -144,17 +144,17 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
     func deleteTopic(at indexPath: IndexPath, completionHandler: @escaping (Bool) -> Void) {
         guard let topicID = topics[indexPath]?.id else { return completionHandler(false) }
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Announcement", bundle: .core, comment: ""),
-            message: NSLocalizedString("Are you sure you would like to delete this announcement?", bundle: .core, comment: ""),
+            title: String(localized: "Delete Announcement", bundle: .core),
+            message: String(localized: "Are you sure you would like to delete this announcement?", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(String(localized: "Delete", bundle: .core), style: .destructive) { _ in
             let useCase = DeleteDiscussionTopic(context: self.context, topicID: topicID)
             useCase.fetch { [weak self] _, _, error in performUIUpdate {
                 if let error = error { self?.showError(error) }
             } }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
         completionHandler(true)
     }
@@ -180,7 +180,7 @@ extension AnnouncementListViewController: UITableViewDataSource, UITableViewDele
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         var actions: [UIContextualAction] = []
         if topics[indexPath]?.canDelete == true {
-            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] (_, _, handler) in
+            let action = UIContextualAction(style: .destructive, title: String(localized: "Delete", bundle: .core)) { [weak self] (_, _, handler) in
                 self?.deleteTopic(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundDanger
@@ -214,9 +214,9 @@ class AnnouncementListCell: UITableViewCell {
         if let delayed = topic?.delayedPostAt, delayed > Clock.now {
             iconImageView.icon = .calendarClockLine
             iconImageView.state = nil
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Delayed until %@", bundle: .core, comment: ""), delayed.dateTimeString)
+            dateText = String.localizedStringWithFormat(String(localized: "Delayed until %@", bundle: .core), delayed.dateTimeString)
         } else if let replyAt = topic?.lastReplyAt {
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", bundle: .core, comment: ""), replyAt.dateTimeString)
+            dateText = String.localizedStringWithFormat(String(localized: "Last post %@", bundle: .core), replyAt.dateTimeString)
         } else {
             dateText = topic?.postedAt?.dateTimeString
         }

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -599,7 +599,7 @@ extension DiscussionDetailsViewController {
         if topic.subscribed {
             sheet.addAction(
                 image: .noSolid,
-                title: NSLocalizedString("Unsubscribe", comment: ""),
+                title: NSLocalizedString("Unsubscribe", bundle: .core, comment: ""),
                 accessibilityIdentifier: "DiscussionDetails.unsubscribe"
             ) { [weak self] in
                 self?.subscribe(false)
@@ -607,7 +607,7 @@ extension DiscussionDetailsViewController {
         } else {
             sheet.addAction(
                 image: .checkSolid,
-                title: NSLocalizedString("Subscribe", comment: ""),
+                title: NSLocalizedString("Subscribe", bundle: .core, comment: ""),
                 accessibilityIdentifier: "DiscussionDetails.subscribe"
             ) { [weak self] in
                 self?.subscribe(true)

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -122,12 +122,12 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
     public override func viewDidLoad() {
         super.viewDidLoad()
         setupTitleViewInNavbar(title: isAnnouncement
-            ? NSLocalizedString("Announcement Details", bundle: .core, comment: "")
-            : NSLocalizedString("Discussion Details", bundle: .core, comment: "")
+            ? String(localized: "Announcement Details", bundle: .core)
+            : String(localized: "Discussion Details", bundle: .core)
         )
         courseSectionsView.isHidden = true
 
-        optionsButton.accessibilityLabel = NSLocalizedString("Options", bundle: .core, comment: "")
+        optionsButton.accessibilityLabel = String(localized: "Options", bundle: .core)
         optionsButton.accessibilityIdentifier = "DiscussionDetails.options"
 
         pointsView.isHidden = true
@@ -164,8 +164,8 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
 
         if showRepliesToEntryID != nil {
             titleSubtitleView.title = isAnnouncement
-                ? NSLocalizedString("Announcement Replies", bundle: .core, comment: "")
-                : NSLocalizedString("Discussion Replies", bundle: .core, comment: "")
+                ? String(localized: "Announcement Replies", bundle: .core)
+                : String(localized: "Discussion Replies", bundle: .core)
             navigationItem.rightBarButtonItem = nil
         }
 
@@ -212,12 +212,12 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         refreshControl.color = color
         titleSubtitleView.title = showRepliesToEntryID != nil ? (
             isAnnouncement
-                ? NSLocalizedString("Announcement Replies", bundle: .core, comment: "")
-                : NSLocalizedString("Discussion Replies", bundle: .core, comment: "")
+                ? String(localized: "Announcement Replies", bundle: .core)
+                : String(localized: "Discussion Replies", bundle: .core)
         ) : (
             isAnnouncement
-                ? NSLocalizedString("Announcement Details", bundle: .core, comment: "")
-                : NSLocalizedString("Discussion Details", bundle: .core, comment: "")
+                ? String(localized: "Announcement Details", bundle: .core)
+                : String(localized: "Discussion Details", bundle: .core)
         )
         updateNavBar(subtitle: name, color: color)
     }
@@ -237,7 +237,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
 
         if let sections = topic.first?.sections, topic.first?.isSectionSpecific == true {
             courseSectionsLabel.text = String.localizedStringWithFormat(
-                NSLocalizedString("Sections: %@", bundle: .core, comment: ""),
+                String(localized: "Sections: %@", bundle: .core),
                 ListFormatter.localizedString(from: sections.map { $0.name })
             )
             courseSectionsView.isHidden = false
@@ -258,8 +258,8 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         publishedIcon.image = isPublished ? .publishSolid : .noSolid
         publishedIcon.tintColor = isPublished ? .textSuccess : .textDark
         publishedLabel.text = isPublished
-            ? NSLocalizedString("Published", bundle: .core, comment: "")
-            : NSLocalizedString("Unpublished", bundle: .core, comment: "")
+            ? String(localized: "Published", bundle: .core)
+            : String(localized: "Unpublished", bundle: .core)
         publishedLabel.textColor = isPublished ? .textSuccess : .textDark
         publishedView.isHidden = env.app != .teacher || isAnnouncement || showRepliesToEntryID != nil
 
@@ -581,7 +581,7 @@ extension DiscussionDetailsViewController {
         if entries.contains(where: { $0.isRead == false }) {
             sheet.addAction(
                 image: .checkSolid,
-                title: NSLocalizedString("Mark All as Read", bundle: .core, comment: ""),
+                title: String(localized: "Mark All as Read", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.markAllRead"
             ) { [weak self] in
                 self?.markAllRead(isRead: true)
@@ -590,7 +590,7 @@ extension DiscussionDetailsViewController {
         if entries.contains(where: { $0.isRead == true }) {
             sheet.addAction(
                 image: .noSolid,
-                title: NSLocalizedString("Mark All as Unread", bundle: .core, comment: ""),
+                title: String(localized: "Mark All as Unread", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.markAllUnread"
             ) { [weak self] in
                 self?.markAllRead(isRead: false)
@@ -599,7 +599,7 @@ extension DiscussionDetailsViewController {
         if topic.subscribed {
             sheet.addAction(
                 image: .noSolid,
-                title: NSLocalizedString("Unsubscribe", bundle: .core, comment: ""),
+                title: String(localized: "Unsubscribe", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.unsubscribe"
             ) { [weak self] in
                 self?.subscribe(false)
@@ -607,7 +607,7 @@ extension DiscussionDetailsViewController {
         } else {
             sheet.addAction(
                 image: .checkSolid,
-                title: NSLocalizedString("Subscribe", bundle: .core, comment: ""),
+                title: String(localized: "Subscribe", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.subscribe"
             ) { [weak self] in
                 self?.subscribe(true)
@@ -616,7 +616,7 @@ extension DiscussionDetailsViewController {
         if topic.canUpdate {
             sheet.addAction(
                 image: .editLine,
-                title: NSLocalizedString("Edit", bundle: .core, comment: ""),
+                title: String(localized: "Edit", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.edit"
             ) { [weak self] in
                 self?.editTopic()
@@ -625,7 +625,7 @@ extension DiscussionDetailsViewController {
         if topic.canDelete {
             sheet.addAction(
                 image: .trashLine,
-                title: NSLocalizedString("Delete", bundle: .core, comment: ""),
+                title: String(localized: "Delete", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.delete"
             ) { [weak self] in
                 self?.deleteTopic()
@@ -734,7 +734,7 @@ extension DiscussionDetailsViewController {
         if entry.isRead == false {
             sheet.addAction(
                 image: .checkSolid,
-                title: NSLocalizedString("Mark as Read", bundle: .core, comment: ""),
+                title: String(localized: "Mark as Read", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.markAsRead"
             ) { [weak self] in
                 self?.markRead(entryID, isRead: true)
@@ -742,7 +742,7 @@ extension DiscussionDetailsViewController {
         } else {
             sheet.addAction(
                 image: .noSolid,
-                title: NSLocalizedString("Mark as Unread", bundle: .core, comment: ""),
+                title: String(localized: "Mark as Unread", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.markAsUnread"
             ) { [weak self] in
                 self?.markRead(entryID, isRead: false)
@@ -751,7 +751,7 @@ extension DiscussionDetailsViewController {
         if canEdit {
             sheet.addAction(
                 image: .editLine,
-                title: NSLocalizedString("Edit", bundle: .core, comment: ""),
+                title: String(localized: "Edit", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.edit"
             ) { [weak self] in
                 self?.editEntry(entryID)
@@ -760,7 +760,7 @@ extension DiscussionDetailsViewController {
         if canDelete {
             sheet.addAction(
                 image: .trashLine,
-                title: NSLocalizedString("Delete", bundle: .core, comment: ""),
+                title: String(localized: "Delete", bundle: .core),
                 accessibilityIdentifier: "DiscussionDetails.delete"
             ) { [weak self] in
                 self?.deleteEntry(entryID)

--- a/Core/Core/Discussions/DiscussionEditorView.swift
+++ b/Core/Core/Discussions/DiscussionEditorView.swift
@@ -144,8 +144,8 @@ public struct DiscussionEditorView: View {
 
             EditorSection(label: Text("Description", bundle: .core)) {
                 RichContentEditor(
-                    placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
-                    a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Add description", bundle: .core),
+                    a11yLabel: String(localized: "Description", bundle: .core),
                     html: $message,
                     context: context,
                     uploadTo: .context(context),
@@ -256,7 +256,7 @@ public struct DiscussionEditorView: View {
                     ButtonRow(action: {
                         let options = GradingType.allCases
                         self.env.router.show(ItemPickerViewController.create(
-                            title: NSLocalizedString("Display Grade as", bundle: .core, comment: ""),
+                            title: String(localized: "Display Grade as", bundle: .core),
                             sections: [ ItemPickerSection(items: options.map {
                                 ItemPickerItem(title: $0.string)
                             }), ],

--- a/Core/Core/Discussions/DiscussionEditorView.swift
+++ b/Core/Core/Discussions/DiscussionEditorView.swift
@@ -144,8 +144,8 @@ public struct DiscussionEditorView: View {
 
             EditorSection(label: Text("Description", bundle: .core)) {
                 RichContentEditor(
-                    placeholder: NSLocalizedString("Add description", comment: ""),
-                    a11yLabel: NSLocalizedString("Description", comment: ""),
+                    placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
+                    a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
                     html: $message,
                     context: context,
                     uploadTo: .context(context),
@@ -256,7 +256,7 @@ public struct DiscussionEditorView: View {
                     ButtonRow(action: {
                         let options = GradingType.allCases
                         self.env.router.show(ItemPickerViewController.create(
-                            title: NSLocalizedString("Display Grade as", comment: ""),
+                            title: NSLocalizedString("Display Grade as", bundle: .core, comment: ""),
                             sections: [ ItemPickerSection(items: options.map {
                                 ItemPickerItem(title: $0.string)
                             }), ],

--- a/Core/Core/Discussions/DiscussionEntry.swift
+++ b/Core/Core/Discussions/DiscussionEntry.swift
@@ -45,7 +45,7 @@ public final class DiscussionEntry: NSManagedObject {
 
     public var likeCountText: String {
         String.localizedStringWithFormat(
-            NSLocalizedString("d_likes", bundle: .core, comment: ""),
+            String(localized: "d_likes", bundle: .core),
             likeCount
         )
     }

--- a/Core/Core/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Discussions/DiscussionHTML.swift
@@ -91,7 +91,7 @@ public enum DiscussionHTML {
         if entry.isRemoved {
             return """
             <p class="\(Styles.deleted)">
-                \(t(NSLocalizedString("Deleted this reply.", bundle: .core, comment: "")))
+                \(t(String(localized: "Deleted this reply.", bundle: .core)))
             </p>
             """
         }
@@ -192,7 +192,7 @@ public enum DiscussionHTML {
         isRead:\(entry.isRead),
         isRemoved:\(entry.isRemoved),
         likeCountShort:\(s(entry.likeCount <= 0 ? nil : String.localizedStringWithFormat(
-            NSLocalizedString("(%d)", bundle: .core, comment: "number of likes next to the like button"),
+            String(localized: "(%d)", bundle: .core, comment: "number of likes next to the like button"),
             entry.likeCount
         ))),
         likeCountText:\(s(entry.likeCount > 0 ? entry.likeCountText : "")),
@@ -238,7 +238,7 @@ public enum DiscussionHTML {
             h(Discussion.ReplyButton, topic),
             h(Discussion.GroupTopicChildren, props),
             entries.length > 0 && h('h2', { class: \(s(.heading)) },
-                \(s(NSLocalizedString("Replies", bundle: .core, comment: "")))
+                \(s(String(localized: "Replies", bundle: .core)))
             ),
             entries.map(entry => h(Discussion.Entry, { key: entry.id, topic, entry, depth: 0, maxDepth, canLike }))
         )
@@ -287,9 +287,9 @@ public enum DiscussionHTML {
             h('a', {
                 style: '\(Styles.font(.semibold, 16))text-decoration:none',
                 href: `${id}/reply`,
-                'aria-label': \(s(NSLocalizedString("Reply to main discussion", bundle: .core, comment: "")))
+                'aria-label': \(s(String(localized: "Reply to main discussion", bundle: .core)))
             },
-                \(s(NSLocalizedString("Reply", bundle: .core, comment: "")))
+                \(s(String(localized: "Reply", bundle: .core)))
             )
         )
     }
@@ -299,9 +299,9 @@ public enum DiscussionHTML {
         return h(Fragment, null,
             h('div', { class: \(s(.divider)) }),
             h('div', { class: \(s(.groupTopicChildren)), style: `background:${contextColor}33` },
-                h('p', null, \(s(NSLocalizedString(
+                h('p', null, \(s(String(localized:
                     "Since this is a group discussion, each group has its own conversation for this topic. Here are the discussions you have access to.",
-                    bundle: .core, comment: ""
+                    bundle: .core
                 )))),
                 groupTopicChildren.map(({ id, name, topicID }) => h('a', {
                     key: id,
@@ -322,7 +322,7 @@ public enum DiscussionHTML {
         class: \(s(.entry))
     },
         h('div', { class: entry.isRead ? \(s(.read)) : \(s(.unread)) },
-            \(s(NSLocalizedString("Unread", bundle: .core, comment: "")))
+            \(s(String(localized: "Unread", bundle: .core)))
         ),
         h(Discussion.Header, entry),
         h('div', { class: \(s(.entryContent)) },
@@ -335,7 +335,7 @@ public enum DiscussionHTML {
                 href: `${topic.id}/replies/${entry.id}`,
                 class: \(s(.moreReplies))
             },
-                \(s(NSLocalizedString("View more replies", bundle: .core, comment: "")))
+                \(s(String(localized: "View more replies", bundle: .core)))
             ),
             depth < maxDepth && entry.replies && entry.replies.map(entry =>
                 h(Discussion.Entry, { key: entry.id, topic, entry, depth: depth + 1, maxDepth, canLike })
@@ -350,14 +350,14 @@ public enum DiscussionHTML {
                 h('a', {
                     href: `${topic.id}/entries/${entry.id}/replies`,
                     class: \(s(.reply)),
-                    'aria-label': \(s(NSLocalizedString("Reply to thread", bundle: .core, comment: "")))
+                    'aria-label': \(s(String(localized: "Reply to thread", bundle: .core)))
                 },
-                    \(s(NSLocalizedString("Reply", bundle: .core, comment: "")))
+                    \(s(String(localized: "Reply", bundle: .core)))
                 ),
                 h('div', { class: \(s(.replyPipe)) })
             ),
             h('button', {
-                "aria-label": \(s(NSLocalizedString("Show more options", bundle: .core, comment: ""))),
+                "aria-label": \(s(String(localized: "Show more options", bundle: .core))),
                 class: \(s(.moreOptions)),
                 onClick: event => {
                     const button = event.target.closest(".\(Styles.moreOptions)")
@@ -383,7 +383,7 @@ public enum DiscussionHTML {
                         type: 'checkbox',
                         checked: entry.isLiked,
                         class: \(s(.hiddenCheck)),
-                        'aria-label': \(s(NSLocalizedString("Like", bundle: .core, comment: "like action"))),
+                        'aria-label': \(s(String(localized: "Like", bundle: .core, comment: "like action"))),
                         onInput: event => {
                             window.webkit.messageHandlers.like.postMessage({ entryID: entry.id, isLiked: event.target.checked })
                         }

--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -68,14 +68,14 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Discussions", comment: ""))
+        setupTitleViewInNavbar(title: NSLocalizedString("Discussions", bundle: .core, comment: ""))
 
-        addButton.accessibilityLabel = NSLocalizedString("Create Discussion", comment: "")
+        addButton.accessibilityLabel = NSLocalizedString("Create Discussion", bundle: .core, comment: "")
         addButton.accessibilityIdentifier = "DiscussionList.newButton"
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like discussions haven’t been created in this space yet.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Discussions", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading discussions. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = NSLocalizedString("It looks like discussions haven’t been created in this space yet.", bundle: .core, comment: "")
+        emptyTitleLabel.text = NSLocalizedString("No Discussions", bundle: .core, comment: "")
+        errorView.messageLabel.text = NSLocalizedString("There was an error loading discussions. Pull to refresh to try again.", bundle: .core, comment: "")
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil
@@ -186,17 +186,17 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
     func deleteTopic(at indexPath: IndexPath, completionHandler: @escaping (Bool) -> Void) {
         guard let topicID = topics[indexPath]?.id else { return completionHandler(false) }
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Discussion", comment: ""),
-            message: NSLocalizedString("Are you sure you would like to delete this discussion?", comment: ""),
+            title: NSLocalizedString("Delete Discussion", bundle: .core, comment: ""),
+            message: NSLocalizedString("Are you sure you would like to delete this discussion?", bundle: .core, comment: ""),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Delete", comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { _ in
             let useCase = DeleteDiscussionTopic(context: self.context, topicID: topicID)
             useCase.fetch { [weak self] _, _, error in performUIUpdate {
                 if let error = error { self?.showError(error) }
             } }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
         completionHandler(true)
     }
@@ -210,11 +210,11 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         switch topics.sections?[section].name {
         case "0":
-            return SectionHeaderView.create(title: NSLocalizedString("Pinned Discussions", comment: ""), section: section)
+            return SectionHeaderView.create(title: NSLocalizedString("Pinned Discussions", bundle: .core, comment: ""), section: section)
         case "1":
-            return SectionHeaderView.create(title: NSLocalizedString("Discussions", comment: ""), section: section)
+            return SectionHeaderView.create(title: NSLocalizedString("Discussions", bundle: .core, comment: ""), section: section)
         case "2":
-            return SectionHeaderView.create(title: NSLocalizedString("Closed for Comments", comment: ""), section: section)
+            return SectionHeaderView.create(title: NSLocalizedString("Closed for Comments", bundle: .core, comment: ""), section: section)
         default:
             return nil
         }
@@ -261,20 +261,20 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         var actions: [UIContextualAction] = []
         if topics[indexPath]?.canDelete == true {
-            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", comment: "")) { [weak self] (_, _, handler) in
+            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] (_, _, handler) in
                 self?.deleteTopic(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundDanger
             actions.append(action)
         }
         if course?.first?.hasTeacherEnrollment == true {
-            var title = topics[indexPath]?.locked == true ? NSLocalizedString("Open", comment: "") : NSLocalizedString("Close", comment: "")
+            var title = topics[indexPath]?.locked == true ? NSLocalizedString("Open", bundle: .core, comment: "") : NSLocalizedString("Close", bundle: .core, comment: "")
             var action = UIContextualAction(style: .normal, title: title) { [weak self] (_, _, handler) in
                 self?.toggleLocked(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundWarning
             actions.append(action)
-            title = topics[indexPath]?.pinned == true ? NSLocalizedString("Unpin", comment: "") : NSLocalizedString("Pin", comment: "")
+            title = topics[indexPath]?.pinned == true ? NSLocalizedString("Unpin", bundle: .core, comment: "") : NSLocalizedString("Pin", bundle: .core, comment: "")
             action = UIContextualAction(style: .normal, title: title) { [weak self] (_, _, handler) in
                 self?.togglePinned(at: indexPath, completionHandler: handler)
             }
@@ -327,12 +327,12 @@ class DiscussionListCell: UITableViewCell {
         let dateText: String?
 
         if topic?.assignment?.dueAt == nil, let replyAt = topic?.lastReplyAt {
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", comment: ""), replyAt.dateTimeString)
+            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", bundle: .core, comment: ""), replyAt.dateTimeString)
         } else if isTeacher, topic?.assignment?.dueAt != nil, topic?.assignment?.hasOverrides == true {
-            dateText = NSLocalizedString("Multiple Due Dates", comment: "")
+            dateText = NSLocalizedString("Multiple Due Dates", bundle: .core, comment: "")
         } else if topic?.assignment?.dueAt != nil, let lockAt = topic?.assignment?.lockAt, lockAt < Clock.now {
             dateText = topic?.assignment?.dueText
-            statusLabel.text = NSLocalizedString("Closed", comment: "")
+            statusLabel.text = NSLocalizedString("Closed", bundle: .core, comment: "")
             statusLabel.isHidden = false
             statusDot.isHidden = false
         } else {

--- a/Core/Core/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Discussions/DiscussionListViewController.swift
@@ -68,14 +68,14 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Discussions", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Discussions", bundle: .core))
 
-        addButton.accessibilityLabel = NSLocalizedString("Create Discussion", bundle: .core, comment: "")
+        addButton.accessibilityLabel = String(localized: "Create Discussion", bundle: .core)
         addButton.accessibilityIdentifier = "DiscussionList.newButton"
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like discussions haven’t been created in this space yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Discussions", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading discussions. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "It looks like discussions haven’t been created in this space yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Discussions", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading discussions. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil
@@ -186,17 +186,17 @@ public class DiscussionListViewController: ScreenViewTrackableViewController, Co
     func deleteTopic(at indexPath: IndexPath, completionHandler: @escaping (Bool) -> Void) {
         guard let topicID = topics[indexPath]?.id else { return completionHandler(false) }
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Discussion", bundle: .core, comment: ""),
-            message: NSLocalizedString("Are you sure you would like to delete this discussion?", bundle: .core, comment: ""),
+            title: String(localized: "Delete Discussion", bundle: .core),
+            message: String(localized: "Are you sure you would like to delete this discussion?", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(String(localized: "Delete", bundle: .core), style: .destructive) { _ in
             let useCase = DeleteDiscussionTopic(context: self.context, topicID: topicID)
             useCase.fetch { [weak self] _, _, error in performUIUpdate {
                 if let error = error { self?.showError(error) }
             } }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
         completionHandler(true)
     }
@@ -210,11 +210,11 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         switch topics.sections?[section].name {
         case "0":
-            return SectionHeaderView.create(title: NSLocalizedString("Pinned Discussions", bundle: .core, comment: ""), section: section)
+            return SectionHeaderView.create(title: String(localized: "Pinned Discussions", bundle: .core), section: section)
         case "1":
-            return SectionHeaderView.create(title: NSLocalizedString("Discussions", bundle: .core, comment: ""), section: section)
+            return SectionHeaderView.create(title: String(localized: "Discussions", bundle: .core), section: section)
         case "2":
-            return SectionHeaderView.create(title: NSLocalizedString("Closed for Comments", bundle: .core, comment: ""), section: section)
+            return SectionHeaderView.create(title: String(localized: "Closed for Comments", bundle: .core), section: section)
         default:
             return nil
         }
@@ -231,7 +231,7 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
         if topic?.anonymousState != nil && !featureFlags.isFeatureFlagEnabled(.discussionRedesign) {
             cell.selectionStyle = .none
             cell.contentView.alpha = 0.5
-            cell.statusLabel.text = NSLocalizedString("Not supported", bundle: .core, comment: "")
+            cell.statusLabel.text = String(localized: "Not supported", bundle: .core)
             cell.statusLabel.isHidden = false
             cell.statusDot.isHidden = true
             cell.repliesLabel.isHidden = true
@@ -261,20 +261,20 @@ extension DiscussionListViewController: UITableViewDataSource, UITableViewDelega
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         var actions: [UIContextualAction] = []
         if topics[indexPath]?.canDelete == true {
-            let action = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] (_, _, handler) in
+            let action = UIContextualAction(style: .destructive, title: String(localized: "Delete", bundle: .core)) { [weak self] (_, _, handler) in
                 self?.deleteTopic(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundDanger
             actions.append(action)
         }
         if course?.first?.hasTeacherEnrollment == true {
-            var title = topics[indexPath]?.locked == true ? NSLocalizedString("Open", bundle: .core, comment: "") : NSLocalizedString("Close", bundle: .core, comment: "")
+            var title = topics[indexPath]?.locked == true ? String(localized: "Open", bundle: .core) : String(localized: "Close", bundle: .core)
             var action = UIContextualAction(style: .normal, title: title) { [weak self] (_, _, handler) in
                 self?.toggleLocked(at: indexPath, completionHandler: handler)
             }
             action.backgroundColor = .backgroundWarning
             actions.append(action)
-            title = topics[indexPath]?.pinned == true ? NSLocalizedString("Unpin", bundle: .core, comment: "") : NSLocalizedString("Pin", bundle: .core, comment: "")
+            title = topics[indexPath]?.pinned == true ? String(localized: "Unpin", bundle: .core) : String(localized: "Pin", bundle: .core)
             action = UIContextualAction(style: .normal, title: title) { [weak self] (_, _, handler) in
                 self?.togglePinned(at: indexPath, completionHandler: handler)
             }
@@ -327,12 +327,12 @@ class DiscussionListCell: UITableViewCell {
         let dateText: String?
 
         if topic?.assignment?.dueAt == nil, let replyAt = topic?.lastReplyAt {
-            dateText = String.localizedStringWithFormat(NSLocalizedString("Last post %@", bundle: .core, comment: ""), replyAt.dateTimeString)
+            dateText = String.localizedStringWithFormat(String(localized: "Last post %@", bundle: .core), replyAt.dateTimeString)
         } else if isTeacher, topic?.assignment?.dueAt != nil, topic?.assignment?.hasOverrides == true {
-            dateText = NSLocalizedString("Multiple Due Dates", bundle: .core, comment: "")
+            dateText = String(localized: "Multiple Due Dates", bundle: .core)
         } else if topic?.assignment?.dueAt != nil, let lockAt = topic?.assignment?.lockAt, lockAt < Clock.now {
             dateText = topic?.assignment?.dueText
-            statusLabel.text = NSLocalizedString("Closed", bundle: .core, comment: "")
+            statusLabel.text = String(localized: "Closed", bundle: .core)
             statusLabel.isHidden = false
             statusDot.isHidden = false
         } else {

--- a/Core/Core/Discussions/DiscussionReplyViewController.swift
+++ b/Core/Core/Discussions/DiscussionReplyViewController.swift
@@ -69,7 +69,7 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
     }()
     let attachBadge = UIView()
     lazy var sendButton = UIBarButtonItem(
-        title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done,
+        title: String(localized: "Send", bundle: .core), style: .done,
         target: self, action: #selector(sendReply)
     )
 
@@ -136,8 +136,8 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
         view.backgroundColor = .backgroundLightest
         navigationItem.titleView = titleSubtitleView
         titleSubtitleView.title = editEntryID != nil
-            ? NSLocalizedString("Edit", bundle: .core, comment: "")
-            : NSLocalizedString("Reply", bundle: .core, comment: "")
+            ? String(localized: "Edit", bundle: .core)
+            : String(localized: "Reply", bundle: .core)
 
         addCancelButton(side: .left)
         attachButton.accessibilityIdentifier = "DiscussionEditReply.attachmentButton"
@@ -146,15 +146,15 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
         navigationItem.rightBarButtonItem = sendButton
 
         editor.delegate = self
-        editor.placeholder = NSLocalizedString("Add message", bundle: .core, comment: "")
-        editor.a11yLabel = NSLocalizedString("Message", bundle: .core, comment: "")
+        editor.placeholder = String(localized: "Add message", bundle: .core)
+        editor.a11yLabel = String(localized: "Message", bundle: .core)
         editor.webView.autoresizesHeight = true
         editor.webView.heightAnchor.constraint(equalToConstant: 64).isActive = true
         editor.webView.scrollView.alwaysBounceVertical = false
         embed(editor, in: editorContainer)
 
         viewMoreButton.isHidden = true
-        viewMoreButton.setTitle(NSLocalizedString("View More", bundle: .core, comment: ""), for: .normal)
+        viewMoreButton.setTitle(String(localized: "View More", bundle: .core), for: .normal)
         viewMoreButton.layer.borderColor = UIColor.borderMedium.cgColor
         viewMoreButton.layer.borderWidth = 1 / UIScreen.main.scale
 
@@ -241,10 +241,10 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
         )
 
         if attachmentURL == nil {
-            attachButton.accessibilityLabel = NSLocalizedString("Edit attachment (none)", bundle: .core, comment: "")
+            attachButton.accessibilityLabel = String(localized: "Edit attachment (none)", bundle: .core)
             attachBadge.isHidden = true
         } else {
-            attachButton.accessibilityLabel = NSLocalizedString("Edit attachment (1)", bundle: .core, comment: "")
+            attachButton.accessibilityLabel = String(localized: "Edit attachment (1)", bundle: .core)
             attachBadge.isHidden = false
         }
     }
@@ -256,8 +256,8 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
             self.view.layoutIfNeeded()
         }
         viewMoreButton.setTitle(isExpanded
-            ? NSLocalizedString("View Less", bundle: .core, comment: "")
-            : NSLocalizedString("View More", bundle: .core, comment: ""),
+            ? String(localized: "View Less", bundle: .core)
+            : String(localized: "View More", bundle: .core),
         for: .normal)
         webView.scrollView.isScrollEnabled = isExpanded
     }
@@ -314,7 +314,7 @@ public class DiscussionReplyViewController: ScreenViewTrackableViewController, E
         }
 
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
-            UIAccessibility.announce(NSLocalizedString("Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
+            UIAccessibility.announce(String(localized: "Reply sent", bundle: .core, comment: "VoiceOver announcement after a reply was successfully posted."))
         }
         env.router.dismiss(self)
     }
@@ -327,7 +327,7 @@ extension DiscussionReplyViewController: FilePickerDelegate, QLPreviewController
         let sheet = BottomSheetPickerViewController.create()
         sheet.addAction(
             image: .eyeLine,
-            title: NSLocalizedString("View", bundle: .core, comment: ""),
+            title: String(localized: "View", bundle: .core),
             accessibilityIdentifier: "DiscussionEditReply.viewMenuAction"
         ) { [weak self] in
             guard let self = self else { return }
@@ -337,7 +337,7 @@ extension DiscussionReplyViewController: FilePickerDelegate, QLPreviewController
         }
         sheet.addAction(
             image: .trashLine,
-            title: NSLocalizedString("Delete", bundle: .core, comment: ""),
+            title: String(localized: "Delete", bundle: .core),
             accessibilityIdentifier: "DiscussionEditReply.deleteMenuAction"
         ) { [weak self] in
             guard let self = self, let url = self.attachmentURL else { return }

--- a/Core/Core/Discussions/DiscussionTopic.swift
+++ b/Core/Core/Discussions/DiscussionTopic.swift
@@ -69,11 +69,11 @@ public final class DiscussionTopic: NSManagedObject, WriteableModel {
     }
 
     public var nRepliesString: String {
-        String.localizedStringWithFormat(NSLocalizedString("%d Replies", bundle: .core, comment: ""), discussionSubEntryCount)
+        String.localizedStringWithFormat(String(localized: "%d Replies", bundle: .core), discussionSubEntryCount)
     }
 
     public var nUnreadString: String {
-        String.localizedStringWithFormat(NSLocalizedString("%d Unread", bundle: .core, comment: ""), unreadCount)
+        String.localizedStringWithFormat(String(localized: "%d Unread", bundle: .core), unreadCount)
     }
 
     @discardableResult

--- a/Core/Core/Discussions/DiscussionTopic.swift
+++ b/Core/Core/Discussions/DiscussionTopic.swift
@@ -69,11 +69,11 @@ public final class DiscussionTopic: NSManagedObject, WriteableModel {
     }
 
     public var nRepliesString: String {
-        String.localizedStringWithFormat(NSLocalizedString("%d Replies", comment: ""), discussionSubEntryCount)
+        String.localizedStringWithFormat(NSLocalizedString("%d Replies", bundle: .core, comment: ""), discussionSubEntryCount)
     }
 
     public var nUnreadString: String {
-        String.localizedStringWithFormat(NSLocalizedString("%d Unread", comment: ""), unreadCount)
+        String.localizedStringWithFormat(NSLocalizedString("%d Unread", bundle: .core, comment: ""), unreadCount)
     }
 
     @discardableResult

--- a/Core/Core/DocViewer/Comments/CommentListViewController.swift
+++ b/Core/Core/DocViewer/Comments/CommentListViewController.swift
@@ -49,19 +49,19 @@ class CommentListViewController: UIViewController {
     }
 
     override func viewDidLoad() {
-        navigationItem.title = NSLocalizedString("Comments", bundle: .core, comment: "")
+        navigationItem.title = String(localized: "Comments", bundle: .core)
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(donePressed(_:)))
 
         replyBorderView.backgroundColor = .backgroundLightest
         replyBorderView.layer.borderWidth = 1 / UIScreen.main.scale
         replyBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         replyTextView.placeholderColor = .textDark
-        replyTextView.placeholder = NSLocalizedString("Reply", bundle: .core, comment: "")
+        replyTextView.placeholder = String(localized: "Reply", bundle: .core)
         replyTextView.font(.scaledNamedFont(.regular16), lineHeight: .body)
         replyTextView.adjustsFontForContentSizeCategory = true
-        replyTextView.accessibilityLabel = NSLocalizedString("Reply to the annotation or previous comments", bundle: .core, comment: "")
+        replyTextView.accessibilityLabel = String(localized: "Reply to the annotation or previous comments", bundle: .core)
         replyTextView.textColor = .textDarkest
-        replyButton.accessibilityLabel = NSLocalizedString("Send comment", bundle: .core, comment: "")
+        replyButton.accessibilityLabel = String(localized: "Send comment", bundle: .core)
         replyView.backgroundColor = .backgroundLight
 
         if (metadata?.permissions ?? APIDocViewerPermissions.none) == APIDocViewerPermissions.none {
@@ -124,12 +124,12 @@ extension CommentListViewController: UITableViewDataSource {
 extension CommentListViewController: CommentListCellDelegate {
     func deletePressed(on comment: DocViewerCommentReplyAnnotation) {
         let alert = UIAlertController(
-            title: NSLocalizedString("Delete Comment", bundle: .core, comment: ""),
-            message: NSLocalizedString("Are you sure you would like to delete this comment?", bundle: .core, comment: ""),
+            title: String(localized: "Delete Comment", bundle: .core),
+            message: String(localized: "Are you sure you would like to delete this comment?", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Delete", bundle: .core), style: .destructive) { _ in
             guard let index = self.comments.firstIndex(of: comment) else { return }
             self.document?.remove(annotations: [comment], options: nil)
             self.comments.remove(at: index)

--- a/Core/Core/DocViewer/Comments/Views/CommentListCell.swift
+++ b/Core/Core/DocViewer/Comments/Views/CommentListCell.swift
@@ -43,16 +43,16 @@ class CommentListCell: UITableViewCell {
         let isDeletable = metadata?.permissions == .readwritemanage || comment.isEditable
         deleteButton?.isHidden = !isDeletable || comment.isDeleted
         deleteButton?.accessibilityIdentifier = "CommentListItem.\(comment.name ?? "").deleteButton"
-        deleteButton?.accessibilityLabel = NSLocalizedString("Delete comment", bundle: .core, comment: "")
+        deleteButton?.accessibilityLabel = String(localized: "Delete comment", bundle: .core)
         if comment.isDeleted {
             removedLabel?.isHidden = false
             removedLabelHeightConstraint?.constant = 19.5
             let date = DateFormatter.localizedString(from: comment.deletedAt ?? Date(), dateStyle: .medium, timeStyle: .none)
             if let deletedBy = comment.deletedBy ?? comment.deletedByID {
-                let format = NSLocalizedString("Removed %1$@ by %2$@", bundle: .core, comment: "")
+                let format = String(localized: "Removed %1$@ by %2$@", bundle: .core)
                 removedLabel?.text = String.localizedStringWithFormat(format, date, deletedBy)
             } else {
-                let format = NSLocalizedString("Removed %1$@", bundle: .core, comment: "")
+                let format = String(localized: "Removed %1$@", bundle: .core)
                 removedLabel?.text = String.localizedStringWithFormat(format, date)
             }
         } else {

--- a/Core/Core/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/DocViewer/DocViewerViewController.swift
@@ -220,7 +220,7 @@ public class DocViewerViewController: UIViewController {
     public func showError(_ error: Error) {
         loadingView.isHidden = true
         let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Dismiss", bundle: .core, comment: ""), style: .default))
+        alert.addAction(AlertAction(String(localized: "Dismiss", bundle: .core), style: .default))
         env.router.show(alert, from: self, options: .modal())
     }
 }
@@ -298,15 +298,15 @@ extension DocViewerViewController: DocViewerAnnotationProviderDelegate {
     func annotationDidFailToSave(error: Error) { performUIUpdate {
         self.syncAnnotationsButton.isEnabled = true
         self.syncAnnotationsButton.backgroundColor = .backgroundDanger
-        self.syncAnnotationsButton.setTitle(NSLocalizedString("Error Saving. Tap to retry.", bundle: .core, comment: ""), for: .normal)
+        self.syncAnnotationsButton.setTitle(String(localized: "Error Saving. Tap to retry.", bundle: .core), for: .normal)
     } }
 
     func annotationSaveStateChanges(saving: Bool) { performUIUpdate {
         self.syncAnnotationsButton.isEnabled = false
         self.syncAnnotationsButton.backgroundColor = .backgroundLight
         self.syncAnnotationsButton.setTitle(saving
-            ? NSLocalizedString("Saving...", bundle: .core, comment: "")
-            : NSLocalizedString("All annotations saved.", bundle: .core, comment: ""),
+            ? String(localized: "Saving...", bundle: .core)
+            : String(localized: "All annotations saved.", bundle: .core),
         for: .normal)
     } }
 }

--- a/Core/Core/DocViewer/Model/AnnotationContextMenu/MenuItems.swift
+++ b/Core/Core/DocViewer/Model/AnnotationContextMenu/MenuItems.swift
@@ -22,13 +22,13 @@ import PSPDFKitUI
 extension UIAction {
 
     static func style(annotation: Annotation, pageView: PDFPageView) -> UIAction {
-        UIAction(title: NSLocalizedString("Style", bundle: .core, comment: "")) { _ in
+        UIAction(title: String(localized: "Style", bundle: .core)) { _ in
             pageView.presentInspector(for: [annotation])
         }
     }
 
     static func deleteAnnotation(document: Document, annotation: Annotation) -> UIAction {
-        UIAction(title: NSLocalizedString("Remove", bundle: .core, comment: ""),
+        UIAction(title: String(localized: "Remove", bundle: .core),
                  image: .trashLine) { _ in
             document.remove(annotations: [annotation], options: nil)
         }
@@ -40,7 +40,7 @@ extension UIAction {
                              document: Document,
                              container: UIViewController,
                              router: Router) -> UIAction {
-        UIAction(title: NSLocalizedString("Comments", bundle: .core, comment: "")) { _ in
+        UIAction(title: String(localized: "Comments", bundle: .core)) { _ in
             let comments = annotationProvider.getReplies(to: annotation)
             let view = CommentListViewController.create(comments: comments,
                                                         inReplyTo: annotation,

--- a/Core/Core/DocViewer/Views/DocViewerAnnotationToolbar.swift
+++ b/Core/Core/DocViewer/Views/DocViewerAnnotationToolbar.swift
@@ -34,7 +34,7 @@ public class DocViewerAnnotationToolbar: AnnotationToolbar {
         let dragButton = ToolbarSelectableButton()
         dragButton.image = .grab
         dragButton.isCollapsible = false
-        dragButton.accessibilityLabel = NSLocalizedString("Move Annotation", bundle: .core, comment: "")
+        dragButton.accessibilityLabel = String(localized: "Move Annotation", bundle: .core)
         dragButton.selectionPadding = 4
         dragButtonStateUpdater = DragButtonStateViewModel(dragButton: dragButton, annotationStateManager: annotationStateManager)
 

--- a/Core/Core/DocViewer/Views/DocViewerAnnotationToolbar.swift
+++ b/Core/Core/DocViewer/Views/DocViewerAnnotationToolbar.swift
@@ -34,7 +34,7 @@ public class DocViewerAnnotationToolbar: AnnotationToolbar {
         let dragButton = ToolbarSelectableButton()
         dragButton.image = .grab
         dragButton.isCollapsible = false
-        dragButton.accessibilityLabel = NSLocalizedString("Move Annotation", comment: "")
+        dragButton.accessibilityLabel = NSLocalizedString("Move Annotation", bundle: .core, comment: "")
         dragButton.selectionPadding = 4
         dragButtonStateUpdater = DragButtonStateViewModel(dragButton: dragButton, annotationStateManager: annotationStateManager)
 

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
@@ -80,10 +80,10 @@ public class EmbeddedWebPageViewModelLive: EmbeddedWebPageViewModel {
             // announcements/\(id) shows a navigation bar at the top
             // so we need to use discussion topics
             urlPathComponent = "discussion_topics/\(id)"
-            navTitle = NSLocalizedString("Announcement Details", comment: "")
+            navTitle = NSLocalizedString("Announcement Details", bundle: .core, comment: "")
         case .discussion(let id):
             urlPathComponent = "discussion_topics/\(id)"
-            navTitle = NSLocalizedString("Discussion Details", comment: "")
+            navTitle = NSLocalizedString("Discussion Details", bundle: .core, comment: "")
         }
 
         self.url = {

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModelLive.swift
@@ -80,10 +80,10 @@ public class EmbeddedWebPageViewModelLive: EmbeddedWebPageViewModel {
             // announcements/\(id) shows a navigation bar at the top
             // so we need to use discussion topics
             urlPathComponent = "discussion_topics/\(id)"
-            navTitle = NSLocalizedString("Announcement Details", bundle: .core, comment: "")
+            navTitle = String(localized: "Announcement Details", bundle: .core)
         case .discussion(let id):
             urlPathComponent = "discussion_topics/\(id)"
-            navTitle = NSLocalizedString("Discussion Details", bundle: .core, comment: "")
+            navTitle = String(localized: "Discussion Details", bundle: .core)
         }
 
         self.url = {

--- a/Core/Core/Enrollments/Enrollment.swift
+++ b/Core/Core/Enrollments/Enrollment.swift
@@ -121,7 +121,7 @@ extension Enrollment {
 
     // Used when "Base on graded assignment" is ON
     public func formattedCurrentScore(gradingPeriodID: String?) -> String {
-        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        let notAvailable = String(localized: "N/A", bundle: .core)
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
             return notAvailable
         }
@@ -133,7 +133,7 @@ extension Enrollment {
 
     // Used when "Base on graded assignment" is OFF
     public func formattedFinalScore(gradingPeriodID: String?) -> String {
-        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        let notAvailable = String(localized: "N/A", bundle: .core)
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
             return notAvailable
         }
@@ -145,7 +145,7 @@ extension Enrollment {
 
     // Used when "Base on graded assignment" is ON
     public func convertedLetterGrade(gradingPeriodID: String?, gradingScheme: [GradingSchemeEntry]) -> String {
-        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        let notAvailable = String(localized: "N/A", bundle: .core)
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
             return notAvailable
         }
@@ -158,7 +158,7 @@ extension Enrollment {
 
     // Used when "Base on graded assignment" is OFF
     public func convertedFinalLetterGrade(gradingPeriodID: String?, gradingScheme: [GradingSchemeEntry]) -> String {
-        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        let notAvailable = String(localized: "N/A", bundle: .core)
         if gradingPeriodID == nil, multipleGradingPeriodsEnabled, !totalsForAllGradingPeriodsOption {
             return notAvailable
         }
@@ -170,7 +170,7 @@ extension Enrollment {
     }
 
     public func convertedLetterGrade(scorePercentage: Double, gradingScheme: [GradingSchemeEntry]) -> String {
-        let notAvailable = NSLocalizedString("N/A", bundle: .core, comment: "")
+        let notAvailable = String(localized: "N/A", bundle: .core)
         let normalizedScore = scorePercentage / 100.0
         return gradingScheme.convertScoreToLetterGrade(score: normalizedScore) ?? notAvailable
     }

--- a/Core/Core/Enrollments/Role.swift
+++ b/Core/Core/Enrollments/Role.swift
@@ -57,15 +57,15 @@ public enum Role: RawRepresentable {
     public func description() -> String {
         switch self {
         case .student:
-            return NSLocalizedString("Student", bundle: .core, comment: "")
+            return String(localized: "Student", bundle: .core)
         case .teacher:
-            return NSLocalizedString("Teacher", bundle: .core, comment: "")
+            return String(localized: "Teacher", bundle: .core)
         case .ta:
-            return NSLocalizedString("TA", bundle: .core, comment: "Teacher's Assistant (abbreviated)")
+            return String(localized: "TA", bundle: .core, comment: "Teacher's Assistant (abbreviated)")
         case .observer:
-            return NSLocalizedString("Observer", bundle: .core, comment: "")
+            return String(localized: "Observer", bundle: .core)
         case .designer:
-            return NSLocalizedString("Designer", bundle: .core, comment: "")
+            return String(localized: "Designer", bundle: .core)
         case .custom(let role):
             return role
         }

--- a/Core/Core/ErrorReports/ErrorReportViewController.swift
+++ b/Core/Core/ErrorReports/ErrorReportViewController.swift
@@ -47,24 +47,24 @@ public class ErrorReportViewController: ScreenViewTrackableViewController {
     var selectedImpact: IndexPath?
     let impacts = [ ItemPickerSection(items: [
         ItemPickerItem(
-            title: NSLocalizedString("Comment", bundle: .core, comment: ""),
-            subtitle: NSLocalizedString("Casual question or suggestion", bundle: .core, comment: "")
+            title: String(localized: "Comment", bundle: .core),
+            subtitle: String(localized: "Casual question or suggestion", bundle: .core)
         ),
         ItemPickerItem(
-            title: NSLocalizedString("Not Urgent", bundle: .core, comment: ""),
-            subtitle: NSLocalizedString("I need help but it's not urgent", bundle: .core, comment: "")
+            title: String(localized: "Not Urgent", bundle: .core),
+            subtitle: String(localized: "I need help but it's not urgent", bundle: .core)
         ),
         ItemPickerItem(
-            title: NSLocalizedString("Workaround", bundle: .core, comment: ""),
-            subtitle: NSLocalizedString("Something is broken but I can work around it", bundle: .core, comment: "")
+            title: String(localized: "Workaround", bundle: .core),
+            subtitle: String(localized: "Something is broken but I can work around it", bundle: .core)
         ),
         ItemPickerItem(
-            title: NSLocalizedString("Blocking", bundle: .core, comment: ""),
-            subtitle: NSLocalizedString("I can't get things done until I hear back from you", bundle: .core, comment: "")
+            title: String(localized: "Blocking", bundle: .core),
+            subtitle: String(localized: "I can't get things done until I hear back from you", bundle: .core)
         ),
         ItemPickerItem(
-            title: NSLocalizedString("Emergency", bundle: .core, comment: ""),
-            subtitle: NSLocalizedString("Extremely critical emergency", bundle: .core, comment: "")
+            title: String(localized: "Emergency", bundle: .core),
+            subtitle: String(localized: "Extremely critical emergency", bundle: .core)
         ),
     ]), ]
 
@@ -82,45 +82,45 @@ public class ErrorReportViewController: ScreenViewTrackableViewController {
 
         switch type {
         case .problem:
-            title = NSLocalizedString("Report a Problem", bundle: .core, comment: "")
-            subjectField?.placeholder = NSLocalizedString("Something is Wrong", bundle: .core, comment: "")
-            commentsPlaceholder?.text = NSLocalizedString("Describe the problem", bundle: .core, comment: "")
+            title = String(localized: "Report a Problem", bundle: .core)
+            subjectField?.placeholder = String(localized: "Something is Wrong", bundle: .core)
+            commentsPlaceholder?.text = String(localized: "Describe the problem", bundle: .core)
         case .feature:
-            title = NSLocalizedString("Request a Feature", bundle: .core, comment: "")
-            subjectField?.placeholder = NSLocalizedString("Something is Missing", bundle: .core, comment: "")
-            commentsPlaceholder?.text = NSLocalizedString("Describe the feature", bundle: .core, comment: "")
+            title = String(localized: "Request a Feature", bundle: .core)
+            subjectField?.placeholder = String(localized: "Something is Missing", bundle: .core)
+            commentsPlaceholder?.text = String(localized: "Describe the feature", bundle: .core)
         }
 
         addCancelButton(side: .left)
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Send", bundle: .core, comment: ""), style: .done, target: self, action: #selector(send))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Send", bundle: .core), style: .done, target: self, action: #selector(send))
         navigationItem.rightBarButtonItem?.isEnabled = false
 
         backgroundColorView?.backgroundColor = .backgroundLightest
 
         emailField?.textAlignment = view.effectiveUserInterfaceLayoutDirection == .rightToLeft ? .left : .right
-        emailLabel?.text = NSLocalizedString("Your Email", bundle: .core, comment: "")
+        emailLabel?.text = String(localized: "Your Email", bundle: .core)
         emailLabel?.accessibilityElementsHidden = true
         if let email = AppEnvironment.shared.currentSession?.userEmail, !email.isEmpty {
             emailField?.text = email
             emailView?.isHidden = true
         }
-        emailField?.accessibilityLabel = NSLocalizedString("Email address", bundle: .core, comment: "")
+        emailField?.accessibilityLabel = String(localized: "Email address", bundle: .core)
 
         subjectField?.textAlignment = view.effectiveUserInterfaceLayoutDirection == .rightToLeft ? .left : .right
         subjectField?.text = initialSubject
-        let subjectLabelText = NSLocalizedString("Subject", bundle: .core, comment: "")
+        let subjectLabelText = String(localized: "Subject", bundle: .core)
         subjectLabel?.text = subjectLabelText
         subjectLabel?.accessibilityElementsHidden = true
         subjectField?.accessibilityLabel = subjectLabelText
 
-        impactButton?.setTitle(NSLocalizedString("Select One", bundle: .core, comment: ""), for: .normal)
-        impactButton?.accessibilityLabel = NSLocalizedString("Select Impact", bundle: .core, comment: "")
-        impactLabel?.text = NSLocalizedString("Impact", bundle: .core, comment: "")
+        impactButton?.setTitle(String(localized: "Select One", bundle: .core), for: .normal)
+        impactButton?.accessibilityLabel = String(localized: "Select Impact", bundle: .core)
+        impactLabel?.text = String(localized: "Impact", bundle: .core)
         impactLabel?.accessibilityElementsHidden = true
 
         commentsField?.textColor = .textDarkest
         commentsField?.textContainerInset = UIEdgeInsets(top: 11.5, left: 11, bottom: 11, right: 11)
-        commentsField?.accessibilityLabel = NSLocalizedString("Description", bundle: .core, comment: "")
+        commentsField?.accessibilityLabel = String(localized: "Description", bundle: .core)
 
         commentsMinHeight = commentsField?.heightAnchor.constraint(greaterThanOrEqualTo: scrollView!.heightAnchor)
         commentsMinHeight?.isActive = true
@@ -148,14 +148,14 @@ public class ErrorReportViewController: ScreenViewTrackableViewController {
         let request = PostErrorReportRequest(error: error, email: email, subject: subject, impact: impact, comments: comments)
         env.api.makeRequest(request) { (_, response, error) in DispatchQueue.main.async {
             let isError = error != nil || ((response as? HTTPURLResponse)?.statusCode ?? 0) >= 300
-            var title = NSLocalizedString("Success!", bundle: .core, comment: "")
-            var message = NSLocalizedString("Thanks, your request was received!", bundle: .core, comment: "")
+            var title = String(localized: "Success!", bundle: .core)
+            var message = String(localized: "Thanks, your request was received!", bundle: .core)
             if isError {
-                title = NSLocalizedString("Request Failed!", bundle: .core, comment: "")
-                message = NSLocalizedString("Check network and try again!", bundle: .core, comment: "")
+                title = String(localized: "Request Failed!", bundle: .core)
+                message = String(localized: "Check network and try again!", bundle: .core)
             }
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: NSLocalizedString("Dismiss", bundle: .core, comment: ""), style: .default) { _ in
+            alert.addAction(UIAlertAction(title: String(localized: "Dismiss", bundle: .core), style: .default) { _ in
                 if !isError { self.dismiss(animated: true) }
             })
             self.present(alert, animated: true)
@@ -175,7 +175,7 @@ public class ErrorReportViewController: ScreenViewTrackableViewController {
 extension ErrorReportViewController: ItemPickerDelegate {
     @IBAction public func pickImpact() {
         show(ItemPickerViewController.create(
-            title: NSLocalizedString("Impact Level", bundle: .core, comment: ""),
+            title: String(localized: "Impact Level", bundle: .core),
             sections: impacts,
             selected: selectedImpact,
             delegate: self

--- a/Core/Core/Extensions/BundleExtensions.swift
+++ b/Core/Core/Extensions/BundleExtensions.swift
@@ -86,8 +86,3 @@ public extension Bundle {
         }
     }
 }
-
-// The comment parameter is necessary for -exportLocalizations to find these
-internal func NSLocalizedString(_ key: String, comment: String) -> String {
-    return NSLocalizedString(key, bundle: .core, comment: comment)
-}

--- a/Core/Core/Extensions/NSErrorExtensions.swift
+++ b/Core/Core/Extensions/NSErrorExtensions.swift
@@ -48,33 +48,33 @@ extension NSError {
 
     public func showAlert(from: UIViewController?) {
         guard let from = from else { return }
-        let dismiss = AlertAction(NSLocalizedString("Dismiss", bundle: .core, comment: "Dismiss button for error messages"), style: .default)
+        let dismiss = AlertAction(String(localized: "Dismiss", bundle: .core, comment: "Dismiss button for error messages"), style: .default)
 
-        let report = AlertAction(NSLocalizedString("Report", bundle: .core, comment: "Button to report an error"), style: .default) { _ in
+        let report = AlertAction(String(localized: "Report", bundle: .core, comment: "Button to report an error"), style: .default) { _ in
             AppEnvironment.shared.router.show(ErrorReportViewController.create(error: self), from: from, options: .modal(embedInNav: true))
         }
 
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .alert)
         switch (domain, code) {
         case (NSCocoaErrorDomain, 13): // NSCocoaErrorDomain 13 NSUnderlyingException: error during SQL execution : database or disk is full
-            alert.title = NSLocalizedString("Disk Error", bundle: .core, comment: "")
-            alert.message = NSLocalizedString("Your device is out of storage space. Please free up space and try again.", bundle: .core, comment: "")
+            alert.title = String(localized: "Disk Error", bundle: .core)
+            alert.message = String(localized: "Your device is out of storage space. Please free up space and try again.", bundle: .core)
             alert.addAction(dismiss)
 
         case (NSURLErrorDomain, _):
-            alert.title = NSLocalizedString("Network Error", bundle: .core, comment: "")
+            alert.title = String(localized: "Network Error", bundle: .core)
             alert.message = localizedDescription
             alert.addAction(report)
             alert.addAction(dismiss)
 
         case ("com.instructure.canvas", 90211): // push channel error. no idea where 90211 comes from.
-            alert.title = NSLocalizedString("Notification Error", bundle: .core, comment: "")
-            alert.message = NSLocalizedString("There was a problem registering your device for push notifications.", bundle: .core, comment: "")
+            alert.title = String(localized: "Notification Error", bundle: .core)
+            alert.message = String(localized: "There was a problem registering your device for push notifications.", bundle: .core)
             alert.addAction(report)
             alert.addAction(dismiss)
 
         default:
-            alert.title = NSLocalizedString("Unknown Error", bundle: .core, comment: "")
+            alert.title = String(localized: "Unknown Error", bundle: .core)
             alert.message = localizedFailureReason.flatMap {
                 "\(localizedDescription)\n\n\($0)"
             } ?? localizedDescription

--- a/Core/Core/Extensions/UIImageExtensions.swift
+++ b/Core/Core/Extensions/UIImageExtensions.swift
@@ -42,7 +42,7 @@ extension UIImage {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
         let url = directory.appendingPathComponent(name, isDirectory: false).appendingPathExtension("jpg")
         guard let data = jpegData(compressionQuality: 0.8) else {
-            throw NSError.instructureError(NSLocalizedString("Failed to save image", bundle: .core, comment: ""))
+            throw NSError.instructureError(String(localized: "Failed to save image", bundle: .core))
         }
         if FileManager.default.fileExists(atPath: url.path) {
             try FileManager.default.removeItem(at: url)

--- a/Core/Core/Extensions/UIViewControllerExtensions.swift
+++ b/Core/Core/Extensions/UIViewControllerExtensions.swift
@@ -177,12 +177,12 @@ extension UIViewController {
     }
 
     public func showPermissionError(_ error: PermissionError) {
-        let alert = UIAlertController(title: NSLocalizedString("Permission Needed", comment: ""), message: error.message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Settings", comment: ""), style: .default) { _ in
+        let alert = UIAlertController(title: NSLocalizedString("Permission Needed", bundle: .core, comment: ""), message: error.message, preferredStyle: .alert)
+        alert.addAction(AlertAction(NSLocalizedString("Settings", bundle: .core, comment: ""), style: .default) { _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
             AppEnvironment.shared.loginDelegate?.openExternalURL(url)
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
         AppEnvironment.shared.router.show(alert, from: self, options: .modal())
     }
 
@@ -216,11 +216,11 @@ extension UIViewController {
         var message: String {
             switch self {
             case .camera:
-                return NSLocalizedString("You must enable Camera permissions in Settings.", comment: "")
+                return NSLocalizedString("You must enable Camera permissions in Settings.", bundle: .core, comment: "")
             case .microphone:
-                return NSLocalizedString("You must enable Microphone permissions in Settings.", comment: "")
+                return NSLocalizedString("You must enable Microphone permissions in Settings.", bundle: .core, comment: "")
             case .notifications:
-                return NSLocalizedString("You must allow notifications in Settings to set reminders.", comment: "")
+                return NSLocalizedString("You must allow notifications in Settings to set reminders.", bundle: .core, comment: "")
             }
         }
     }

--- a/Core/Core/Extensions/UIViewControllerExtensions.swift
+++ b/Core/Core/Extensions/UIViewControllerExtensions.swift
@@ -61,7 +61,7 @@ extension UIViewController {
         let isExpanded = splitView.displayMode == .oneOverSecondary || splitView.displayMode == .secondaryOnly
         let icon: UIImage = isExpanded ? .exitFullScreenLine : .fullScreenLine
         let buttonItem = UIBarButtonItem(image: icon, style: .plain, target: defaultButton.target, action: defaultButton.action)
-        buttonItem.accessibilityLabel = splitView.isCollapsed ? NSLocalizedString("Collapse", bundle: .core, comment: "") : NSLocalizedString("Expand", bundle: .core, comment: "")
+        buttonItem.accessibilityLabel = splitView.isCollapsed ? String(localized: "Collapse", bundle: .core) : String(localized: "Expand", bundle: .core)
         return buttonItem
     }
 
@@ -177,12 +177,12 @@ extension UIViewController {
     }
 
     public func showPermissionError(_ error: PermissionError) {
-        let alert = UIAlertController(title: NSLocalizedString("Permission Needed", bundle: .core, comment: ""), message: error.message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Settings", bundle: .core, comment: ""), style: .default) { _ in
+        let alert = UIAlertController(title: String(localized: "Permission Needed", bundle: .core), message: error.message, preferredStyle: .alert)
+        alert.addAction(AlertAction(String(localized: "Settings", bundle: .core), style: .default) { _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
             AppEnvironment.shared.loginDelegate?.openExternalURL(url)
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         AppEnvironment.shared.router.show(alert, from: self, options: .modal())
     }
 
@@ -191,14 +191,14 @@ extension UIViewController {
         // Don't show the theme selector popup for UI Tests
         guard !ProcessInfo.isUITest else { return }
 
-        let alert = UIAlertController(title: NSLocalizedString("Canvas is now available in dark theme", bundle: .core, comment: ""),
-                                      message: NSLocalizedString("Choose your app appearance!\nYou can change it later in the settings menu.", bundle: .core, comment: ""),
+        let alert = UIAlertController(title: String(localized: "Canvas is now available in dark theme", bundle: .core),
+                                      message: String(localized: "Choose your app appearance!\nYou can change it later in the settings menu.", bundle: .core),
                                       preferredStyle: .alert)
 
-        alert.addAction(AlertAction(NSLocalizedString("System settings", bundle: .core, comment: ""), style: .default) {_ in self.setStyle(style: .unspecified)})
-        alert.addAction(AlertAction(NSLocalizedString("Light theme", bundle: .core, comment: ""), style: .default) {_ in self.setStyle(style: .light)})
-        alert.addAction(AlertAction(NSLocalizedString("Dark theme", bundle: .core, comment: ""), style: .default) {_ in self.setStyle(style: .dark)})
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) {_ in self.setStyle(style: .light)})
+        alert.addAction(AlertAction(String(localized: "System settings", bundle: .core), style: .default) {_ in self.setStyle(style: .unspecified)})
+        alert.addAction(AlertAction(String(localized: "Light theme", bundle: .core), style: .default) {_ in self.setStyle(style: .light)})
+        alert.addAction(AlertAction(String(localized: "Dark theme", bundle: .core), style: .default) {_ in self.setStyle(style: .dark)})
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel) {_ in self.setStyle(style: .light)})
         AppEnvironment.shared.router.show(alert, from: self, options: .modal())
     }
 
@@ -216,11 +216,11 @@ extension UIViewController {
         var message: String {
             switch self {
             case .camera:
-                return NSLocalizedString("You must enable Camera permissions in Settings.", bundle: .core, comment: "")
+                return String(localized: "You must enable Camera permissions in Settings.", bundle: .core)
             case .microphone:
-                return NSLocalizedString("You must enable Microphone permissions in Settings.", bundle: .core, comment: "")
+                return String(localized: "You must enable Microphone permissions in Settings.", bundle: .core)
             case .notifications:
-                return NSLocalizedString("You must allow notifications in Settings to set reminders.", bundle: .core, comment: "")
+                return String(localized: "You must allow notifications in Settings to set reminders.", bundle: .core)
             }
         }
     }

--- a/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarter.swift
+++ b/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarter.swift
@@ -51,7 +51,7 @@ public class FileSubmissionItemsUploadStarter {
 
             for file in submission.files {
                 guard let uploadTarget = file.uploadTarget else {
-                    file.uploadError = NSLocalizedString("Failed to start upload.", comment: "")
+                    file.uploadError = NSLocalizedString("Failed to start upload.", bundle: .core, comment: "")
                     continue
                 }
 
@@ -67,7 +67,7 @@ public class FileSubmissionItemsUploadStarter {
                     task.taskID = file.objectID.uriRepresentation().absoluteString
                     task.resume()
                 } catch {
-                    file.uploadError = NSLocalizedString("Failed to start upload.", comment: "")
+                    file.uploadError = NSLocalizedString("Failed to start upload.", bundle: .core, comment: "")
                 }
             }
 

--- a/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarter.swift
+++ b/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarter.swift
@@ -51,7 +51,7 @@ public class FileSubmissionItemsUploadStarter {
 
             for file in submission.files {
                 guard let uploadTarget = file.uploadTarget else {
-                    file.uploadError = NSLocalizedString("Failed to start upload.", bundle: .core, comment: "")
+                    file.uploadError = String(localized: "Failed to start upload.", bundle: .core)
                     continue
                 }
 
@@ -67,7 +67,7 @@ public class FileSubmissionItemsUploadStarter {
                     task.taskID = file.objectID.uriRepresentation().absoluteString
                     task.resume()
                 } catch {
-                    file.uploadError = NSLocalizedString("Failed to start upload.", bundle: .core, comment: "")
+                    file.uploadError = String(localized: "Failed to start upload.", bundle: .core)
                 }
             }
 

--- a/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileUploadProgressObserver.swift
+++ b/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileUploadProgressObserver.swift
@@ -69,7 +69,7 @@ extension FileUploadProgressObserver: URLSessionTaskDelegate {
                 if let error = error {
                     item.uploadError = error.localizedDescription
                 } else {
-                    item.uploadError = NSLocalizedString("Upload failed due to unknown reason.", bundle: .core, comment: "")
+                    item.uploadError = String(localized: "Upload failed due to unknown reason.", bundle: .core)
                 }
             }
 

--- a/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileUploadProgressObserver.swift
+++ b/Core/Core/Files/FileSubmission/Model/BinaryUpload/FileUploadProgressObserver.swift
@@ -69,7 +69,7 @@ extension FileUploadProgressObserver: URLSessionTaskDelegate {
                 if let error = error {
                     item.uploadError = error.localizedDescription
                 } else {
-                    item.uploadError = NSLocalizedString("Upload failed due to unknown reason.", comment: "")
+                    item.uploadError = NSLocalizedString("Upload failed due to unknown reason.", bundle: .core, comment: "")
                 }
             }
 

--- a/Core/Core/Files/FileSubmission/Model/FileSubmissionBackgroundTerminationHandler.swift
+++ b/Core/Core/Files/FileSubmission/Model/FileSubmissionBackgroundTerminationHandler.swift
@@ -30,7 +30,7 @@ public struct FileSubmissionBackgroundTerminationHandler {
     func handleTermination(fileUploadItemID: NSManagedObjectID) {
         context.performAndWait {
             guard let fileUploadItem = try? context.existingObject(with: fileUploadItemID) as? FileUploadItem else { return }
-            let errorDescription = NSLocalizedString("The submission process was terminated by the operating system.", bundle: .core, comment: "")
+            let errorDescription = String(localized: "The submission process was terminated by the operating system.", bundle: .core)
             let notSubmitted = !fileUploadItem.fileSubmission.isSubmitted
 
             if fileUploadItem.apiID == nil {

--- a/Core/Core/Files/FileSubmission/Model/FileSubmissionBackgroundTerminationHandler.swift
+++ b/Core/Core/Files/FileSubmission/Model/FileSubmissionBackgroundTerminationHandler.swift
@@ -30,7 +30,7 @@ public struct FileSubmissionBackgroundTerminationHandler {
     func handleTermination(fileUploadItemID: NSManagedObjectID) {
         context.performAndWait {
             guard let fileUploadItem = try? context.existingObject(with: fileUploadItemID) as? FileUploadItem else { return }
-            let errorDescription = NSLocalizedString("The submission process was terminated by the operating system.", comment: "")
+            let errorDescription = NSLocalizedString("The submission process was terminated by the operating system.", bundle: .core, comment: "")
             let notSubmitted = !fileUploadItem.fileSubmission.isSubmitted
 
             if fileUploadItem.apiID == nil {

--- a/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
+++ b/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
@@ -60,7 +60,7 @@ public class FileSubmissionSubmitter {
             }
 
             guard let response = response else {
-                let validError: Error = error ?? NSError.instructureError(NSLocalizedString("Submission failed due to unknown error.", bundle: .core, comment: ""))
+                let validError: Error = error ?? NSError.instructureError(String(localized: "Submission failed due to unknown error.", bundle: .core))
                 submission.submissionError = validError.localizedDescription
                 submission.isSubmitted = false
                 try? context.saveAndNotify()

--- a/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
+++ b/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
@@ -60,7 +60,7 @@ public class FileSubmissionSubmitter {
             }
 
             guard let response = response else {
-                let validError: Error = error ?? NSError.instructureError(NSLocalizedString("Submission failed due to unknown error.", comment: ""))
+                let validError: Error = error ?? NSError.instructureError(NSLocalizedString("Submission failed due to unknown error.", bundle: .core, comment: ""))
                 submission.submissionError = validError.localizedDescription
                 submission.isSubmitted = false
                 try? context.saveAndNotify()

--- a/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
+++ b/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
@@ -157,8 +157,8 @@ struct FileProgressListView<ViewModel>: View where ViewModel: FileProgressListVi
     }
 
     private func showAlertDialog(message: String) {
-        let dismissAction = UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel)
-        let alert = UIAlertController(title: NSLocalizedString("Error Details", bundle: .core, comment: ""), message: message, preferredStyle: .alert)
+        let dismissAction = UIAlertAction(title: String(localized: "OK", bundle: .core), style: .cancel)
+        let alert = UIAlertController(title: String(localized: "Error Details", bundle: .core), message: message, preferredStyle: .alert)
         alert.addAction(dismissAction)
         controller.value.present(alert, animated: true)
     }

--- a/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
+++ b/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
@@ -99,7 +99,7 @@ struct FileProgressListView<ViewModel>: View where ViewModel: FileProgressListVi
         switch viewModel.state {
         case .waiting:
             VStack(spacing: 15) {
-                Text("Preparing Files For Upload")
+                Text("Preparing Files For Upload", bundle: .core)
                     .font(.regular14)
                     .foregroundColor(.textDarkest)
                 progressView()

--- a/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
+++ b/Core/Core/Files/FileUploadProgress/View/FileProgressListView.swift
@@ -157,8 +157,8 @@ struct FileProgressListView<ViewModel>: View where ViewModel: FileProgressListVi
     }
 
     private func showAlertDialog(message: String) {
-        let dismissAction = UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .cancel)
-        let alert = UIAlertController(title: NSLocalizedString("Error Details", comment: ""), message: message, preferredStyle: .alert)
+        let dismissAction = UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel)
+        let alert = UIAlertController(title: NSLocalizedString("Error Details", bundle: .core, comment: ""), message: message, preferredStyle: .alert)
         alert.addAction(dismissAction)
         controller.value.present(alert, animated: true)
     }

--- a/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
+++ b/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
@@ -26,15 +26,15 @@ public class FileProgressItemViewModel: ObservableObject {
     public let size: String
     public let icon: Image
     public var accessibilityLabel: String {
-        let fileInfo = String(localized: "File \(fileName) size \(size).", bundle: .core, comment: "")
+        let fileInfo = String(localized: "File \(fileName) size \(size).", bundle: .core)
         let status: String = {
             switch file.state {
             case .waiting, .readyForUpload: return ""
             case .uploading(progress: let progress):
                 let percentage = Int(100 * progress)
                 return String(localized: "Upload in progress \(percentage)%", bundle: .core)
-            case .uploaded: return String(localized: "Upload completed.", bundle: .core, comment: "")
-            case .error: return String(localized: "Upload failed.", bundle: .core, comment: "")
+            case .uploaded: return String(localized: "Upload completed.", bundle: .core)
+            case .error: return String(localized: "Upload failed.", bundle: .core)
             }
         }()
 

--- a/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
+++ b/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
@@ -32,7 +32,7 @@ public class FileProgressItemViewModel: ObservableObject {
             case .waiting, .readyForUpload: return ""
             case .uploading(progress: let progress):
                 let percentage = Int(100 * progress)
-                return String(localized: "Upload in progress \(percentage)%")
+                return String(localized: "Upload in progress \(percentage)%", bundle: .core)
             case .uploaded: return NSLocalizedString("Upload completed.", comment: "")
             case .error: return NSLocalizedString("Upload failed.", comment: "")
             }

--- a/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
+++ b/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressItemViewModel.swift
@@ -26,15 +26,15 @@ public class FileProgressItemViewModel: ObservableObject {
     public let size: String
     public let icon: Image
     public var accessibilityLabel: String {
-        let fileInfo = NSLocalizedString("File \(fileName) size \(size).", comment: "")
+        let fileInfo = String(localized: "File \(fileName) size \(size).", bundle: .core, comment: "")
         let status: String = {
             switch file.state {
             case .waiting, .readyForUpload: return ""
             case .uploading(progress: let progress):
                 let percentage = Int(100 * progress)
                 return String(localized: "Upload in progress \(percentage)%", bundle: .core)
-            case .uploaded: return NSLocalizedString("Upload completed.", comment: "")
-            case .error: return NSLocalizedString("Upload failed.", comment: "")
+            case .uploaded: return String(localized: "Upload completed.", bundle: .core, comment: "")
+            case .error: return String(localized: "Upload failed.", bundle: .core, comment: "")
             }
         }()
 

--- a/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressListViewModel.swift
+++ b/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressListViewModel.swift
@@ -41,7 +41,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     @Published public private(set) var state: FileProgressListViewState = .waiting
     @Published public private(set) var leftBarButton: BarButtonItemViewModel?
     @Published public private(set) var rightBarButton: BarButtonItemViewModel?
-    public let title = NSLocalizedString("Submission", comment: "")
+    public let title = NSLocalizedString("Submission", bundle: .core, comment: "")
     public let submissionID: NSManagedObjectID
     public weak var delegate: FileProgressListViewModelDelegate?
 
@@ -112,16 +112,16 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     }
 
     private func showCancelDialog() {
-        let title = NSLocalizedString("Cancel Submission?", comment: "")
-        let message = NSLocalizedString("This will cancel and delete your upload.", comment: "")
+        let title = NSLocalizedString("Cancel Submission?", bundle: .core, comment: "")
+        let message = NSLocalizedString("This will cancel and delete your upload.", bundle: .core, comment: "")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Yes", comment: ""), style: .destructive) { [weak self] _ in
+        alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
             guard let self = self else { return }
             self.dismissSubject.send {
                 self.delegate?.fileProgressViewModelCancel(self)
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("No", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("No", bundle: .core, comment: ""), style: .cancel))
         presentDialogSubject.send(alert)
     }
 
@@ -150,16 +150,16 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             return
         }
 
-        let title = NSLocalizedString("Remove From List?", comment: "")
-        let message = NSLocalizedString("This will cancel and delete your upload.", comment: "")
+        let title = NSLocalizedString("Remove From List?", bundle: .core, comment: "")
+        let message = NSLocalizedString("This will cancel and delete your upload.", bundle: .core, comment: "")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Yes", comment: ""), style: .destructive) { [weak self] _ in
+        alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
             guard let self = self else { return }
             self.dismissSubject.send {
                 self.delegate?.fileProgressViewModel(self, delete: fileUploadItemID)
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("No", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("No", bundle: .core, comment: ""), style: .cancel))
         presentDialogSubject.send(alert)
     }
 
@@ -173,7 +173,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
         case .waiting:
             state = .waiting
         case .uploading:
-            let format = NSLocalizedString("Uploading %@ of %@", comment: "")
+            let format = NSLocalizedString("Uploading %@ of %@", bundle: .core, comment: "")
 
             let progress: Float
             let totalUploadedSize: Int
@@ -195,10 +195,10 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             )
             state = .uploading(progressText: progressText, progress: progress)
         case .failedUpload:
-            state = .failed(message: NSLocalizedString("One or more files failed to upload. Check your internet connection and retry to submit.", comment: ""), error: nil)
+            state = .failed(message: NSLocalizedString("One or more files failed to upload. Check your internet connection and retry to submit.", bundle: .core, comment: ""), error: nil)
             isErrorDisplayed = true
         case .failedSubmission(message: let message):
-            let format = NSLocalizedString("submission_failed_for_files", comment: "")
+            let format = NSLocalizedString("submission_failed_for_files", bundle: .core, comment: "")
             let title = String.localizedStringWithFormat(format, submission.files.count)
             state = .failed(message: title, error: message)
             isErrorDisplayed = true
@@ -208,7 +208,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     }
 
     private func updateNavBarButtons() {
-        let cancelButton = BarButtonItemViewModel(title: NSLocalizedString("Cancel", comment: "")) { [weak self] in
+        let cancelButton = BarButtonItemViewModel(title: NSLocalizedString("Cancel", bundle: .core, comment: "")) { [weak self] in
             self?.showCancelDialog()
         }
         switch state {
@@ -217,19 +217,19 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             rightBarButton = nil
         case .uploading:
             leftBarButton = cancelButton
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Dismiss", comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Dismiss", bundle: .core, comment: "")) { [weak self] in
                 self?.flowCompleted()
             }
         case .failed:
             leftBarButton = cancelButton
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Retry", comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Retry", bundle: .core, comment: "")) { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.fileProgressViewModelRetry(self)
                 self.isErrorDisplayed = false
             }
         case .success:
             leftBarButton = nil
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Done", comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Done", bundle: .core, comment: "")) { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.fileProgressViewModel(self, didAcknowledgeSuccess: self.submissionID)
                 self.flowCompleted()

--- a/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressListViewModel.swift
+++ b/Core/Core/Files/FileUploadProgress/ViewModel/FileProgressListViewModel.swift
@@ -41,7 +41,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     @Published public private(set) var state: FileProgressListViewState = .waiting
     @Published public private(set) var leftBarButton: BarButtonItemViewModel?
     @Published public private(set) var rightBarButton: BarButtonItemViewModel?
-    public let title = NSLocalizedString("Submission", bundle: .core, comment: "")
+    public let title = String(localized: "Submission", bundle: .core)
     public let submissionID: NSManagedObjectID
     public weak var delegate: FileProgressListViewModelDelegate?
 
@@ -112,16 +112,16 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     }
 
     private func showCancelDialog() {
-        let title = NSLocalizedString("Cancel Submission?", bundle: .core, comment: "")
-        let message = NSLocalizedString("This will cancel and delete your upload.", bundle: .core, comment: "")
+        let title = String(localized: "Cancel Submission?", bundle: .core)
+        let message = String(localized: "This will cancel and delete your upload.", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Yes", bundle: .core), style: .destructive) { [weak self] _ in
             guard let self = self else { return }
             self.dismissSubject.send {
                 self.delegate?.fileProgressViewModelCancel(self)
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("No", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "No", bundle: .core), style: .cancel))
         presentDialogSubject.send(alert)
     }
 
@@ -150,16 +150,16 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             return
         }
 
-        let title = NSLocalizedString("Remove From List?", bundle: .core, comment: "")
-        let message = NSLocalizedString("This will cancel and delete your upload.", bundle: .core, comment: "")
+        let title = String(localized: "Remove From List?", bundle: .core)
+        let message = String(localized: "This will cancel and delete your upload.", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Yes", bundle: .core), style: .destructive) { [weak self] _ in
             guard let self = self else { return }
             self.dismissSubject.send {
                 self.delegate?.fileProgressViewModel(self, delete: fileUploadItemID)
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("No", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "No", bundle: .core), style: .cancel))
         presentDialogSubject.send(alert)
     }
 
@@ -173,7 +173,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
         case .waiting:
             state = .waiting
         case .uploading:
-            let format = NSLocalizedString("Uploading %@ of %@", bundle: .core, comment: "")
+            let format = String(localized: "Uploading %@ of %@", bundle: .core)
 
             let progress: Float
             let totalUploadedSize: Int
@@ -195,10 +195,10 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             )
             state = .uploading(progressText: progressText, progress: progress)
         case .failedUpload:
-            state = .failed(message: NSLocalizedString("One or more files failed to upload. Check your internet connection and retry to submit.", bundle: .core, comment: ""), error: nil)
+            state = .failed(message: String(localized: "One or more files failed to upload. Check your internet connection and retry to submit.", bundle: .core), error: nil)
             isErrorDisplayed = true
         case .failedSubmission(message: let message):
-            let format = NSLocalizedString("submission_failed_for_files", bundle: .core, comment: "")
+            let format = String(localized: "submission_failed_for_files", bundle: .core)
             let title = String.localizedStringWithFormat(format, submission.files.count)
             state = .failed(message: title, error: message)
             isErrorDisplayed = true
@@ -208,7 +208,7 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
     }
 
     private func updateNavBarButtons() {
-        let cancelButton = BarButtonItemViewModel(title: NSLocalizedString("Cancel", bundle: .core, comment: "")) { [weak self] in
+        let cancelButton = BarButtonItemViewModel(title: String(localized: "Cancel", bundle: .core)) { [weak self] in
             self?.showCancelDialog()
         }
         switch state {
@@ -217,19 +217,19 @@ public class FileProgressListViewModel: FileProgressListViewModelProtocol {
             rightBarButton = nil
         case .uploading:
             leftBarButton = cancelButton
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Dismiss", bundle: .core, comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: String(localized: "Dismiss", bundle: .core)) { [weak self] in
                 self?.flowCompleted()
             }
         case .failed:
             leftBarButton = cancelButton
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Retry", bundle: .core, comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: String(localized: "Retry", bundle: .core)) { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.fileProgressViewModelRetry(self)
                 self.isErrorDisplayed = false
             }
         case .success:
             leftBarButton = nil
-            rightBarButton = BarButtonItemViewModel(title: NSLocalizedString("Done", bundle: .core, comment: "")) { [weak self] in
+            rightBarButton = BarButtonItemViewModel(title: String(localized: "Done", bundle: .core)) { [weak self] in
                 guard let self = self else { return }
                 self.delegate?.fileProgressViewModel(self, didAcknowledgeSuccess: self.submissionID)
                 self.flowCompleted()

--- a/Core/Core/Files/Model/API/UploadFileComment.swift
+++ b/Core/Core/Files/Model/API/UploadFileComment.swift
@@ -89,7 +89,7 @@ public class UploadFileComment {
             placeholder.authorAvatarURL = session.userAvatarURL
             placeholder.authorID = session.userID
             placeholder.authorName = session.userName
-            placeholder.comment = NSLocalizedString("See attached files.", bundle: .core, comment: "")
+            placeholder.comment = String(localized: "See attached files.", bundle: .core)
             placeholder.createdAt = Date()
             placeholder.id = "placeholder-\(UploadFileComment.placeholderSuffix)"
             placeholder.userID = self.userID

--- a/Core/Core/Files/Model/Entities/FileVisibility.swift
+++ b/Core/Core/Files/Model/Entities/FileVisibility.swift
@@ -27,10 +27,10 @@ public enum FileVisibility: String, CaseIterable, Identifiable {
     public var id: FileVisibility { self }
     public var label: String {
         switch self {
-        case .inheritCourse: return String(localized: "Inherit From Course")
-        case .courseMembers: return String(localized: "Course Members")
-        case .institutionMembers: return String(localized: "Institution Members")
-        case .publiclyAvailable: return String(localized: "Public")
+        case .inheritCourse: return String(localized: "Inherit From Course", bundle: .core)
+        case .courseMembers: return String(localized: "Course Members", bundle: .core)
+        case .institutionMembers: return String(localized: "Institution Members", bundle: .core)
+        case .publiclyAvailable: return String(localized: "Public", bundle: .core)
         }
     }
     public var isLastCase: Bool {

--- a/Core/Core/Files/Model/Entities/UsageRights.swift
+++ b/Core/Core/Files/Model/Entities/UsageRights.swift
@@ -45,15 +45,15 @@ public enum UseJustification: String, Codable, CaseIterable {
     public var label: String {
         switch self {
         case .own_copyright:
-            return NSLocalizedString("I hold the copyright", bundle: .core, comment: "")
+            return String(localized: "I hold the copyright", bundle: .core)
         case .used_by_permission:
-            return NSLocalizedString("I obtained permission", bundle: .core, comment: "")
+            return String(localized: "I obtained permission", bundle: .core)
         case .public_domain:
-            return NSLocalizedString("It is in the public domain", bundle: .core, comment: "")
+            return String(localized: "It is in the public domain", bundle: .core)
         case .fair_use:
-            return NSLocalizedString("It is a fair use or similar exception", bundle: .core, comment: "")
+            return String(localized: "It is a fair use or similar exception", bundle: .core)
         case .creative_commons:
-            return NSLocalizedString("It is licensed under Creative Commons", bundle: .core, comment: "")
+            return String(localized: "It is licensed under Creative Commons", bundle: .core)
         }
     }
 }

--- a/Core/Core/Files/Model/UploadManager.swift
+++ b/Core/Core/Files/Model/UploadManager.swift
@@ -311,7 +311,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
                 for file in successfullyUploadedFiles {
                     file.id = nil
                     file.taskID = nil
-                    file.uploadError = NSLocalizedString("File upload failed. Please cancel your submission and try uploading again.", comment: "")
+                    file.uploadError = NSLocalizedString("File upload failed. Please cancel your submission and try uploading again.", bundle: .core, comment: "")
                 }
             }
         }

--- a/Core/Core/Files/Model/UploadManager.swift
+++ b/Core/Core/Files/Model/UploadManager.swift
@@ -311,7 +311,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
                 for file in successfullyUploadedFiles {
                     file.id = nil
                     file.taskID = nil
-                    file.uploadError = NSLocalizedString("File upload failed. Please cancel your submission and try uploading again.", bundle: .core, comment: "")
+                    file.uploadError = String(localized: "File upload failed. Please cancel your submission and try uploading again.", bundle: .core)
                 }
             }
         }

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -350,10 +350,10 @@ extension FileDetailsViewController: URLSessionDownloadDelegate, LocalFileURLCre
     }
 
     private func showFileNoLongerExistsDialog() {
-        let alert = UIAlertController(title: NSLocalizedString("File No Longer Exists", comment: ""),
-                                      message: NSLocalizedString("The file has been deleted by the author.", comment: ""),
+        let alert = UIAlertController(title: NSLocalizedString("File No Longer Exists", bundle: .core, comment: ""),
+                                      message: NSLocalizedString("The file has been deleted by the author.", bundle: .core, comment: ""),
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Close", comment: ""),
+        alert.addAction(UIAlertAction(title: NSLocalizedString("Close", bundle: .core, comment: ""),
                                       style: .default,
                                       handler: { [env] _ in
             env.router.dismiss(self)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -39,7 +39,7 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
     @IBOutlet weak var toolbarShareButton: UIBarButtonItem!
     @IBOutlet weak var viewModulesButton: UIButton!
 
-    lazy var editButton = UIBarButtonItem(title: NSLocalizedString("Edit", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(edit))
+    lazy var editButton = UIBarButtonItem(title: String(localized: "Edit", bundle: .core), style: .plain, target: self, action: #selector(edit))
     lazy var shareButton = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(share(_:)))
 
     var assignmentID: String?
@@ -85,11 +85,11 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         view.backgroundColor = .backgroundLightest
         contentView.backgroundColor = .backgroundLightest
 
-        arButton.setTitle(NSLocalizedString("Augment Reality", bundle: .core, comment: ""), for: .normal)
+        arButton.setTitle(String(localized: "Augment Reality", bundle: .core), for: .normal)
         arButton.isHidden = true
         arImageView.isHidden = true
 
-        copiedLabel.text = NSLocalizedString("Copied!", bundle: .core, comment: "")
+        copiedLabel.text = String(localized: "Copied!", bundle: .core)
 
         lockView.isHidden = true
 
@@ -107,10 +107,10 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         toolbar.isHidden = env.app != .teacher
         toolbar.tintColor = Brand.shared.linkColor
         toolbarLinkButton.accessibilityIdentifier = "FileDetails.copyButton"
-        toolbarLinkButton.accessibilityLabel = NSLocalizedString("Copy Link", bundle: .core, comment: "")
+        toolbarLinkButton.accessibilityLabel = String(localized: "Copy Link", bundle: .core)
         toolbarShareButton.accessibilityIdentifier = "FileDetails.shareButton"
 
-        viewModulesButton.setTitle(NSLocalizedString("View Modules", bundle: .core, comment: ""), for: .normal)
+        viewModulesButton.setTitle(String(localized: "View Modules", bundle: .core), for: .normal)
         viewModulesButton.isHidden = true
 
         NotificationCenter.default.addObserver(self, selector: #selector(fileEdited(_:)), name: .init("file-edit"), object: nil)
@@ -350,10 +350,10 @@ extension FileDetailsViewController: URLSessionDownloadDelegate, LocalFileURLCre
     }
 
     private func showFileNoLongerExistsDialog() {
-        let alert = UIAlertController(title: NSLocalizedString("File No Longer Exists", bundle: .core, comment: ""),
-                                      message: NSLocalizedString("The file has been deleted by the author.", bundle: .core, comment: ""),
+        let alert = UIAlertController(title: String(localized: "File No Longer Exists", bundle: .core),
+                                      message: String(localized: "The file has been deleted by the author.", bundle: .core),
                                       preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Close", bundle: .core, comment: ""),
+        alert.addAction(UIAlertAction(title: String(localized: "Close", bundle: .core),
                                       style: .default,
                                       handler: { [env] _ in
             env.router.dismiss(self)
@@ -387,7 +387,7 @@ extension FileDetailsViewController: UIScrollViewDelegate {
     func embedImageView(for url: URL) {
         let image = UIImageView(image: UIImage(contentsOfFile: url.path))
         image.accessibilityIdentifier = "FileDetails.imageView"
-        image.accessibilityLabel = files.first?.displayName ?? NSLocalizedString("File", bundle: .core, comment: "")
+        image.accessibilityLabel = files.first?.displayName ?? String(localized: "File", bundle: .core)
         image.isAccessibilityElement = true
         let imageSize = image.frame.size
         let scroll = UIScrollView(frame: contentView.bounds)

--- a/Core/Core/Files/View/FileEditor/FileEditorView.swift
+++ b/Core/Core/Files/View/FileEditor/FileEditorView.swift
@@ -121,7 +121,7 @@ public struct FileEditorView: View {
             EditorSection(label: Text("Access", bundle: .core)) {
                 ButtonRow(action: {
                     env.router.show(ItemPickerViewController.create(
-                        title: NSLocalizedString("Access", comment: ""),
+                        title: NSLocalizedString("Access", bundle: .core, comment: ""),
                         sections: [ ItemPickerSection(items: Access.allCases.map {
                             ItemPickerItem(title: $0.label)
                         }), ],
@@ -166,14 +166,14 @@ public struct FileEditorView: View {
                 EditorSection(label: Text("Usage Rights", bundle: .core)) {
                     TextFieldRow(
                         label: Text("Copyright Holder", bundle: .core),
-                        placeholder: NSLocalizedString("Name", comment: ""),
+                        placeholder: NSLocalizedString("Name", bundle: .core, comment: ""),
                         text: $copyright
                     )
                         .identifier("FileEditor.copyrightField")
                     Divider()
                     ButtonRow(action: {
                         env.router.show(ItemPickerViewController.create(
-                            title: NSLocalizedString("Usage Right", comment: ""),
+                            title: NSLocalizedString("Usage Right", bundle: .core, comment: ""),
                             sections: [ ItemPickerSection(items: UseJustification.allCases.map {
                                 ItemPickerItem(title: $0.label)
                             }), ],
@@ -192,7 +192,7 @@ public struct FileEditorView: View {
                         Divider()
                         ButtonRow(action: {
                             env.router.show(ItemPickerViewController.create(
-                                title: NSLocalizedString("Creative Commons License", comment: ""),
+                                title: NSLocalizedString("Creative Commons License", bundle: .core, comment: ""),
                                 sections: [ ItemPickerSection(items: License.allCases.map {
                                     ItemPickerItem(title: $0.label)
                                 }), ],
@@ -362,13 +362,13 @@ public struct FileEditorView: View {
         var label: String {
             switch self {
             case .published:
-                return NSLocalizedString("Publish", comment: "")
+                return NSLocalizedString("Publish", bundle: .core, comment: "")
             case .unpublished:
-                return NSLocalizedString("Unpublish", comment: "")
+                return NSLocalizedString("Unpublish", bundle: .core, comment: "")
             case .hidden:
-                return NSLocalizedString("Only available to students with link", comment: "")
+                return NSLocalizedString("Only available to students with link", bundle: .core, comment: "")
             case .scheduled:
-                return NSLocalizedString("Schedule student availability", comment: "")
+                return NSLocalizedString("Schedule student availability", bundle: .core, comment: "")
             }
         }
     }
@@ -380,17 +380,17 @@ public struct FileEditorView: View {
         var label: String {
             switch self {
             case .cc_by:
-                return NSLocalizedString("Attribution", comment: "")
+                return NSLocalizedString("Attribution", bundle: .core, comment: "")
             case .cc_by_sa:
-                return NSLocalizedString("Attribution Share Alike", comment: "")
+                return NSLocalizedString("Attribution Share Alike", bundle: .core, comment: "")
             case .cc_by_nc:
-                return NSLocalizedString("Attribution Non-Commercial", comment: "")
+                return NSLocalizedString("Attribution Non-Commercial", bundle: .core, comment: "")
             case .cc_by_nc_sa:
-                return NSLocalizedString("Attribution Non-Commercial Share Alike", comment: "")
+                return NSLocalizedString("Attribution Non-Commercial Share Alike", bundle: .core, comment: "")
             case .cc_by_nd:
-                return NSLocalizedString("Attribution No Derivatives", comment: "")
+                return NSLocalizedString("Attribution No Derivatives", bundle: .core, comment: "")
             case .cc_by_nc_nd:
-                return NSLocalizedString("Attribution Non-Commercial No Derivatives", comment: "")
+                return NSLocalizedString("Attribution Non-Commercial No Derivatives", bundle: .core, comment: "")
             }
         }
     }

--- a/Core/Core/Files/View/FileEditor/FileEditorView.swift
+++ b/Core/Core/Files/View/FileEditor/FileEditorView.swift
@@ -121,7 +121,7 @@ public struct FileEditorView: View {
             EditorSection(label: Text("Access", bundle: .core)) {
                 ButtonRow(action: {
                     env.router.show(ItemPickerViewController.create(
-                        title: NSLocalizedString("Access", bundle: .core, comment: ""),
+                        title: String(localized: "Access", bundle: .core),
                         sections: [ ItemPickerSection(items: Access.allCases.map {
                             ItemPickerItem(title: $0.label)
                         }), ],
@@ -166,14 +166,14 @@ public struct FileEditorView: View {
                 EditorSection(label: Text("Usage Rights", bundle: .core)) {
                     TextFieldRow(
                         label: Text("Copyright Holder", bundle: .core),
-                        placeholder: NSLocalizedString("Name", bundle: .core, comment: ""),
+                        placeholder: String(localized: "Name", bundle: .core),
                         text: $copyright
                     )
                         .identifier("FileEditor.copyrightField")
                     Divider()
                     ButtonRow(action: {
                         env.router.show(ItemPickerViewController.create(
-                            title: NSLocalizedString("Usage Right", bundle: .core, comment: ""),
+                            title: String(localized: "Usage Right", bundle: .core),
                             sections: [ ItemPickerSection(items: UseJustification.allCases.map {
                                 ItemPickerItem(title: $0.label)
                             }), ],
@@ -192,7 +192,7 @@ public struct FileEditorView: View {
                         Divider()
                         ButtonRow(action: {
                             env.router.show(ItemPickerViewController.create(
-                                title: NSLocalizedString("Creative Commons License", bundle: .core, comment: ""),
+                                title: String(localized: "Creative Commons License", bundle: .core),
                                 sections: [ ItemPickerSection(items: License.allCases.map {
                                     ItemPickerItem(title: $0.label)
                                 }), ],
@@ -362,13 +362,13 @@ public struct FileEditorView: View {
         var label: String {
             switch self {
             case .published:
-                return NSLocalizedString("Publish", bundle: .core, comment: "")
+                return String(localized: "Publish", bundle: .core)
             case .unpublished:
-                return NSLocalizedString("Unpublish", bundle: .core, comment: "")
+                return String(localized: "Unpublish", bundle: .core)
             case .hidden:
-                return NSLocalizedString("Only available to students with link", bundle: .core, comment: "")
+                return String(localized: "Only available to students with link", bundle: .core)
             case .scheduled:
-                return NSLocalizedString("Schedule student availability", bundle: .core, comment: "")
+                return String(localized: "Schedule student availability", bundle: .core)
             }
         }
     }
@@ -380,17 +380,17 @@ public struct FileEditorView: View {
         var label: String {
             switch self {
             case .cc_by:
-                return NSLocalizedString("Attribution", bundle: .core, comment: "")
+                return String(localized: "Attribution", bundle: .core)
             case .cc_by_sa:
-                return NSLocalizedString("Attribution Share Alike", bundle: .core, comment: "")
+                return String(localized: "Attribution Share Alike", bundle: .core)
             case .cc_by_nc:
-                return NSLocalizedString("Attribution Non-Commercial", bundle: .core, comment: "")
+                return String(localized: "Attribution Non-Commercial", bundle: .core)
             case .cc_by_nc_sa:
-                return NSLocalizedString("Attribution Non-Commercial Share Alike", bundle: .core, comment: "")
+                return String(localized: "Attribution Non-Commercial Share Alike", bundle: .core)
             case .cc_by_nd:
-                return NSLocalizedString("Attribution No Derivatives", bundle: .core, comment: "")
+                return String(localized: "Attribution No Derivatives", bundle: .core)
             case .cc_by_nc_nd:
-                return NSLocalizedString("Attribution Non-Commercial No Derivatives", bundle: .core, comment: "")
+                return String(localized: "Attribution Non-Commercial No Derivatives", bundle: .core)
             }
         }
     }

--- a/Core/Core/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Files/View/FileList/FileListViewController.swift
@@ -213,7 +213,7 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
     }
 
     func showDeleteAlert(name: String, handler: @escaping ((UIAlertAction) -> Void)) {
-        let title = String.localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete %@?", comment: ""), name)
+        let title = String.localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete %@?", bundle: .core, comment: ""), name)
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
         alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
         alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .default, handler: handler))

--- a/Core/Core/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Files/View/FileList/FileListViewController.swift
@@ -32,7 +32,7 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
 
     lazy var addButton = UIBarButtonItem(image: .addSolid, style: .plain, target: self, action: #selector(addItem))
     lazy var editButton = UIBarButtonItem(
-        title: NSLocalizedString("Edit", bundle: .core, comment: ""), style: .plain,
+        title: String(localized: "Edit", bundle: .core), style: .plain,
         target: self, action: #selector(edit)
     )
 
@@ -85,17 +85,17 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Files", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Files", bundle: .core))
 
         addButton.accessibilityIdentifier = "FileList.addButton"
-        addButton.accessibilityLabel = NSLocalizedString("Add Item", bundle: .core, comment: "")
+        addButton.accessibilityLabel = String(localized: "Add Item", bundle: .core)
 
         editButton.accessibilityIdentifier = "FileList.editButton"
 
         emptyImageView.image = UIImage(named: Panda.FilePicker.name, in: .core, compatibleWith: nil)
-        emptyMessageLabel.text = NSLocalizedString("This folder is empty.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Files", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading files. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "This folder is empty.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Files", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading files. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil
@@ -103,7 +103,7 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
         refreshControl.color = nil
 
-        searchBar.placeholder = NSLocalizedString("Search", bundle: .core, comment: "")
+        searchBar.placeholder = String(localized: "Search", bundle: .core)
         searchBar.backgroundColor = .backgroundLightest
 
         tableView.backgroundColor = .backgroundLightest
@@ -159,7 +159,7 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
 
         loadingView.isHidden = !folder.pending || !folder.isEmpty || folder.error != nil || refreshControl.isRefreshing
         errorView.isHidden = folder.error == nil
-        let title = (path.isEmpty ? nil : folder.first?.name) ?? NSLocalizedString("Files", bundle: .core, comment: "")
+        let title = (path.isEmpty ? nil : folder.first?.name) ?? String(localized: "Files", bundle: .core)
         setupTitleViewInNavbar(title: title)
         updateNavButtons()
 
@@ -213,10 +213,10 @@ public class FileListViewController: ScreenViewTrackableViewController, ColoredN
     }
 
     func showDeleteAlert(name: String, handler: @escaping ((UIAlertAction) -> Void)) {
-        let title = String.localizedStringWithFormat(NSLocalizedString("Are you sure you want to delete %@?", bundle: .core, comment: ""), name)
+        let title = String.localizedStringWithFormat(String(localized: "Are you sure you want to delete %@?", bundle: .core), name)
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .default, handler: handler))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Delete", bundle: .core), style: .default, handler: handler))
         env.router.show(alert, from: self, options: .modal())
     }
 }
@@ -253,12 +253,12 @@ extension FileListViewController: UISearchBarDelegate {
         searchTerm = newSearch
         if searchTerm != nil {
             emptyImageView.image = UIImage(named: Panda.NoResults.name, in: .core, compatibleWith: nil)
-            emptyMessageLabel.text = NSLocalizedString("We couldn’t find any files like that.", bundle: .core, comment: "")
-            emptyTitleLabel.text = NSLocalizedString("No Results", bundle: .core, comment: "")
+            emptyMessageLabel.text = String(localized: "We couldn’t find any files like that.", bundle: .core)
+            emptyTitleLabel.text = String(localized: "No Results", bundle: .core)
         } else {
             emptyImageView.image = UIImage(named: Panda.FilePicker.name, in: .core, compatibleWith: nil)
-            emptyMessageLabel.text = NSLocalizedString("This folder is empty.", bundle: .core, comment: "")
-            emptyTitleLabel.text = NSLocalizedString("No Files", bundle: .core, comment: "")
+            emptyMessageLabel.text = String(localized: "This folder is empty.", bundle: .core)
+            emptyTitleLabel.text = String(localized: "No Files", bundle: .core)
         }
         search()
     }
@@ -315,14 +315,14 @@ extension FileListViewController: FilePickerDelegate {
         let sheet = BottomSheetPickerViewController.create()
         sheet.addAction(
             image: .folderLine,
-            title: NSLocalizedString("Add Folder", bundle: .core, comment: ""),
+            title: String(localized: "Add Folder", bundle: .core),
             accessibilityIdentifier: "FileList.addFolderButton"
         ) { [weak self] in
             self?.addFolder()
         }
         sheet.addAction(
             image: .addDocumentLine,
-            title: NSLocalizedString("Add File", bundle: .core, comment: ""),
+            title: String(localized: "Add File", bundle: .core),
             accessibilityIdentifier: "FileList.addFileButton"
         ) { [weak self] in
             guard let self = self else { return }
@@ -332,13 +332,13 @@ extension FileListViewController: FilePickerDelegate {
     }
 
     func addFolder() {
-        let prompt = UIAlertController(title: NSLocalizedString("Add Folder", bundle: .core, comment: ""), message: nil, preferredStyle: .alert)
+        let prompt = UIAlertController(title: String(localized: "Add Folder", bundle: .core), message: nil, preferredStyle: .alert)
         prompt.addTextField { field in
-            field.placeholder = NSLocalizedString("Name", bundle: .core, comment: "")
-            field.accessibilityLabel = NSLocalizedString("Folder Name", bundle: .core, comment: "")
+            field.placeholder = String(localized: "Name", bundle: .core)
+            field.accessibilityLabel = String(localized: "Folder Name", bundle: .core)
         }
-        prompt.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        prompt.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { [weak self] _ in
+        prompt.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        prompt.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { [weak self] _ in
             let name = prompt.textFields?[0].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             guard !name.isEmpty else { return }
             self?.addFolder(name: name)
@@ -448,7 +448,7 @@ extension FileListViewController: UITableViewDataSource, UITableViewDelegate {
             return nil
         }
 
-        let deleteAction = UIContextualAction(style: .destructive, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] _, _, completion in
+        let deleteAction = UIContextualAction(style: .destructive, title: String(localized: "Delete", bundle: .core)) { [weak self] _, _, completion in
             guard let self = self else { return }
             if indexPath.section == 1 {
                 let file = self.results[indexPath.row]
@@ -492,7 +492,7 @@ class FileListUploadCell: UITableViewCell {
         progressView.progress = file.map { CGFloat($0.bytesSent) / CGFloat($0.size) }
         progressView.isHidden = file?.uploadError != nil
         let sizeText = file?.uploadError ?? file.map { String.localizedStringWithFormat(
-            NSLocalizedString("Uploading %@ of %@", bundle: .core, comment: "Uploading X KB of Y MB"),
+            String(localized: "Uploading %@ of %@", bundle: .core, comment: "Uploading X KB of Y MB"),
             $0.bytesSent.humanReadableFileSize,
             $0.size.humanReadableFileSize
         ) }
@@ -518,7 +518,7 @@ class FileListCell: UITableViewCell {
             iconView.icon = .folderSolid
             iconView.setState(locked: folder.locked, hidden: folder.hidden, unlockAt: folder.unlockAt, lockAt: folder.lockAt)
             let sizeText = String.localizedStringWithFormat(
-                NSLocalizedString("d_items", bundle: .core, comment: ""),
+                String(localized: "d_items", bundle: .core),
                 folder.filesCount + folder.foldersCount
             )
             sizeLabel.setText(sizeText, style: .textCellSupportingText)

--- a/Core/Core/Files/View/FilePicker/FilePicker.swift
+++ b/Core/Core/Files/View/FilePicker/FilePicker.swift
@@ -176,10 +176,10 @@ extension FilePicker: FilePickerControllerDelegate {
         batchAction = action
         let uiViewController = FilePickerViewController.create()
         uiViewController.delegate = self
-        uiViewController.title = NSLocalizedString("Attachments", comment: "")
-        uiViewController.submitButtonTitle = NSLocalizedString("Send", comment: "")
+        uiViewController.title = NSLocalizedString("Attachments", bundle: .core, comment: "")
+        uiViewController.submitButtonTitle = NSLocalizedString("Send", bundle: .core, comment: "")
         uiViewController.loadViewIfNeeded()
-        uiViewController.emptyView.bodyText = NSLocalizedString("Attach files by tapping an option below.", comment: "")
+        uiViewController.emptyView.bodyText = NSLocalizedString("Attach files by tapping an option below.", bundle: .core, comment: "")
         env.router.show(uiViewController, from: from, options: .modal(embedInNav: true))
     }
 

--- a/Core/Core/Files/View/FilePicker/FilePicker.swift
+++ b/Core/Core/Files/View/FilePicker/FilePicker.swift
@@ -43,7 +43,7 @@ public class FilePicker: NSObject {
     public func pick(from: UIViewController) {
         let sheet = BottomSheetPickerViewController.create()
 
-        sheet.addAction(image: .audioLine, title: NSLocalizedString("Record Audio", bundle: .core, comment: "")) { [weak self] in
+        sheet.addAction(image: .audioLine, title: String(localized: "Record Audio", bundle: .core)) { [weak self] in
             let controller = AudioRecorderViewController.create()
             controller.delegate = self
             controller.view.backgroundColor = UIColor.backgroundLightest
@@ -52,7 +52,7 @@ public class FilePicker: NSObject {
         }
 
         if UIImagePickerController.isSourceTypeAvailable(.camera) {
-            sheet.addAction(image: .cameraLine, title: NSLocalizedString("Use Camera", bundle: .core, comment: "")) { [weak self] in
+            sheet.addAction(image: .cameraLine, title: String(localized: "Use Camera", bundle: .core)) { [weak self] in
                 let controller = UIImagePickerController()
                 controller.delegate = self
                 controller.sourceType = .camera
@@ -61,7 +61,7 @@ public class FilePicker: NSObject {
             }
         }
 
-        sheet.addAction(image: .paperclipLine, title: NSLocalizedString("Upload File", bundle: .core, comment: "")) { [weak self] in
+        sheet.addAction(image: .paperclipLine, title: String(localized: "Upload File", bundle: .core)) { [weak self] in
             // The asCopy: true ensures that file operations leave the original file untouched
             // and we can safely work (annotate for example) on a copy of the original file
             let controller = UIDocumentPickerViewController(forOpeningContentTypes: [.item], asCopy: true)
@@ -70,7 +70,7 @@ public class FilePicker: NSObject {
         }
 
         if UIImagePickerController.isSourceTypeAvailable(.photoLibrary) {
-            sheet.addAction(image: .imageLine, title: NSLocalizedString("Photo Library", bundle: .core, comment: "")) { [weak self] in
+            sheet.addAction(image: .imageLine, title: String(localized: "Photo Library", bundle: .core)) { [weak self] in
                 let controller = UIImagePickerController()
                 controller.delegate = self
                 controller.sourceType = .photoLibrary
@@ -86,12 +86,12 @@ public class FilePicker: NSObject {
         let sheet = BottomSheetPickerViewController.create()
 
         if file.uploadError != nil {
-            sheet.addAction(image: .refreshLine, title: NSLocalizedString("Retry", bundle: .core, comment: "")) { [weak self] in
+            sheet.addAction(image: .refreshLine, title: String(localized: "Retry", bundle: .core)) { [weak self] in
                 self?.delegate?.filePicker(didRetry: file)
             }
         }
 
-        sheet.addAction(image: .trashLine, title: NSLocalizedString("Delete", bundle: .core, comment: "")) { [weak self] in
+        sheet.addAction(image: .trashLine, title: String(localized: "Delete", bundle: .core)) { [weak self] in
             if let id = file.id {
                 self?.env.api.makeRequest(DeleteFileRequest(fileID: id)) { _, _, error in performUIUpdate {
                     if let error = error {
@@ -176,10 +176,10 @@ extension FilePicker: FilePickerControllerDelegate {
         batchAction = action
         let uiViewController = FilePickerViewController.create()
         uiViewController.delegate = self
-        uiViewController.title = NSLocalizedString("Attachments", bundle: .core, comment: "")
-        uiViewController.submitButtonTitle = NSLocalizedString("Send", bundle: .core, comment: "")
+        uiViewController.title = String(localized: "Attachments", bundle: .core)
+        uiViewController.submitButtonTitle = String(localized: "Send", bundle: .core)
         uiViewController.loadViewIfNeeded()
-        uiViewController.emptyView.bodyText = NSLocalizedString("Attach files by tapping an option below.", bundle: .core, comment: "")
+        uiViewController.emptyView.bodyText = String(localized: "Attach files by tapping an option below.", bundle: .core)
         env.router.show(uiViewController, from: from, options: .modal(embedInNav: true))
     }
 

--- a/Core/Core/Files/View/FilePicker/FilePickerCell.swift
+++ b/Core/Core/Files/View/FilePicker/FilePickerCell.swift
@@ -35,11 +35,11 @@ class FilePickerCell: UITableViewCell {
             backgroundColor = .backgroundLightest
             nameLabel.text = file?.localFileURL?.lastPathComponent
             if let filename = file?.filename {
-                removeButton.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Remove %@", bundle: .core, comment: ""), filename)
+                removeButton.accessibilityLabel = String.localizedStringWithFormat(String(localized: "Remove %@", bundle: .core), filename)
             }
             if file?.uploadError != nil {
                 errorIcon.isHidden = false
-                subtitleLabel.text = NSLocalizedString("Failed upload", bundle: .core, comment: "")
+                subtitleLabel.text = String(localized: "Failed upload", bundle: .core)
                 subtitleLabel.textColor = .textDanger
             } else {
                 errorIcon.isHidden = true

--- a/Core/Core/Files/View/FilePicker/FilePickerProgressView.swift
+++ b/Core/Core/Files/View/FilePicker/FilePickerProgressView.swift
@@ -70,7 +70,7 @@ class FilePickerProgressView: UIView {
         header.textAlignment = .center
         header.textColor = .electric
 
-        header.text = NSLocalizedString("Uploading...", bundle: .core, comment: "")
+        header.text = String(localized: "Uploading...", bundle: .core)
         progressView.backgroundColor = .backgroundLight
         progress = 0.75
     }

--- a/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
+++ b/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
@@ -42,9 +42,9 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
     @IBOutlet weak var progressView: FilePickerProgressView!
     @IBOutlet weak var dividerView: UIView!
 
-    public var submitButtonTitle = NSLocalizedString("Submit", bundle: .core, comment: "")
+    public var submitButtonTitle = String(localized: "Submit", bundle: .core)
     /// The cancel button that shows while the files are being uploaded
-    public var cancelButtonTitle = NSLocalizedString("Cancel", bundle: .core, comment: "")
+    public var cancelButtonTitle = String(localized: "Cancel", bundle: .core)
 
     let env = AppEnvironment.shared
     public weak var delegate: FilePickerControllerDelegate?
@@ -68,13 +68,13 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         view.backgroundColor = .backgroundLightest
         sourcesTabBar.barTintColor = .backgroundLightest
         tableView.tableFooterView = UIView(frame: .zero)
-        emptyView.titleText = NSLocalizedString("Choose a File", bundle: .core, comment: "")
-        emptyView.bodyText = NSLocalizedString("Attach files to your submission by tapping an option below.", bundle: .core, comment: "")
+        emptyView.titleText = String(localized: "Choose a File", bundle: .core)
+        emptyView.bodyText = String(localized: "Attach files to your submission by tapping an option below.", bundle: .core)
 
         var tabBarItems: [UITabBarItem] = []
         if sources.contains(.audio) {
             let item = UITabBarItem(
-                title: NSLocalizedString("Audio", bundle: .core, comment: ""),
+                title: String(localized: "Audio", bundle: .core),
                 image: .addAudioLine,
                 tag: FilePickerSource.audio.rawValue
             )
@@ -83,7 +83,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         }
         if sources.contains(.camera) {
             let item = UITabBarItem(
-                title: NSLocalizedString("Camera", bundle: .core, comment: ""),
+                title: String(localized: "Camera", bundle: .core),
                 image: .addCameraLine,
                 tag: FilePickerSource.camera.rawValue
             )
@@ -92,7 +92,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         }
         if sources.contains(.library) {
             let item = UITabBarItem(
-                title: NSLocalizedString("Library", bundle: .core, comment: ""),
+                title: String(localized: "Library", bundle: .core),
                 image: .addImageLine,
                 tag: FilePickerSource.library.rawValue
             )
@@ -101,7 +101,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         }
         if sources.contains(.files) {
             let item = UITabBarItem(
-                title: NSLocalizedString("Files", bundle: .core, comment: ""),
+                title: String(localized: "Files", bundle: .core),
                 image: .addDocumentLine,
                 tag: FilePickerSource.files.rawValue
             )
@@ -110,7 +110,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         }
         if sources.contains(.documentScan) {
             let item = UITabBarItem(
-                title: NSLocalizedString("Scanner", bundle: .core, comment: ""),
+                title: String(localized: "Scanner", bundle: .core),
                 image: UIImage(systemName: "doc.text.viewfinder")?.imageWithoutBaseline(),
                 tag: FilePickerSource.documentScan.rawValue
             )
@@ -148,7 +148,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         }
         showProgressBar()
         let progress: Float = Float(sent) / Float(total)
-        let format: String = NSLocalizedString("Uploading %@ of %@", bundle: .core, comment: "")
+        let format: String = String(localized: "Uploading %@ of %@", bundle: .core)
         progressView.text = String.localizedStringWithFormat(format, sent.humanReadableFileSize, total.humanReadableFileSize)
         progressView.progress = progress
     }
@@ -159,7 +159,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         if inProgress {
             navigationController?.setToolbarHidden(false, animated: true)
             navigationItem.leftBarButtonItems = []
-            navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Dismiss", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(close))
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Dismiss", bundle: .core), style: .plain, target: self, action: #selector(close))
             navigationItem.rightBarButtonItem?.accessibilityIdentifier = "FilePicker.closeButton"
             let cancelButton = UIBarButtonItem(title: cancelButtonTitle, style: .plain, target: self, action: #selector(cancelClicked))
             cancelButton.accessibilityIdentifier = "FilePicker.cancelButton"
@@ -171,11 +171,11 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         } else if failed {
             navigationController?.setToolbarHidden(false, animated: true)
             navigationItem.leftBarButtonItems = []
-            navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Done", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(close))
+            navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Done", bundle: .core), style: .plain, target: self, action: #selector(close))
             navigationItem.rightBarButtonItem?.accessibilityIdentifier = "FilePicker.closeButton"
-            let cancelButton = UIBarButtonItem(title: NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(cancelClicked))
+            let cancelButton = UIBarButtonItem(title: String(localized: "Cancel", bundle: .core), style: .plain, target: self, action: #selector(cancelClicked))
             cancelButton.accessibilityIdentifier = "FilePicker.cancelButton"
-            let retryButton = UIBarButtonItem(title: NSLocalizedString("Retry", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(retry))
+            let retryButton = UIBarButtonItem(title: String(localized: "Retry", bundle: .core), style: .plain, target: self, action: #selector(retry))
             retryButton.accessibilityIdentifier = "FilePicker.retryButton"
             toolbarItems = [
                 cancelButton,
@@ -184,7 +184,7 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
             ]
         } else {
             navigationController?.setToolbarHidden(true, animated: true)
-            navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(cancelClicked))
+            navigationItem.leftBarButtonItem = UIBarButtonItem(title: String(localized: "Cancel", bundle: .core), style: .plain, target: self, action: #selector(cancelClicked))
             navigationItem.leftBarButtonItem?.accessibilityIdentifier = "FilePicker.cancelButton"
             let submitButton = UIBarButtonItem(title: submitButtonTitle, style: .done, target: self, action: #selector(submit))
             submitButton.isEnabled = delegate?.canSubmit(self) == true
@@ -391,11 +391,11 @@ extension FilePickerViewController: VNDocumentCameraViewControllerDelegate {
 
 extension FilePickerViewController: FilePickerCellDelegate {
     func removeFile(_ file: File) {
-        let title = NSLocalizedString("Remove File", bundle: .core, comment: "")
-        let message = NSLocalizedString("Are you sure you want to remove this file?", bundle: .core, comment: "")
+        let title = String(localized: "Remove File", bundle: .core)
+        let message = String(localized: "Are you sure you want to remove this file?", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("Remove", bundle: .core, comment: ""), style: .default, handler: {_ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Remove", bundle: .core), style: .default, handler: {_ in
             UploadManager.shared.cancel(file: file)
         }))
         env.router.show(alert, from: self, options: .modal())

--- a/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
+++ b/Core/Core/Files/View/FilePicker/FilePickerViewController.swift
@@ -68,8 +68,8 @@ open class FilePickerViewController: UIViewController, ErrorViewController {
         view.backgroundColor = .backgroundLightest
         sourcesTabBar.barTintColor = .backgroundLightest
         tableView.tableFooterView = UIView(frame: .zero)
-        emptyView.titleText = NSLocalizedString("Choose a File", comment: "")
-        emptyView.bodyText = NSLocalizedString("Attach files to your submission by tapping an option below.", comment: "")
+        emptyView.titleText = NSLocalizedString("Choose a File", bundle: .core, comment: "")
+        emptyView.bodyText = NSLocalizedString("Attach files to your submission by tapping an option below.", bundle: .core, comment: "")
 
         var tabBarItems: [UITabBarItem] = []
         if sources.contains(.audio) {

--- a/Core/Core/Grades/Model/GradeFormatter.swift
+++ b/Core/Core/Grades/Model/GradeFormatter.swift
@@ -29,9 +29,9 @@ public class GradeFormatter {
         var localizedString: String {
             switch self {
             case .complete:
-                return NSLocalizedString("Complete", bundle: .core, comment: "")
+                return String(localized: "Complete", bundle: .core)
             case .incomplete:
-                return NSLocalizedString("Incomplete", bundle: .core, comment: "")
+                return String(localized: "Incomplete", bundle: .core)
             }
         }
     }
@@ -97,7 +97,7 @@ public class GradeFormatter {
         guard var formattedGrade = formattedGrade else { return nil }
 
         formattedGrade = formattedGrade.replacingOccurrences(of: " / ", with: "/")
-        formattedGrade = formattedGrade.replacingOccurrences(of: "/", with: " " + NSLocalizedString("out of", bundle: .core, comment: "5 out of 10") + " ")
+        formattedGrade = formattedGrade.replacingOccurrences(of: "/", with: " " + String(localized: "out of", bundle: .core, comment: "5 out of 10") + " ")
 
         return formattedGrade
     }
@@ -109,7 +109,7 @@ public class GradeFormatter {
     public func string(from submission: Submission?) -> String? {
         let isExcused = submission?.excused == true
         guard let submission = submission, let score = submission.score, !isExcused else {
-            let excused = NSLocalizedString("Excused", bundle: .core, comment: "")
+            let excused = String(localized: "Excused", bundle: .core)
             switch gradeStyle {
             case .short: return isExcused ? excused : nil
             case .medium: return isExcused ? medium(score: excused) : medium(score: placeholder)
@@ -138,14 +138,14 @@ public class GradeFormatter {
         case .gpa_scale:
             if hideScores {
                 if let grade = submission.grade, !grade.containsNumber {
-                    return String.localizedStringWithFormat(NSLocalizedString("%@ GPA", bundle: .core, comment: ""), grade)
+                    return String.localizedStringWithFormat(String(localized: "%@ GPA", bundle: .core), grade)
                 }
                 return nil
             }
             switch gradeStyle {
             case .short:
                 guard let grade = submission.grade else { return nil }
-                return String.localizedStringWithFormat(NSLocalizedString("%@ GPA", bundle: .core, comment: ""), grade)
+                return String.localizedStringWithFormat(String(localized: "%@ GPA", bundle: .core), grade)
             case .medium:
                 return medium(score: score, grade: submission.grade)
             }
@@ -207,12 +207,12 @@ public class GradeFormatter {
     public static func shortString(for assignment: Assignment?, submission: Submission?) -> String {
         guard assignment?.gradingType != .not_graded else { return "" }
 
-        let placeholder = NSLocalizedString("--", bundle: .core, comment: "placeholder for the score of an ungraded submission")
+        let placeholder = String(localized: "--", bundle: .core, comment: "placeholder for the score of an ungraded submission")
         guard let assignment = assignment, let submission = submission,
             submission.workflowState != .unsubmitted, !submission.needsGrading
         else { return placeholder }
 
-        guard submission.excused != true else { return NSLocalizedString("Excused", bundle: .core, comment: "") }
+        guard submission.excused != true else { return String(localized: "Excused", bundle: .core) }
 
         return gradeString(for: assignment, submission: submission) ?? placeholder
     }
@@ -235,13 +235,13 @@ public class GradeFormatter {
         default:
             switch grade {
             case "pass":
-                return NSLocalizedString("Pass", bundle: .core, comment: "")
+                return String(localized: "Pass", bundle: .core)
             case "fail":
-                return NSLocalizedString("Fail", bundle: .core, comment: "")
+                return String(localized: "Fail", bundle: .core)
             case "complete":
-                return NSLocalizedString("Complete", bundle: .core, comment: "")
+                return String(localized: "Complete", bundle: .core)
             case "incomplete":
-                return NSLocalizedString("Incomplete", bundle: .core, comment: "")
+                return String(localized: "Incomplete", bundle: .core)
             default:
                 if shouldHideScore, grade?.containsNumber == true { return "" }
                 return grade.flatMap { Double($0) }
@@ -261,12 +261,12 @@ public class GradeFormatter {
         }
         if let grade = grade {
             return String.localizedStringWithFormat(
-                NSLocalizedString("%@/%@ (%@)", bundle: .core, comment: "score/points possible (grade)"),
+                String(localized: "%@/%@ (%@)", bundle: .core, comment: "score/points possible (grade)"),
                 scoreString, possibleString, grade
             )
         }
         return String.localizedStringWithFormat(
-            NSLocalizedString("%@/%@", bundle: .core, comment: "score/points"),
+            String(localized: "%@/%@", bundle: .core, comment: "score/points"),
             scoreString, possibleString
         )
     }

--- a/Core/Core/Grades/Model/GradeFormatter.swift
+++ b/Core/Core/Grades/Model/GradeFormatter.swift
@@ -97,7 +97,7 @@ public class GradeFormatter {
         guard var formattedGrade = formattedGrade else { return nil }
 
         formattedGrade = formattedGrade.replacingOccurrences(of: " / ", with: "/")
-        formattedGrade = formattedGrade.replacingOccurrences(of: "/", with: " " + NSLocalizedString("out of", comment: "5 out of 10") + " ")
+        formattedGrade = formattedGrade.replacingOccurrences(of: "/", with: " " + NSLocalizedString("out of", bundle: .core, comment: "5 out of 10") + " ")
 
         return formattedGrade
     }
@@ -207,12 +207,12 @@ public class GradeFormatter {
     public static func shortString(for assignment: Assignment?, submission: Submission?) -> String {
         guard assignment?.gradingType != .not_graded else { return "" }
 
-        let placeholder = NSLocalizedString("--", comment: "placeholder for the score of an ungraded submission")
+        let placeholder = NSLocalizedString("--", bundle: .core, comment: "placeholder for the score of an ungraded submission")
         guard let assignment = assignment, let submission = submission,
             submission.workflowState != .unsubmitted, !submission.needsGrading
         else { return placeholder }
 
-        guard submission.excused != true else { return NSLocalizedString("Excused", comment: "") }
+        guard submission.excused != true else { return NSLocalizedString("Excused", bundle: .core, comment: "") }
 
         return gradeString(for: assignment, submission: submission) ?? placeholder
     }
@@ -235,13 +235,13 @@ public class GradeFormatter {
         default:
             switch grade {
             case "pass":
-                return NSLocalizedString("Pass", comment: "")
+                return NSLocalizedString("Pass", bundle: .core, comment: "")
             case "fail":
-                return NSLocalizedString("Fail", comment: "")
+                return NSLocalizedString("Fail", bundle: .core, comment: "")
             case "complete":
-                return NSLocalizedString("Complete", comment: "")
+                return NSLocalizedString("Complete", bundle: .core, comment: "")
             case "incomplete":
-                return NSLocalizedString("Incomplete", comment: "")
+                return NSLocalizedString("Incomplete", bundle: .core, comment: "")
             default:
                 if shouldHideScore, grade?.containsNumber == true { return "" }
                 return grade.flatMap { Double($0) }
@@ -261,12 +261,12 @@ public class GradeFormatter {
         }
         if let grade = grade {
             return String.localizedStringWithFormat(
-                NSLocalizedString("%@/%@ (%@)", comment: "score/points possible (grade)"),
+                NSLocalizedString("%@/%@ (%@)", bundle: .core, comment: "score/points possible (grade)"),
                 scoreString, possibleString, grade
             )
         }
         return String.localizedStringWithFormat(
-            NSLocalizedString("%@/%@", comment: "score/points"),
+            NSLocalizedString("%@/%@", bundle: .core, comment: "score/points"),
             scoreString, possibleString
         )
     }

--- a/Core/Core/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Grades/Model/GradeListInteractor.swift
@@ -247,17 +247,17 @@ public final class GradeListInteractorLive: GradeListInteractor {
         var assignmentSections: [GradeListData.AssignmentSections] = []
         var overdueAssignments = GradeListData.AssignmentSections(
             id: UUID.string,
-            title: String(localized: "Overdue Assignments"),
+            title: String(localized: "Overdue Assignments", bundle: .core),
             assignments: []
         )
         var upcomingAssignments = GradeListData.AssignmentSections(
             id: UUID.string,
-            title: String(localized: "Upcoming Assignments"),
+            title: String(localized: "Upcoming Assignments", bundle: .core),
             assignments: []
         )
         var pastAssignments = GradeListData.AssignmentSections(
             id: UUID.string,
-            title: String(localized: "Past Assignments"),
+            title: String(localized: "Past Assignments", bundle: .core),
             assignments: []
         )
 

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -95,7 +95,7 @@ public struct GradeListView: View, ScreenViewTrackable {
             }
             .animation(.smooth, value: isScoreEditorPresented)
         }
-        .navigationTitle(String(localized: "Grades"))
+        .navigationTitle(String(localized: "Grades", bundle: .core))
         .toolbar {
             RevertWhatIfScoreButton(isWhatIfScoreModeOn: viewModel.isWhatIfScoreModeOn) {
                 viewModel.isShowingRevertDialog = true
@@ -172,8 +172,8 @@ public struct GradeListView: View, ScreenViewTrackable {
     private func emptyView() -> some View {
         InteractivePanda(
             scene: SpacePanda(),
-            title: String(localized: "No Assignments"),
-            subtitle: String(localized: "It looks like assignments haven’t been created in this space yet.")
+            title: String(localized: "No Assignments", bundle: .core),
+            subtitle: String(localized: "It looks like assignments haven’t been created in this space yet.", bundle: .core)
         )
         .padding(.horizontal, 16)
     }
@@ -183,8 +183,8 @@ public struct GradeListView: View, ScreenViewTrackable {
         Spacer()
         InteractivePanda(
             scene: NoResultsPanda(),
-            title: String(localized: "Something Went Wrong"),
-            subtitle: String(localized: "Pull to refresh to try again.")
+            title: String(localized: "Something Went Wrong", bundle: .core),
+            subtitle: String(localized: "Pull to refresh to try again.", bundle: .core)
         )
         .padding(.horizontal, 16)
         Spacer()
@@ -327,7 +327,7 @@ public struct GradeListView: View, ScreenViewTrackable {
             Button {
                 viewModel.selectedGradingPeriod.accept(nil)
             } label: {
-                gradingAndArrangeText(title: String(localized: "All"))
+                gradingAndArrangeText(title: String(localized: "All", bundle: .core))
             }
             ForEach(gradingPeriods) { gradingPeriod in
                 if let title = gradingPeriod.title {
@@ -344,7 +344,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                     if let title = currentGradingPeriod?.title {
                         gradingAndArrangeText(title: title)
                     } else {
-                        gradingAndArrangeText(title: String(localized: "All"))
+                        gradingAndArrangeText(title: String(localized: "All", bundle: .core))
                     }
                 },
                 icon: { Image.arrowOpenDownSolid.resizable().frame(width: 12, height: 12) }
@@ -360,21 +360,21 @@ public struct GradeListView: View, ScreenViewTrackable {
             Button {
                 viewModel.selectedGroupByOption.accept(.groupName)
             } label: {
-                gradingAndArrangeText(title: String(localized: "By Group"))
+                gradingAndArrangeText(title: String(localized: "By Group", bundle: .core))
             }
             Button {
                 viewModel.selectedGroupByOption.accept(.dueDate)
             } label: {
-                gradingAndArrangeText(title: String(localized: "By Due Date"))
+                gradingAndArrangeText(title: String(localized: "By Due Date", bundle: .core))
             }
         } label: {
             Label(
                 title: {
                     switch viewModel.selectedGroupByOption.value {
                     case .dueDate:
-                        gradingAndArrangeText(title: String(localized: "Arrange By Due Date"))
+                        gradingAndArrangeText(title: String(localized: "Arrange By Due Date", bundle: .core))
                     case .groupName:
-                        gradingAndArrangeText(title: String(localized: "Arrange By Group"))
+                        gradingAndArrangeText(title: String(localized: "Arrange By Group", bundle: .core))
                     }
                 },
                 icon: { Image.arrowOpenDownSolid.resizable().frame(width: 12, height: 12) }

--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -285,7 +285,7 @@ public struct GradeListView: View, ScreenViewTrackable {
         Text(courseName)
             .foregroundStyle(Color.textDarkest)
             .font(.semibold28)
-            .accessibilityLabel(Text("\(courseName) course"))
+            .accessibilityLabel(Text("\(courseName) course", bundle: .core))
             .fixedSize(horizontal: false, vertical: true)
     }
 
@@ -446,10 +446,10 @@ public struct GradeListView: View, ScreenViewTrackable {
         .listRowInsets(EdgeInsets())
         .iOS16RemoveListRowSeparatorLeadingInset()
         .swipeActions(edge: .trailing) { revertWhatIfScoreSwipeButton() }
-        .accessibilityAction(named: Text("Edit What-if score")) {
+        .accessibilityAction(named: Text("Edit What-if score", bundle: .core)) {
             isScoreEditorPresented.toggle()
         }
-        .accessibilityAction(named: Text("Revert to official score")) {
+        .accessibilityAction(named: Text("Revert to official score", bundle: .core)) {
             viewModel.isShowingRevertDialog = true
         }
     }
@@ -505,8 +505,8 @@ private struct RevertWhatIfScoreButton: ToolbarContent {
                         .foregroundColor(Color.white)
                 }
                 .frame(alignment: .leading)
-                .accessibilityLabel(Text("Revert"))
-                .accessibilityHint(Text("Double tap to revert to official score."))
+                .accessibilityLabel(Text("Revert", bundle: .core))
+                .accessibilityHint(Text("Double tap to revert to official score.", bundle: .core))
             }
         }
     }

--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -85,7 +85,7 @@ public struct GradeRowView: View {
                     userID: userID,
                     style: .medium
                 )
-                .flatMap { String(localized: "Grade") + ", " + $0 } ?? ""
+                .flatMap { String(localized: "Grade", bundle: .core) + ", " + $0 } ?? ""
             ))
     }
 

--- a/Core/Core/Grades/View/WhatIfScoreEditorView.swift
+++ b/Core/Core/Grades/View/WhatIfScoreEditorView.swift
@@ -110,12 +110,12 @@ struct WhatIfScoreEditorView: View {
         .frame(width: 44)
         .frame(minHeight: 42)
         .padding(.trailing, -16)
-        .accessibilityLabel(Text("Revert"))
-        .accessibilityHint(Text("Double tap to remove what-if score"))
+        .accessibilityLabel(Text("Revert", bundle: .core))
+        .accessibilityHint(Text("Double tap to remove what-if score", bundle: .core))
     }
 
     private var titleLabel: some View {
-        Text("What-if Score")
+        Text("What-if Score", bundle: .core)
             .font(
                 .system(
                     size: UIFontMetrics.default.scaledValue(for: 17),
@@ -130,7 +130,7 @@ struct WhatIfScoreEditorView: View {
     }
 
     private var whatIfLabel: some View {
-        Text("What-if")
+        Text("What-if", bundle: .core)
             .font(
                 .system(
                     size: UIFontMetrics.default.scaledValue(for: 13),
@@ -142,7 +142,7 @@ struct WhatIfScoreEditorView: View {
     }
 
     private var maximumLabel: some View {
-        Text("Maximum")
+        Text("Maximum", bundle: .core)
             .font(
                 .system(
                     size: UIFontMetrics.default.scaledValue(for: 13),
@@ -163,7 +163,7 @@ struct WhatIfScoreEditorView: View {
                     design: .default
                 )
             )
-            .accessibilityLabel(Text("What-if score is \(whatIfScore)"))
+            .accessibilityLabel(Text("What-if score is \(whatIfScore)", bundle: .core))
     }
 
     private var maximumScoreText: some View {
@@ -176,14 +176,14 @@ struct WhatIfScoreEditorView: View {
                 )
             )
             .frame(maxWidth: .infinity, alignment: .leading)
-            .accessibilityLabel(Text(verbatim: "Maximum score is 100."))
+            .accessibilityLabel(Text("Maximum score is 100.", bundle: .core))
     }
 
     private var cancelButton: some View {
         Button {
             isPresented = false
         } label: {
-            Text("Cancel")
+            Text("Cancel", bundle: .core)
                 .fontWeight(.semibold)
                 .foregroundStyle(Color.blue)
                 .multilineTextAlignment(.center)
@@ -197,7 +197,7 @@ struct WhatIfScoreEditorView: View {
             isPresented = false
             doneButtonDidTap?()
         } label: {
-            Text("Done")
+            Text("Done", bundle: .core)
                 .foregroundStyle(Color.blue)
                 .multilineTextAlignment(.center)
                 .padding(12)

--- a/Core/Core/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Grades/ViewModel/GradeListViewModel.swift
@@ -54,10 +54,10 @@ public final class GradeListViewModel: ObservableObject {
     let pullToRefreshDidTrigger = PassthroughRelay<RefreshCompletion?>()
     let didSelectAssignment = PassthroughRelay<(WeakViewController, Assignment)>()
     let confirmRevertAlertViewModel = ConfirmationAlertViewModel(
-        title: String(localized: "Revert to Official Score?"),
-        message: String(localized: "This will revert all your what-if scores in this course to the official score."),
-        cancelButtonTitle: String(localized: "Cancel"),
-        confirmButtonTitle: String(localized: "Revert"),
+        title: String(localized: "Revert to Official Score?", bundle: .core),
+        message: String(localized: "This will revert all your what-if scores in this course to the official score.", bundle: .core),
+        cancelButtonTitle: String(localized: "Cancel", bundle: .core),
+        confirmButtonTitle: String(localized: "Revert", bundle: .core),
         isDestructive: false
     )
 

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -96,7 +96,7 @@ public struct AddressbookRecipientView: View {
                     viewModel.recipientDidTap.send(viewModel.allRecipient)
                 }, label: {
                     HStack(alignment: .center, spacing: 16) {
-                        Avatar(name: NSLocalizedString("All", comment: ""), url: nil, size: 36, isAccessible: false)
+                        Avatar(name: NSLocalizedString("All", bundle: .core, comment: ""), url: nil, size: 36, isAccessible: false)
                         VStack(alignment: .leading, spacing: 8) {
                             Text(viewModel.allRecipient.displayName)
                                 .font(.regular16)

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -96,7 +96,7 @@ public struct AddressbookRecipientView: View {
                     viewModel.recipientDidTap.send(viewModel.allRecipient)
                 }, label: {
                     HStack(alignment: .center, spacing: 16) {
-                        Avatar(name: NSLocalizedString("All", bundle: .core, comment: ""), url: nil, size: 36, isAccessible: false)
+                        Avatar(name: String(localized: "All", bundle: .core), url: nil, size: 36, isAccessible: false)
                         VStack(alignment: .leading, spacing: 8) {
                             Text(viewModel.allRecipient.displayName)
                                 .font(.regular16)

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
@@ -155,7 +155,7 @@ struct AddressbookRoleView: View {
                 viewModel.recipientDidTap.send(viewModel.allRecipient)
             }, label: {
                 HStack(alignment: .center, spacing: 16) {
-                    Avatar(name: NSLocalizedString("All", comment: ""), url: nil, size: 36, isAccessible: false)
+                    Avatar(name: NSLocalizedString("All", bundle: .core, comment: ""), url: nil, size: 36, isAccessible: false)
                     VStack(alignment: .leading, spacing: 8) {
                         Text("All in \(viewModel.recipientContext.name)", bundle: .core)
                             .font(.regular16)

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
@@ -155,7 +155,7 @@ struct AddressbookRoleView: View {
                 viewModel.recipientDidTap.send(viewModel.allRecipient)
             }, label: {
                 HStack(alignment: .center, spacing: 16) {
-                    Avatar(name: NSLocalizedString("All", bundle: .core, comment: ""), url: nil, size: 36, isAccessible: false)
+                    Avatar(name: String(localized: "All", bundle: .core), url: nil, size: 36, isAccessible: false)
                     VStack(alignment: .leading, spacing: 8) {
                         Text("All in \(viewModel.recipientContext.name)", bundle: .core)
                             .font(.regular16)

--- a/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
+++ b/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
@@ -31,7 +31,7 @@ class AddressbookRecipientViewModel: ObservableObject {
         searchText.value.isEmpty && canSelectAllRecipient
     }
 
-    public let title = NSLocalizedString("Select Recipients", bundle: .core, comment: "")
+    public let title = String(localized: "Select Recipients", bundle: .core)
     public let roleName: String
 
     // MARK: - Inputs

--- a/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
+++ b/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
@@ -60,7 +60,7 @@ class AddressbookRoleViewModel: ObservableObject {
         var isNotStudent = false
         if let userId = env.currentSession?.userID {
             roleRecipients.forEach { (roleName, recipients) in
-                if roleName != NSLocalizedString("Students", comment: "") && recipients.flatMap({ $0.ids }).contains(userId) {
+                if roleName != NSLocalizedString("Students", bundle: .core, comment: "") && recipients.flatMap({ $0.ids }).contains(userId) {
                     isNotStudent = true
                     return
                 }
@@ -182,17 +182,17 @@ private extension SearchRecipient {
     static func roleName(from enrollmentName: String) -> String {
         switch enrollmentName {
         case "TeacherEnrollment":
-            return NSLocalizedString("Teachers", comment: "")
+            return NSLocalizedString("Teachers", bundle: .core, comment: "")
         case "StudentEnrollment":
-            return NSLocalizedString("Students", comment: "")
+            return NSLocalizedString("Students", bundle: .core, comment: "")
         case "ObserverEnrollment":
-            return NSLocalizedString("Observers", comment: "")
+            return NSLocalizedString("Observers", bundle: .core, comment: "")
         case "TaEnrollment":
-            return NSLocalizedString("Teaching Assistants", comment: "")
+            return NSLocalizedString("Teaching Assistants", bundle: .core, comment: "")
         case "DesignerEnrollment":
-            return NSLocalizedString("Course Designers", comment: "")
+            return NSLocalizedString("Course Designers", bundle: .core, comment: "")
         default:
-            return NSLocalizedString("Others", comment: "")
+            return NSLocalizedString("Others", bundle: .core, comment: "")
         }
     }
 }

--- a/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
+++ b/Core/Core/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
@@ -40,7 +40,7 @@ class AddressbookRoleViewModel: ObservableObject {
         Recipient(ids: recipients.flatMap { $0.ids }, name: "All in \(recipientContext.name)", avatarURL: nil)
     }
 
-    public let title = NSLocalizedString("Select Recipients", bundle: .core, comment: "")
+    public let title = String(localized: "Select Recipients", bundle: .core)
     public let recipientContext: RecipientContext
 
     // MARK: - Inputs
@@ -60,7 +60,7 @@ class AddressbookRoleViewModel: ObservableObject {
         var isNotStudent = false
         if let userId = env.currentSession?.userID {
             roleRecipients.forEach { (roleName, recipients) in
-                if roleName != NSLocalizedString("Students", bundle: .core, comment: "") && recipients.flatMap({ $0.ids }).contains(userId) {
+                if roleName != String(localized: "Students", bundle: .core) && recipients.flatMap({ $0.ids }).contains(userId) {
                     isNotStudent = true
                     return
                 }
@@ -182,17 +182,17 @@ private extension SearchRecipient {
     static func roleName(from enrollmentName: String) -> String {
         switch enrollmentName {
         case "TeacherEnrollment":
-            return NSLocalizedString("Teachers", bundle: .core, comment: "")
+            return String(localized: "Teachers", bundle: .core)
         case "StudentEnrollment":
-            return NSLocalizedString("Students", bundle: .core, comment: "")
+            return String(localized: "Students", bundle: .core)
         case "ObserverEnrollment":
-            return NSLocalizedString("Observers", bundle: .core, comment: "")
+            return String(localized: "Observers", bundle: .core)
         case "TaEnrollment":
-            return NSLocalizedString("Teaching Assistants", bundle: .core, comment: "")
+            return String(localized: "Teaching Assistants", bundle: .core)
         case "DesignerEnrollment":
-            return NSLocalizedString("Course Designers", bundle: .core, comment: "")
+            return String(localized: "Course Designers", bundle: .core)
         default:
-            return NSLocalizedString("Others", bundle: .core, comment: "")
+            return String(localized: "Others", bundle: .core)
         }
     }
 }

--- a/Core/Core/Inbox/AttachmentPicker/ViewModel/AttachmentPickerViewModel.swift
+++ b/Core/Core/Inbox/AttachmentPicker/ViewModel/AttachmentPickerViewModel.swift
@@ -31,9 +31,9 @@ class AttachmentPickerViewModel: ObservableObject {
     @Published public var isAudioRecordVisible: Bool = false
     @Published public private(set) var fileList: [File] = []
     @Published public var isFileErrorOccured: Bool = false
-    public let title = NSLocalizedString("Attachments", comment: "")
-    public let fileErrorTitle = NSLocalizedString("Error", comment: "")
-    public let fileErrorMessage = NSLocalizedString("Failed to add attachment. Please try again!", comment: "")
+    public let title = NSLocalizedString("Attachments", bundle: .core, comment: "")
+    public let fileErrorTitle = NSLocalizedString("Error", bundle: .core, comment: "")
+    public let fileErrorMessage = NSLocalizedString("Failed to add attachment. Please try again!", bundle: .core, comment: "")
 
     public let cancelButtonDidTap = PassthroughRelay<WeakViewController>()
     public let doneButtonDidTap = PassthroughRelay<WeakViewController>()

--- a/Core/Core/Inbox/AttachmentPicker/ViewModel/AttachmentPickerViewModel.swift
+++ b/Core/Core/Inbox/AttachmentPicker/ViewModel/AttachmentPickerViewModel.swift
@@ -31,9 +31,9 @@ class AttachmentPickerViewModel: ObservableObject {
     @Published public var isAudioRecordVisible: Bool = false
     @Published public private(set) var fileList: [File] = []
     @Published public var isFileErrorOccured: Bool = false
-    public let title = NSLocalizedString("Attachments", bundle: .core, comment: "")
-    public let fileErrorTitle = NSLocalizedString("Error", bundle: .core, comment: "")
-    public let fileErrorMessage = NSLocalizedString("Failed to add attachment. Please try again!", bundle: .core, comment: "")
+    public let title = String(localized: "Attachments", bundle: .core)
+    public let fileErrorTitle = String(localized: "Error", bundle: .core)
+    public let fileErrorMessage = String(localized: "Failed to add attachment. Please try again!", bundle: .core)
 
     public let cancelButtonDidTap = PassthroughRelay<WeakViewController>()
     public let doneButtonDidTap = PassthroughRelay<WeakViewController>()
@@ -61,28 +61,28 @@ class AttachmentPickerViewModel: ObservableObject {
 
         sheet.addAction(
             image: .documentLine,
-            title: NSLocalizedString("Upload file", bundle: .core, comment: ""),
+            title: String(localized: "Upload file", bundle: .core),
             accessibilityIdentifier: nil
         ) { [weak self] in
             self?.isFilePickerVisible = true
         }
         sheet.addAction(
             image: .imageLine,
-            title: NSLocalizedString("Upload photo", bundle: .core, comment: ""),
+            title: String(localized: "Upload photo", bundle: .core),
             accessibilityIdentifier: nil
         ) { [weak self] in
             self?.isImagePickerVisible = true
         }
         sheet.addAction(
             image: .cameraLine,
-            title: NSLocalizedString("Take photo", bundle: .core, comment: ""),
+            title: String(localized: "Take photo", bundle: .core),
             accessibilityIdentifier: nil
         ) { [weak self] in
             self?.isTakePhotoVisible = true
         }
         sheet.addAction(
             image: .audioLine,
-            title: NSLocalizedString("Record audio", bundle: .core, comment: ""),
+            title: String(localized: "Record audio", bundle: .core),
             accessibilityIdentifier: nil
         ) { [weak self] in
             self?.isAudioRecordVisible = true
@@ -91,7 +91,7 @@ class AttachmentPickerViewModel: ObservableObject {
     }
 
     func showFileErrorDialog() {
-        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
+        let actionTitle = String(localized: "OK", bundle: .core)
         let alert = UIAlertController(title: fileErrorTitle, message: fileErrorMessage, preferredStyle: .alert)
         let action = UIAlertAction(title: actionTitle, style: .default) { [weak self] _ in
             self?.isImagePickerVisible = false

--- a/Core/Core/Inbox/AttachmentPicker/ViewModel/AudioPickerViewModel.swift
+++ b/Core/Core/Inbox/AttachmentPicker/ViewModel/AudioPickerViewModel.swift
@@ -36,8 +36,8 @@ class AudioPickerViewModel: NSObject, ObservableObject {
     @Published public private(set) var audioPlayerDurationString: String = ""
     var audioChartDataSet: [AudioPlotData] = []
     public let defaultDurationString: String
-    public let audioRecorderErrorTitle = NSLocalizedString("Error", bundle: .core, comment: "")
-    public let audioRecorderErrorMessage = NSLocalizedString("Some error occured with audio recorder. Please try again!", bundle: .core, comment: "")
+    public let audioRecorderErrorTitle = String(localized: "Error", bundle: .core)
+    public let audioRecorderErrorMessage = String(localized: "Some error occured with audio recorder. Please try again!", bundle: .core)
 
     // MARK: Inputs / Outputs
 
@@ -79,7 +79,7 @@ class AudioPickerViewModel: NSObject, ObservableObject {
     }
 
     private func showAudioErrorDialog() {
-        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
+        let actionTitle = String(localized: "OK", bundle: .core)
         let alert = UIAlertController(title: audioRecorderErrorTitle, message: audioRecorderErrorMessage, preferredStyle: .alert)
 
         if let top = AppEnvironment.shared.window?.rootViewController?.topMostViewController() {

--- a/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageInteractorLive.swift
+++ b/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageInteractorLive.swift
@@ -44,7 +44,7 @@ public class ComposeMessageInteractorLive: ComposeMessageInteractor {
             .fetchWithFuture()
         } else {
             return Future<URLResponse?, Error> { promise in
-                promise(.failure(NSError.instructureError(String(localized: "Invalid conversation ID"))))
+                promise(.failure(NSError.instructureError(String(localized: "Invalid conversation ID", bundle: .core))))
             }
         }
     }

--- a/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageOptions.swift
+++ b/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageOptions.swift
@@ -104,7 +104,7 @@ extension ComposeMessageOptions {
         )
         var fieldContents = DefaultMessageFieldContents()
 
-        fieldContents.subjectText = String(localized: "Fw: \(conversation.subject)", comment: "New conversation subject for forwarded message")
+        fieldContents.subjectText = String(localized: "Fw: \(conversation.subject)", bundle: .core, comment: "New conversation subject for forwarded message")
 
         if let context = Context(canvasContextID: conversation.contextCode ?? "") {
             fieldContents.selectedContext = .init(name: conversation.contextName ?? "", context: context)

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -206,7 +206,7 @@ class ComposeMessageViewModel: ObservableObject {
     }
 
     private func showResultDialog(title: String, message: String, completion: (() -> Void)? = nil) {
-        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
+        let actionTitle = String(localized: "OK", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: actionTitle, style: .default) { _ in
             completion?()
@@ -253,8 +253,8 @@ class ComposeMessageViewModel: ObservableObject {
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     Logger.shared.error("ComposeMessageView message failure")
-                    let title = NSLocalizedString("Message could not be sent", bundle: .core, comment: "")
-                    let message = NSLocalizedString("Please try again!", bundle: .core, comment: "")
+                    let title = String(localized: "Message could not be sent", bundle: .core)
+                    let message = String(localized: "Please try again!", bundle: .core)
                     self.showResultDialog(title: title, message: message)
                     self.isSendingMessage = false
                 }

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -31,7 +31,7 @@ class ComposeMessageViewModel: ObservableObject {
     @Published public private(set) var isMessageDisabled: Bool = false
     @Published public private(set) var isIndividualDisabled: Bool = false
 
-    public let title = String(localized: "New Message")
+    public let title = String(localized: "New Message", bundle: .core)
     public var sendButtonActive: Bool {
         !bodyText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
         !subject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -206,7 +206,7 @@ class ComposeMessageViewModel: ObservableObject {
     }
 
     private func showResultDialog(title: String, message: String, completion: (() -> Void)? = nil) {
-        let actionTitle = NSLocalizedString("OK", comment: "")
+        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: actionTitle, style: .default) { _ in
             completion?()
@@ -253,8 +253,8 @@ class ComposeMessageViewModel: ObservableObject {
             .sink(receiveCompletion: { completion in
                 if case .failure = completion {
                     Logger.shared.error("ComposeMessageView message failure")
-                    let title = NSLocalizedString("Message could not be sent", comment: "")
-                    let message = NSLocalizedString("Please try again!", comment: "")
+                    let title = NSLocalizedString("Message could not be sent", bundle: .core, comment: "")
+                    let message = NSLocalizedString("Please try again!", bundle: .core, comment: "")
                     self.showResultDialog(title: title, message: message)
                     self.isSendingMessage = false
                 }

--- a/Core/Core/Inbox/MessageDetails/Model/MessageDetailsInteratorLive.swift
+++ b/Core/Core/Inbox/MessageDetails/Model/MessageDetailsInteratorLive.swift
@@ -51,7 +51,7 @@ public class MessageDetailsInteractorLive: MessageDetailsInteractor {
         conversationStore
             .allObjects
             .map {
-                $0.first?.subject ?? NSLocalizedString("No Subject", comment: "")
+                $0.first?.subject ?? NSLocalizedString("No Subject", bundle: .core, comment: "")
             }
             .subscribe(subject)
             .store(in: &subscriptions)

--- a/Core/Core/Inbox/MessageDetails/Model/MessageDetailsInteratorLive.swift
+++ b/Core/Core/Inbox/MessageDetails/Model/MessageDetailsInteratorLive.swift
@@ -51,7 +51,7 @@ public class MessageDetailsInteractorLive: MessageDetailsInteractor {
         conversationStore
             .allObjects
             .map {
-                $0.first?.subject ?? NSLocalizedString("No Subject", bundle: .core, comment: "")
+                $0.first?.subject ?? String(localized: "No Subject", bundle: .core)
             }
             .subscribe(subject)
             .store(in: &subscriptions)

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -102,10 +102,10 @@ public struct MessageDetailsView: View {
             model.starDidTap.send(!model.starred)
         }, label: {
             var star = Image.starLine
-            var a11yLabel = NSLocalizedString("Un-starred", bundle: .core, comment: "")
+            var a11yLabel = String(localized: "Un-starred", bundle: .core)
             if model.starred {
                 star = Image.starSolid
-                a11yLabel = NSLocalizedString("Starred", bundle: .core, comment: "")
+                a11yLabel = String(localized: "Starred", bundle: .core)
             }
             return star
                 .size(30)

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -70,7 +70,7 @@ public struct MessageView: View {
                     .size(uiScale.iconScale * 20)
                     .foregroundColor(.textDark)
                     .padding(.leading, 6)
-                    .accessibilityLabel(Text("Reply"))
+                    .accessibilityLabel(Text("Reply", bundle: .core))
             }
             Button {
                 moreDidTap()
@@ -80,7 +80,7 @@ public struct MessageView: View {
                     .size(uiScale.iconScale * 20)
                     .foregroundColor(.textDark)
                     .padding(.horizontal, 6)
-                    .accessibilityLabel(Text("Conversation options"))
+                    .accessibilityLabel(Text("Conversation options", bundle: .core))
             }
         }
     }

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -31,7 +31,7 @@ class MessageDetailsViewModel: ObservableObject {
     @Published public var isShowingCancelDialog = false
     public let confirmAlert = ConfirmationAlertViewModel(
         title: String(localized: "Are your sure?", bundle: .core),
-        message: String(localized:"It will permanently delete this message from your profile.", bundle: .core),
+        message: String(localized: "It will permanently delete this message from your profile.", bundle: .core),
         cancelButtonTitle: String(localized: "No", bundle: .core),
         confirmButtonTitle: String(localized: "Yes", bundle: .core),
         isDestructive: false

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -26,17 +26,14 @@ class MessageDetailsViewModel: ObservableObject {
     @Published public private(set) var conversations: [Conversation] = []
     @Published public private(set) var starred: Bool = false
 
-    public let title = String(localized: "Message Details")
+    public let title = String(localized: "Message Details", bundle: .core)
 
     @Published public var isShowingCancelDialog = false
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: String(localized: "Are your sure?"),
-        message: String(localized:
-           """
-           It will permanently delete this message from your profile.
-           """),
-        cancelButtonTitle: String(localized: "No"),
-        confirmButtonTitle: String(localized: "Yes"),
+        title: String(localized: "Are your sure?", bundle: .core),
+        message: String(localized:"It will permanently delete this message from your profile.", bundle: .core),
+        cancelButtonTitle: String(localized: "No", bundle: .core),
+        confirmButtonTitle: String(localized: "Yes", bundle: .core),
         isDestructive: false
     )
 
@@ -73,7 +70,7 @@ class MessageDetailsViewModel: ObservableObject {
         }
         sheet.addAction(
             image: .replyAllLine,
-            title: String(localized: "Reply All"),
+            title: String(localized: "Reply All", bundle: .core),
             accessibilityIdentifier: "MessageDetails.replyAll"
         ) {
             self.replyAllTapped(message: nil, viewController: viewController)
@@ -81,7 +78,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         sheet.addAction(
             image: .forwardLine,
-            title: String(localized: "Forward"),
+            title: String(localized: "Forward", bundle: .core),
             accessibilityIdentifier: "MessageDetails.forward"
         ) {
             self.forwardTapped(message: nil, viewController: viewController)
@@ -90,7 +87,7 @@ class MessageDetailsViewModel: ObservableObject {
         if (conversations.first?.workflowState == .read) {
             sheet.addAction(
                 image: .nextUnreadLine,
-                title: String(localized: "Mark as Unread"),
+                title: String(localized: "Mark as Unread", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.markAsUnread"
             ) {
                 self.updateState.send(.unread)
@@ -98,7 +95,7 @@ class MessageDetailsViewModel: ObservableObject {
         } else {
             sheet.addAction(
                 image: .emailLine,
-                title: String(localized: "Mark as Read"),
+                title: String(localized: "Mark as Read", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.markAsRead"
             ) {
                 self.updateState.send(.read)
@@ -108,7 +105,7 @@ class MessageDetailsViewModel: ObservableObject {
         if conversations.first?.workflowState != .archived {
             sheet.addAction(
                 image: .archiveLine,
-                title: String(localized: "Archive"),
+                title: String(localized: "Archive", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.archive"
             ) {
                 self.updateState.send(.archived)
@@ -117,7 +114,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         sheet.addAction(
             image: .trashLine,
-            title: String(localized: "Delete Conversation"),
+            title: String(localized: "Delete Conversation", bundle: .core),
             accessibilityIdentifier: "MessageDetails.delete"
         ) {
             if let conversationId = self.conversations.first?.id {
@@ -131,7 +128,7 @@ class MessageDetailsViewModel: ObservableObject {
         let sheet = BottomSheetPickerViewController.create()
         sheet.addAction(
             image: .replyLine,
-            title: String(localized: "Reply"),
+            title: String(localized: "Reply", bundle: .core),
             accessibilityIdentifier: "MessageDetails.reply"
         ) {
             if let message {
@@ -140,7 +137,7 @@ class MessageDetailsViewModel: ObservableObject {
         }
         sheet.addAction(
             image: .replyAllLine,
-            title: String(localized: "Reply All"),
+            title: String(localized: "Reply All", bundle: .core),
             accessibilityIdentifier: "MessageDetails.replyAll"
         ) {
             if let message {
@@ -150,7 +147,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         sheet.addAction(
             image: .forwardLine,
-            title: String(localized: "Forward"),
+            title: String(localized: "Forward", bundle: .core),
             accessibilityIdentifier: "MessageDetails.forward"
         ) {
             self.forwardTapped(message: message, viewController: viewController)
@@ -158,7 +155,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         sheet.addAction(
             image: .trashLine,
-            title: String(localized: "Delete Message"),
+            title: String(localized: "Delete Message", bundle: .core),
             accessibilityIdentifier: "MessageDetails.delete"
         ) {
             if let conversationId = self.conversations.first?.id, let messageId = message?.id {

--- a/Core/Core/Inbox/Model/Entities/ConversationParticipantNames.swift
+++ b/Core/Core/Inbox/Model/Entities/ConversationParticipantNames.swift
@@ -27,7 +27,7 @@ public extension Array where Element == APIConversationParticipant {
             let sample = prefix(maxNamesCount - 1).map { $0.displayName.trimmingCharacters(in: .whitespacesAndNewlines) }
             let sampledNames = sample.joined(separator: ", ")
             let remainingNamesCount = count - sample.count
-            return NSLocalizedString("\(sampledNames) + \(remainingNamesCount) more", bundle: .core, comment: "(Alice, Bob) + (2) more")
+            return String(localized: "\(sampledNames) + \(remainingNamesCount) more", bundle: .core, comment: "(Alice, Bob) + (2) more")
         } else {
             return map(\.displayName).joined(separator: ", ")
         }

--- a/Core/Core/Inbox/Model/Entities/InboxMessageScope.swift
+++ b/Core/Core/Inbox/Model/Entities/InboxMessageScope.swift
@@ -23,11 +23,11 @@ public enum InboxMessageScope: String, CaseIterable, Hashable {
 
     public var localizedName: String {
         switch self {
-        case .inbox: return NSLocalizedString("Inbox", bundle: .core, comment: "")
-        case .unread: return NSLocalizedString("Unread", bundle: .core, comment: "")
-        case .starred: return NSLocalizedString("Starred", bundle: .core, comment: "")
-        case .sent: return NSLocalizedString("Sent", bundle: .core, comment: "")
-        case .archived: return NSLocalizedString("Archived", bundle: .core, comment: "")
+        case .inbox: return String(localized: "Inbox", bundle: .core)
+        case .unread: return String(localized: "Unread", bundle: .core)
+        case .starred: return String(localized: "Starred", bundle: .core)
+        case .sent: return String(localized: "Sent", bundle: .core)
+        case .archived: return String(localized: "Archived", bundle: .core)
         }
     }
 

--- a/Core/Core/Inbox/Model/Entities/InboxMessageScope.swift
+++ b/Core/Core/Inbox/Model/Entities/InboxMessageScope.swift
@@ -23,11 +23,11 @@ public enum InboxMessageScope: String, CaseIterable, Hashable {
 
     public var localizedName: String {
         switch self {
-        case .inbox: return NSLocalizedString("Inbox", comment: "")
-        case .unread: return NSLocalizedString("Unread", comment: "")
-        case .starred: return NSLocalizedString("Starred", comment: "")
-        case .sent: return NSLocalizedString("Sent", comment: "")
-        case .archived: return NSLocalizedString("Archived", comment: "")
+        case .inbox: return NSLocalizedString("Inbox", bundle: .core, comment: "")
+        case .unread: return NSLocalizedString("Unread", bundle: .core, comment: "")
+        case .starred: return NSLocalizedString("Starred", bundle: .core, comment: "")
+        case .sent: return NSLocalizedString("Sent", bundle: .core, comment: "")
+        case .archived: return NSLocalizedString("Archived", bundle: .core, comment: "")
         }
     }
 

--- a/Core/Core/Inbox/ViewModel/InboxMessageListItemViewModel.swift
+++ b/Core/Core/Inbox/ViewModel/InboxMessageListItemViewModel.swift
@@ -49,9 +49,9 @@ public struct InboxMessageListItemViewModel: Identifiable, Equatable {
                     message.message,
                     message.participantName,
                     message.date,
-                    message.isStarred ? NSLocalizedString("Starred", bundle: .core, comment: "") : "",
-                    message.state == .unread ? NSLocalizedString("Unread", bundle: .core, comment: "") : "",
-                    message.hasAttachment ? NSLocalizedString("Attachments available", bundle: .core, comment: "") : "",
+                    message.isStarred ? String(localized: "Starred", bundle: .core) : "",
+                    message.state == .unread ? String(localized: "Unread", bundle: .core) : "",
+                    message.hasAttachment ? String(localized: "Attachments available", bundle: .core) : "",
                    ].joined(separator: ","))
         }()
     }

--- a/Core/Core/Inbox/ViewModel/InboxMessageListItemViewModel.swift
+++ b/Core/Core/Inbox/ViewModel/InboxMessageListItemViewModel.swift
@@ -49,9 +49,9 @@ public struct InboxMessageListItemViewModel: Identifiable, Equatable {
                     message.message,
                     message.participantName,
                     message.date,
-                    message.isStarred ? NSLocalizedString("Starred", comment: "") : "",
-                    message.state == .unread ? NSLocalizedString("Unread", comment: "") : "",
-                    message.hasAttachment ? NSLocalizedString("Attachments available", comment: "") : "",
+                    message.isStarred ? NSLocalizedString("Starred", bundle: .core, comment: "") : "",
+                    message.state == .unread ? NSLocalizedString("Unread", bundle: .core, comment: "") : "",
+                    message.hasAttachment ? NSLocalizedString("Attachments available", bundle: .core, comment: "") : "",
                    ].joined(separator: ","))
         }()
     }

--- a/Core/Core/Inbox/ViewModel/InboxViewModel.swift
+++ b/Core/Core/Inbox/ViewModel/InboxViewModel.swift
@@ -24,19 +24,19 @@ public class InboxViewModel: ObservableObject {
     @Published public private(set) var state: StoreState = .loading
     @Published public private(set) var messages: [InboxMessageListItemViewModel] = []
     @Published public private(set) var scope: InboxMessageScope = DefaultScope
-    @Published public private(set) var course: String = NSLocalizedString("All Courses", comment: "")
+    @Published public private(set) var course: String = NSLocalizedString("All Courses", bundle: .core, comment: "")
     @Published public private(set) var courses: [InboxCourse] = []
     @Published public private(set) var hasNextPage = false
     @Published public var isShowingScopeSelector = false
     @Published public var isShowingCourseSelector = false
     public let scopes = InboxMessageScope.allCases
     public let emptyState = (scene: SpacePanda() as PandaScene,
-                             title: NSLocalizedString("No Messages", comment: ""),
-                             text: NSLocalizedString("Tap the \"+\" to create a new conversation", comment: ""))
+                             title: NSLocalizedString("No Messages", bundle: .core, comment: ""),
+                             text: NSLocalizedString("Tap the \"+\" to create a new conversation", bundle: .core, comment: ""))
 
     public let errorState = (scene: NoResultsPanda() as PandaScene,
-                             title: NSLocalizedString("Something Went Wrong", comment: ""),
-                             text: NSLocalizedString("Pull to refresh to try again", comment: ""))
+                             title: NSLocalizedString("Something Went Wrong", bundle: .core, comment: ""),
+                             text: NSLocalizedString("Pull to refresh to try again", bundle: .core, comment: ""))
 
     // MARK: - Inputs
     public let refreshDidTrigger = PassthroughSubject<() -> Void, Never>()
@@ -67,7 +67,7 @@ public class InboxViewModel: ObservableObject {
             .assign(to: &$scope)
         courseDidChange
             .map { $0?.name }
-            .replaceNil(with: NSLocalizedString("All Courses", comment: ""))
+            .replaceNil(with: NSLocalizedString("All Courses", bundle: .core, comment: ""))
             .assign(to: &$course)
 
         let interactor = self.interactor

--- a/Core/Core/Inbox/ViewModel/InboxViewModel.swift
+++ b/Core/Core/Inbox/ViewModel/InboxViewModel.swift
@@ -24,19 +24,19 @@ public class InboxViewModel: ObservableObject {
     @Published public private(set) var state: StoreState = .loading
     @Published public private(set) var messages: [InboxMessageListItemViewModel] = []
     @Published public private(set) var scope: InboxMessageScope = DefaultScope
-    @Published public private(set) var course: String = NSLocalizedString("All Courses", bundle: .core, comment: "")
+    @Published public private(set) var course: String = String(localized: "All Courses", bundle: .core)
     @Published public private(set) var courses: [InboxCourse] = []
     @Published public private(set) var hasNextPage = false
     @Published public var isShowingScopeSelector = false
     @Published public var isShowingCourseSelector = false
     public let scopes = InboxMessageScope.allCases
     public let emptyState = (scene: SpacePanda() as PandaScene,
-                             title: NSLocalizedString("No Messages", bundle: .core, comment: ""),
-                             text: NSLocalizedString("Tap the \"+\" to create a new conversation", bundle: .core, comment: ""))
+                             title: String(localized: "No Messages", bundle: .core),
+                             text: String(localized: "Tap the \"+\" to create a new conversation", bundle: .core))
 
     public let errorState = (scene: NoResultsPanda() as PandaScene,
-                             title: NSLocalizedString("Something Went Wrong", bundle: .core, comment: ""),
-                             text: NSLocalizedString("Pull to refresh to try again", bundle: .core, comment: ""))
+                             title: String(localized: "Something Went Wrong", bundle: .core),
+                             text: String(localized: "Pull to refresh to try again", bundle: .core))
 
     // MARK: - Inputs
     public let refreshDidTrigger = PassthroughSubject<() -> Void, Never>()
@@ -67,7 +67,7 @@ public class InboxViewModel: ObservableObject {
             .assign(to: &$scope)
         courseDidChange
             .map { $0?.name }
-            .replaceNil(with: NSLocalizedString("All Courses", bundle: .core, comment: ""))
+            .replaceNil(with: String(localized: "All Courses", bundle: .core))
             .assign(to: &$course)
 
         let interactor = self.interactor

--- a/Core/Core/LTI/LTIViewController.swift
+++ b/Core/Core/LTI/LTIViewController.swift
@@ -53,8 +53,8 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         spinnerView.isHidden = true
-        nameLabel.text = name ?? NSLocalizedString("LTI Tool", bundle: .core, comment: "")
-        setupTitleViewInNavbar(title: NSLocalizedString("External Tool", bundle: .core, comment: ""))
+        nameLabel.text = name ?? String(localized: "LTI Tool", bundle: .core)
+        setupTitleViewInNavbar(title: String(localized: "External Tool", bundle: .core))
         if name == nil {
             // try to get a more descriptive name of the tool
             tools.getSessionlessLaunch { [weak self] response in
@@ -80,7 +80,7 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
                 self?.spinnerView.isHidden = true
                 sender?.isEnabled = true
                 if !success {
-                    self?.showError(message: NSLocalizedString("Could not launch tool. Please try again.", bundle: .core, comment: ""))
+                    self?.showError(message: String(localized: "Could not launch tool. Please try again.", bundle: .core))
                 }
             }
         }

--- a/Core/Core/Login/LoginDelegate.swift
+++ b/Core/Core/Login/LoginDelegate.swift
@@ -38,7 +38,7 @@ public extension LoginDelegate {
     var supportsCanvasNetwork: Bool { true }
     var helpURL: URL? { URL(string: "https://community.canvaslms.com/docs/DOC-1543") }
     var whatsNewURL: URL? { nil }
-    var findSchoolButtonTitle: String { NSLocalizedString("Find my school", bundle: .core, comment: "") }
+    var findSchoolButtonTitle: String { String(localized: "Find my school", bundle: .core) }
 
     func changeUser() {}
     func openExternalURLinSafari(_ url: URL) {}

--- a/Core/Core/Login/LoginFindSchoolViewController.swift
+++ b/Core/Core/Login/LoginFindSchoolViewController.swift
@@ -25,7 +25,7 @@ class LoginFindSchoolViewController: UIViewController {
     @IBOutlet weak var resultsTableView: UITableView!
     @IBOutlet weak var searchField: UITextField!
 
-    private lazy var nextButton = UIBarButtonItem(title: NSLocalizedString("Next", comment: ""), style: .done, target: self, action: #selector(nextPressed))
+    private lazy var nextButton = UIBarButtonItem(title: NSLocalizedString("Next", bundle: .core, comment: ""), style: .done, target: self, action: #selector(nextPressed))
 
     var accounts = [APIAccountResult]()
     var api: API = API()

--- a/Core/Core/Login/LoginFindSchoolViewController.swift
+++ b/Core/Core/Login/LoginFindSchoolViewController.swift
@@ -25,7 +25,7 @@ class LoginFindSchoolViewController: UIViewController {
     @IBOutlet weak var resultsTableView: UITableView!
     @IBOutlet weak var searchField: UITextField!
 
-    private lazy var nextButton = UIBarButtonItem(title: NSLocalizedString("Next", bundle: .core, comment: ""), style: .done, target: self, action: #selector(nextPressed))
+    private lazy var nextButton = UIBarButtonItem(title: String(localized: "Next", bundle: .core), style: .done, target: self, action: #selector(nextPressed))
 
     var accounts = [APIAccountResult]()
     var api: API = API()
@@ -37,8 +37,8 @@ class LoginFindSchoolViewController: UIViewController {
     var searchTask: APITask?
 
     var notFoundAttributedText: NSAttributedString = {
-        let text = NSLocalizedString("Can’t find your school? Try typing the full school URL.", bundle: .core, comment: "")
-        let link = NSLocalizedString("Login help.", bundle: .core, comment: "")
+        let text = String(localized: "Can’t find your school? Try typing the full school URL.", bundle: .core)
+        let link = String(localized: "Login help.", bundle: .core)
         let combined = "\(text) \(link)"
         let attributedText = NSMutableAttributedString(string: combined, attributes: [
             .foregroundColor: UIColor.textDark,
@@ -49,7 +49,7 @@ class LoginFindSchoolViewController: UIViewController {
     }()
 
     var helpAttributedText = NSAttributedString(
-        string: NSLocalizedString("How do I find my school?", bundle: .core, comment: ""),
+        string: String(localized: "How do I find my school?", bundle: .core),
         attributes: [.foregroundColor: UIColor.electric]
     )
 
@@ -69,14 +69,14 @@ class LoginFindSchoolViewController: UIViewController {
         logoView.heightAnchor.constraint(equalToConstant: 32).isActive = true
         logoView.widthAnchor.constraint(equalToConstant: 32).isActive = true
         navigationItem.titleView = logoView
-        navigationItem.title = NSLocalizedString("Find School", bundle: .core, comment: "")
+        navigationItem.title = String(localized: "Find School", bundle: .core)
 
-        promptLabel.text = NSLocalizedString("What’s your school’s name?", bundle: .core, comment: "")
+        promptLabel.text = String(localized: "What’s your school’s name?", bundle: .core)
         searchField.attributedPlaceholder = NSAttributedString(
-            string: NSLocalizedString("Find your school or district", bundle: .core, comment: ""),
+            string: String(localized: "Find your school or district", bundle: .core),
             attributes: [.foregroundColor: UIColor.textDark]
         )
-        searchField.accessibilityLabel = NSLocalizedString("School’s name", bundle: .core, comment: "")
+        searchField.accessibilityLabel = String(localized: "School’s name", bundle: .core)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/Core/Core/Login/LoginQRCodeTutorialViewController.swift
+++ b/Core/Core/Login/LoginQRCodeTutorialViewController.swift
@@ -33,9 +33,9 @@ class LoginQRCodeTutorialViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        navigationItem.title = NSLocalizedString("Locate QR Code", bundle: .core, comment: "")
+        navigationItem.title = String(localized: "Locate QR Code", bundle: .core)
         let next = UIBarButtonItem(
-            title: NSLocalizedString("Next", bundle: .core, comment: ""),
+            title: String(localized: "Next", bundle: .core),
             style: .plain,
             target: self,
             action: #selector(done(_:))

--- a/Core/Core/Login/LoginStartSessionCell.swift
+++ b/Core/Core/Login/LoginStartSessionCell.swift
@@ -40,7 +40,7 @@ class LoginStartSessionCell: UITableViewCell {
         avatarView?.url = entry.userAvatarURL
         backgroundColor = .backgroundLightest
         domainLabel?.text = entry.baseURL.host
-        forgetButton?.accessibilityLabel = String.localizedStringWithFormat(NSLocalizedString("Forget %@", bundle: .core, comment: ""), entry.userName)
+        forgetButton?.accessibilityLabel = String.localizedStringWithFormat(String(localized: "Forget %@", bundle: .core), entry.userName)
         forgetButton?.accessibilityIdentifier = "\(identifier).removeButton"
         nameLabel?.text = entry.userName
     }

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -57,7 +57,7 @@ class LoginStartViewController: UIViewController {
             lastLoginButton.isHidden = lastLoginAccount == nil
             guard let lastLoginAccount = lastLoginAccount else { return }
             let buttonTitle = lastLoginAccount.name.isEmpty ? lastLoginAccount.domain : lastLoginAccount.name
-            lastLoginButton.setTitle(NSLocalizedString(buttonTitle, bundle: .core, comment: ""), for: .normal)
+            lastLoginButton.setTitle(buttonTitle, for: .normal)
             alternateFindSchoolButton()
         }
     }

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -291,12 +291,12 @@ class LoginStartViewController: UIViewController {
         guard isNetworkOnline() else { return }
         if app == .parent {
             let sheet = BottomSheetPickerViewController.create()
-            sheet.addAction(image: nil, title: NSLocalizedString("I have a Canvas account", comment: "")) { [weak self] in
+            sheet.addAction(image: nil, title: NSLocalizedString("I have a Canvas account", bundle: .core, comment: "")) { [weak self] in
                 self?.showLoginQRCodeTutorial()
             }
             sheet.addAction(
                 image: nil,
-                title: NSLocalizedString("I don't have a Canvas account", comment: ""),
+                title: NSLocalizedString("I don't have a Canvas account", bundle: .core, comment: ""),
                 accessibilityIdentifier: "LoginStart.dontHaveAccountAction"
             ) { [weak self] in
                 self?.showInstructionsToPairFromStudentApp()

--- a/Core/Core/Login/LoginStartViewController.swift
+++ b/Core/Core/Login/LoginStartViewController.swift
@@ -89,9 +89,9 @@ class LoginStartViewController: UIViewController {
         animatableLogo.tintColor = logoView.tintColor
         previousLoginsView.isHidden = true
         self.lastLoginAccount = nil
-        previousLoginsLabel.text = NSLocalizedString("Previous Logins", bundle: .core, comment: "")
-        whatsNewLabel.text = NSLocalizedString("We've made a few changes.", bundle: .core, comment: "")
-        whatsNewLink.setTitle(NSLocalizedString("See what's new.", bundle: .core, comment: ""), for: .normal)
+        previousLoginsLabel.text = String(localized: "Previous Logins", bundle: .core)
+        whatsNewLabel.text = String(localized: "We've made a few changes.", bundle: .core)
+        whatsNewLink.setTitle(String(localized: "See what's new.", bundle: .core), for: .normal)
         whatsNewContainer.isHidden = loginDelegate?.whatsNewURL == nil
         wordmarkLabel.attributedText = NSAttributedString.init(string: (
             Bundle.main.isParentApp ? "PARENT"
@@ -100,7 +100,7 @@ class LoginStartViewController: UIViewController {
         ), attributes: [.kern: 2])
         wordmarkLabel.textColor = .textDarkest
         logoView.superview?.accessibilityLabel = "Canvas " + (wordmarkLabel.text ?? "")
-        let loginText = NSLocalizedString("Log In", bundle: .core, comment: "")
+        let loginText = String(localized: "Log In", bundle: .core)
         if MDMManager.shared.host != nil {
             findSchoolButton.isHidden = true
             lastLoginButton.setTitle(loginText, for: .normal)
@@ -145,7 +145,7 @@ class LoginStartViewController: UIViewController {
     }
 
     func configureButtons() {
-        canvasNetworkButton.setTitle(NSLocalizedString("Canvas Network", bundle: .core, comment: ""), for: .normal)
+        canvasNetworkButton.setTitle(String(localized: "Canvas Network", bundle: .core), for: .normal)
         canvasNetworkButton.isHidden = loginDelegate?.supportsCanvasNetwork == false || MDMManager.shared.host != nil
         useQRCodeDivider.isHidden = canvasNetworkButton.isHidden
     }
@@ -291,12 +291,12 @@ class LoginStartViewController: UIViewController {
         guard isNetworkOnline() else { return }
         if app == .parent {
             let sheet = BottomSheetPickerViewController.create()
-            sheet.addAction(image: nil, title: NSLocalizedString("I have a Canvas account", bundle: .core, comment: "")) { [weak self] in
+            sheet.addAction(image: nil, title: String(localized: "I have a Canvas account", bundle: .core)) { [weak self] in
                 self?.showLoginQRCodeTutorial()
             }
             sheet.addAction(
                 image: nil,
-                title: NSLocalizedString("I don't have a Canvas account", bundle: .core, comment: ""),
+                title: String(localized: "I don't have a Canvas account", bundle: .core),
                 accessibilityIdentifier: "LoginStart.dontHaveAccountAction"
             ) { [weak self] in
                 self?.showInstructionsToPairFromStudentApp()
@@ -316,13 +316,13 @@ class LoginStartViewController: UIViewController {
         switch method {
         case .normalLogin:
             method = .canvasLogin
-            authenticationMethodLabel.text = NSLocalizedString("Canvas Login", bundle: .core, comment: "")
+            authenticationMethodLabel.text = String(localized: "Canvas Login", bundle: .core)
         case .canvasLogin:
             method = .siteAdminLogin
-            authenticationMethodLabel.text = NSLocalizedString("Site Admin Login", bundle: .core, comment: "")
+            authenticationMethodLabel.text = String(localized: "Site Admin Login", bundle: .core)
         case .siteAdminLogin:
             method = .manualOAuthLogin
-            authenticationMethodLabel.text = NSLocalizedString("Manual OAuth Login", bundle: .core, comment: "")
+            authenticationMethodLabel.text = String(localized: "Manual OAuth Login", bundle: .core)
         case .manualOAuthLogin:
             method = .normalLogin
             authenticationMethodLabel.text = nil
@@ -358,12 +358,12 @@ class LoginStartViewController: UIViewController {
         }
         var cancelled = false
         let loading = UIAlertController(
-            title: NSLocalizedString("Logging you in", bundle: .core, comment: ""),
-            message: NSLocalizedString("Please wait, this might take a minute.", bundle: .core, comment: ""),
+            title: String(localized: "Logging you in", bundle: .core),
+            message: String(localized: "Please wait, this might take a minute.", bundle: .core),
             preferredStyle: .alert
         )
         loading.addAction(UIAlertAction(
-            title: NSLocalizedString("Cancel", bundle: .core, comment: ""),
+            title: String(localized: "Cancel", bundle: .core),
             style: .cancel,
             handler: { _ in cancelled = true }
         ))
@@ -388,13 +388,13 @@ class LoginStartViewController: UIViewController {
     func showQRCodeError() {
         Analytics.shared.logEvent("qr_code_login_failure")
         showAlert(
-            title: NSLocalizedString("Login Error", bundle: .core, comment: ""),
-            message: NSLocalizedString("Please generate another QR Code and try again.", bundle: .core, comment: "")
+            title: String(localized: "Login Error", bundle: .core),
+            message: String(localized: "Please generate another QR Code and try again.", bundle: .core)
         )
     }
 
     private func alternateFindSchoolButton() {
-        findSchoolButton.setTitle(NSLocalizedString("Find another school", bundle: .core, comment: ""), for: .normal)
+        findSchoolButton.setTitle(String(localized: "Find another school", bundle: .core), for: .normal)
         findSchoolButton.backgroundColorName = "white"
         findSchoolButton.textColorName = "oxford"
         findSchoolButton.borderColorName = "oxford"

--- a/Core/Core/Login/LoginUsePolicy/LoginUsePolicyView.swift
+++ b/Core/Core/Login/LoginUsePolicy/LoginUsePolicyView.swift
@@ -84,7 +84,7 @@ struct LoginUsePolicyView: View {
             }).disabled(!viewModel.isAccepted)
         )
         .alert(isPresented: $viewModel.showError) {
-            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")))
+            Alert(title: Text(viewModel.errorText ?? String(localized: "Something went wrong", bundle: .core)))
         }
     }
 }

--- a/Core/Core/Login/LoginUsePolicy/LoginUsePolicyView.swift
+++ b/Core/Core/Login/LoginUsePolicy/LoginUsePolicyView.swift
@@ -84,7 +84,7 @@ struct LoginUsePolicyView: View {
             }).disabled(!viewModel.isAccepted)
         )
         .alert(isPresented: $viewModel.showError) {
-            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", comment: "")))
+            Alert(title: Text(viewModel.errorText ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")))
         }
     }
 }

--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -35,9 +35,9 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         public var text: Text {
             switch self {
             case .invalidDomain:
-                return Text("Go back and make sure you entered a valid institution name.")
+                return Text("Go back and make sure you entered a valid institution name.", bundle: .core)
             case .timeout:
-                return Text("We received no response from the institution.\nGo back and make sure you entered a valid institution name.")
+                return Text("We received no response from the institution.\nGo back and make sure you entered a valid institution name.", bundle: .core)
             }
         }
     }
@@ -235,7 +235,7 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
 
     private func showFailedPanda(reason: FailureReason) {
         let panda = InteractivePanda(scene: NoResultsPanda(),
-                                     title: Text("Failed to Load Login Page"),
+                                     title: Text("Failed to Load Login Page", bundle: .core),
                                      subtitle: reason.text)
         let hostVC = CoreHostingController(panda)
         addChild(hostVC)

--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -136,8 +136,8 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         webView.uiDelegate = self
         webView.handle("selfRegistrationError") { [weak self] _ in performUIUpdate {
             self?.showAlert(
-                title: NSLocalizedString("Self Registration Not Allowed", comment: ""),
-                message: NSLocalizedString("Contact your school to create an account.", comment: "")
+                title: NSLocalizedString("Self Registration Not Allowed", bundle: .core, comment: ""),
+                message: NSLocalizedString("Contact your school to create an account.", bundle: .core, comment: "")
             )
         } }
     }

--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -136,8 +136,8 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         webView.uiDelegate = self
         webView.handle("selfRegistrationError") { [weak self] _ in performUIUpdate {
             self?.showAlert(
-                title: NSLocalizedString("Self Registration Not Allowed", bundle: .core, comment: ""),
-                message: NSLocalizedString("Contact your school to create an account.", bundle: .core, comment: "")
+                title: String(localized: "Self Registration Not Allowed", bundle: .core),
+                message: String(localized: "Contact your school to create an account.", bundle: .core)
             )
         } }
     }
@@ -291,7 +291,7 @@ extension LoginWebViewController: WKNavigationDelegate {
         } else if queryItems?.first(where: { $0.name == "error" })?.value == "access_denied" {
             // access_denied is the only currently implemented error code
             // https://canvas.instructure.com/doc/api/file.oauth.html#oauth2-flow-2
-            let error = NSError.instructureError(NSLocalizedString("Authentication failed. Most likely the user denied the request for access.", bundle: .core, comment: ""))
+            let error = NSError.instructureError(String(localized: "Authentication failed. Most likely the user denied the request for access.", bundle: .core))
             self.showError(error)
             return decisionHandler(.cancel)
         }
@@ -340,18 +340,18 @@ extension LoginWebViewController: WKNavigationDelegate {
             return
         }
         performUIUpdate {
-            let alert = UIAlertController(title: NSLocalizedString("Login", bundle: .core, comment: ""), message: nil, preferredStyle: .alert)
+            let alert = UIAlertController(title: String(localized: "Login", bundle: .core), message: nil, preferredStyle: .alert)
             alert.addTextField { textField in
-                textField.placeholder = NSLocalizedString("Username", bundle: .core, comment: "")
+                textField.placeholder = String(localized: "Username", bundle: .core)
             }
             alert.addTextField { textField in
-                textField.placeholder = NSLocalizedString("Password", bundle: .core, comment: "")
+                textField.placeholder = String(localized: "Password", bundle: .core)
                 textField.isSecureTextEntry = true
             }
-            alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel) { _ in
+            alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel) { _ in
                 completionHandler(.performDefaultHandling, nil)
             })
-            alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { _ in
+            alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { _ in
                 if let username = alert.textFields?.first?.text, let password = alert.textFields?.last?.text {
                     let credential = URLCredential(user: username, password: password, persistence: .forSession)
                     completionHandler(.useCredential, credential)

--- a/Core/Core/Login/PairWithStudentQRCodeTutorialViewController.swift
+++ b/Core/Core/Login/PairWithStudentQRCodeTutorialViewController.swift
@@ -33,15 +33,15 @@ public class PairWithStudentQRCodeTutorialViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Create Account", bundle: .core, comment: "")
-        headerLabel.text = NSLocalizedString(
+        title = String(localized: "Create Account", bundle: .core)
+        headerLabel.text = String(localized:
         """
         To create an account, have your student create a pairing code for you from the Settings section of the Canvas Student app as shown below, and then scan that code from here.
         If your student doesn't see the option to create a pairing code, you'll need to reach out to your school to create your account.
-        """, bundle: .core, comment: "")
+        """, bundle: .core)
         headerLabel.accessibilityIdentifier = "PairWithStudentQRCodeTutorial.headerLabel"
         let next = UIBarButtonItem(
-            title: NSLocalizedString("Next", bundle: .core, comment: ""),
+            title: String(localized: "Next", bundle: .core),
             style: .plain,
             target: self,
             action: #selector(done(_:))

--- a/Core/Core/Login/PairWithStudentQRCodeTutorialViewController.swift
+++ b/Core/Core/Login/PairWithStudentQRCodeTutorialViewController.swift
@@ -33,12 +33,12 @@ public class PairWithStudentQRCodeTutorialViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Create Account", comment: "")
+        title = NSLocalizedString("Create Account", bundle: .core, comment: "")
         headerLabel.text = NSLocalizedString(
         """
         To create an account, have your student create a pairing code for you from the Settings section of the Canvas Student app as shown below, and then scan that code from here.
         If your student doesn't see the option to create a pairing code, you'll need to reach out to your school to create your account.
-        """, comment: "")
+        """, bundle: .core, comment: "")
         headerLabel.accessibilityIdentifier = "PairWithStudentQRCodeTutorial.headerLabel"
         let next = UIBarButtonItem(
             title: NSLocalizedString("Next", bundle: .core, comment: ""),

--- a/Core/Core/Models/Viewable/DueViewable.swift
+++ b/Core/Core/Models/Viewable/DueViewable.swift
@@ -25,19 +25,19 @@ public protocol DueViewable {
 extension DueViewable {
     public var dueText: String {
         guard let dueAt = self.dueAt else {
-            return NSLocalizedString("No Due Date", bundle: .core, comment: "")
+            return String(localized: "No Due Date", bundle: .core)
         }
-        let format = NSLocalizedString("Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
+        let format = String(localized: "Due %@", bundle: .core, comment: "i.e. Due <Jan 10, 2020 at 9:00 PM>")
         return String.localizedStringWithFormat(format, dueAt.relativeDateTimeString)
     }
 
     public var assignmentDueByText: String {
         guard let dueAt = self.dueAt else {
-            return NSLocalizedString("No Due Date", bundle: .core, comment: "")
+            return String(localized: "No Due Date", bundle: .core)
         }
         let format = dueAt > Clock.now
-            ? NSLocalizedString("This assignment is due by %@", bundle: .core, comment: "")
-            : NSLocalizedString("This assignment was due by %@", bundle: .core, comment: "")
+            ? String(localized: "This assignment is due by %@", bundle: .core)
+            : String(localized: "This assignment was due by %@", bundle: .core)
 
         let formatter = DateFormatter()
         formatter.dateStyle = .long

--- a/Core/Core/Models/Viewable/GradeViewable.swift
+++ b/Core/Core/Models/Viewable/GradeViewable.swift
@@ -30,27 +30,27 @@ public protocol GradeViewable {
 extension GradeViewable {
     public var pointsPossibleText: String {
         guard let points = pointsPossible else {
-            return NSLocalizedString("Not Graded", bundle: .core, comment: "")
+            return String(localized: "Not Graded", bundle: .core)
         }
-        let format = NSLocalizedString("g_pts", bundle: .core, comment: "")
+        let format = String(localized: "g_pts", bundle: .core)
         return String.localizedStringWithFormat(format, points)
     }
 
     public var pointsText: String? {
         guard let score = viewableScore else { return nil }
-        let format = NSLocalizedString("plural_points", bundle: .core, comment: "")
+        let format = String(localized: "plural_points", bundle: .core)
         return String.localizedStringWithFormat(format, score)
     }
 
     public var outOfText: String? {
         guard let points = pointsPossible else { return nil }
-        let format = NSLocalizedString("out_of_g_pts", bundle: .core, comment: "")
+        let format = String(localized: "out_of_g_pts", bundle: .core)
         return String.localizedStringWithFormat(format, points)
     }
 
     public var scoreOutOfPointsPossibleText: String? {
         guard let score = viewableScore, let points = pointsPossible else { return nil }
-        let format = NSLocalizedString("g_out_of_g_points_possible", bundle: .core, comment: "")
+        let format = String(localized: "g_out_of_g_points_possible", bundle: .core)
         return String.localizedStringWithFormat(format, score, points)
     }
 
@@ -65,10 +65,10 @@ extension GradeViewable {
 
     public var finalGradeText: String? {
         if gradingType == .points, let score = viewableScore {
-            let format = NSLocalizedString("final_grade_g_pts", bundle: .core, comment: "")
+            let format = String(localized: "final_grade_g_pts", bundle: .core)
             return String.localizedStringWithFormat(format, score)
         } else if let grade = viewableGrade {
-            let format = NSLocalizedString("Final Grade: %@", bundle: .core, comment: "")
+            let format = String(localized: "Final Grade: %@", bundle: .core)
             return String.localizedStringWithFormat(format, grade)
         }
         return nil

--- a/Core/Core/Models/Viewable/LockStatusViewable.swift
+++ b/Core/Core/Models/Viewable/LockStatusViewable.swift
@@ -26,6 +26,6 @@ public protocol LockStatusViewable {
 extension LockStatusViewable {
     public var lockStatusText: String? {
         guard dueAt != nil, let lockAt = lockAt, lockAt < Date() else { return nil }
-        return NSLocalizedString("Closed", bundle: .core, comment: "")
+        return String(localized: "Closed", bundle: .core)
     }
 }

--- a/Core/Core/Models/Viewable/SubmissionViewable.swift
+++ b/Core/Core/Models/Viewable/SubmissionViewable.swift
@@ -57,14 +57,14 @@ extension SubmissionViewable {
 
     public var submissionStatusText: String {
         if !isSubmitted {
-            return NSLocalizedString("Not Submitted", bundle: .core, comment: "")
+            return String(localized: "Not Submitted", bundle: .core)
         }
 
         if submission?.workflowState == .graded {
-            return NSLocalizedString("Graded", bundle: .core, comment: "")
+            return String(localized: "Graded", bundle: .core)
         }
 
-        return NSLocalizedString("Submitted", bundle: .core, comment: "")
+        return String(localized: "Submitted", bundle: .core)
     }
     public var submissionDateText: String? {
         submission?.submittedAt?.dateTimeString
@@ -72,7 +72,7 @@ extension SubmissionViewable {
     public var submissionAttemptNumberText: String? {
         guard let attempt = submission?.attempt else { return nil }
 
-        let format = NSLocalizedString("Attempt %d", bundle: .core, comment: "")
+        let format = String(localized: "Attempt %d", bundle: .core)
         return String.localizedStringWithFormat(format, attempt)
     }
 
@@ -82,7 +82,7 @@ extension SubmissionViewable {
 
     public var latePenaltyText: String? {
         guard submission?.late == true, let deducted = submission?.pointsDeducted else { return nil }
-        let format = NSLocalizedString("late_penalty_g_pts", bundle: .core, comment: "")
+        let format = String(localized: "late_penalty_g_pts", bundle: .core)
         return String.localizedStringWithFormat(format, -deducted)
     }
 

--- a/Core/Core/Modules/CompletionRequirement.swift
+++ b/Core/Core/Modules/CompletionRequirement.swift
@@ -27,26 +27,26 @@ public struct CompletionRequirement: Codable, Equatable {
         switch type {
         case .must_view:
             return completed != true
-                ? NSLocalizedString("View", bundle: .core, comment: "")
-                : NSLocalizedString("Viewed", bundle: .core, comment: "")
+                ? String(localized: "View", bundle: .core)
+                : String(localized: "Viewed", bundle: .core)
         case .must_submit:
             return completed != true
-                ? NSLocalizedString("Submit", bundle: .core, comment: "")
-                : NSLocalizedString("Submitted", bundle: .core, comment: "")
+                ? String(localized: "Submit", bundle: .core)
+                : String(localized: "Submitted", bundle: .core)
         case .must_contribute:
             return completed != true
-                ? NSLocalizedString("Contribute", bundle: .core, comment: "")
-                : NSLocalizedString("Contributed", bundle: .core, comment: "")
+                ? String(localized: "Contribute", bundle: .core)
+                : String(localized: "Contributed", bundle: .core)
         case .min_score:
             guard let score = NSNumber(value: min_score) else { return nil }
             let template = completed != true
-                ? NSLocalizedString("Score at least %@", bundle: .core, comment: "")
-                : NSLocalizedString("Scored at least %@", bundle: .core, comment: "")
+                ? String(localized: "Score at least %@", bundle: .core)
+                : String(localized: "Scored at least %@", bundle: .core)
             return String.localizedStringWithFormat(template, score)
         case .must_mark_done:
             return completed != true
-                ? NSLocalizedString("Mark done", bundle: .core, comment: "")
-                : NSLocalizedString("Marked done", bundle: .core, comment: "")
+                ? String(localized: "Mark done", bundle: .core)
+                : String(localized: "Marked done", bundle: .core)
         }
     }
 }

--- a/Core/Core/Modules/Mastery Paths/MasteryPathViewController.swift
+++ b/Core/Core/Modules/Mastery Paths/MasteryPathViewController.swift
@@ -38,7 +38,7 @@ class MasteryPathViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = NSLocalizedString("Select a Path", bundle: .core, comment: "")
+        navigationItem.title = String(localized: "Select a Path", bundle: .core)
         let sets = masteryPath.assignmentSets.sorted { $0.position < $1.position }
         for (index, set) in sets.enumerated() {
             if index > 0 {
@@ -145,7 +145,7 @@ class MasteryPathAssignmentCell: UIView {
         nameLabel.text = assignment.name
         if let pointsPossible = assignment.pointsPossible?.doubleValue {
             pointsLabel.isHidden = false
-            pointsLabel.text = String.localizedStringWithFormat(NSLocalizedString("g_points", bundle: .core, comment: ""), pointsPossible)
+            pointsLabel.text = String.localizedStringWithFormat(String(localized: "g_points", bundle: .core), pointsPossible)
         } else {
             pointsLabel.isHidden = true
         }
@@ -210,7 +210,7 @@ class MasteryPathAssignmentSetSelectCell: UIView {
         button.backgroundColor = selected ? .clear : Brand.shared.buttonPrimaryBackground
         button.setTitleColor(selected ? .textDark : Brand.shared.buttonPrimaryText, for: .normal)
         button.setTitleColor(.textDark, for: .highlighted)
-        let title = selected ? NSLocalizedString("Selected!", bundle: .core, comment: "") : NSLocalizedString("Select", bundle: .core, comment: "")
+        let title = selected ? String(localized: "Selected!", bundle: .core) : String(localized: "Select", bundle: .core)
         button.setTitle(title, for: .normal)
     }
 

--- a/Core/Core/Modules/Module.swift
+++ b/Core/Core/Modules/Module.swift
@@ -69,12 +69,12 @@ public class Module: NSManagedObject {
         guard state == .locked else { return nil }
         if let unlockAt = unlockAt, unlockAt > Clock.now {
             return String.localizedStringWithFormat(
-                NSLocalizedString("Will unlock %@", bundle: .core, comment: ""),
+                String(localized: "Will unlock %@", bundle: .core),
                 DateFormatter.localizedString(from: unlockAt, dateStyle: .medium, timeStyle: .short)
             )
         } else if prerequisiteModuleIDs.count > 0 {
             return String.localizedStringWithFormat(
-                NSLocalizedString("Prerequisite: %@", bundle: .core, comment: ""),
+                String(localized: "Prerequisite: %@", bundle: .core),
                 prerequisiteModules.map(\.name).joined(separator: ", ")
             )
         }

--- a/Core/Core/Modules/ModuleItem.swift
+++ b/Core/Core/Modules/ModuleItem.swift
@@ -183,8 +183,8 @@ public class ModuleItem: NSManagedObject {
                 path.moduleID = item.module_id.value
                 path.position = Double(item.position) + 0.5
                 path.title = item.mastery_paths?.locked == true
-                    ? String.localizedStringWithFormat(NSLocalizedString("Locked until \"%@\" is graded", bundle: .core, comment: ""), item.title)
-                    : NSLocalizedString("Select a Path", bundle: .core, comment: "")
+                    ? String.localizedStringWithFormat(String(localized: "Locked until \"%@\" is graded", bundle: .core), item.title)
+                    : String(localized: "Select a Path", bundle: .core)
                 path.indent = item.indent
                 path.type = item.content
                 path.masteryPath = MasteryPath.save(masteryPath, in: context)

--- a/Core/Core/Modules/ModuleItem.swift
+++ b/Core/Core/Modules/ModuleItem.swift
@@ -183,8 +183,8 @@ public class ModuleItem: NSManagedObject {
                 path.moduleID = item.module_id.value
                 path.position = Double(item.position) + 0.5
                 path.title = item.mastery_paths?.locked == true
-                    ? String.localizedStringWithFormat(NSLocalizedString("Locked until \"%@\" is graded", comment: ""), item.title)
-                    : NSLocalizedString("Select a Path", comment: "")
+                    ? String.localizedStringWithFormat(NSLocalizedString("Locked until \"%@\" is graded", bundle: .core, comment: ""), item.title)
+                    : NSLocalizedString("Select a Path", bundle: .core, comment: "")
                 path.indent = item.indent
                 path.type = item.content
                 path.masteryPath = MasteryPath.save(masteryPath, in: context)

--- a/Core/Core/Modules/ModuleItemType.swift
+++ b/Core/Core/Modules/ModuleItemType.swift
@@ -123,19 +123,19 @@ public enum ModuleItemType: Equatable, Codable {
         case .subHeader:
             return nil
         case .file:
-            return NSLocalizedString("file", bundle: .core, comment: "")
+            return String(localized: "file", bundle: .core)
         case .page:
-            return NSLocalizedString("page", bundle: .core, comment: "")
+            return String(localized: "page", bundle: .core)
         case .discussion:
-            return NSLocalizedString("discussion", bundle: .core, comment: "")
+            return String(localized: "discussion", bundle: .core)
         case .assignment:
-            return NSLocalizedString("assignment", bundle: .core, comment: "")
+            return String(localized: "assignment", bundle: .core)
         case .quiz:
-            return NSLocalizedString("quiz", bundle: .core, comment: "")
+            return String(localized: "quiz", bundle: .core)
         case .externalURL:
-            return NSLocalizedString("external URL", bundle: .core, comment: "")
+            return String(localized: "external URL", bundle: .core)
         case .externalTool:
-            return NSLocalizedString("external tool", bundle: .core, comment: "")
+            return String(localized: "external tool", bundle: .core)
         }
     }
 }

--- a/Core/Core/Modules/ModuleItems/ExternalURLViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ExternalURLViewController.swift
@@ -54,7 +54,7 @@ public class ExternalURLViewController: UIViewController, ColoredNavViewProtocol
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         nameLabel.text = name
-        setupTitleViewInNavbar(title: NSLocalizedString("External URL", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "External URL", bundle: .core))
         colors.refresh()
         courses?.refresh()
     }

--- a/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -62,7 +62,7 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Module Item", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Module Item", bundle: .core))
         Analytics.shared.logEvent("module_item", parameters: ["moduleID": moduleID!, "itemID": itemID!])
         errorView.isHidden = true
         errorView.retryButton.addTarget(self, action: #selector(retryButtonPressed), for: .primaryActionTriggered)
@@ -109,21 +109,21 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         let title: String
         switch item?.type {
         case .assignment:
-            title = NSLocalizedString("Assignment Details", bundle: .core, comment: "")
+            title = String(localized: "Assignment Details", bundle: .core)
         case .discussion:
-            title = NSLocalizedString("Discussion Details", bundle: .core, comment: "")
+            title = String(localized: "Discussion Details", bundle: .core)
         case .externalTool:
-            title = NSLocalizedString("External Tool", bundle: .core, comment: "")
+            title = String(localized: "External Tool", bundle: .core)
         case .externalURL:
-            title = NSLocalizedString("External URL", bundle: .core, comment: "")
+            title = String(localized: "External URL", bundle: .core)
         case .file:
-            title = NSLocalizedString("File Details", bundle: .core, comment: "")
+            title = String(localized: "File Details", bundle: .core)
         case .quiz:
-            title = NSLocalizedString("Quiz Details", bundle: .core, comment: "")
+            title = String(localized: "Quiz Details", bundle: .core)
         case .page:
-            title = NSLocalizedString("Page Details", bundle: .core, comment: "")
+            title = String(localized: "Page Details", bundle: .core)
         case nil, .subHeader:
-            title = NSLocalizedString("Module Item", bundle: .core, comment: "")
+            title = String(localized: "Module Item", bundle: .core)
         }
         setupTitleViewInNavbar(title: title)
         if item?.completionRequirementType == .must_mark_done {
@@ -168,13 +168,13 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.addAction(AlertAction(
             item?.completed == true
-                ? NSLocalizedString("Mark as Undone", bundle: .core, comment: "")
-                : NSLocalizedString("Mark as Done", bundle: .core, comment: ""),
+                ? String(localized: "Mark as Undone", bundle: .core)
+                : String(localized: "Mark as Done", bundle: .core),
             style: .default
         ) { [weak self] _ in
             self?.markAsDone()
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         alert.popoverPresentationController?.barButtonItem = sender
         env.router.show(alert, from: self, options: .modal())
     }

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -92,7 +92,7 @@ public final class ModuleItemSequenceViewController: UIViewController {
             return match
         } else {
             let external = ExternalURLViewController.create(
-                name: NSLocalizedString("Unsupported Item", bundle: .core, comment: ""),
+                name: String(localized: "Unsupported Item", bundle: .core),
                 url: url,
                 courseID: courseID
             )

--- a/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
+++ b/Core/Core/Modules/ModuleList/Model/ModulePublishInteractor.swift
@@ -273,54 +273,54 @@ extension Subscribers.Completion<Error> {
             switch action.subject {
             case .none:
                 return isPublish
-                    ? String(localized: "Item Published")
-                    : String(localized: "Item Unpublished")
+                    ? String(localized: "Item Published", bundle: .core)
+                    : String(localized: "Item Unpublished", bundle: .core)
             case .onlyModules:
                 if isAllModules {
                     return isPublish
-                        ? String(localized: "Only Modules published")
-                        : String(localized: "Only Modules unpublished")
+                        ? String(localized: "Only Modules published", bundle: .core)
+                        : String(localized: "Only Modules unpublished", bundle: .core)
                 } else {
                     return isPublish
-                        ? String(localized: "Only Module published")
-                        : String(localized: "Only Module unpublished")
+                        ? String(localized: "Only Module published", bundle: .core)
+                        : String(localized: "Only Module unpublished", bundle: .core)
                 }
             case .modulesAndItems:
                 if isAllModules {
                     return isPublish
-                        ? String(localized: "All Modules and all Items published")
-                        : String(localized: "All Modules and all Items unpublished")
+                        ? String(localized: "All Modules and all Items published", bundle: .core)
+                        : String(localized: "All Modules and all Items unpublished", bundle: .core)
                 } else {
                     return isPublish
-                        ? String(localized: "Module and all Items published")
-                        : String(localized: "Module and all Items unpublished")
+                        ? String(localized: "Module and all Items published", bundle: .core)
+                        : String(localized: "Module and all Items unpublished", bundle: .core)
                 }
             }
         case .failure:
             switch action.subject {
             case .none:
                 return isPublish
-                    ? String(localized: "Failed To Publish Item")
-                    : String(localized: "Failed To Unpublish Item")
+                    ? String(localized: "Failed To Publish Item", bundle: .core)
+                    : String(localized: "Failed To Unpublish Item", bundle: .core)
             case .onlyModules:
                 if isAllModules {
                     return isPublish
-                        ? String(localized: "Failed to publish only Modules")
-                        : String(localized: "Failed to unpublish only Modules")
+                        ? String(localized: "Failed to publish only Modules", bundle: .core)
+                        : String(localized: "Failed to unpublish only Modules", bundle: .core)
                 } else {
                     return isPublish
-                        ? String(localized: "Failed to publish only Module")
-                        : String(localized: "Failed to unpublish only Module")
+                        ? String(localized: "Failed to publish only Module", bundle: .core)
+                        : String(localized: "Failed to unpublish only Module", bundle: .core)
                 }
             case .modulesAndItems:
                 if isAllModules {
                     return isPublish
-                        ? String(localized: "Failed to publish all Modules and all Items")
-                        : String(localized: "Failed to unpublish all Modules and all Items")
+                        ? String(localized: "Failed to publish all Modules and all Items", bundle: .core)
+                        : String(localized: "Failed to unpublish all Modules and all Items", bundle: .core)
                 } else {
                     return isPublish
-                        ? String(localized: "Failed to publish Module and all Items")
-                        : String(localized: "Failed to unpublish Module and all Items")
+                        ? String(localized: "Failed to publish Module and all Items", bundle: .core)
+                        : String(localized: "Failed to unpublish Module and all Items", bundle: .core)
                 }
             }
         }

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -111,14 +111,14 @@ class ModuleItemCell: UITableViewCell {
                 return nil
             } else {
                 return String.localizedStringWithFormat(
-                    NSLocalizedString("%@ pts", bundle: .core, comment: ""),
+                    String(localized: "%@ pts", bundle: .core),
                     NSNumber(value: $0)
                 )
             }
         }
         let requirement = item.completionRequirement?.description
         if let masteryPath = item.masteryPath, masteryPath.needsSelection, !masteryPath.locked {
-            let format = NSLocalizedString("d_options", bundle: .core, comment: "")
+            let format = String(localized: "d_options", bundle: .core)
             dueLabel.setText(String.localizedStringWithFormat(format, masteryPath.numberOfOptions), style: .textCellSupportingText)
             dueLabel.textColor = tintColor
             accessoryView = UIImageView(image: .masteryPathsLine)

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -139,22 +139,22 @@ class ModuleItemCell: UITableViewCell {
         if shouldShowPublishControl {
             let publishedText = {
                 if isPublishing {
-                    return String(localized: "Publish state modification in progress")
+                    return String(localized: "Publish state modification in progress", bundle: .core)
                 }
 
                 if let availability = item.fileAvailability {
                     return availability.a11yLabel
                 } else {
                     return item.published == true
-                        ? String(localized: "published")
-                        : String(localized: "unpublished")
+                        ? String(localized: "published", bundle: .core)
+                        : String(localized: "unpublished", bundle: .core)
                 }
             }()
             a11yLabels.append(publishedText)
         } else {
             a11yLabels.append(contentsOf: [
                 dueLabel.text,
-                item.isLocked ? String(localized: "locked") : nil,
+                item.isLocked ? String(localized: "locked", bundle: .core) : nil,
             ])
         }
 
@@ -220,7 +220,7 @@ class ModuleItemCell: UITableViewCell {
             }
             accessibilityCustomActions = [
                 .init(
-                    name: String(localized: "Edit permissions"),
+                    name: String(localized: "Edit permissions", bundle: .core),
                     target: self,
                     selector: #selector(presentFilePermissionEditorDialog)
                 ),
@@ -259,7 +259,7 @@ class ModuleItemCell: UITableViewCell {
 
     @objc
     private func showCantUnpublishSnackBar() {
-        let message = String(localized: "Can’t unpublish, if there are student submissions.")
+        let message = String(localized: "Can’t unpublish, if there are student submissions.", bundle: .core)
         host?.findSnackBarViewModel()?.showSnack(message)
     }
 
@@ -295,10 +295,10 @@ private extension ModuleItem {
 private extension FileAvailability {
     var a11yLabel: String {
         switch self {
-        case .published: return String(localized: "published")
-        case .unpublished: return String(localized: "unpublished")
-        case .hidden: return String(localized: "only available with link")
-        case .scheduledAvailability: return String(localized: "scheduled availability")
+        case .published: return String(localized: "published", bundle: .core)
+        case .unpublished: return String(localized: "unpublished", bundle: .core)
+        case .hidden: return String(localized: "only available with link", bundle: .core)
+        case .scheduledAvailability: return String(localized: "scheduled availability", bundle: .core)
         }
     }
 }

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -70,15 +70,15 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Modules", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Modules", bundle: .core))
 
         collapsedIDs[courseID] = collapsedIDs[courseID] ?? []
         if let moduleID = moduleID {
             collapsedIDs[courseID]?.removeAll { $0 == moduleID }
         }
 
-        emptyMessageLabel.text = NSLocalizedString("There are no modules to display yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Modules", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "There are no modules to display yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Modules", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         refreshControl.color = nil
@@ -92,7 +92,7 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         tableView.registerHeaderFooterView(ModuleSectionHeaderView.self, fromNib: false)
         if let footer = tableView.tableFooterView as? UILabel {
             footer.isHidden = true
-            footer.text = NSLocalizedString("Loading more modules...", bundle: .core, comment: "")
+            footer.text = String(localized: "Loading more modules...", bundle: .core)
             tableView.contentInset.bottom = -footer.frame.height
         }
 
@@ -119,10 +119,10 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         emptyView.isHidden = modules.pending || !modules.isEmpty || modules.error != nil || isPageDisabled
         errorView.isHidden = pending || (modules.error == nil && !isPageDisabled)
         if isPageDisabled {
-            errorView.messageLabel.text = NSLocalizedString("This page has been disabled for this course.", bundle: .core, comment: "")
+            errorView.messageLabel.text = String(localized: "This page has been disabled for this course.", bundle: .core)
             errorView.retryButton.isHidden = true
         } else {
-            errorView.messageLabel.text = NSLocalizedString("There was an error loading modules.", bundle: .core, comment: "")
+            errorView.messageLabel.text = String(localized: "There was an error loading modules.", bundle: .core)
             errorView.retryButton.isHidden = false
         }
         tableView.tableFooterView?.setNeedsLayout()
@@ -255,12 +255,12 @@ extension ModuleListViewController: UITableViewDataSource {
     private func showLockedMessage(module: Module) {
         guard let message = module.lockedMessage else { return }
         let alert = UIAlertController(
-            title: NSLocalizedString("Locked", bundle: .core, comment: ""),
+            title: String(localized: "Locked", bundle: .core),
             message: message,
             preferredStyle: .alert
         )
         alert.addAction(UIAlertAction(
-            title: NSLocalizedString("OK", bundle: .core, comment: ""),
+            title: String(localized: "OK", bundle: .core),
             style: .default,
             handler: nil
         ))
@@ -316,7 +316,7 @@ extension ModuleListViewController {
             fullDivider = true
             let label = UILabel()
             label.translatesAutoresizingMaskIntoConstraints = false
-            label.text = NSLocalizedString("This module is empty.", bundle: .core, comment: "")
+            label.text = String(localized: "This module is empty.", bundle: .core)
             label.textAlignment = .center
             label.font = .scaledNamedFont(.medium12)
             label.textColor = .textDark

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -143,7 +143,7 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
         button.menu = .makePublishAllModulesMenu(host: self) { [weak self] action in
             self?.didPerformPublishAction(action: action)
         }
-        button.accessibilityLabel = String(localized: "Publish options")
+        button.accessibilityLabel = String(localized: "Publish options", bundle: .core)
         navigationItem.setRightBarButton(button, animated: true)
 
         publishInteractor

--- a/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -102,7 +102,7 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
     private func updateA11yLabel(_ module: Module, isPublishing: Bool) {
         let publishedState: String? = {
             if isPublishing {
-                return String(localized: "Publish state modification in progress")
+                return String(localized: "Publish state modification in progress", bundle: .core)
             }
 
             guard let published = module.published, shouldShowPublishControl else {
@@ -110,16 +110,16 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
             }
 
             return published
-                ? String(localized: "published")
-                : String(localized: "unpublished")
+                ? String(localized: "published", bundle: .core)
+                : String(localized: "unpublished", bundle: .core)
         }()
 
         accessibilityLabel = [
             module.name,
             publishedState,
             isExpanded
-                ? String(localized: "expanded")
-                : String(localized: "collapsed"),
+                ? String(localized: "expanded", bundle: .core)
+                : String(localized: "collapsed", bundle: .core),
         ].compactMap { $0 }.joined(separator: ", ")
     }
 

--- a/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
@@ -37,8 +37,8 @@ struct ModuleFilePermissionEditorView: View {
             case .error:
                 InteractivePanda(
                     scene: FilesPanda(),
-                    title: Text("Something went wrong"),
-                    subtitle: Text("There was an unexpected error. Please try again.")
+                    title: Text("Something went wrong", bundle: .core),
+                    subtitle: Text("There was an unexpected error. Please try again.", bundle: .core)
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
             case .data:
@@ -46,13 +46,13 @@ struct ModuleFilePermissionEditorView: View {
             }
         }
         .background(Color.backgroundLightest)
-        .navigationTitle(Text("Edit Permissions"))
+        .navigationTitle(Text("Edit Permissions", bundle: .core))
         .navigationBarItems(leading: cancelNavButton)
     }
 
     private var form: some View {
         EditorForm(isSpinning: viewModel.isUploading) {
-            EditorSection(label: Text("Availability")) {
+            EditorSection(label: Text("Availability", bundle: .core)) {
                 ForEach(FileAvailability.allCases) { availability in
                     let binding = Binding {
                         viewModel.availability == availability
@@ -69,7 +69,7 @@ struct ModuleFilePermissionEditorView: View {
                 }
             }
 
-            EditorSection(label: Text("Visibility")) {
+            EditorSection(label: Text("Visibility", bundle: .core)) {
                 ForEach(FileVisibility.allCases) { visibility in
                     let binding = Binding {
                         viewModel.visibility == visibility
@@ -86,8 +86,8 @@ struct ModuleFilePermissionEditorView: View {
         .navigationBarItems(trailing: doneNavButton)
         .alert(isPresented: $viewModel.showError) {
             Alert(
-                title: Text("Something went wrong"),
-                message: Text("There was an unexpected error. Please try again.")
+                title: Text("Something went wrong", bundle: .core),
+                message: Text("There was an unexpected error. Please try again.", bundle: .core)
             )
         }
     }
@@ -103,13 +103,13 @@ struct ModuleFilePermissionEditorView: View {
             DatePickerRow(date: fromBinding,
                           defaultDate: viewModel.defaultFromDate,
                           validUntil: viewModel.availableUntil?.addMinutes(-1) ?? .distantFuture,
-                          label: Text("From"))
+                          label: Text("From", bundle: .core))
             .animation(.default, value: viewModel.availableFrom)
             separator.padding(.leading, 16)
             DatePickerRow(date: untilBinding,
                           defaultDate: viewModel.defaultUntilDate,
                           validFrom: viewModel.availableFrom?.addMinutes(1) ?? .distantPast,
-                          label: Text("Until"))
+                          label: Text("Until", bundle: .core))
             .animation(.default, value: viewModel.availableUntil)
         }
         .transition(.move(edge: .top))
@@ -120,7 +120,7 @@ struct ModuleFilePermissionEditorView: View {
         Button {
             viewModel.cancelDidPress.send(viewController.value)
         } label: {
-            Text("Cancel")
+            Text("Cancel", bundle: .core)
         }
     }
 
@@ -128,7 +128,7 @@ struct ModuleFilePermissionEditorView: View {
         Button {
             viewModel.doneDidPress.send(viewController.value)
         } label: {
-            Text("Done")
+            Text("Done", bundle: .core)
         }
         .disabled(!viewModel.isDoneButtonActive)
     }

--- a/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModuleFilePermissionEditorView.swift
@@ -142,10 +142,10 @@ struct ModuleFilePermissionEditorView: View {
 private extension FileAvailability {
     var label: String {
         switch self {
-        case .published: return String(localized: "Publish")
-        case .unpublished: return String(localized: "Unpublish")
-        case .hidden: return String(localized: "Only Available With Link")
-        case .scheduledAvailability: return String(localized: "Schedule Availability")
+        case .published: return String(localized: "Publish", bundle: .core)
+        case .unpublished: return String(localized: "Unpublish", bundle: .core)
+        case .hidden: return String(localized: "Only Available With Link", bundle: .core)
+        case .scheduledAvailability: return String(localized: "Schedule Availability", bundle: .core)
         }
     }
 }

--- a/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
@@ -53,13 +53,13 @@ struct ModulePublishProgressView: View {
     private var titleText: Text {
         switch viewModel.title {
         case .allModulesAndItems:
-            Text("All Modules and Items")
+            Text("All Modules and Items", bundle: .core)
         case .allModules:
             Text("All Modules")
         case .selectedModuleAndItems:
-            Text("Selected Module and Items")
+            Text("Selected Module and Items", bundle: .core)
         case .selectedModule:
-            Text("Selected Module")
+            Text("Selected Module", bundle: .core)
         }
     }
 
@@ -69,17 +69,17 @@ struct ModulePublishProgressView: View {
             viewModel.didTapDismiss.send(viewController)
         } label: {
             Image.xLine.navigationBarButtonStyle()
-                .accessibilityLabel(Text("Dismiss"))
+                .accessibilityLabel(Text("Dismiss", bundle: .core))
         }
     }
 
     @ViewBuilder
     private var cancelButton: some View {
-        let snackBarTitle = String(localized: "Update cancelled")
+        let snackBarTitle = String(localized: "Update cancelled", bundle: .core)
         Button {
             viewModel.didTapCancel.send((viewController, snackBarTitle))
         } label: {
-            Text("Cancel").navigationBarButtonStyle()
+            Text("Cancel", bundle: .core).navigationBarButtonStyle()
         }
     }
 
@@ -88,7 +88,7 @@ struct ModulePublishProgressView: View {
         Button {
             viewModel.didTapDone.send(viewController)
         } label: {
-            Text("Done").navigationBarButtonStyle()
+            Text("Done", bundle: .core).navigationBarButtonStyle()
         }
     }
 
@@ -147,15 +147,15 @@ struct ModulePublishProgressView: View {
     @ViewBuilder
     private var textArea: some View {
         VStack(spacing: 0) {
-            Text("This process could take a few minutes. You may close the modal or navigate away from the page during this process.")
+            Text("This process could take a few minutes. You may close the modal or navigate away from the page during this process.", bundle: .core)
                 .font(.regular16).foregroundStyle(Color.textDarkest)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 24)
-            Text("Note")
+            Text("Note", bundle: .core)
                 .font(.regular14).foregroundStyle(Color.textDark)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.bottom, 4)
-            Text("Modules and items that have already been processed will not be reverted to their previous state when the process is discontinued.")
+            Text("Modules and items that have already been processed will not be reverted to their previous state when the process is discontinued.", bundle: .core)
                 .font(.regular16).foregroundStyle(Color.textDarkest)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }

--- a/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
+++ b/Core/Core/Modules/ModuleList/View/ModulePublishProgressView.swift
@@ -123,21 +123,21 @@ struct ModulePublishProgressView: View {
         switch viewModel.state {
         case .inProgress:
             if viewModel.isPublish {
-                return String(localized: "Publishing \(percentage)%")
+                return String(localized: "Publishing \(percentage)%", bundle: .core)
             } else {
-                return String(localized: "Unpublishing \(percentage)%")
+                return String(localized: "Unpublishing \(percentage)%", bundle: .core)
             }
         case .completed:
             if viewModel.isPublish {
-                return String(localized: "Published 100%")
+                return String(localized: "Published 100%", bundle: .core)
             } else {
-                return String(localized: "Unpublished 100%")
+                return String(localized: "Unpublished 100%", bundle: .core)
             }
         case .error:
             if forAccessibility {
-                return String(localized: "Update failed at \(percentage)%")
+                return String(localized: "Update failed at \(percentage)%", bundle: .core)
             } else {
-                return String(localized: "Update failed")
+                return String(localized: "Update failed", bundle: .core)
             }
         }
     }

--- a/Core/Core/Modules/ModuleList/ViewModel/ModulePublishMenu.swift
+++ b/Core/Core/Modules/ModuleList/ViewModel/ModulePublishMenu.swift
@@ -125,54 +125,54 @@ private enum ModulePublishMenuModel {
 
     enum AllModules {
         static let publishWithItems = ModulePublishItem(
-            title: String(localized: "Publish All Modules And Items"),
-            confirmMessage: String(localized: "This will make all modules and items visible to students."),
+            title: String(localized: "Publish All Modules And Items", bundle: .core),
+            confirmMessage: String(localized: "This will make all modules and items visible to students.", bundle: .core),
             action: .publish(.modulesAndItems)
         )
 
         static let publishWithoutItems = ModulePublishItem(
-            title: String(localized: "Publish Modules Only"),
-            confirmMessage: String(localized: "This will make only the modules visible to students."),
+            title: String(localized: "Publish Modules Only", bundle: .core),
+            confirmMessage: String(localized: "This will make only the modules visible to students.", bundle: .core),
             action: .publish(.onlyModules)
         )
 
         static let unpublishWithItems = ModulePublishItem(
-            title: String(localized: "Unpublish All Modules And Items"),
-            confirmMessage: String(localized: "This will make all modules and items invisible to students."),
+            title: String(localized: "Unpublish All Modules And Items", bundle: .core),
+            confirmMessage: String(localized: "This will make all modules and items invisible to students.", bundle: .core),
             action: .unpublish(.modulesAndItems)
         )
     }
 
     enum Module {
         static let publishWithItems = ModulePublishItem(
-            title: String(localized: "Publish Module And All Items"),
-            confirmMessage: String(localized: "This will make the module and all items visible to students."),
+            title: String(localized: "Publish Module And All Items", bundle: .core),
+            confirmMessage: String(localized: "This will make the module and all items visible to students.", bundle: .core),
             action: .publish(.modulesAndItems)
         )
 
         static let publishWithoutItems = ModulePublishItem(
-            title: String(localized: "Publish Module Only"),
-            confirmMessage: String(localized: "This will make only the module visible to students."),
+            title: String(localized: "Publish Module Only", bundle: .core),
+            confirmMessage: String(localized: "This will make only the module visible to students.", bundle: .core),
             action: .publish(.onlyModules)
         )
 
         static let unpublishWithItems = ModulePublishItem(
-            title: String(localized: "Unpublish Module And All Items"),
-            confirmMessage: String(localized: "This will make the module and all items invisible to students."),
+            title: String(localized: "Unpublish Module And All Items", bundle: .core),
+            confirmMessage: String(localized: "This will make the module and all items invisible to students.", bundle: .core),
             action: .unpublish(.modulesAndItems)
         )
     }
 
     enum Item {
         static let publish = ModulePublishItem(
-            title: String(localized: "Publish"),
-            confirmMessage: String(localized: "This will make only this item visible to students."),
+            title: String(localized: "Publish", bundle: .core),
+            confirmMessage: String(localized: "This will make only this item visible to students.", bundle: .core),
             action: .publish
         )
 
         static let unpublish = ModulePublishItem(
-            title: String(localized: "Unpublish"),
-            confirmMessage: String(localized: "This will make only this item invisible to students."),
+            title: String(localized: "Unpublish", bundle: .core),
+            confirmMessage: String(localized: "This will make only this item invisible to students.", bundle: .core),
             action: .unpublish
         )
     }
@@ -275,7 +275,7 @@ private extension UIAlertController {
         addAction(AlertAction(modulePublishItem.action.alertConfirmation, style: .default) { _ in
             actionDidPerform()
         })
-        addAction(AlertAction(String(localized: "Cancel"), style: .cancel))
+        addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
     }
 }
 
@@ -283,15 +283,15 @@ private extension ModulePublishAction {
 
     var alertTitle: String {
         switch self {
-        case .publish: return String(localized: "Publish?")
-        case .unpublish: return String(localized: "Unpublish?")
+        case .publish: return String(localized: "Publish?", bundle: .core)
+        case .unpublish: return String(localized: "Unpublish?", bundle: .core)
         }
     }
 
     var alertConfirmation: String {
         switch self {
-        case .publish: return String(localized: "Publish")
-        case .unpublish: return String(localized: "Unpublish")
+        case .publish: return String(localized: "Publish", bundle: .core)
+        case .unpublish: return String(localized: "Unpublish", bundle: .core)
         }
     }
 }

--- a/Core/Core/Notifications/APICommunicationChannel.swift
+++ b/Core/Core/Notifications/APICommunicationChannel.swift
@@ -34,19 +34,19 @@ public enum CommunicationChannelType: String, Codable {
     var name: String {
         switch self {
         case .chat:
-            return NSLocalizedString("Chat Notifications", bundle: .core, comment: "Description for Chat communication channel")
+            return String(localized: "Chat Notifications", bundle: .core, comment: "Description for Chat communication channel")
         case .email:
-            return NSLocalizedString("Email Notifications", bundle: .core, comment: "Description for email communication channel")
+            return String(localized: "Email Notifications", bundle: .core, comment: "Description for email communication channel")
         case .push:
-            return NSLocalizedString("Push Notifications", bundle: .core, comment: "Description for Push Notification channel")
+            return String(localized: "Push Notifications", bundle: .core, comment: "Description for Push Notification channel")
         case .slack:
-            return NSLocalizedString("Slack Notifications", bundle: .core, comment: "Description for Slack communication channel")
+            return String(localized: "Slack Notifications", bundle: .core, comment: "Description for Slack communication channel")
         case .sms:
-            return NSLocalizedString("SMS Notifications", bundle: .core, comment: "Description for SMS communication channel")
+            return String(localized: "SMS Notifications", bundle: .core, comment: "Description for SMS communication channel")
         case .twitter:
-            return NSLocalizedString("Twitter Notifications", bundle: .core, comment: "Description for Twitter communication channel")
+            return String(localized: "Twitter Notifications", bundle: .core, comment: "Description for Twitter communication channel")
         case .yo:
-            return NSLocalizedString("Yo Notifications", bundle: .core, comment: "Description for Yo communication channel")
+            return String(localized: "Yo Notifications", bundle: .core, comment: "Description for Yo communication channel")
         }
     }
 }

--- a/Core/Core/Notifications/APINotificationPreferences.swift
+++ b/Core/Core/Notifications/APINotificationPreferences.swift
@@ -31,26 +31,26 @@ public enum NotificationFrequency: String, CaseIterable, Codable {
     var name: String {
         switch self {
         case .immediately:
-            return NSLocalizedString("Immediately", bundle: .core, comment: "")
+            return String(localized: "Immediately", bundle: .core)
         case .daily:
-            return NSLocalizedString("Daily", bundle: .core, comment: "")
+            return String(localized: "Daily", bundle: .core)
         case .weekly:
-            return NSLocalizedString("Weekly", bundle: .core, comment: "")
+            return String(localized: "Weekly", bundle: .core)
         case .never:
-            return NSLocalizedString("Never", bundle: .core, comment: "")
+            return String(localized: "Never", bundle: .core)
         }
     }
 
     var label: String {
         switch self {
         case .immediately:
-            return NSLocalizedString("Notify me right away", bundle: .core, comment: "")
+            return String(localized: "Notify me right away", bundle: .core)
         case .daily:
-            return NSLocalizedString("Send daily summary", bundle: .core, comment: "")
+            return String(localized: "Send daily summary", bundle: .core)
         case .weekly:
-            return NSLocalizedString("Send weekly summary", bundle: .core, comment: "")
+            return String(localized: "Send weekly summary", bundle: .core)
         case .never:
-            return NSLocalizedString("Do not send me anything", bundle: .core, comment: "")
+            return String(localized: "Do not send me anything", bundle: .core)
         }
     }
 }

--- a/Core/Core/Notifications/AlertThreshold.swift
+++ b/Core/Core/Notifications/AlertThreshold.swift
@@ -31,19 +31,19 @@ public enum AlertThresholdType: String, CaseIterable, Codable {
     public var name: String {
         switch self {
         case .courseGradeLow:
-            return NSLocalizedString("Course grade below", bundle: .core, comment: "")
+            return String(localized: "Course grade below", bundle: .core)
         case .courseGradeHigh:
-            return NSLocalizedString("Course grade above", bundle: .core, comment: "")
+            return String(localized: "Course grade above", bundle: .core)
         case .assignmentMissing:
-            return NSLocalizedString("Assignment missing", bundle: .core, comment: "")
+            return String(localized: "Assignment missing", bundle: .core)
         case .assignmentGradeLow:
-            return NSLocalizedString("Assignment grade below", bundle: .core, comment: "")
+            return String(localized: "Assignment grade below", bundle: .core)
         case .assignmentGradeHigh:
-            return NSLocalizedString("Assignment grade above", bundle: .core, comment: "")
+            return String(localized: "Assignment grade above", bundle: .core)
         case .institutionAnnouncement:
-            return NSLocalizedString("Institution announcements", bundle: .core, comment: "")
+            return String(localized: "Institution announcements", bundle: .core)
         case .courseAnnouncement:
-            return NSLocalizedString("Course announcements", bundle: .core, comment: "")
+            return String(localized: "Course announcements", bundle: .core)
         }
     }
 
@@ -51,19 +51,19 @@ public enum AlertThresholdType: String, CaseIterable, Codable {
         let title: String
         switch self {
         case .courseGradeLow:
-            title = NSLocalizedString("Course Grade Below %d", bundle: .core, comment: "")
+            title = String(localized: "Course Grade Below %d", bundle: .core)
         case .courseGradeHigh:
-            title = NSLocalizedString("Course Grade Above %d", bundle: .core, comment: "")
+            title = String(localized: "Course Grade Above %d", bundle: .core)
         case .assignmentMissing:
-            title = NSLocalizedString("Assignment Missing", bundle: .core, comment: "")
+            title = String(localized: "Assignment Missing", bundle: .core)
         case .assignmentGradeLow:
-            title = NSLocalizedString("Assignment Grade Below %d", bundle: .core, comment: "")
+            title = String(localized: "Assignment Grade Below %d", bundle: .core)
         case .assignmentGradeHigh:
-            title = NSLocalizedString("Assignment Grade Above %d", bundle: .core, comment: "")
+            title = String(localized: "Assignment Grade Above %d", bundle: .core)
         case .courseAnnouncement:
-            title = NSLocalizedString("Course Announcement", bundle: .core, comment: "")
+            title = String(localized: "Course Announcement", bundle: .core)
         case .institutionAnnouncement:
-            title = NSLocalizedString("Institution Announcement", bundle: .core, comment: "")
+            title = String(localized: "Institution Announcement", bundle: .core)
         }
         return String.localizedStringWithFormat(title, value ?? 0)
     }

--- a/Core/Core/Notifications/LocalNotifications.swift
+++ b/Core/Core/Notifications/LocalNotifications.swift
@@ -43,8 +43,8 @@ public extension NotificationManager {
     }
 
     func sendOfflineSyncCompletedSuccessfullyNotification(syncedItemsCount: Int) -> Future<Void, Error> {
-        let title = NSLocalizedString("Offline Content Sync Success", bundle: .core, comment: "")
-        let bodyFormat = NSLocalizedString("offline_sync_finished", bundle: .core, comment: "")
+        let title = String(localized: "Offline Content Sync Success", bundle: .core)
+        let bodyFormat = String(localized: "offline_sync_finished", bundle: .core)
         let body = String.localizedStringWithFormat(bodyFormat, syncedItemsCount, syncedItemsCount)
 
         return notify(identifier: "OfflineSyncCompletedSuccessfully", title: title, body: body, route: nil)
@@ -55,8 +55,8 @@ public extension NotificationManager {
      */
     @discardableResult
     func sendOfflineSyncFailedNotificationAndWait() -> Bool {
-        let title = NSLocalizedString("Offline Content Sync Failed", bundle: .core, comment: "")
-        let body = NSLocalizedString("One or more items failed to sync.", bundle: .core, comment: "")
+        let title = String(localized: "Offline Content Sync Failed", bundle: .core)
+        let body = String(localized: "One or more items failed to sync.", bundle: .core)
         let semaphore = DispatchSemaphore(value: 0)
         var isScheduled = false
         notify(identifier: "OfflineSyncFailed", title: title, body: body, route: nil) { error in

--- a/Core/Core/Notifications/LocalNotifications.swift
+++ b/Core/Core/Notifications/LocalNotifications.swift
@@ -43,8 +43,8 @@ public extension NotificationManager {
     }
 
     func sendOfflineSyncCompletedSuccessfullyNotification(syncedItemsCount: Int) -> Future<Void, Error> {
-        let title = NSLocalizedString("Offline Content Sync Success", comment: "")
-        let bodyFormat = NSLocalizedString("offline_sync_finished", comment: "")
+        let title = NSLocalizedString("Offline Content Sync Success", bundle: .core, comment: "")
+        let bodyFormat = NSLocalizedString("offline_sync_finished", bundle: .core, comment: "")
         let body = String.localizedStringWithFormat(bodyFormat, syncedItemsCount, syncedItemsCount)
 
         return notify(identifier: "OfflineSyncCompletedSuccessfully", title: title, body: body, route: nil)
@@ -55,8 +55,8 @@ public extension NotificationManager {
      */
     @discardableResult
     func sendOfflineSyncFailedNotificationAndWait() -> Bool {
-        let title = NSLocalizedString("Offline Content Sync Failed", comment: "")
-        let body = NSLocalizedString("One or more items failed to sync.", comment: "")
+        let title = NSLocalizedString("Offline Content Sync Failed", bundle: .core, comment: "")
+        let body = NSLocalizedString("One or more items failed to sync.", bundle: .core, comment: "")
         let semaphore = DispatchSemaphore(value: 0)
         var isScheduled = false
         notify(identifier: "OfflineSyncFailed", title: title, body: body, route: nil) { error in

--- a/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
+++ b/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
@@ -27,9 +27,9 @@ extension UIAlertController {
     }
 
     public static func showItemNotAvailableInOfflineAlert(_ completion: (() -> Void)? = nil) {
-        let title = NSLocalizedString("Offline mode", comment: "")
-        let message = NSLocalizedString("This item is not available offline.", comment: "")
-        let actionTitle = NSLocalizedString("OK", comment: "")
+        let title = NSLocalizedString("Offline mode", bundle: .core, comment: "")
+        let message = NSLocalizedString("This item is not available offline.", bundle: .core, comment: "")
+        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: actionTitle, style: .default) { _ in
             completion?()

--- a/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
+++ b/Core/Core/Offline/View/NotSupportedInOfflineAlert.swift
@@ -27,9 +27,9 @@ extension UIAlertController {
     }
 
     public static func showItemNotAvailableInOfflineAlert(_ completion: (() -> Void)? = nil) {
-        let title = NSLocalizedString("Offline mode", bundle: .core, comment: "")
-        let message = NSLocalizedString("This item is not available offline.", bundle: .core, comment: "")
-        let actionTitle = NSLocalizedString("OK", bundle: .core, comment: "")
+        let title = String(localized: "Offline mode", bundle: .core)
+        let message = String(localized: "This item is not available offline.", bundle: .core)
+        let actionTitle = String(localized: "OK", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         let action = UIAlertAction(title: actionTitle, style: .default) { _ in
             completion?()

--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -77,7 +77,7 @@ public final class PageDetailsViewController: UIViewController, ColoredNavViewPr
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Page Details", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Page Details", bundle: .core))
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
         webView.linkDelegate = self
@@ -154,25 +154,25 @@ public final class PageDetailsViewController: UIViewController, ColoredNavViewPr
 
     @objc private func showOptions(_ sender: UIBarButtonItem) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.addAction(AlertAction(NSLocalizedString("Edit", bundle: .core, comment: ""), style: .default) { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Edit", bundle: .core), style: .default) { [weak self] _ in
             guard let self = self, let page = self.page else { return }
             guard let url = page.htmlURL?.appendingPathComponent("edit") else { return }
             self.env.router.route(to: url, from: self, options: .modal(isDismissable: false, embedInNav: true))
         })
         if canDelete {
-            alert.addAction(AlertAction(NSLocalizedString("Delete", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
+            alert.addAction(AlertAction(String(localized: "Delete", bundle: .core), style: .destructive) { [weak self] _ in
                 self?.showDeleteConfirmation()
             })
         }
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         alert.popoverPresentationController?.barButtonItem = sender
         env.router.show(alert, from: self, options: .modal())
     }
 
     private func showDeleteConfirmation() {
-        let alert = UIAlertController(title: NSLocalizedString("Are you sure you want to delete this page?", bundle: .core, comment: ""), message: nil, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .destructive) { [weak self] _ in
+        let alert = UIAlertController(title: String(localized: "Are you sure you want to delete this page?", bundle: .core), message: nil, preferredStyle: .alert)
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .destructive) { [weak self] _ in
             self?.deletePage()
         })
         env.router.show(alert, from: self)

--- a/Core/Core/Pages/PageEditor/PageEditorView.swift
+++ b/Core/Core/Pages/PageEditor/PageEditorView.swift
@@ -88,8 +88,8 @@ public struct PageEditorView: View {
 
             EditorSection(label: Text("Content", bundle: .core)) {
                 RichContentEditor(
-                    placeholder: NSLocalizedString("Add content", bundle: .core, comment: ""),
-                    a11yLabel: NSLocalizedString("Page content", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Add content", bundle: .core),
+                    a11yLabel: String(localized: "Page content", bundle: .core),
                     html: $html,
                     context: context,
                     uploadTo: .context(context),
@@ -123,7 +123,7 @@ public struct PageEditorView: View {
                             ? [ .members, .public ]
                             : [ .teachers, .teachersAndStudents, .public ]
                         self.env.router.show(ItemPickerViewController.create(
-                            title: NSLocalizedString("Can Edit", bundle: .core, comment: ""),
+                            title: String(localized: "Can Edit", bundle: .core),
                             sections: [ ItemPickerSection(items: options.map {
                                 ItemPickerItem(title: $0.string)
                             }), ],
@@ -199,13 +199,13 @@ public struct PageEditorView: View {
         var string: String {
             switch self {
             case .public:
-                return NSLocalizedString("Anyone", bundle: .core, comment: "")
+                return String(localized: "Anyone", bundle: .core)
             case .members:
-                return NSLocalizedString("Only members", bundle: .core, comment: "")
+                return String(localized: "Only members", bundle: .core)
             case .teachers:
-                return NSLocalizedString("Only teachers", bundle: .core, comment: "")
+                return String(localized: "Only teachers", bundle: .core)
             case .teachersAndStudents:
-                return NSLocalizedString("Teachers and students", bundle: .core, comment: "")
+                return String(localized: "Teachers and students", bundle: .core)
             }
         }
     }

--- a/Core/Core/Pages/PageList/PageListViewController.swift
+++ b/Core/Core/Pages/PageList/PageListViewController.swift
@@ -63,16 +63,16 @@ public class PageListViewController: ScreenViewTrackableViewController, ColoredN
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Pages", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Pages", bundle: .core))
         if canCreatePage {
             let item = UIBarButtonItem(image: .addSolid, style: .plain, target: self, action: #selector(createPage))
             item.accessibilityIdentifier = "PageList.add"
             navigationItem.rightBarButtonItem = item
         }
 
-        emptyMessageLabel.text = NSLocalizedString("There are no pages to display yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Pages", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading pages. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "There are no pages to display yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Pages", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading pages. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
@@ -218,7 +218,7 @@ class PageListFrontPageCell: UITableViewCell {
     func update(_ page: Page?) {
         backgroundColor = .backgroundLightest
         accessibilityIdentifier = "PageList.frontPage"
-        headingLabel.text = NSLocalizedString("Front Page", bundle: .core, comment: "")
+        headingLabel.text = String(localized: "Front Page", bundle: .core)
         headingLabel.accessibilityIdentifier = "PageList.frontPageHeading"
         titleLabel.text = page?.title
         titleLabel.accessibilityIdentifier = "PageList.frontPageTitle"

--- a/Core/Core/People/ContextCard/Course/ContextCardGradesView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardGradesView.swift
@@ -75,22 +75,22 @@ struct ContextCardGradesView: View {
     var body: some View {
         if let grade = grade {
             VStack(alignment: .leading, spacing: 10) {
-                Text("Grades")
+                Text("Grades", bundle: .core)
                     .font(.semibold14)
                     .foregroundColor(.textDark)
                 HStack {
-                    let subTitle = unpostedGrade != nil ? Text("Grade before posting") : Text("Current Grade")
+                    let subTitle = unpostedGrade != nil ? Text("Grade before posting", bundle: .core) : Text("Current Grade", bundle: .core)
                     ContextCardBoxView(title: Text(grade), subTitle: subTitle, selectedColor: gradeSelected ? color : nil)
                         .accessibility(label: Text("\(subTitle.key ?? "") \(grade)", bundle: .core))
                         .identifier("ContextCard.currentGradeLabel")
                     if let unpostedGrade = unpostedGrade {
-                        let subTitle = Text("Grade after posting")
+                        let subTitle = Text("Grade after posting", bundle: .core)
                         ContextCardBoxView(title: Text(unpostedGrade), subTitle: subTitle, selectedColor: unpostedSelected ? color : nil)
                             .accessibility(label: Text("\(subTitle.key ?? "") \(unpostedGrade)", bundle: .core))
                             .identifier("ContextCard.unpostedGradeLabel")
                     }
                     if let overrideGrade = overrideGrade {
-                        let subTitle = Text("Grade Override")
+                        let subTitle = Text("Grade Override", bundle: .core)
 
                         ContextCardBoxView(title: Text(overrideGrade), subTitle: subTitle, selectedColor: color)
                             .accessibility(label: Text("\(subTitle.key ?? "") \(overrideGrade)", bundle: .core))

--- a/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
@@ -41,7 +41,7 @@ struct ContextCardHeaderView: View {
                     .identifier("ContextCard.userEmailLabel")
             }
             if showLastActivity, let activityTime = enrollment.lastActivityAt?.dateTimeString {
-                Text("Last activity on \(activityTime)")
+                Text("Last activity on \(activityTime)", bundle: .core)
                     .font(.regular12)
                     .foregroundColor(.textDark)
                     .identifier("ContextCard.lastActivityLabel")

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
@@ -50,7 +50,7 @@ struct ContextCardSubmissionRow: View {
             }
         }
         .padding(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
-        .accessibility(label: Text("Submission \(assignment.name), \(submission.status.text), \(a11ySubmissionStatus)"))
+        .accessibility(label: Text("Submission \(assignment.name), \(submission.status.text), \(a11ySubmissionStatus)", bundle: .core))
         .identifier("ContextCard.submissionCell(\(assignment.id))")
     }
 

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
@@ -77,9 +77,9 @@ struct ContextCardSubmissionRow: View {
         }()
         self.a11ySubmissionStatus = {
             if submission.needsGrading {
-                return NSLocalizedString("NEEDS GRADING", comment: "")
+                return NSLocalizedString("NEEDS GRADING", bundle: .core, comment: "")
             } else if submission.workflowState == .graded, submission.score != nil, let grade = GradeFormatter.string(from: assignment, submission: submission) {
-                return NSLocalizedString("grade", comment: "") + " " + grade
+                return NSLocalizedString("grade", bundle: .core, comment: "") + " " + grade
             } else {
                 return ""
             }

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
@@ -77,9 +77,9 @@ struct ContextCardSubmissionRow: View {
         }()
         self.a11ySubmissionStatus = {
             if submission.needsGrading {
-                return NSLocalizedString("NEEDS GRADING", bundle: .core, comment: "")
+                return String(localized: "NEEDS GRADING", bundle: .core)
             } else if submission.workflowState == .graded, submission.score != nil, let grade = GradeFormatter.string(from: assignment, submission: submission) {
-                return NSLocalizedString("grade", bundle: .core, comment: "") + " " + grade
+                return String(localized: "grade", bundle: .core) + " " + grade
             } else {
                 return ""
             }

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
@@ -41,17 +41,17 @@ struct ContextCardSubmissionsView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
-            Text("Submissions")
+            Text("Submissions", bundle: .core)
                 .font(.semibold14)
                 .foregroundColor(.textDark)
             HStack {
-                ContextCardBoxView(title: Text("\(submitted)"), subTitle: Text("Submitted"))
+                ContextCardBoxView(title: Text("\(submitted)"), subTitle: Text("Submitted", bundle: .core))
                     .accessibility(label: Text("\(submitted) submitted", bundle: .core))
                     .identifier("ContextCard.submissionsTotalLabel")
-                ContextCardBoxView(title: Text("\(late)"), subTitle: Text("Late"))
+                ContextCardBoxView(title: Text("\(late)"), subTitle: Text("Late", bundle: .core))
                     .accessibility(label: Text("\(late) late", bundle: .core))
                     .identifier("ContextCard.submissionsLateLabel")
-                ContextCardBoxView(title: Text("\(missing)"), subTitle: Text("Missing"))
+                ContextCardBoxView(title: Text("\(missing)"), subTitle: Text("Missing", bundle: .core))
                     .accessibility(label: Text("\(missing) missing", bundle: .core))
                     .identifier("ContextCard.submissionsMissingLabel")
             }

--- a/Core/Core/People/ContextCard/Course/ContextCardView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardView.swift
@@ -80,9 +80,9 @@ public struct ContextCardView: View {
             } else if let course = model.course.first, let apiUser = model.apiUser,
                       let apiEnrollment = apiUser.enrollments?.first(where: { $0.course_id?.rawValue == course.id}),
                       apiEnrollment.enrollment_state == EnrollmentState.invited {
-                EmptyPanda(.Sleeping, title: Text("Not enrolled"), message: Text("Invitation pending"))
+                EmptyPanda(.Sleeping, title: Text("Not enrolled", bundle: .core), message: Text("Invitation pending", bundle: .core))
             } else {
-                EmptyPanda(.Unsupported, title: Text("Something went wrong"), message: Text("There was an error while communicating with the server"))
+                EmptyPanda(.Unsupported, title: Text("Something went wrong", bundle: .core), message: Text("There was an error while communicating with the server", bundle: .core))
             }
         }
     }

--- a/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
+++ b/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
@@ -78,7 +78,7 @@ public struct GroupContextCardView: View {
                     UIAccessibility.post(notification: .screenChanged, argument: nil)
                 }
             } else {
-                EmptyPanda(.Unsupported, title: Text("Something went wrong"), message: Text("There was an error while communicating with the server"))
+                EmptyPanda(.Unsupported, title: Text("Something went wrong", bundle: .core), message: Text("There was an error while communicating with the server", bundle: .core))
             }
         }
     }

--- a/Core/Core/People/GetContextUsers.swift
+++ b/Core/Core/People/GetContextUsers.swift
@@ -66,15 +66,15 @@ public enum BaseEnrollmentType: String, CaseIterable {
     var name: String {
         switch self {
         case .designer:
-            return NSLocalizedString("Designers", bundle: .core, comment: "")
+            return String(localized: "Designers", bundle: .core)
         case .observer:
-            return NSLocalizedString("Observers", bundle: .core, comment: "")
+            return String(localized: "Observers", bundle: .core)
         case .student:
-            return NSLocalizedString("Students", bundle: .core, comment: "")
+            return String(localized: "Students", bundle: .core)
         case .ta:
-            return NSLocalizedString("Teaching Assistants", bundle: .core, comment: "")
+            return String(localized: "Teaching Assistants", bundle: .core)
         case .teacher:
-            return NSLocalizedString("Teachers", bundle: .core, comment: "")
+            return String(localized: "Teachers", bundle: .core)
         }
     }
 }

--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -68,14 +68,14 @@ public class PeopleListViewController: ScreenViewTrackableViewController, Colore
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("People", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "People", bundle: .core))
 
-        emptyMessageLabel.text = NSLocalizedString("We couldn’t find somebody like that.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Results", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading people. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "We couldn’t find somebody like that.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Results", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading people. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
-        searchBar.placeholder = NSLocalizedString("Search", bundle: .core, comment: "")
+        searchBar.placeholder = String(localized: "Search", bundle: .core)
         searchBar.backgroundColor = .backgroundLightest
         tableView.backgroundColor = .backgroundLightest
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
@@ -153,14 +153,14 @@ public class PeopleListViewController: ScreenViewTrackableViewController, Colore
             accessibilityFocusAfterReload = nil
             return updateUsers()
         }
-        let alert = UIAlertController(title: NSLocalizedString("Filter by:", bundle: .core, comment: ""), message: nil, preferredStyle: .actionSheet)
+        let alert = UIAlertController(title: String(localized: "Filter by:", bundle: .core), message: nil, preferredStyle: .actionSheet)
         for type in enrollmentTypes {
             alert.addAction(AlertAction(type.name, style: .default) { _ in
                 self.enrollmentType = type
                 self.updateUsers()
             })
         }
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         alert.popoverPresentationController?.sourceView = sender
         alert.popoverPresentationController?.sourceRect = sender.bounds
         env.router.show(alert, from: self, options: .modal())
@@ -212,12 +212,12 @@ extension PeopleListViewController: UITableViewDataSource, UITableViewDelegate {
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard context.contextType == .course else { return nil }
         let header: FilterHeaderView = tableView.dequeueHeaderFooter()
-        header.titleLabel.text = enrollmentType?.name ?? NSLocalizedString("All People", bundle: .core, comment: "")
+        header.titleLabel.text = enrollmentType?.name ?? String(localized: "All People", bundle: .core)
         header.filterButton.removeTarget(self, action: nil, for: .primaryActionTriggered)
         header.filterButton.addTarget(self, action: #selector(filter(_:)), for: .primaryActionTriggered)
         header.filterButton.setTitle(enrollmentType == nil
-            ? NSLocalizedString("Filter", bundle: .core, comment: "")
-            : NSLocalizedString("Clear filter", bundle: .core, comment: ""), for: .normal)
+            ? String(localized: "Filter", bundle: .core)
+            : String(localized: "Clear filter", bundle: .core), for: .normal)
         header.filterButton.setTitleColor(Brand.shared.linkColor, for: .normal)
         header.filterButton.makeUnavailableInOfflineMode()
         accessibilityFocusAfterReload = (enrollmentType != nil ? header.filterButton : nil)

--- a/Core/Core/Planner/CalendarEventDetails/ViewModel/CalendarEventDetailsViewModel.swift
+++ b/Core/Core/Planner/CalendarEventDetails/ViewModel/CalendarEventDetailsViewModel.swift
@@ -27,7 +27,7 @@ public class CalendarEventDetailsViewModel: ObservableObject {
     @Published public private(set) var locationInfo: [InstUI.TextSectionView.Model] = []
     @Published public private(set) var details: InstUI.TextSectionView.Model?
     @Published public private(set) var contextColor: UIColor?
-    public let pageTitle = String(localized: "Event Details")
+    public let pageTitle = String(localized: "Event Details", bundle: .core)
     @Published public private(set) var pageSubtitle: String?
     public let pageViewEvent = ScreenViewTrackingParameters(eventName: "/calendar")
 
@@ -74,22 +74,22 @@ public class CalendarEventDetailsViewModel: ObservableObject {
                 }
 
                 if let seriesInfo = event.seriesInNaturalLanguage {
-                    date?.append("\n\(String(localized: "Repeats")) \(seriesInfo)")
+                    date?.append("\n\(String(localized: "Repeats", bundle: .core)) \(seriesInfo)")
                 } else {
-                    date?.append("\n\(String(localized: "Does Not Repeat"))")
+                    date?.append("\n\(String(localized: "Does Not Repeat", bundle: .core))")
                 }
 
                 locationInfo = {
                     var result: [InstUI.TextSectionView.Model] = []
                     if let locationName = event.locationName, locationName.isNotEmpty {
                         result.append(.init(
-                            title: String(localized: "Location"),
+                            title: String(localized: "Location", bundle: .core),
                             description: locationName)
                         )
                     }
                     if let address = event.locationAddress, address.isNotEmpty {
                         result.append(.init(
-                            title: String(localized: "Address"),
+                            title: String(localized: "Address", bundle: .core),
                             description: address)
                         )
                     }
@@ -98,7 +98,7 @@ public class CalendarEventDetailsViewModel: ObservableObject {
 
                 if let details = event.details {
                     self.details = .init(
-                        title: String(localized: "Details"),
+                        title: String(localized: "Details", bundle: .core),
                         description: details,
                         isRichContent: true
                     )

--- a/Core/Core/Planner/ToDoDetails/View/ToDoDetailsScreen.swift
+++ b/Core/Core/Planner/ToDoDetails/View/ToDoDetailsScreen.swift
@@ -40,11 +40,11 @@ public struct ToDoDetailsScreen: View {
                     .paragraphStyle(.heading)
             }
             if let date = viewModel.date {
-                InstUI.TextSectionView(title: String(localized: "Date"),
+                InstUI.TextSectionView(title: String(localized: "Date", bundle: .core),
                                        description: date)
             }
             if let description = viewModel.description {
-                InstUI.TextSectionView(title: String(localized: "Description"),
+                InstUI.TextSectionView(title: String(localized: "Description", bundle: .core),
                                        description: description)
             }
         }

--- a/Core/Core/Planner/ToDoDetails/ViewModel/ToDoDetailsScreenViewModel.swift
+++ b/Core/Core/Planner/ToDoDetails/ViewModel/ToDoDetailsScreenViewModel.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 public class ToDoDetailsScreenViewModel: ObservableObject {
-    public let navigationTitle = String(localized: "To Do")
+    public let navigationTitle = String(localized: "To Do", bundle: .core)
     public let title: String?
     public let date: String?
     public let description: String?

--- a/Core/Core/Planner/View/CalendarDaysViewController.swift
+++ b/Core/Core/Planner/View/CalendarDaysViewController.swift
@@ -152,7 +152,7 @@ class CalendarDayButton: UIButton {
                 dot.isHidden = d >= activityDotCount
             }
             accessibilityLabel = String.localizedStringWithFormat(
-                NSLocalizedString("date_d_events", bundle: .core, comment: ""),
+                String(localized: "date_d_events", bundle: .core),
                 DateFormatter.localizedString(from: date, dateStyle: .long, timeStyle: .none),
                 activityDotCount
             )

--- a/Core/Core/Planner/View/CalendarEventDetailsViewController.swift
+++ b/Core/Core/Planner/View/CalendarEventDetailsViewController.swift
@@ -56,7 +56,7 @@ public class CalendarEventDetailsViewController: ScreenViewTrackableViewControll
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Event Details", comment: ""))
+        setupTitleViewInNavbar(title: NSLocalizedString("Event Details", bundle: .core, comment: ""))
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
         webView.autoresizesHeight = true
@@ -67,7 +67,7 @@ public class CalendarEventDetailsViewController: ScreenViewTrackableViewControll
         scrollView.refreshControl = refreshControl
 
         dateLabel.text = ""
-        locationHeadingLabel.text = NSLocalizedString("Location", comment: "")
+        locationHeadingLabel.text = NSLocalizedString("Location", bundle: .core, comment: "")
         locationView.isHidden = true
         titleLabel.text = ""
 

--- a/Core/Core/Planner/View/CalendarEventDetailsViewController.swift
+++ b/Core/Core/Planner/View/CalendarEventDetailsViewController.swift
@@ -56,7 +56,7 @@ public class CalendarEventDetailsViewController: ScreenViewTrackableViewControll
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Event Details", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Event Details", bundle: .core))
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
         webView.autoresizesHeight = true
@@ -67,7 +67,7 @@ public class CalendarEventDetailsViewController: ScreenViewTrackableViewControll
         scrollView.refreshControl = refreshControl
 
         dateLabel.text = ""
-        locationHeadingLabel.text = NSLocalizedString("Location", bundle: .core, comment: "")
+        locationHeadingLabel.text = String(localized: "Location", bundle: .core)
         locationView.isHidden = true
         titleLabel.text = ""
 

--- a/Core/Core/Planner/View/CalendarViewController.swift
+++ b/Core/Core/Planner/View/CalendarViewController.swift
@@ -94,7 +94,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
         }
         monthButton.configuration?.background.backgroundColor = .clear
         monthButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 28)
-        monthButton.accessibilityLabel = NSLocalizedString("Show a month at a time", bundle: .core, comment: "")
+        monthButton.accessibilityLabel = String(localized: "Show a month at a time", bundle: .core)
 
         updateFilterButton()
 
@@ -148,13 +148,13 @@ class CalendarViewController: ScreenViewTrackableViewController {
         }
 
         if let count = delegate?.numberOfCalendars() {
-            let template = NSLocalizedString("Calendars (%d)", bundle: .core, comment: "")
+            let template = String(localized: "Calendars (%d)", bundle: .core)
             filterButton.setTitle(String.localizedStringWithFormat(template, count), for: .normal)
-            let a11y = NSLocalizedString("filter_events_d_calendars_selected", bundle: .core, comment: "")
+            let a11y = String(localized: "filter_events_d_calendars_selected", bundle: .core)
             filterButton.accessibilityLabel = String.localizedStringWithFormat(a11y, count)
         } else {
-            filterButton.setTitle(NSLocalizedString("Calendars", bundle: .core, comment: ""), for: .normal)
-            filterButton.accessibilityLabel = NSLocalizedString("Filter events", bundle: .core, comment: "")
+            filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
+            filterButton.accessibilityLabel = String(localized: "Filter events", bundle: .core)
         }
     }
 
@@ -263,7 +263,7 @@ extension CalendarViewController: PagesViewControllerDataSource, PagesViewContro
         // Announced with accessibilityScroll
         days.title = isExpanded ? monthPageTitleFormatter.string(from: selectedDate)
             : String.localizedStringWithFormat(
-                NSLocalizedString("Week of %@", bundle: .core, comment: ""),
+                String(localized: "Week of %@", bundle: .core),
                 DateFormatter.localizedString(from: selectedDate, dateStyle: .long, timeStyle: .none)
             )
         return days

--- a/Core/Core/Planner/View/CreateTodoViewController.swift
+++ b/Core/Core/Planner/View/CreateTodoViewController.swift
@@ -43,7 +43,7 @@ public class CreateTodoViewController: ScreenViewTrackableViewController, ErrorV
         }
     }
     var selectedCourseName: String? {
-        guard let c = selectedCourse else { return NSLocalizedString("None", bundle: .core, comment: "")  }
+        guard let c = selectedCourse else { return String(localized: "None", bundle: .core)  }
         return c.name
     }
     var selectedCourse: Course?
@@ -57,29 +57,29 @@ public class CreateTodoViewController: ScreenViewTrackableViewController, ErrorV
 
     override public func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("New To Do", bundle: .core, comment: "")
-        titleLabel.placeholder = NSLocalizedString("Title...", bundle: .core, comment: "")
+        title = String(localized: "New To Do", bundle: .core)
+        titleLabel.placeholder = String(localized: "Title...", bundle: .core)
         titleLabel.delegate = self
-        titleLabel.accessibilityLabel = NSLocalizedString("Title", bundle: .core, comment: "")
-        dateTitleLabel.text = NSLocalizedString("Date", bundle: .core, comment: "")
+        titleLabel.accessibilityLabel = String(localized: "Title", bundle: .core)
+        dateTitleLabel.text = String(localized: "Date", bundle: .core)
         dateTitleLabel.accessibilityElementsHidden = true
         descTextView.font(.scaledNamedFont(.regular16), lineHeight: .body)
         descTextView.textColor = UIColor.textDarkest
         descTextView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        descTextView.placeholder = NSLocalizedString("Description", bundle: .core, comment: "")
-        descTextView.accessibilityLabel = NSLocalizedString("Description", bundle: .core, comment: "")
+        descTextView.placeholder = String(localized: "Description", bundle: .core)
+        descTextView.accessibilityLabel = String(localized: "Description", bundle: .core)
         dateTextField.text = selectedDate?.dateTimeString
         dateTextField.accessibilityElementsHidden = true
         dateTextField.textColor = .textDark
-        selectDateButton.accessibilityLabel = NSLocalizedString("Date", bundle: .core, comment: "")
+        selectDateButton.accessibilityLabel = String(localized: "Date", bundle: .core)
         courseSelectionLabel.text = selectedCourseName
         courseSelectionLabel.textColor = UIColor.textDark
         courseSelectionLabel.accessibilityElementsHidden = true
         courseTitleLabel.accessibilityElementsHidden = true
-        courseTitleLabel.text = NSLocalizedString("Course (optional)", bundle: .core, comment: "")
+        courseTitleLabel.text = String(localized: "Course (optional)", bundle: .core)
         updateCourseAccessibilityLabel()
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(actionCancel))
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Done", bundle: .core, comment: ""), style: .done, target: self, action: #selector(actionDone))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: String(localized: "Cancel", bundle: .core), style: .plain, target: self, action: #selector(actionCancel))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Done", bundle: .core), style: .done, target: self, action: #selector(actionDone))
         keyboardListener = KeyboardTransitioning(view: view, space: scrollViewBottomConstraint)
     }
 
@@ -123,8 +123,8 @@ public class CreateTodoViewController: ScreenViewTrackableViewController, ErrorV
     }
 
     func updateCourseAccessibilityLabel() {
-        let courseLabel = NSLocalizedString("Course (optional)", bundle: .core, comment: "")
-        let courseName = selectedCourseName ?? NSLocalizedString("None", bundle: .core, comment: "")
+        let courseLabel = String(localized: "Course (optional)", bundle: .core)
+        let courseName = selectedCourseName ?? String(localized: "None", bundle: .core)
         selectCourseButton.accessibilityLabel = courseLabel + ", " + courseName
     }
 }
@@ -168,13 +168,13 @@ class SelectCourseViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Select Course", bundle: .core, comment: "")
+        title = String(localized: "Select Course", bundle: .core)
         tableView.registerCell(RightDetailTableViewCell.self)
         tableView.separatorColor = .borderMedium
         tableView.separatorInset = .zero
         tableView.tableFooterView = UIView()
         courses.exhaust()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Clear Course", bundle: .core, comment: ""), style: .plain, target: self, action: #selector(clearCourse))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Clear Course", bundle: .core), style: .plain, target: self, action: #selector(clearCourse))
     }
 
     func coursesDidUpdate() {

--- a/Core/Core/Planner/View/PlannerFilterViewController.swift
+++ b/Core/Core/Planner/View/PlannerFilterViewController.swift
@@ -52,17 +52,17 @@ public class PlannerFilterViewController: UIViewController, ErrorViewController 
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.title = NSLocalizedString("Calendars", bundle: .core, comment: "")
+        navigationItem.title = String(localized: "Calendars", bundle: .core)
 
         let refresh = CircleRefreshControl()
         refresh.addTarget(self, action: #selector(refresh(_:)), for: .valueChanged)
         tableView.refreshControl = refresh
         tableView.registerHeaderFooterView(SectionHeaderView.self)
-        headerLabel.text = NSLocalizedString("Tap to select the courses you want to see on the calendar.", bundle: .core, comment: "")
+        headerLabel.text = String(localized: "Tap to select the courses you want to see on the calendar.", bundle: .core)
 
-        emptyTitleLabel.text = NSLocalizedString("No Courses", bundle: .core, comment: "")
-        emptyMessageLabel.text = NSLocalizedString("Your child's courses might not be published yet.", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading courses. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyTitleLabel.text = String(localized: "No Courses", bundle: .core)
+        emptyMessageLabel.text = String(localized: "Your child's courses might not be published yet.", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading courses. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh(_:)), for: .primaryActionTriggered)
         emptyStateView.isHidden = true
         errorView.isHidden = true
@@ -125,7 +125,7 @@ extension PlannerFilterViewController: UITableViewDataSource {
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard section == 0 else { return nil }
         let header = tableView.dequeueHeaderFooter(SectionHeaderView.self)
-        header.titleLabel?.text = NSLocalizedString("Courses", bundle: .core, comment: "")
+        header.titleLabel?.text = String(localized: "Courses", bundle: .core)
         return header
     }
 }

--- a/Core/Core/Planner/View/PlannerListViewController.swift
+++ b/Core/Core/Planner/View/PlannerListViewController.swift
@@ -51,9 +51,9 @@ public class PlannerListViewController: UIViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        emptyStateHeader.text = NSLocalizedString("No Events Today!", bundle: .core, comment: "")
-        emptyStateSubHeader.text = NSLocalizedString("It looks like a great day to rest, relax, and recharge.", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading events. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyStateHeader.text = String(localized: "No Events Today!", bundle: .core)
+        emptyStateSubHeader.text = String(localized: "It looks like a great day to rest, relax, and recharge.", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading events. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(retryAfterError), for: .primaryActionTriggered)
 
         refreshControl.addTarget(self, action: #selector(plannerListWillRefresh), for: .primaryActionTriggered)
@@ -159,7 +159,7 @@ class PlannerListCell: UITableViewCell {
         dueDate.setText(dueDateText, style: .textCellSupportingText)
         icon.image = p?.icon()
         let pointsText: String? = p?.pointsPossible.flatMap {
-            let format = NSLocalizedString("g_points", bundle: .core, comment: "")
+            let format = String(localized: "g_points", bundle: .core)
             return String.localizedStringWithFormat(format, $0)
         }
         points.setText(pointsText, style: .textCellSupportingText)

--- a/Core/Core/Planner/View/PlannerViewController.swift
+++ b/Core/Core/Planner/View/PlannerViewController.swift
@@ -54,11 +54,11 @@ public class PlannerViewController: UIViewController {
         navigationItem.leftBarButtonItem = profileButton
         navigationItem.rightBarButtonItems = ExperimentalFeature.teacherCalendar.isEnabled ? [todayButton] : [addNoteButton, todayButton]
         profileButton.accessibilityIdentifier = "PlannerCalendar.profileButton"
-        profileButton.accessibilityLabel = NSLocalizedString("Profile Menu", bundle: .core, comment: "")
+        profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .core)
         addNoteButton.accessibilityIdentifier = "PlannerCalendar.addNoteButton"
-        addNoteButton.accessibilityLabel = NSLocalizedString("Add Planner Note", bundle: .core, comment: "")
+        addNoteButton.accessibilityLabel = String(localized: "Add Planner Note", bundle: .core)
         todayButton.accessibilityIdentifier = "PlannerCalendar.todayButton"
-        todayButton.accessibilityLabel = NSLocalizedString("Go to today", bundle: .core, comment: "")
+        todayButton.accessibilityLabel = String(localized: "Go to today", bundle: .core)
 
         addChild(calendar)
         view.addSubview(calendar.view)

--- a/Core/Core/Presenter/ErrorViewController.swift
+++ b/Core/Core/Presenter/ErrorViewController.swift
@@ -27,7 +27,7 @@ public protocol ErrorViewController: AnyObject {
 extension ErrorViewController where Self: UIViewController {
     public func showAlert(title: String?, message: String?) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .default))
+        alert.addAction(UIAlertAction(title: String(localized: "OK", bundle: .core), style: .default))
         AppEnvironment.shared.router.show(alert, from: self, options: .modal())
     }
 }

--- a/Core/Core/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Profile/Settings/NotificationCategoriesViewController.swift
@@ -100,28 +100,28 @@ class NotificationCategoriesViewController: UIViewController, ErrorViewControlle
     }
 
     lazy var categoryMap: [String: (Int, String, String)] = {
-        let courseActivities = NSLocalizedString("Course Activities", bundle: .core, comment: "")
-        let discussions = NSLocalizedString("Discussions", bundle: .core, comment: "")
-        let conversations = NSLocalizedString("Conversations", bundle: .core, comment: "")
-        let scheduling = NSLocalizedString("Scheduling", bundle: .core, comment: "")
-        let groups = NSLocalizedString("Groups", bundle: .core, comment: "")
-        let conferences = NSLocalizedString("Conferences", bundle: .core, comment: "")
-        let alerts = NSLocalizedString("Alerts", bundle: .core, comment: "")
+        let courseActivities = String(localized: "Course Activities", bundle: .core)
+        let discussions = String(localized: "Discussions", bundle: .core)
+        let conversations = String(localized: "Conversations", bundle: .core)
+        let scheduling = String(localized: "Scheduling", bundle: .core)
+        let groups = String(localized: "Groups", bundle: .core)
+        let conferences = String(localized: "Conferences", bundle: .core)
+        let alerts = String(localized: "Alerts", bundle: .core)
 
         var map = [
-            "all_submissions": (0, NSLocalizedString("All Submissions", bundle: .core, comment: ""), courseActivities),
-            "announcement": (0, NSLocalizedString("Announcement", bundle: .core, comment: ""), courseActivities),
-            "announcement_created_by_you": (0, NSLocalizedString("Announcement Created By You", bundle: .core, comment: ""), courseActivities),
-            "appointment_availability": (3, NSLocalizedString("Appointment Availability", bundle: .core, comment: ""), scheduling),
-            "appointment_cancelations": (3, NSLocalizedString("Appointment Cancellations", bundle: .core, comment: ""), scheduling),
-            "calendar": (3, NSLocalizedString("Calendar", bundle: .core, comment: ""), scheduling),
-            "conversation_message": (2, NSLocalizedString("Conversation Message", bundle: .core, comment: ""), conversations),
-            "course_content": (0, NSLocalizedString("Course Content", bundle: .core, comment: ""), courseActivities),
-            "due_date": (0, NSLocalizedString("Due Date", bundle: .core, comment: ""), courseActivities),
-            "grading": (0, NSLocalizedString("Grading", bundle: .core, comment: ""), courseActivities),
-            "invitation": (0, NSLocalizedString("Invitation", bundle: .core, comment: ""), courseActivities),
-            "student_appointment_signups": (3, NSLocalizedString("Student Appointment Signups", bundle: .core, comment: ""), scheduling),
-            "submission_comment": (0, NSLocalizedString("Submission Comment", bundle: .core, comment: ""), courseActivities),
+            "all_submissions": (0, String(localized: "All Submissions", bundle: .core), courseActivities),
+            "announcement": (0, String(localized: "Announcement", bundle: .core), courseActivities),
+            "announcement_created_by_you": (0, String(localized: "Announcement Created By You", bundle: .core), courseActivities),
+            "appointment_availability": (3, String(localized: "Appointment Availability", bundle: .core), scheduling),
+            "appointment_cancelations": (3, String(localized: "Appointment Cancellations", bundle: .core), scheduling),
+            "calendar": (3, String(localized: "Calendar", bundle: .core), scheduling),
+            "conversation_message": (2, String(localized: "Conversation Message", bundle: .core), conversations),
+            "course_content": (0, String(localized: "Course Content", bundle: .core), courseActivities),
+            "due_date": (0, String(localized: "Due Date", bundle: .core), courseActivities),
+            "grading": (0, String(localized: "Grading", bundle: .core), courseActivities),
+            "invitation": (0, String(localized: "Invitation", bundle: .core), courseActivities),
+            "student_appointment_signups": (3, String(localized: "Student Appointment Signups", bundle: .core), scheduling),
+            "submission_comment": (0, String(localized: "Submission Comment", bundle: .core), courseActivities),
         ]
 
         if channelType == .push {
@@ -129,17 +129,17 @@ class NotificationCategoriesViewController: UIViewController, ErrorViewControlle
         }
 
         map.merge( [
-            "added_to_conversation": (2, NSLocalizedString("Added To Conversation", bundle: .core, comment: ""), conversations),
-            "appointment_signups": (3, NSLocalizedString("Appointment Signups", bundle: .core, comment: ""), scheduling),
-            "conversation_created": (2, NSLocalizedString("Conversation Created By Me", bundle: .core, comment: ""), conversations),
-            "content_link_error": (5, NSLocalizedString("Content Link Error", bundle: .core, comment: ""), alerts),
-            "discussion": (1, NSLocalizedString("Discussion", bundle: .core, comment: ""), discussions),
-            "discussion_entry": (1, NSLocalizedString("Discussion Post", bundle: .core, comment: ""), discussions),
-            "files": (0, NSLocalizedString("Files", bundle: .core, comment: ""), courseActivities),
-            "grading_policies": (0, NSLocalizedString("Grading Policies", bundle: .core, comment: ""), courseActivities),
-            "late_grading": (0, NSLocalizedString("Late Grading", bundle: .core, comment: ""), courseActivities),
-            "membership_update": (4, NSLocalizedString("Membership Update", bundle: .core, comment: ""), groups),
-            "other": (5, NSLocalizedString("Administrative Notifications", bundle: .core, comment: ""), alerts),
+            "added_to_conversation": (2, String(localized: "Added To Conversation", bundle: .core), conversations),
+            "appointment_signups": (3, String(localized: "Appointment Signups", bundle: .core), scheduling),
+            "conversation_created": (2, String(localized: "Conversation Created By Me", bundle: .core), conversations),
+            "content_link_error": (5, String(localized: "Content Link Error", bundle: .core), alerts),
+            "discussion": (1, String(localized: "Discussion", bundle: .core), discussions),
+            "discussion_entry": (1, String(localized: "Discussion Post", bundle: .core), discussions),
+            "files": (0, String(localized: "Files", bundle: .core), courseActivities),
+            "grading_policies": (0, String(localized: "Grading Policies", bundle: .core), courseActivities),
+            "late_grading": (0, String(localized: "Late Grading", bundle: .core), courseActivities),
+            "membership_update": (4, String(localized: "Membership Update", bundle: .core), groups),
+            "other": (5, String(localized: "Administrative Notifications", bundle: .core), alerts),
         ]) { (_, new) in new }
         return map
     }()
@@ -161,7 +161,7 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
     func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
         guard !isNotificationsEnabled else { return nil }
         let footer: GroupedSectionFooterView = tableView.dequeueHeaderFooter()
-        footer.titleLabel.text = NSLocalizedString("Notifications are currently disabled in Settings. Tap to enable them again.", bundle: .core, comment: "")
+        footer.titleLabel.text = String(localized: "Notifications are currently disabled in Settings. Tap to enable them again.", bundle: .core)
         return footer
     }
 
@@ -178,7 +178,7 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard isNotificationsEnabled else {
             let cell: RightDetailTableViewCell = tableView.dequeue(for: indexPath)
-            cell.textLabel?.text = NSLocalizedString("Enable Push Notifications", bundle: .core, comment: "")
+            cell.textLabel?.text = String(localized: "Enable Push Notifications", bundle: .core)
             cell.accessibilityIdentifier = "NotificationCategories.enableNotificationsCell"
             return cell
         }
@@ -241,7 +241,7 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
                 self?.showError(error)
             } else if response == nil {
                 self?.showError(NSError.instructureError(
-                    NSLocalizedString("Could not save notification preference", bundle: .core, comment: "")
+                    String(localized: "Could not save notification preference", bundle: .core)
                 ))
             }
         }

--- a/Core/Core/Profile/Settings/PairWithObserverViewController.swift
+++ b/Core/Core/Profile/Settings/PairWithObserverViewController.swift
@@ -37,7 +37,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = NSLocalizedString("Pair with Observer", bundle: .core, comment: "")
-        instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", comment: "")
+        instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", bundle: .core, comment: "")
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(actionShare(sender:)))
     }
@@ -92,7 +92,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
         qrCodeImageView.accessibilityIdentifier = "QRCodeImage"
         qrCodeContainer.isHidden = false
         let attrStr = NSAttributedString(
-            string: NSLocalizedString("Pairing Code: ", comment: ""),
+            string: NSLocalizedString("Pairing Code: ", bundle: .core, comment: ""),
             attributes: [
                 NSAttributedString.Key.font: UIFont.scaledNamedFont(.regular20),
                 NSAttributedString.Key.foregroundColor: UIColor.textDarkest,

--- a/Core/Core/Profile/Settings/PairWithObserverViewController.swift
+++ b/Core/Core/Profile/Settings/PairWithObserverViewController.swift
@@ -36,8 +36,8 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Pair with Observer", bundle: .core, comment: "")
-        instructionsLabel.text = NSLocalizedString("Have your parent scan this QR code from the Canvas Parent app to pair with you.", bundle: .core, comment: "")
+        title = String(localized: "Pair with Observer", bundle: .core)
+        instructionsLabel.text = String(localized: "Have your parent scan this QR code from the Canvas Parent app to pair with you.", bundle: .core)
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .action, target: self, action: #selector(actionShare(sender:)))
     }
@@ -92,7 +92,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
         qrCodeImageView.accessibilityIdentifier = "QRCodeImage"
         qrCodeContainer.isHidden = false
         let attrStr = NSAttributedString(
-            string: NSLocalizedString("Pairing Code: ", bundle: .core, comment: ""),
+            string: String(localized: "Pairing Code: ", bundle: .core),
             attributes: [
                 NSAttributedString.Key.font: UIFont.scaledNamedFont(.regular20),
                 NSAttributedString.Key.foregroundColor: UIColor.textDarkest,
@@ -118,7 +118,7 @@ class PairWithObserverViewController: UIViewController, ErrorViewController {
 
     @objc func actionShare(sender: UIBarButtonItem) {
         guard let code = pairingCode, !code.isEmpty else { return }
-        let template = NSLocalizedString("Use this code to pair with me in Canvas Parent: %@", bundle: .core, comment: "")
+        let template = String(localized: "Use this code to pair with me in Canvas Parent: %@", bundle: .core)
         let message = String.localizedStringWithFormat(template, code)
         let vc = CoreActivityViewController(activityItems: [message], applicationActivities: nil)
         let popover = vc.popoverPresentationController

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -164,8 +164,8 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
             return CourseSyncSettingsInteractorLive(storage: defaults).getOfflineSyncSettingsLabel()
         }()
-        return Section(NSLocalizedString("Offline Content", comment: ""), rows: [
-                Row(NSLocalizedString("Synchronization", comment: ""),
+        return Section(NSLocalizedString("Offline Content", bundle: .core, comment: ""), rows: [
+                Row(NSLocalizedString("Synchronization", bundle: .core, comment: ""),
                     detail: detailLabel,
                     isSupportedOffline: true) { [weak self] in
                         guard let self = self else { return }
@@ -260,7 +260,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
     private var aboutRow: [Row] {
         return [
-            Row(NSLocalizedString("About", comment: ""), isSupportedOffline: true) { [weak self] in
+            Row(NSLocalizedString("About", bundle: .core, comment: ""), isSupportedOffline: true) { [weak self] in
                 guard let self else { return }
                 self.env.router.route(to: "/about", from: self)
             },

--- a/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Profile/Settings/ProfileSettingsViewController.swift
@@ -66,7 +66,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        title = NSLocalizedString("Settings", bundle: .core, comment: "")
+        title = String(localized: "Settings", bundle: .core)
 
         view.backgroundColor = .backgroundLightest
         tableView.backgroundColor = .backgroundGrouped
@@ -133,16 +133,16 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
         }
 
         sections.append(
-            Section(NSLocalizedString("Legal", bundle: .core, comment: ""), rows: [
-                Row(NSLocalizedString("Privacy Policy", bundle: .core, comment: ""), isSupportedOffline: false) { [weak self] in
+            Section(String(localized: "Legal", bundle: .core), rows: [
+                Row(String(localized: "Privacy Policy", bundle: .core), isSupportedOffline: false) { [weak self] in
                     guard let self = self else { return }
                     self.env.router.route(to: "https://www.instructure.com/canvas/privacy/", from: self)
                 },
-                Row(NSLocalizedString("Terms of Use", bundle: .core, comment: ""), isSupportedOffline: false) { [weak self] in
+                Row(String(localized: "Terms of Use", bundle: .core), isSupportedOffline: false) { [weak self] in
                     guard let self = self else { return }
                     self.env.router.route(to: "/accounts/self/terms_of_service", from: self)
                 },
-                Row(NSLocalizedString("Canvas on GitHub", bundle: .core, comment: ""), isSupportedOffline: false) { [weak self] in
+                Row(String(localized: "Canvas on GitHub", bundle: .core), isSupportedOffline: false) { [weak self] in
                     guard let self = self else { return }
                     self.env.router.route(to: "https://github.com/instructure/canvas-ios", from: self)
                 },
@@ -164,8 +164,8 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
             return CourseSyncSettingsInteractorLive(storage: defaults).getOfflineSyncSettingsLabel()
         }()
-        return Section(NSLocalizedString("Offline Content", bundle: .core, comment: ""), rows: [
-                Row(NSLocalizedString("Synchronization", bundle: .core, comment: ""),
+        return Section(String(localized: "Offline Content", bundle: .core), rows: [
+                Row(String(localized: "Synchronization", bundle: .core),
                     detail: detailLabel,
                     isSupportedOffline: true) { [weak self] in
                         guard let self = self else { return }
@@ -175,7 +175,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     }
 
     private var preferencesSection: Section {
-        Section(NSLocalizedString("Preferences", bundle: .core, comment: ""), rows: preferencesRows)
+        Section(String(localized: "Preferences", bundle: .core), rows: preferencesRows)
     }
 
     private var preferencesRows: [Any] {
@@ -187,9 +187,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
         rows.append(contentsOf: pairWithObserverButton)
 
         if AppEnvironment.shared.app == .student {
-            let row = Row(NSLocalizedString("Subscribe to Calendar Feed",
-                                            bundle: .core,
-                                            comment: ""),
+            let row = Row(String(localized: "Subscribe to Calendar Feed", bundle: .core),
                           hasDisclosure: false,
                           isSupportedOffline: false) { [weak self] in
                 guard let url = self?.profile.first?.calendarURL else { return }
@@ -205,17 +203,17 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
     private var interfaceStyleSettings: [Row] {
         let options = [
-            ItemPickerItem(title: NSLocalizedString("System Settings", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Light Theme", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Dark Theme", bundle: .core, comment: "")),
+            ItemPickerItem(title: String(localized: "System Settings", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Light Theme", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Dark Theme", bundle: .core)),
         ]
         let selectedStyleIndex = env.userDefaults?.interfaceStyle?.rawValue ?? 0
 
         return [
-            Row(NSLocalizedString("Appearance", bundle: .core, comment: ""), detail: options[selectedStyleIndex].title, isSupportedOffline: true) { [weak self] in
+            Row(String(localized: "Appearance", bundle: .core), detail: options[selectedStyleIndex].title, isSupportedOffline: true) { [weak self] in
                 guard let self = self else { return }
 
-                let pickerVC = ItemPickerViewController.create(title: NSLocalizedString("Appearance", bundle: .core, comment: ""),
+                let pickerVC = ItemPickerViewController.create(title: String(localized: "Appearance", bundle: .core),
                                                                sections: [ ItemPickerSection(items: options) ],
                                                                selected: IndexPath(row: selectedStyleIndex, section: 0)) { indexPath in
                     if let window = self.env.window, let style = UIUserInterfaceStyle(rawValue: indexPath.row) {
@@ -230,10 +228,10 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
     private var landingPageRow: [Row] {
         return [
-            Row(NSLocalizedString("Landing Page", bundle: .core, comment: ""), detail: landingPage.name, isSupportedOffline: true) { [weak self] in
+            Row(String(localized: "Landing Page", bundle: .core), detail: landingPage.name, isSupportedOffline: true) { [weak self] in
                 guard let self = self else { return }
                 self.show(ItemPickerViewController.create(
-                    title: NSLocalizedString("Landing Page", bundle: .core, comment: ""),
+                    title: String(localized: "Landing Page", bundle: .core),
                     sections: [ ItemPickerSection(items: LandingPage.appCases.map { page in
                         ItemPickerItem(title: page.name)
                     }), ],
@@ -250,7 +248,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
         guard isPairingWithObserverAllowed else { return [] }
 
         return [
-            Row(NSLocalizedString("Pair with Observer", bundle: .core, comment: ""), isSupportedOffline: false) { [weak self] in
+            Row(String(localized: "Pair with Observer", bundle: .core), isSupportedOffline: false) { [weak self] in
                 guard let self = self else { return }
                 let vc = PairWithObserverViewController.create()
                 self.env.router.show(vc, from: self, options: .modal(.formSheet, isDismissable: true, embedInNav: true, addDoneButton: true))
@@ -260,7 +258,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
 
     private var aboutRow: [Row] {
         return [
-            Row(NSLocalizedString("About", bundle: .core, comment: ""), isSupportedOffline: true) { [weak self] in
+            Row(String(localized: "About", bundle: .core), isSupportedOffline: true) { [weak self] in
                 guard let self else { return }
                 self.env.router.route(to: "/about", from: self)
             },
@@ -270,7 +268,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     private var k5DashboardSwitch: [Any] {
         guard AppEnvironment.shared.k5.isK5Account, AppEnvironment.shared.k5.isRemoteFeatureFlagEnabled else { return [] }
 
-        let row = Switch(NSLocalizedString("Homeroom View", bundle: .core, comment: ""),
+        let row = Switch(String(localized: "Homeroom View", bundle: .core),
                          initialValue: AppEnvironment.shared.userDefaults?.isElementaryViewEnabled ?? false,
                          isSupportedOffline: true) { [weak self] isOn in
             AppEnvironment.shared.userDefaults?.isElementaryViewEnabled = isOn
@@ -436,17 +434,17 @@ private enum LandingPage: String {
         switch self {
         case .dashboard:
             if Bundle.main.isTeacherApp {
-                return NSLocalizedString("Courses", bundle: .core, comment: "")
+                return String(localized: "Courses", bundle: .core)
             }
-            return NSLocalizedString("Dashboard", bundle: .core, comment: "")
+            return String(localized: "Dashboard", bundle: .core)
         case .calendar:
-            return NSLocalizedString("Calendar", bundle: .core, comment: "")
+            return String(localized: "Calendar", bundle: .core)
         case .todo:
-            return NSLocalizedString("To Do", bundle: .core, comment: "")
+            return String(localized: "To Do", bundle: .core)
         case .notifications:
-            return NSLocalizedString("Notifications", bundle: .core, comment: "")
+            return String(localized: "Notifications", bundle: .core)
         case .inbox:
-            return NSLocalizedString("Inbox", bundle: .core, comment: "")
+            return String(localized: "Inbox", bundle: .core)
         }
     }
 

--- a/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuBottomSection.swift
@@ -171,13 +171,13 @@ struct SideMenuBottomSection: View {
     }
 
     func showUploadAlert(completionHandler: @escaping () -> Void) {
-        let title = NSLocalizedString("Upload in progress", bundle: .core, comment: "")
-        let message = NSLocalizedString("One of your submissions is still being uploaded. Logging out might interrupt it.\nAre you sure you want to log out?", bundle: .core, comment: "")
+        let title = String(localized: "Upload in progress", bundle: .core)
+        let message = String(localized: "One of your submissions is still being uploaded. Logging out might interrupt it.\nAre you sure you want to log out?", bundle: .core)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Yes", bundle: .core, comment: ""), style: .destructive) { _ in
+        alert.addAction(AlertAction(String(localized: "Yes", bundle: .core), style: .destructive) { _ in
             completionHandler()
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
         env.router.show(alert, from: controller.value, options: .modal())
     }
 

--- a/Core/Core/Profile/SideMenu/SideMenuDeveloperOptionsSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuDeveloperOptionsSection.swift
@@ -32,13 +32,13 @@ struct SideMenuDeveloperOptionsSection: View {
                 SideMenuItem(
                     id: "networkAvailabilityStatus",
                     image: .attendance,
-                    title: Text("Connected via \(connectionType.rawValue.capitalized)")
+                    title: Text("Connected via \(connectionType.rawValue.capitalized)", bundle: .core)
                 )
             case .disconnected:
                 SideMenuItem(
                     id: "networkAvailabilityStatus",
                     image: .attendance,
-                    title: Text("Disconnected")
+                    title: Text("Disconnected", bundle: .core)
                 )
                 .foregroundColor(.red)
             }

--- a/Core/Core/Profile/SideMenu/SideMenuHeaderView.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuHeaderView.swift
@@ -115,7 +115,7 @@ struct SideMenuHeaderView: View {
 
     public func showError(_ error: Error) {
         let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Dismiss", bundle: .core, comment: ""), style: .default))
+        alert.addAction(AlertAction(String(localized: "Dismiss", bundle: .core), style: .default))
         env.router.show(alert, from: controller.value, options: .modal())
     }
 }

--- a/Core/Core/Profile/SideMenu/SideMenuItem.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuItem.swift
@@ -28,7 +28,7 @@ struct SideMenuItem: View {
     var accessibilityHint: Text {
         guard badgeValue > 0 else { return Text(verbatim: "") }
         return Text(String.localizedStringWithFormat(
-            NSLocalizedString("conversation_unread_messages", bundle: .core, comment: ""),
+            String(localized: "conversation_unread_messages", bundle: .core),
             badgeValue))
     }
 

--- a/Core/Core/Profile/SideMenu/SideMenuTransitioning.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuTransitioning.swift
@@ -103,7 +103,7 @@ public class SideMenuPresentationController: UIPresentationController {
             dimmer.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
         ])
         dimmer.addTarget(self, action: #selector(tapped), for: .primaryActionTriggered)
-        dimmer.accessibilityLabel = NSLocalizedString("Close", bundle: .core, comment: "")
+        dimmer.accessibilityLabel = String(localized: "Close", bundle: .core)
         dimmer.accessibilityFrame = CGRect(x: drawerWidth, y: 0, width: containerView.bounds.width - drawerWidth, height: containerView.bounds.height)
 
         presentingViewController.transitionCoordinator?.animate(alongsideTransition: { _ in

--- a/Core/Core/Quizzes/Quiz.swift
+++ b/Core/Core/Quizzes/Quiz.swift
@@ -133,7 +133,7 @@ extension Quiz: DueViewable, GradeViewable, LockStatusViewable {
 
     public var allowedAttemptsText: String {
         if allowedAttempts < 1 {
-            return NSLocalizedString("Unlimited", bundle: .core, comment: "")
+            return String(localized: "Unlimited", bundle: .core)
         }
         return NumberFormatter.localizedString(from: NSNumber(value: allowedAttempts), number: .none)
     }
@@ -143,13 +143,13 @@ extension Quiz: DueViewable, GradeViewable, LockStatusViewable {
     }
 
     public var nQuestionsText: String {
-        let format = NSLocalizedString("d_questions", bundle: .core, comment: "")
+        let format = String(localized: "d_questions", bundle: .core)
         return String.localizedStringWithFormat(format, questionCount)
     }
 
     public var timeLimitText: String? {
         guard var limit = timeLimit else {
-            return NSLocalizedString("None", bundle: .core, comment: "")
+            return String(localized: "None", bundle: .core)
         }
         limit += submission?.extraTime ?? 0
         let formatter = DateComponentsFormatter()
@@ -224,9 +224,9 @@ public enum QuizHideResults: String, Codable, CaseIterable {
     public var text: String {
         switch self {
         case .always:
-            return NSLocalizedString("No", bundle: .core, comment: "")
+            return String(localized: "No", bundle: .core)
         case .until_after_last_attempt:
-            return NSLocalizedString("After Last Attempt", bundle: .core, comment: "")
+            return String(localized: "After Last Attempt", bundle: .core)
         }
     }
 }
@@ -237,30 +237,30 @@ public enum QuizType: String, Codable, CaseIterable {
     public var sectionTitle: String {
         switch self {
         case .assignment:
-            return NSLocalizedString("Assignments", bundle: .core, comment: "")
+            return String(localized: "Assignments", bundle: .core)
         case .practice_quiz:
-            return NSLocalizedString("Practice Quizzes", bundle: .core, comment: "")
+            return String(localized: "Practice Quizzes", bundle: .core)
         case .graded_survey:
-            return NSLocalizedString("Graded Surveys", bundle: .core, comment: "")
+            return String(localized: "Graded Surveys", bundle: .core)
         case .survey:
-            return NSLocalizedString("Surveys", bundle: .core, comment: "")
+            return String(localized: "Surveys", bundle: .core)
         case .quizzes_next:
-            return NSLocalizedString("New Quizzes", bundle: .core, comment: "")
+            return String(localized: "New Quizzes", bundle: .core)
         }
     }
 
     public var name: String {
         switch self {
         case .assignment:
-            return NSLocalizedString("Graded Quiz", bundle: .core, comment: "")
+            return String(localized: "Graded Quiz", bundle: .core)
         case .practice_quiz:
-            return NSLocalizedString("Practice Quiz", bundle: .core, comment: "")
+            return String(localized: "Practice Quiz", bundle: .core)
         case .graded_survey:
-            return NSLocalizedString("Graded Survey", bundle: .core, comment: "")
+            return String(localized: "Graded Survey", bundle: .core)
         case .survey:
-            return NSLocalizedString("Ungraded Survey", bundle: .core, comment: "")
+            return String(localized: "Ungraded Survey", bundle: .core)
         case .quizzes_next:
-            return NSLocalizedString("New Quiz", bundle: .core, comment: "")
+            return String(localized: "New Quiz", bundle: .core)
         }
     }
 }
@@ -271,11 +271,11 @@ public enum ScoringPolicy: String, Codable, CaseIterable {
     public var text: String {
         switch self {
         case .keep_latest:
-            return NSLocalizedString("Latest", bundle: .core, comment: "")
+            return String(localized: "Latest", bundle: .core)
         case .keep_highest:
-            return NSLocalizedString("Highest", bundle: .core, comment: "")
+            return String(localized: "Highest", bundle: .core)
         case .keep_average:
-            return NSLocalizedString("Average", bundle: .core, comment: "")
+            return String(localized: "Average", bundle: .core)
         }
     }
 }

--- a/Core/Core/Quizzes/QuizDetails/View/QuizDetailsView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizDetailsView.swift
@@ -36,7 +36,7 @@ public struct QuizDetailsView<ViewModel: QuizDetailsViewModelProtocol>: View {
             .rightBarButtonItems {
                 [
                     UIBarButtonItemWithCompletion(
-                        title: NSLocalizedString("Edit", bundle: .core, comment: ""),
+                        title: String(localized: "Edit", bundle: .core),
                         actionHandler: {
                             viewModel.editTapped(router: env.router, viewController: controller)
                         }

--- a/Core/Core/Quizzes/QuizDetails/View/QuizDetailsView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizDetailsView.swift
@@ -36,7 +36,7 @@ public struct QuizDetailsView<ViewModel: QuizDetailsViewModelProtocol>: View {
             .rightBarButtonItems {
                 [
                     UIBarButtonItemWithCompletion(
-                        title: NSLocalizedString("Edit", comment: ""),
+                        title: NSLocalizedString("Edit", bundle: .core, comment: ""),
                         actionHandler: {
                             viewModel.editTapped(router: env.router, viewController: controller)
                         }

--- a/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
@@ -111,8 +111,8 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
 
         EditorSection(label: Text("Description", bundle: .core)) {
             RichContentEditor(
-                placeholder: NSLocalizedString("Add description", comment: ""),
-                a11yLabel: NSLocalizedString("Description", comment: ""),
+                placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
+                a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
                 html: $viewModel.description,
                 context: .course(viewModel.courseID),
                 uploadTo: .context(.course(viewModel.courseID)),
@@ -213,7 +213,7 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
                 Divider()
                 TextFieldRow(
                     label: Text("Access Code", bundle: .core),
-                    placeholder: NSLocalizedString("Enter code", comment: ""),
+                    placeholder: NSLocalizedString("Enter code", bundle: .core, comment: ""),
                     text: $viewModel.accessCode
                 )
                 .accessibilityIdentifier("QuizEditor.accessCode")

--- a/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
@@ -81,7 +81,7 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
                 accessCodeSection
                 assignmentOverridesSection
             case .error(let errorMessage):
-                EmptyPanda(.Unsupported, title: Text("Something went wrong"), message: Text(errorMessage))
+                EmptyPanda(.Unsupported, title: Text("Something went wrong", bundle: .core), message: Text(errorMessage))
             default:
                 Spacer()
             }

--- a/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
@@ -111,8 +111,8 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
 
         EditorSection(label: Text("Description", bundle: .core)) {
             RichContentEditor(
-                placeholder: NSLocalizedString("Add description", bundle: .core, comment: ""),
-                a11yLabel: NSLocalizedString("Description", bundle: .core, comment: ""),
+                placeholder: String(localized: "Add description", bundle: .core),
+                a11yLabel: String(localized: "Description", bundle: .core),
                 html: $viewModel.description,
                 context: .course(viewModel.courseID),
                 uploadTo: .context(.course(viewModel.courseID)),
@@ -179,7 +179,7 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
                 Divider()
                 IntFieldRow(
                     label: Text("Allowed Attempts", bundle: .core),
-                    placeholder: NSLocalizedString("Unlimited", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Unlimited", bundle: .core),
                     value: $viewModel.allowedAttempts
                 )
                 .accessibilityIdentifier("QuizEditor.allowedAttempts")
@@ -213,7 +213,7 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
                 Divider()
                 TextFieldRow(
                     label: Text("Access Code", bundle: .core),
-                    placeholder: NSLocalizedString("Enter code", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Enter code", bundle: .core),
                     text: $viewModel.accessCode
                 )
                 .accessibilityIdentifier("QuizEditor.accessCode")

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizAttribute.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizAttribute.swift
@@ -37,85 +37,85 @@ public struct QuizAttributes {
 
         let quizType = quiz.quizType.name
         attributes.append(QuizAttribute(
-            NSLocalizedString("Quiz Type:", bundle: .core, comment: ""),
+            String(localized: "Quiz Type:", bundle: .core),
             quizType
         ))
 
         if let assignmentGroupName = assignment?.assignmentGroup?.name {
             attributes.append(QuizAttribute(
-                NSLocalizedString("Assignment Group:", bundle: .core, comment: ""),
+                String(localized: "Assignment Group:", bundle: .core),
                 assignmentGroupName
             ))
         }
 
         let shuffleAnswers = quiz.shuffleAnswers ?
-            NSLocalizedString("Yes", bundle: .core, comment: "") :
-            NSLocalizedString("No", bundle: .core, comment: "")
+            String(localized: "Yes", bundle: .core) :
+            String(localized: "No", bundle: .core)
         attributes.append(QuizAttribute(
-            NSLocalizedString("Shuffle Answers:", bundle: .core, comment: ""),
+            String(localized: "Shuffle Answers:", bundle: .core),
             shuffleAnswers
         ))
 
-        var timeLimitText = NSLocalizedString("No time Limit", bundle: .core, comment: "")
+        var timeLimitText = String(localized: "No time Limit", bundle: .core)
         if let timeLimit = quiz.timeLimit {
-            let timeLimitTemplate = NSLocalizedString("%d Minutes", bundle: .core, comment: "")
+            let timeLimitTemplate = String(localized: "%d Minutes", bundle: .core)
             timeLimitText = String.localizedStringWithFormat(timeLimitTemplate, Int(timeLimit))
         }
 
         attributes.append(QuizAttribute(
-            NSLocalizedString("Time Limit:", bundle: .core, comment: ""),
+            String(localized: "Time Limit:", bundle: .core),
             timeLimitText
         ))
 
         attributes.append(QuizAttribute(
-            NSLocalizedString("Allowed Attempts:", bundle: .core, comment: ""),
+            String(localized: "Allowed Attempts:", bundle: .core),
             quiz.allowedAttemptsText
         ))
 
-        var hideResultsText = NSLocalizedString("Always", bundle: .core, comment: "")
+        var hideResultsText = String(localized: "Always", bundle: .core)
         if let hideResults = quiz.hideResults {
             hideResultsText = hideResults.text
         }
         attributes.append(QuizAttribute(
-            NSLocalizedString("View Responses:", bundle: .core, comment: ""),
+            String(localized: "View Responses:", bundle: .core),
             hideResultsText
         ))
 
         if let showCorrectAnswers = showCorrectAnswers(quiz: quiz) {
             attributes.append(QuizAttribute(
-                NSLocalizedString("Show Correct Answers:", bundle: .core, comment: ""),
+                String(localized: "Show Correct Answers:", bundle: .core),
                 showCorrectAnswers
             ))
         }
 
         let oneQuestionAtATime = quiz.oneQuestionAtATime ?
-            NSLocalizedString("Yes", bundle: .core, comment: "") :
-            NSLocalizedString("No", bundle: .core, comment: "")
+            String(localized: "Yes", bundle: .core) :
+            String(localized: "No", bundle: .core)
         attributes.append(QuizAttribute(
-            NSLocalizedString("One Question at a Time:", bundle: .core, comment: ""),
+            String(localized: "One Question at a Time:", bundle: .core),
             oneQuestionAtATime
         ))
 
         if quiz.oneQuestionAtATime == true {
             let lockQuestionsAfterAnswering = quiz.cantGoBack ?
-                NSLocalizedString("Yes", bundle: .core, comment: "") :
-                NSLocalizedString("No", bundle: .core, comment: "")
+                String(localized: "Yes", bundle: .core) :
+                String(localized: "No", bundle: .core)
             attributes.append(QuizAttribute(
-                NSLocalizedString("Lock Questions After Answering:", bundle: .core, comment: ""),
+                String(localized: "Lock Questions After Answering:", bundle: .core),
                 lockQuestionsAfterAnswering
             ))
         }
 
         if let scoringPolicy = quiz.scoringPolicy {
             attributes.append(QuizAttribute(
-                NSLocalizedString("Score to Keep:", bundle: .core, comment: ""),
+                String(localized: "Score to Keep:", bundle: .core),
                 scoringPolicy.text
             ))
         }
 
         if let accessCode = quiz.accessCode {
             attributes.append(QuizAttribute(
-                NSLocalizedString("Access Code:", bundle: .core, comment: ""),
+                String(localized: "Access Code:", bundle: .core),
                 accessCode
             ))
         }
@@ -124,24 +124,24 @@ public struct QuizAttributes {
     private func showCorrectAnswers(quiz: Quiz) -> String? {
         if quiz.showCorrectAnswers {
             if let showCorrectAnswersAt = quiz.showCorrectAnswersAt, quiz.hideCorrectAnswersAt == nil {
-                let template = NSLocalizedString("After %@", bundle: .core, comment: "e.g. After 01.02.2022")
+                let template = String(localized: "After %@", bundle: .core, comment: "e.g. After 01.02.2022")
                 return String.localizedStringWithFormat(template, showCorrectAnswersAt.relativeDateTimeString)
             }
             if let hideCorrectAnswersAt = quiz.hideCorrectAnswersAt, quiz.showCorrectAnswersAt == nil {
-                let template = NSLocalizedString("Until %@", bundle: .core, comment: "e.g. Until 01.02.2022")
+                let template = String(localized: "Until %@", bundle: .core, comment: "e.g. Until 01.02.2022")
                 return String.localizedStringWithFormat(template, hideCorrectAnswersAt.relativeDateTimeString)
             }
             if let showCorrectAnswersAt = quiz.showCorrectAnswersAt, let hideCorrectAnswersAt = quiz.hideCorrectAnswersAt {
-                let template = NSLocalizedString("%@ to %@", bundle: .core, comment: "e.g 01.02.2022 to 01.03.2022")
+                let template = String(localized: "%@ to %@", bundle: .core, comment: "e.g 01.02.2022 to 01.03.2022")
                 return String.localizedStringWithFormat(template, showCorrectAnswersAt.relativeDateTimeString, hideCorrectAnswersAt.relativeDateTimeString)
             }
             if quiz.showCorrectAnswersLastAttempt && quiz.allowedAttempts > 0 {
-                return NSLocalizedString("After Last Attempt", bundle: .core, comment: "")
+                return String(localized: "After Last Attempt", bundle: .core)
             }
 
-            return quiz.hideResults != nil ? nil : NSLocalizedString("Always", bundle: .core, comment: "")
+            return quiz.hideResults != nil ? nil : String(localized: "Always", bundle: .core)
         }
 
-        return quiz.hideResults != nil ? nil : NSLocalizedString("No", bundle: .core, comment: "")
+        return quiz.hideResults != nil ? nil : String(localized: "No", bundle: .core)
     }
 }

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDateSectionViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDateSectionViewModel.swift
@@ -47,7 +47,7 @@ public class QuizDateSectionViewModel: DateSectionViewModelProtocol {
 
     public var forText: String {
         if allDatesDate?.base == true {
-            return NSLocalizedString("Everyone", bundle: .core, comment: "")
+            return String(localized: "Everyone", bundle: .core)
         } else {
             return allDatesDate?.title ?? "-"
         }

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
@@ -22,7 +22,7 @@ public class QuizDetailsViewModel: QuizDetailsViewModelProtocol {
     @Published public private(set) var state: QuizDetailsViewModelState = .loading
 
     public private(set) var courseColor: UIColor?
-    public var title: String { NSLocalizedString("Quiz Details", bundle: .core, comment: "") }
+    public var title: String { String(localized: "Quiz Details", bundle: .core) }
     public var subtitle: String { courseUseCase.first?.name ?? "" }
     public var showSubmissions: Bool { courseUseCase.first?.enrollments?.contains(where: { $0.isTeacher || $0.isTA }) == true }
     public private(set) var assignmentSubmissionBreakdownViewModel: AssignmentSubmissionBreakdownViewModel?

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizDetailsViewModel.swift
@@ -22,7 +22,7 @@ public class QuizDetailsViewModel: QuizDetailsViewModelProtocol {
     @Published public private(set) var state: QuizDetailsViewModelState = .loading
 
     public private(set) var courseColor: UIColor?
-    public var title: String { NSLocalizedString("Quiz Details", comment: "") }
+    public var title: String { NSLocalizedString("Quiz Details", bundle: .core, comment: "") }
     public var subtitle: String { courseUseCase.first?.name ?? "" }
     public var showSubmissions: Bool { courseUseCase.first?.enrollments?.contains(where: { $0.isTeacher || $0.isTA }) == true }
     public private(set) var assignmentSubmissionBreakdownViewModel: AssignmentSubmissionBreakdownViewModel?

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizEditorViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizEditorViewModel.swift
@@ -69,7 +69,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core))
                     return
                 }
 
@@ -91,7 +91,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core))
                     return
                 }
 
@@ -107,7 +107,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core))
                     return
                 }
                 self.assignmentGroups = self.env.database.viewContext.fetch(scope: useCase.scope)
@@ -146,13 +146,13 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
 
     func validate() -> Bool {
         if title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let errorMessage = NSLocalizedString("A title is required", bundle: .core, comment: "")
+            let errorMessage = String(localized: "A title is required", bundle: .core)
             showError(title: errorMessage)
             return false
         }
 
         if requireAccessCode && accessCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let errorMessage = NSLocalizedString("You must enter an access code", bundle: .core, comment: "")
+            let errorMessage = String(localized: "You must enter an access code", bundle: .core)
             showError(title: errorMessage)
             return false
         }
@@ -161,7 +161,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
 
     private func showError(title: String) {
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .cancel))
         showErrorPopupSubject.send(alert)
     }
 
@@ -200,7 +200,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
                 guard let self = self else { return }
                 if error != nil {
                     self.state = .ready
-                    let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
+                    let errorMessage = error?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core)
                     self.showError(title: errorMessage)
                     return
                 } else {
@@ -215,7 +215,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
     public func quizTypeTapped(router: Router, viewController: WeakViewController) {
         let options = availableQuizTypes
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Quiz Type", bundle: .core, comment: ""),
+            title: String(localized: "Quiz Type", bundle: .core),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.name)
             }), ],
@@ -230,7 +230,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
         guard let selectedGroup = assignmentGroup else { return}
         let options = assignmentGroups
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Assignment Group", bundle: .core, comment: ""),
+            title: String(localized: "Assignment Group", bundle: .core),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.name)
             }), ],
@@ -244,7 +244,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
     public func scoreToKeepTapped(router: Router, viewController: WeakViewController) {
         let options = ScoringPolicy.allCases
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Quiz Score to Keep", bundle: .core, comment: ""),
+            title: String(localized: "Quiz Score to Keep", bundle: .core),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.text)
             }), ],

--- a/Core/Core/Quizzes/QuizDetails/ViewModel/QuizEditorViewModel.swift
+++ b/Core/Core/Quizzes/QuizDetails/ViewModel/QuizEditorViewModel.swift
@@ -69,7 +69,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
                     return
                 }
 
@@ -91,7 +91,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
                     return
                 }
 
@@ -107,7 +107,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 if fetchError != nil {
-                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: ""))
+                    self.state = .error(fetchError?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: ""))
                     return
                 }
                 self.assignmentGroups = self.env.database.viewContext.fetch(scope: useCase.scope)
@@ -146,13 +146,13 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
 
     func validate() -> Bool {
         if title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let errorMessage = NSLocalizedString("A title is required", comment: "")
+            let errorMessage = NSLocalizedString("A title is required", bundle: .core, comment: "")
             showError(title: errorMessage)
             return false
         }
 
         if requireAccessCode && accessCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let errorMessage = NSLocalizedString("You must enter an access code", comment: "")
+            let errorMessage = NSLocalizedString("You must enter an access code", bundle: .core, comment: "")
             showError(title: errorMessage)
             return false
         }
@@ -161,7 +161,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
 
     private func showError(title: String) {
         let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .cancel))
+        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel))
         showErrorPopupSubject.send(alert)
     }
 
@@ -200,7 +200,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
                 guard let self = self else { return }
                 if error != nil {
                     self.state = .ready
-                    let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
+                    let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
                     self.showError(title: errorMessage)
                     return
                 } else {
@@ -215,7 +215,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
     public func quizTypeTapped(router: Router, viewController: WeakViewController) {
         let options = availableQuizTypes
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Quiz Type", comment: ""),
+            title: NSLocalizedString("Quiz Type", bundle: .core, comment: ""),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.name)
             }), ],
@@ -230,7 +230,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
         guard let selectedGroup = assignmentGroup else { return}
         let options = assignmentGroups
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Assignment Group", comment: ""),
+            title: NSLocalizedString("Assignment Group", bundle: .core, comment: ""),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.name)
             }), ],
@@ -244,7 +244,7 @@ public class QuizEditorViewModel: QuizEditorViewModelProtocol {
     public func scoreToKeepTapped(router: Router, viewController: WeakViewController) {
         let options = ScoringPolicy.allCases
         router.show(ItemPickerViewController.create(
-            title: NSLocalizedString("Quiz Score to Keep", comment: ""),
+            title: NSLocalizedString("Quiz Score to Keep", bundle: .core, comment: ""),
             sections: [ ItemPickerSection(items: options.map {
                 ItemPickerItem(title: $0.text)
             }), ],

--- a/Core/Core/Quizzes/QuizListViewController.swift
+++ b/Core/Core/Quizzes/QuizListViewController.swift
@@ -55,11 +55,11 @@ public class QuizListViewController: ScreenViewTrackableViewController, ColoredN
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Quizzes", comment: ""))
+        setupTitleViewInNavbar(title: NSLocalizedString("Quizzes", bundle: .core, comment: ""))
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like quizzes haven’t been created in this space yet.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Quizzes", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading quizzes. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = NSLocalizedString("It looks like quizzes haven’t been created in this space yet.", bundle: .core, comment: "")
+        emptyTitleLabel.text = NSLocalizedString("No Quizzes", bundle: .core, comment: "")
+        errorView.messageLabel.text = NSLocalizedString("There was an error loading quizzes. Pull to refresh to try again.", bundle: .core, comment: "")
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil

--- a/Core/Core/Quizzes/QuizListViewController.swift
+++ b/Core/Core/Quizzes/QuizListViewController.swift
@@ -55,11 +55,11 @@ public class QuizListViewController: ScreenViewTrackableViewController, ColoredN
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-        setupTitleViewInNavbar(title: NSLocalizedString("Quizzes", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Quizzes", bundle: .core))
 
-        emptyMessageLabel.text = NSLocalizedString("It looks like quizzes haven’t been created in this space yet.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Quizzes", bundle: .core, comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading quizzes. Pull to refresh to try again.", bundle: .core, comment: "")
+        emptyMessageLabel.text = String(localized: "It looks like quizzes haven’t been created in this space yet.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "No Quizzes", bundle: .core)
+        errorView.messageLabel.text = String(localized: "There was an error loading quizzes. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         loadingView.color = nil

--- a/Core/Core/Quizzes/QuizPreview/ViewModel/QuizPreviewViewModel.swift
+++ b/Core/Core/Quizzes/QuizPreview/ViewModel/QuizPreviewViewModel.swift
@@ -20,9 +20,9 @@ import SwiftUI
 
 public class QuizPreviewViewModel: ObservableObject {
     @Published public var state: QuizPreviewInteractorState = .loading
-    public let navigationTitle = NSLocalizedString("Quiz Preview", comment: "")
-    public let errorTitle = NSLocalizedString("Something Went Wrong", comment: "")
-    public let errorDescription = NSLocalizedString("We couldn't load the quiz preview.\nPlease try again later.", comment: "")
+    public let navigationTitle = NSLocalizedString("Quiz Preview", bundle: .core, comment: "")
+    public let errorTitle = NSLocalizedString("Something Went Wrong", bundle: .core, comment: "")
+    public let errorDescription = NSLocalizedString("We couldn't load the quiz preview.\nPlease try again later.", bundle: .core, comment: "")
     /** After the submission the top of the page is the quiz properties so we scroll down to the results. */
     public let scrollToResultsJS =
     """

--- a/Core/Core/Quizzes/QuizPreview/ViewModel/QuizPreviewViewModel.swift
+++ b/Core/Core/Quizzes/QuizPreview/ViewModel/QuizPreviewViewModel.swift
@@ -20,9 +20,9 @@ import SwiftUI
 
 public class QuizPreviewViewModel: ObservableObject {
     @Published public var state: QuizPreviewInteractorState = .loading
-    public let navigationTitle = NSLocalizedString("Quiz Preview", bundle: .core, comment: "")
-    public let errorTitle = NSLocalizedString("Something Went Wrong", bundle: .core, comment: "")
-    public let errorDescription = NSLocalizedString("We couldn't load the quiz preview.\nPlease try again later.", bundle: .core, comment: "")
+    public let navigationTitle = String(localized: "Quiz Preview", bundle: .core)
+    public let errorTitle = String(localized: "Something Went Wrong", bundle: .core)
+    public let errorDescription = String(localized: "We couldn't load the quiz preview.\nPlease try again later.", bundle: .core)
     /** After the submission the top of the page is the quiz properties so we scroll down to the results. */
     public let scrollToResultsJS =
     """

--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -207,18 +207,18 @@ public class RichContentEditorViewController: UIViewController {
 
     func editLink(href: String?, text: String?) {
         backupRange()
-        let alert = UIAlertController(title: NSLocalizedString("Link to Website URL", bundle: .core, comment: ""), message: nil, preferredStyle: .alert)
+        let alert = UIAlertController(title: String(localized: "Link to Website URL", bundle: .core), message: nil, preferredStyle: .alert)
         alert.addTextField { (field: UITextField) in
-            field.placeholder = NSLocalizedString("Text", bundle: .core, comment: "")
+            field.placeholder = String(localized: "Text", bundle: .core)
             field.text = text
         }
         alert.addTextField { (field: UITextField) in
-            field.placeholder = NSLocalizedString("URL", bundle: .core, comment: "")
+            field.placeholder = String(localized: "URL", bundle: .core)
             field.text = href
             field.keyboardType = .URL
         }
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .core, comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .core), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .core), style: .default) { [weak self] _ in
             let text = alert.textFields?[0].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             var href = alert.textFields?[1].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             if !href.isEmpty, URLComponents.parse(href).scheme == nil {
@@ -292,7 +292,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
                 } else if let url = info[.mediaURL] as? URL {
                     self.createFile(url, isRetry: false, then: self.uploadMedia)
                 } else {
-                    throw NSError.instructureError(NSLocalizedString("No image found from image picker", bundle: .core, comment: ""))
+                    throw NSError.instructureError(String(localized: "No image found from image picker", bundle: .core))
                 }
             } catch {
                 self.showError(error)
@@ -373,7 +373,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
             "url": file.url?.absoluteString,
             "mediaEntryID": file.mediaEntryID,
             "uploadError": file.uploadError,
-            "uploadErrorTitle": NSLocalizedString("Failed Upload", bundle: .core, comment: ""),
+            "uploadErrorTitle": String(localized: "Failed Upload", bundle: .core),
             "bytesSent": file.bytesSent,
             "size": file.size,
         ] })

--- a/Core/Core/RichContentEditor/RichContentToolbarView.swift
+++ b/Core/Core/RichContentEditor/RichContentToolbarView.swift
@@ -67,30 +67,30 @@ public class RichContentToolbarView: UIView {
         super.awakeFromNib()
         backgroundColor = .backgroundLightest
         translatesAutoresizingMaskIntoConstraints = false
-        undoButton.accessibilityLabel = NSLocalizedString("Undo", bundle: .core, comment: "")
-        redoButton.accessibilityLabel = NSLocalizedString("Redo", bundle: .core, comment: "")
-        boldButton.accessibilityLabel = NSLocalizedString("Bold", bundle: .core, comment: "")
-        italicButton.accessibilityLabel = NSLocalizedString("Italic", bundle: .core, comment: "")
-        textColorButton.accessibilityLabel = NSLocalizedString("Text Color", bundle: .core, comment: "")
-        unorderedButton.accessibilityLabel = NSLocalizedString("Unordered List", bundle: .core, comment: "")
-        orderedButton.accessibilityLabel = NSLocalizedString("Ordered List", bundle: .core, comment: "")
-        linkButton.accessibilityLabel = NSLocalizedString("Link", bundle: .core, comment: "")
-        cameraButton.accessibilityLabel = NSLocalizedString("Camera", bundle: .core, comment: "")
-        libraryButton.accessibilityLabel = NSLocalizedString("Image", bundle: .core, comment: "")
+        undoButton.accessibilityLabel = String(localized: "Undo", bundle: .core)
+        redoButton.accessibilityLabel = String(localized: "Redo", bundle: .core)
+        boldButton.accessibilityLabel = String(localized: "Bold", bundle: .core)
+        italicButton.accessibilityLabel = String(localized: "Italic", bundle: .core)
+        textColorButton.accessibilityLabel = String(localized: "Text Color", bundle: .core)
+        unorderedButton.accessibilityLabel = String(localized: "Unordered List", bundle: .core)
+        orderedButton.accessibilityLabel = String(localized: "Ordered List", bundle: .core)
+        linkButton.accessibilityLabel = String(localized: "Link", bundle: .core)
+        cameraButton.accessibilityLabel = String(localized: "Camera", bundle: .core)
+        libraryButton.accessibilityLabel = String(localized: "Image", bundle: .core)
         toolsView.backgroundColor = .backgroundLightest
 
         let colors = colorPickerStack.arrangedSubviews
-        colors[0].accessibilityValue = NSLocalizedString("white", bundle: .core, comment: "")
-        colors[1].accessibilityValue = NSLocalizedString("black", bundle: .core, comment: "")
-        colors[2].accessibilityValue = NSLocalizedString("grey", bundle: .core, comment: "")
-        colors[3].accessibilityValue = NSLocalizedString("red", bundle: .core, comment: "")
-        colors[4].accessibilityValue = NSLocalizedString("orange", bundle: .core, comment: "")
-        colors[5].accessibilityValue = NSLocalizedString("yellow", bundle: .core, comment: "")
-        colors[6].accessibilityValue = NSLocalizedString("green", bundle: .core, comment: "")
-        colors[7].accessibilityValue = NSLocalizedString("blue", bundle: .core, comment: "")
-        colors[8].accessibilityValue = NSLocalizedString("purple", bundle: .core, comment: "")
+        colors[0].accessibilityValue = String(localized: "white", bundle: .core)
+        colors[1].accessibilityValue = String(localized: "black", bundle: .core)
+        colors[2].accessibilityValue = String(localized: "grey", bundle: .core)
+        colors[3].accessibilityValue = String(localized: "red", bundle: .core)
+        colors[4].accessibilityValue = String(localized: "orange", bundle: .core)
+        colors[5].accessibilityValue = String(localized: "yellow", bundle: .core)
+        colors[6].accessibilityValue = String(localized: "green", bundle: .core)
+        colors[7].accessibilityValue = String(localized: "blue", bundle: .core)
+        colors[8].accessibilityValue = String(localized: "purple", bundle: .core)
         for color in colors {
-            color.accessibilityLabel = NSLocalizedString("Set text color", bundle: .core, comment: "")
+            color.accessibilityLabel = String(localized: "Set text color", bundle: .core)
         }
 
         colorPickerHeight.constant = 0

--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -485,7 +485,7 @@ public struct PutSubmissionGradeRequest: APIRequestable {
                 group_comment = forGroup
                 media_comment_id = mediaID
                 media_comment_type = type
-                text_comment = forGroup ? NSLocalizedString("This is a media comment", bundle: .core, comment: "") : ""
+                text_comment = forGroup ? String(localized: "This is a media comment", bundle: .core) : ""
                 file_ids = nil
                 self.attempt = attempt
             }

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -349,13 +349,13 @@ public class GetSubmissions: CollectionUseCase {
             case .notSubmitted:
                 return SubmissionStatus.notSubmitted.text
             case .needsGrading:
-                return NSLocalizedString("Needs Grading", comment: "")
+                return NSLocalizedString("Needs Grading", bundle: .core, comment: "")
             case .graded:
-                return NSLocalizedString("Graded", comment: "")
+                return NSLocalizedString("Graded", bundle: .core, comment: "")
             case .scoreBelow(let score):
-                return String.localizedStringWithFormat(NSLocalizedString("Scored below %g", comment: ""), score)
+                return String.localizedStringWithFormat(NSLocalizedString("Scored below %g", bundle: .core, comment: ""), score)
             case .scoreAbove(let score):
-                return String.localizedStringWithFormat(NSLocalizedString("Scored above %g", comment: ""), score)
+                return String.localizedStringWithFormat(NSLocalizedString("Scored above %g", bundle: .core, comment: ""), score)
             case .user(let userID):
                 let user: User? = AppEnvironment.shared.database.viewContext.first(where: #keyPath(User.id), equals: userID)
                 return user?.shortName

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -349,13 +349,13 @@ public class GetSubmissions: CollectionUseCase {
             case .notSubmitted:
                 return SubmissionStatus.notSubmitted.text
             case .needsGrading:
-                return NSLocalizedString("Needs Grading", bundle: .core, comment: "")
+                return String(localized: "Needs Grading", bundle: .core)
             case .graded:
-                return NSLocalizedString("Graded", bundle: .core, comment: "")
+                return String(localized: "Graded", bundle: .core)
             case .scoreBelow(let score):
-                return String.localizedStringWithFormat(NSLocalizedString("Scored below %g", bundle: .core, comment: ""), score)
+                return String.localizedStringWithFormat(String(localized: "Scored below %g", bundle: .core), score)
             case .scoreAbove(let score):
-                return String.localizedStringWithFormat(NSLocalizedString("Scored above %g", bundle: .core, comment: ""), score)
+                return String.localizedStringWithFormat(String(localized: "Scored above %g", bundle: .core), score)
             case .user(let userID):
                 let user: User? = AppEnvironment.shared.database.viewContext.first(where: #keyPath(User.id), equals: userID)
                 return user?.shortName

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -300,15 +300,15 @@ extension Submission {
         switch type {
         case .basic_lti_launch, .external_tool, .online_quiz:
             return String.localizedStringWithFormat(
-                NSLocalizedString("Attempt %d", bundle: .core, comment: ""),
+                String(localized: "Attempt %d", bundle: .core),
                 attempt
             )
         case .discussion_topic:
             return discussionEntriesOrdered.first?.message?.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
         case .media_recording:
             return mediaComment?.mediaType == .audio
-                ? NSLocalizedString("Audio", bundle: .core, comment: "")
-                : NSLocalizedString("Video", bundle: .core, comment: "")
+                ? String(localized: "Audio", bundle: .core)
+                : String(localized: "Video", bundle: .core)
         case .online_text_entry:
             return body?.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
         case .online_upload:
@@ -350,13 +350,13 @@ public enum SubmissionStatus {
     public var text: String {
         switch self {
         case .late:
-            return NSLocalizedString("Late", bundle: .core, comment: "")
+            return String(localized: "Late", bundle: .core)
         case .missing:
-            return NSLocalizedString("Missing", bundle: .core, comment: "")
+            return String(localized: "Missing", bundle: .core)
         case .submitted:
-            return NSLocalizedString("Submitted", bundle: .core, comment: "")
+            return String(localized: "Submitted", bundle: .core)
         case .notSubmitted:
-            return NSLocalizedString("Not Submitted", bundle: .core, comment: "")
+            return String(localized: "Not Submitted", bundle: .core)
         }
     }
 
@@ -403,29 +403,29 @@ public enum SubmissionType: String, Codable {
     public var localizedString: String {
         switch self {
         case .discussion_topic:
-            return NSLocalizedString("Discussion Comment", bundle: .core, comment: "")
+            return String(localized: "Discussion Comment", bundle: .core)
         case .external_tool, .basic_lti_launch:
-            return NSLocalizedString("External Tool", bundle: .core, comment: "")
+            return String(localized: "External Tool", bundle: .core)
         case .media_recording:
-            return NSLocalizedString("Media Recording", bundle: .core, comment: "")
+            return String(localized: "Media Recording", bundle: .core)
         case .none:
-            return NSLocalizedString("No Submission", bundle: .core, comment: "")
+            return String(localized: "No Submission", bundle: .core)
         case .not_graded:
-            return NSLocalizedString("Not Graded", bundle: .core, comment: "")
+            return String(localized: "Not Graded", bundle: .core)
         case .online_quiz:
-            return NSLocalizedString("Quiz", bundle: .core, comment: "")
+            return String(localized: "Quiz", bundle: .core)
         case .online_text_entry:
-            return NSLocalizedString("Text Entry", bundle: .core, comment: "")
+            return String(localized: "Text Entry", bundle: .core)
         case .online_upload:
-            return NSLocalizedString("File Upload", bundle: .core, comment: "")
+            return String(localized: "File Upload", bundle: .core)
         case .online_url:
-            return NSLocalizedString("Website URL", bundle: .core, comment: "")
+            return String(localized: "Website URL", bundle: .core)
         case .on_paper:
-            return NSLocalizedString("On Paper", bundle: .core, comment: "")
+            return String(localized: "On Paper", bundle: .core)
         case .wiki_page:
-            return NSLocalizedString("Page", bundle: .core, comment: "")
+            return String(localized: "Page", bundle: .core)
         case .student_annotation:
-            return NSLocalizedString("Student Annotation", bundle: .core, comment: "")
+            return String(localized: "Student Annotation", bundle: .core)
 
         }
     }

--- a/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
+++ b/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
@@ -45,7 +45,7 @@ struct SubmissionBreakdown<ViewModel: SubmissionBreakdownViewModelProtocol>: Vie
                                 total: viewModel.submissionCount
                             )
                             Text(String.localizedStringWithFormat(
-                                NSLocalizedString("there_are_d_assignees_without_grades", comment: ""),
+                                NSLocalizedString("there_are_d_assignees_without_grades", bundle: .core, comment: ""),
                                 viewModel.ungraded + viewModel.unsubmitted
                             ))
                                 .font(.regular14).foregroundColor(.textDarkest)

--- a/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
+++ b/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
@@ -34,7 +34,7 @@ struct SubmissionBreakdown<ViewModel: SubmissionBreakdownViewModelProtocol>: Vie
                         Spacer()
                     }
                     if viewModel.noSubmissionTypes {
-                        Text("Tap to view submissions list.")
+                        Text("Tap to view submissions list.", bundle: .core)
                             .font(.regular16).foregroundColor(.textDarkest)
                     } else if viewModel.paperSubmissionTypes {
                         HStack(alignment: .top, spacing: 0) {

--- a/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
+++ b/Core/Core/Submissions/SubmissionBreakdown/SubmissionBreakdown.swift
@@ -45,7 +45,7 @@ struct SubmissionBreakdown<ViewModel: SubmissionBreakdownViewModelProtocol>: Vie
                                 total: viewModel.submissionCount
                             )
                             Text(String.localizedStringWithFormat(
-                                NSLocalizedString("there_are_d_assignees_without_grades", bundle: .core, comment: ""),
+                                String(localized: "there_are_d_assignees_without_grades", bundle: .core),
                                 viewModel.ungraded + viewModel.unsubmitted
                             ))
                                 .font(.regular14).foregroundColor(.textDarkest)

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
@@ -61,7 +61,7 @@ public class AssignmentPickerListService: AssignmentPickerListServiceProtocol {
             Analytics.shared.logEvent("assignments_loaded", parameters: ["count": assignments.count])
             result = .success(assignments)
         } else {
-            let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
+            let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
             Analytics.shared.logEvent("error_loading_assignments", parameters: ["error": errorMessage])
             Analytics.shared.logError(name: "Assignment list load failed", reason: error?.localizedDescription)
             result = .failure(errorMessage)

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
@@ -61,7 +61,7 @@ public class AssignmentPickerListService: AssignmentPickerListServiceProtocol {
             Analytics.shared.logEvent("assignments_loaded", parameters: ["count": assignments.count])
             result = .success(assignments)
         } else {
-            let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
+            let errorMessage = error?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core)
             Analytics.shared.logEvent("error_loading_assignments", parameters: ["error": errorMessage])
             Analytics.shared.logError(name: "Assignment list load failed", reason: error?.localizedDescription)
             result = .failure(errorMessage)

--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
@@ -67,7 +67,7 @@ public class AttachmentCopyService {
 
     private func load(attachment: NSItemProvider, callback: @escaping (Result<URL, Error>) -> Void) {
         guard let uti = attachment.uti else {
-            let error = NSError.instructureError(NSLocalizedString("Format not supported", comment: ""))
+            let error = NSError.instructureError(NSLocalizedString("Format not supported", bundle: .core, comment: ""))
             callback(.failure(error))
             return
         }
@@ -100,7 +100,7 @@ public class AttachmentCopyService {
                     try data.write(to: newURL)
                 } else {
                     Analytics.shared.logEvent("processing_file", parameters: ["type": "unknown", "class": "\(type(of: coding))"])
-                    throw NSError.instructureError(NSLocalizedString("Format not supported", comment: ""))
+                    throw NSError.instructureError(NSLocalizedString("Format not supported", bundle: .core, comment: ""))
                 }
                 callback(.success(newURL))
             } catch {
@@ -118,7 +118,7 @@ public class AttachmentCopyService {
         } else if let error = error {
             result = .failure(error)
         } else {
-            result = .failure(NSError.instructureError(NSLocalizedString("No supported files to submit", comment: "")))
+            result = .failure(NSError.instructureError(NSLocalizedString("No supported files to submit", bundle: .core, comment: "")))
         }
 
         state.send(.completed(result))

--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentCopyService.swift
@@ -67,7 +67,7 @@ public class AttachmentCopyService {
 
     private func load(attachment: NSItemProvider, callback: @escaping (Result<URL, Error>) -> Void) {
         guard let uti = attachment.uti else {
-            let error = NSError.instructureError(NSLocalizedString("Format not supported", bundle: .core, comment: ""))
+            let error = NSError.instructureError(String(localized: "Format not supported", bundle: .core))
             callback(.failure(error))
             return
         }
@@ -100,7 +100,7 @@ public class AttachmentCopyService {
                     try data.write(to: newURL)
                 } else {
                     Analytics.shared.logEvent("processing_file", parameters: ["type": "unknown", "class": "\(type(of: coding))"])
-                    throw NSError.instructureError(NSLocalizedString("Format not supported", bundle: .core, comment: ""))
+                    throw NSError.instructureError(String(localized: "Format not supported", bundle: .core))
                 }
                 callback(.success(newURL))
             } catch {
@@ -118,7 +118,7 @@ public class AttachmentCopyService {
         } else if let error = error {
             result = .failure(error)
         } else {
-            result = .failure(NSError.instructureError(NSLocalizedString("No supported files to submit", bundle: .core, comment: "")))
+            result = .failure(NSError.instructureError(String(localized: "No supported files to submit", bundle: .core)))
         }
 
         state.send(.completed(result))

--- a/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
@@ -48,7 +48,7 @@ public struct AssignmentPickerView: View {
             error(message: message)
         case .data(let assignments):
             if assignments.isEmpty {
-                error(message: NSLocalizedString("There are no active assignments in this course.", comment: ""))
+                error(message: NSLocalizedString("There are no active assignments in this course.", bundle: .core, comment: ""))
             } else {
                 self.assignments(assignments: assignments)
             }

--- a/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AssignmentPickerView.swift
@@ -48,7 +48,7 @@ public struct AssignmentPickerView: View {
             error(message: message)
         case .data(let assignments):
             if assignments.isEmpty {
-                error(message: NSLocalizedString("There are no active assignments in this course.", bundle: .core, comment: ""))
+                error(message: String(localized: "There are no active assignments in this course.", bundle: .core))
             } else {
                 self.assignments(assignments: assignments)
             }

--- a/Core/Core/SubmitAssignmentExtension/View/AttachmentPreviewView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/AttachmentPreviewView.swift
@@ -68,7 +68,7 @@ public struct AttachmentPreviewView: View {
                 .foregroundColor(.textDark)
                 .opacity(0.1)
                 .padding()
-            Text("No preview available", comment: "")
+            Text("No preview available", bundle: .core)
                 .font(.regular17)
                 .foregroundColor(.textDarkest)
         }

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -47,7 +47,7 @@ public struct SubmitAssignmentExtensionView: View {
     }
 
     private var notLoggedInView: some View {
-        Text("Please log in via the application")
+        Text("Please log in via the application", bundle: .core)
             .foregroundColor(.textDarkest)
             .font(.regular16)
             .navigationBarGlobal()
@@ -99,7 +99,7 @@ public struct SubmitAssignmentExtensionView: View {
     @ViewBuilder
     private var placeholder: some View {
         if viewModel.comment.isEmpty {
-            Text("Add comment (optional)", comment: "")
+            Text("Add comment (optional)", bundle: .core)
                 .foregroundColor(.textDark)
                 .font(.regular16)
                 .padding(.top, 21)

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -92,7 +92,7 @@ public struct SubmitAssignmentExtensionView: View {
             .padding(.trailing, -20) // Offset parent's padding so our scrollbar will be in line with parent's scrollbar
             .padding(.leading, -5) // Offset TextEditor's default padding so we'll be in line with the course and assignment picker cells
             .overlay(placeholder, alignment: .topLeading)
-            .accessibilityLabel(NSLocalizedString("Add optional comment", comment: ""))
+            .accessibilityLabel(NSLocalizedString("Add optional comment", bundle: .core, comment: ""))
             .toolbar { hideKeyboardButton }
     }
 
@@ -199,7 +199,7 @@ public struct SubmitAssignmentExtensionView: View {
 
     private var filesSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(String.localizedStringWithFormat(NSLocalizedString("d_items", comment: ""), viewModel.previews.count))
+            Text(String.localizedStringWithFormat(NSLocalizedString("d_items", bundle: .core, comment: ""), viewModel.previews.count))
                 .font(.regular12)
                 .foregroundColor(.textDark)
             ScrollView(.horizontal, showsIndicators: false) {

--- a/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -92,7 +92,7 @@ public struct SubmitAssignmentExtensionView: View {
             .padding(.trailing, -20) // Offset parent's padding so our scrollbar will be in line with parent's scrollbar
             .padding(.leading, -5) // Offset TextEditor's default padding so we'll be in line with the course and assignment picker cells
             .overlay(placeholder, alignment: .topLeading)
-            .accessibilityLabel(NSLocalizedString("Add optional comment", bundle: .core, comment: ""))
+            .accessibilityLabel(String(localized: "Add optional comment", bundle: .core))
             .toolbar { hideKeyboardButton }
     }
 
@@ -199,7 +199,7 @@ public struct SubmitAssignmentExtensionView: View {
 
     private var filesSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(String.localizedStringWithFormat(NSLocalizedString("d_items", bundle: .core, comment: ""), viewModel.previews.count))
+            Text(String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), viewModel.previews.count))
                 .font(.regular12)
                 .foregroundColor(.textDark)
             ScrollView(.horizontal, showsIndicators: false) {

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
@@ -27,10 +27,10 @@ public struct AssignmentPickerItem: Equatable, Identifiable {
 
         if !apiItem.allowedExtensions.isEmpty, !incompatibleExtensions.isEmpty {
             let availableExtensions = apiItem.allowedExtensions.sorted()
-            let notCompatibleStringFormat = NSLocalizedString("incompatible_files_for_assignment", bundle: .core, comment: "")
+            let notCompatibleStringFormat = String(localized: "incompatible_files_for_assignment", bundle: .core)
             let notCompatibleText = String.localizedStringWithFormat(notCompatibleStringFormat, incompatibleExtensions.count, incompatibleExtensions.joined(separator: ", "))
 
-            let useExtensionsStringFormat = NSLocalizedString("use_file_extension", bundle: .core, comment: "")
+            let useExtensionsStringFormat = String(localized: "use_file_extension", bundle: .core)
             let compatibleText = String.localizedStringWithFormat(useExtensionsStringFormat, availableExtensions.count, availableExtensions.joined(separator: ", "))
             notAvailableReason = "\(notCompatibleText)\n\(compatibleText)"
         }

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
@@ -27,10 +27,10 @@ public struct AssignmentPickerItem: Equatable, Identifiable {
 
         if !apiItem.allowedExtensions.isEmpty, !incompatibleExtensions.isEmpty {
             let availableExtensions = apiItem.allowedExtensions.sorted()
-            let notCompatibleStringFormat = NSLocalizedString("incompatible_files_for_assignment", comment: "")
+            let notCompatibleStringFormat = NSLocalizedString("incompatible_files_for_assignment", bundle: .core, comment: "")
             let notCompatibleText = String.localizedStringWithFormat(notCompatibleStringFormat, incompatibleExtensions.count, incompatibleExtensions.joined(separator: ", "))
 
-            let useExtensionsStringFormat = NSLocalizedString("use_file_extension", comment: "")
+            let useExtensionsStringFormat = NSLocalizedString("use_file_extension", bundle: .core, comment: "")
             let compatibleText = String.localizedStringWithFormat(useExtensionsStringFormat, availableExtensions.count, availableExtensions.joined(separator: ", "))
             notAvailableReason = "\(notCompatibleText)\n\(compatibleText)"
         }

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
@@ -52,7 +52,7 @@ public class CoursePickerViewModel: ObservableObject {
                 Analytics.shared.logEvent("courses_loaded", parameters: ["count": validCourses.count])
                 newState = .data(validCourses)
             } else {
-                let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", comment: "")
+                let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
                 Analytics.shared.logEvent("error_loading_courses", parameters: ["error": errorMessage])
                 Analytics.shared.logError(name: "Course list loading failed", reason: error?.localizedDescription)
                 newState = .error(errorMessage)

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/CoursePickerViewModel.swift
@@ -52,7 +52,7 @@ public class CoursePickerViewModel: ObservableObject {
                 Analytics.shared.logEvent("courses_loaded", parameters: ["count": validCourses.count])
                 newState = .data(validCourses)
             } else {
-                let errorMessage = error?.localizedDescription ?? NSLocalizedString("Something went wrong", bundle: .core, comment: "")
+                let errorMessage = error?.localizedDescription ?? String(localized: "Something went wrong", bundle: .core)
                 Analytics.shared.logEvent("error_loading_courses", parameters: ["error": errorMessage])
                 Analytics.shared.logError(name: "Course list loading failed", reason: error?.localizedDescription)
                 newState = .error(errorMessage)

--- a/Core/Core/SwiftUIViews/ConfirmationAlert.swift
+++ b/Core/Core/SwiftUIViews/ConfirmationAlert.swift
@@ -129,7 +129,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
                     Button {
                         viewModel.showDidTap.send()
                     } label: {
-                        Text("Show dialog")
+                        Text("Show dialog", bundle: .core)
                     }
                     .alertConfirmation(isPresented: $viewModel.isShowingConfirmationDialog,
                                        presenting: viewModel.confirmDialog)

--- a/Core/Core/SwiftUIViews/EditorForm.swift
+++ b/Core/Core/SwiftUIViews/EditorForm.swift
@@ -284,7 +284,7 @@ public struct DatePickerRow<Label: View>: View {
                         Button {
                             date = defaultDate
                         } label: {
-                            Text("Date")
+                            Text("Date", bundle: .core)
                                 .font(.regular17)
                                 .padding(.horizontal, 20)
                         }
@@ -292,7 +292,7 @@ public struct DatePickerRow<Label: View>: View {
                         Button {
                             date = defaultDate
                         } label: {
-                            Text("Time")
+                            Text("Time", bundle: .core)
                                 .font(.regular17)
                                 .padding(.horizontal, 20)
                         }

--- a/Core/Core/SwiftUIViews/ListCellView/ListCellView.swift
+++ b/Core/Core/SwiftUIViews/ListCellView/ListCellView.swift
@@ -166,7 +166,7 @@ public struct ListCellView: View {
     @ViewBuilder
     private var errorText: some View {
         if case .error(let error) = viewModel.state {
-            Text(error ?? NSLocalizedString("Unknown Error", bundle: .core, comment: ""))
+            Text(error ?? String(localized: "Unknown Error", bundle: .core))
                 .lineLimit(1)
                 .foregroundColor(.textDanger)
                 .font(.regular14)

--- a/Core/Core/SwiftUIViews/ListCellView/ListCellView.swift
+++ b/Core/Core/SwiftUIViews/ListCellView/ListCellView.swift
@@ -166,7 +166,7 @@ public struct ListCellView: View {
     @ViewBuilder
     private var errorText: some View {
         if case .error(let error) = viewModel.state {
-            Text(error ?? NSLocalizedString("Unknown Error", comment: ""))
+            Text(error ?? NSLocalizedString("Unknown Error", bundle: .core, comment: ""))
                 .lineLimit(1)
                 .foregroundColor(.textDanger)
                 .font(.regular14)

--- a/Core/Core/SwiftUIViews/ListCellView/ListCellViewModel.swift
+++ b/Core/Core/SwiftUIViews/ListCellView/ListCellViewModel.swift
@@ -86,17 +86,17 @@ class ListCellViewModel: ObservableObject {
     var accessibilitySelectionText: String {
         switch selectionState {
         case .deselected:
-            return NSLocalizedString("Select item", bundle: .core, comment: "")
+            return String(localized: "Select item", bundle: .core)
         case .selected, .partiallySelected:
-            return NSLocalizedString("Deselect item", bundle: .core, comment: "")
+            return String(localized: "Deselect item", bundle: .core)
         }
     }
 
     var accessibilityAccordionHeaderText: String {
         if isCollapsed == true {
-            return NSLocalizedString("Open section", bundle: .core, comment: "")
+            return String(localized: "Open section", bundle: .core)
         }
-        return NSLocalizedString("Close section", bundle: .core, comment: "")
+        return String(localized: "Close section", bundle: .core)
     }
 
     var accessibilityText: String {
@@ -108,29 +108,29 @@ class ListCellViewModel: ObservableObject {
         if selectionDidToggle != nil {
             switch selectionState {
             case .deselected:
-                selectionText = NSLocalizedString("Deselected", bundle: .core, comment: "")
+                selectionText = String(localized: "Deselected", bundle: .core)
             case .selected:
-                selectionText = NSLocalizedString("Selected", bundle: .core, comment: "")
+                selectionText = String(localized: "Selected", bundle: .core)
             case .partiallySelected:
-                selectionText = NSLocalizedString("Partially selected", bundle: .core, comment: "")
+                selectionText = String(localized: "Partially selected", bundle: .core)
             }
         }
         var collapseText = ""
         if let isCollapsed = isCollapsed {
             switch isCollapsed {
             case true:
-                collapseText = NSLocalizedString("Closed section", bundle: .core, comment: "")
+                collapseText = String(localized: "Closed section", bundle: .core)
             case false:
-                collapseText = NSLocalizedString("Open section", bundle: .core, comment: "")
+                collapseText = String(localized: "Open section", bundle: .core)
             }
         }
 
         var progressText = ""
         if case let .loading(progress) = state, let progress = progress, !state.isError {
             if progress == 1 {
-                progressText = NSLocalizedString("Download complete", bundle: .core, comment: "")
+                progressText = String(localized: "Download complete", bundle: .core)
             } else {
-                progressText = NSLocalizedString("Downloading", bundle: .core, comment: "")
+                progressText = String(localized: "Downloading", bundle: .core)
             }
         }
         return titleText + "," + selectionText + "," + collapseText + "," + progressText + ","

--- a/Core/Core/SwiftUIViews/Pandas/InteractivePandaConfig.swift
+++ b/Core/Core/SwiftUIViews/Pandas/InteractivePandaConfig.swift
@@ -44,8 +44,8 @@ public extension InteractivePanda.Config {
 
     static func error(
         scene: PandaScene = (NoResultsPanda() as PandaScene),
-        title: String = String(localized: "Something Went Wrong"),
-        subtitle: String = String(localized: "Pull to refresh to try again")
+        title: String = String(localized: "Something Went Wrong", bundle: .core),
+        subtitle: String = String(localized: "Pull to refresh to try again", bundle: .core)
     ) -> Self {
         .init(
             scene: scene,
@@ -56,8 +56,8 @@ public extension InteractivePanda.Config {
 
     static func empty(
         scene: PandaScene = (SpacePanda() as PandaScene),
-        title: String = String(localized: "This screen is empty"),
-        subtitle: String = String(localized: "Pull to refresh to reload")
+        title: String = String(localized: "This screen is empty", bundle: .core),
+        subtitle: String = String(localized: "Pull to refresh to reload", bundle: .core)
     ) -> Self {
         .init(
             scene: scene,

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/UINavigationControllerTheme.swift
@@ -81,7 +81,7 @@ struct NavBarBackButtonModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         controller.value.navigationItem.backButtonDisplayMode = .generic
-        controller.value.navigationItem.backButtonTitle = NSLocalizedString("Back", bundle: .core, comment: "")
+        controller.value.navigationItem.backButtonTitle = String(localized: "Back", bundle: .core)
         return content.overlay(Color?.none) // needs something modified to actually run
     }
 }

--- a/Core/Core/Syllabus/SyllabusEditorView.swift
+++ b/Core/Core/Syllabus/SyllabusEditorView.swift
@@ -72,8 +72,8 @@ public struct SyllabusEditorView: View {
         EditorForm(isSpinning: isLoading || isSaving) {
             EditorSection(label: Text("Content", bundle: .core)) {
                 RichContentEditor(
-                    placeholder: NSLocalizedString("Add content", bundle: .core, comment: ""),
-                    a11yLabel: NSLocalizedString("Syllabus content", bundle: .core, comment: ""),
+                    placeholder: String(localized: "Add content", bundle: .core),
+                    a11yLabel: String(localized: "Syllabus content", bundle: .core),
                     html: $html,
                     context: context,
                     uploadTo: .context(context),

--- a/Core/Core/Syllabus/SyllabusSummaryViewController.swift
+++ b/Core/Core/Syllabus/SyllabusSummaryViewController.swift
@@ -150,7 +150,7 @@ class SyllabusSummaryItemCell: UITableViewCell {
         itemNameLabel?.setText(item?.title, style: .textCellTitle)
         iconImageView?.image = item?.type == .assignment ? .assignmentLine : .calendarMonthLine
         iconImageView?.tintColor = color
-        dateLabel?.setText(item?.startAt.flatMap(formatDate(_:)) ?? NSLocalizedString("No Due Date", bundle: .core, comment: ""), style: .textCellSupportingText)
+        dateLabel?.setText(item?.startAt.flatMap(formatDate(_:)) ?? String(localized: "No Due Date", bundle: .core), style: .textCellSupportingText)
         accessibilityIdentifier = "itemCell.\(item?.id ?? "")"
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)
     }

--- a/Core/Core/Syllabus/SyllabusTabViewController.swift
+++ b/Core/Core/Syllabus/SyllabusTabViewController.swift
@@ -50,7 +50,7 @@ open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewContr
     open override func viewDidLoad() {
         super.viewDidLoad()
         delegate = self
-        setupTitleViewInNavbar(title: NSLocalizedString("Course Syllabus", bundle: .core, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Course Syllabus", bundle: .core))
         view.backgroundColor = UIColor.backgroundLightest
 
         settings.refresh()
@@ -91,7 +91,7 @@ extension SyllabusTabViewController: HorizontalPagedMenuDelegate {
 
     public func menuItemTitle(at: IndexPath) -> String {
         return viewControllers.count > at.row && viewControllers[at.row] === syllabus
-            ? NSLocalizedString("Syllabus", bundle: .core, comment: "")
-            : NSLocalizedString("Summary", bundle: .core, comment: "")
+            ? String(localized: "Syllabus", bundle: .core)
+            : String(localized: "Summary", bundle: .core)
     }
 }

--- a/Core/Core/Syllabus/SyllabusTabViewController.swift
+++ b/Core/Core/Syllabus/SyllabusTabViewController.swift
@@ -50,7 +50,7 @@ open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewContr
     open override func viewDidLoad() {
         super.viewDidLoad()
         delegate = self
-        setupTitleViewInNavbar(title: NSLocalizedString("Course Syllabus", comment: ""))
+        setupTitleViewInNavbar(title: NSLocalizedString("Course Syllabus", bundle: .core, comment: ""))
         view.backgroundColor = UIColor.backgroundLightest
 
         settings.refresh()
@@ -91,7 +91,7 @@ extension SyllabusTabViewController: HorizontalPagedMenuDelegate {
 
     public func menuItemTitle(at: IndexPath) -> String {
         return viewControllers.count > at.row && viewControllers[at.row] === syllabus
-            ? NSLocalizedString("Syllabus", comment: "")
-            : NSLocalizedString("Summary", comment: "")
+            ? NSLocalizedString("Syllabus", bundle: .core, comment: "")
+            : NSLocalizedString("Summary", bundle: .core, comment: "")
     }
 }

--- a/Core/Core/TermsOfService/TermsOfServiceViewController.swift
+++ b/Core/Core/TermsOfService/TermsOfServiceViewController.swift
@@ -23,7 +23,7 @@ public class TermsOfServiceViewController: UIViewController {
     let webView = CoreWebView()
 
     public override func viewDidLoad() {
-        title = NSLocalizedString("Terms of Use", bundle: .core, comment: "")
+        title = String(localized: "Terms of Use", bundle: .core)
         view.backgroundColor = .backgroundLightest
         view.addSubview(webView)
         webView.pin(inside: view)
@@ -41,7 +41,7 @@ public class TermsOfServiceViewController: UIViewController {
         let label = UILabel(frame: view.frame)
         label.numberOfLines = 2
         label.textAlignment = .center
-        label.text = NSLocalizedString("There was a problem retrieving the Terms of Use.", bundle: .core, comment: "")
+        label.text = String(localized: "There was a problem retrieving the Terms of Use.", bundle: .core)
         view.addSubview(label)
     }
 }

--- a/Core/Core/Todos/Todo.swift
+++ b/Core/Core/Todos/Todo.swift
@@ -82,14 +82,14 @@ public final class Todo: NSManagedObject, WriteableModel {
 
     public var dueText: String {
         guard let dueAt = assignment.dueAt else {
-            return NSLocalizedString("No Due Date", comment: "")
+            return NSLocalizedString("No Due Date", bundle: .core, comment: "")
         }
-        let format = NSLocalizedString("Due %@", comment: "")
+        let format = NSLocalizedString("Due %@", bundle: .core, comment: "")
         return String.localizedStringWithFormat(format, dueAt.relativeDateTimeStringWithDayOfWeek)
     }
 
     public var needsGradingText: String {
-        let format = NSLocalizedString("d_needs_grading", comment: "")
+        let format = NSLocalizedString("d_needs_grading", bundle: .core, comment: "")
         return String.localizedStringWithFormat(format, needsGradingCount).localizedUppercase
     }
 }

--- a/Core/Core/Todos/Todo.swift
+++ b/Core/Core/Todos/Todo.swift
@@ -82,14 +82,14 @@ public final class Todo: NSManagedObject, WriteableModel {
 
     public var dueText: String {
         guard let dueAt = assignment.dueAt else {
-            return NSLocalizedString("No Due Date", bundle: .core, comment: "")
+            return String(localized: "No Due Date", bundle: .core)
         }
-        let format = NSLocalizedString("Due %@", bundle: .core, comment: "")
+        let format = String(localized: "Due %@", bundle: .core)
         return String.localizedStringWithFormat(format, dueAt.relativeDateTimeStringWithDayOfWeek)
     }
 
     public var needsGradingText: String {
-        let format = NSLocalizedString("d_needs_grading", bundle: .core, comment: "")
+        let format = String(localized: "d_needs_grading", bundle: .core)
         return String.localizedStringWithFormat(format, needsGradingCount).localizedUppercase
     }
 }

--- a/Core/Core/Todos/TodoListViewController.swift
+++ b/Core/Core/Todos/TodoListViewController.swift
@@ -55,17 +55,17 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("To Do", bundle: .core, comment: "")
+        title = String(localized: "To Do", bundle: .core)
         navigationItem.leftBarButtonItem = profileButton
         navigationItem.titleView = Brand.shared.headerImageView()
 
-        emptyDescLabel.text = NSLocalizedString("Your to do list is empty. Time to recharge.", bundle: .core, comment: "")
-        emptyTitleLabel.text = NSLocalizedString("Well Done!", bundle: .core, comment: "")
+        emptyDescLabel.text = String(localized: "Your to do list is empty. Time to recharge.", bundle: .core)
+        emptyTitleLabel.text = String(localized: "Well Done!", bundle: .core)
         emptyView.accessibilityLabel = "\(emptyTitleLabel.text!) \(emptyDescLabel.text!)"
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading items to do. Pull to refresh to try again.", bundle: .core, comment: "")
+        errorView.messageLabel.text = String(localized: "There was an error loading items to do. Pull to refresh to try again.", bundle: .core)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
-        profileButton.accessibilityLabel = NSLocalizedString("Profile Menu", bundle: .core, comment: "")
+        profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .core)
 
         tableView.backgroundColor = .backgroundLightest
         tableView.refreshControl = CircleRefreshControl()
@@ -99,7 +99,7 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
     }
 
     @objc func refresh() {
-        UIAccessibility.post(notification: .announcement, argument: NSLocalizedString("Refreshing", bundle: .core, comment: "Downloading new content has started"))
+        UIAccessibility.post(notification: .announcement, argument: String(localized: "Refreshing", bundle: .core, comment: "Downloading new content has started"))
         lastVoiceoverAnnouncement = nil
         todos.exhaust(force: true) { [weak self] _ in
             if self?.todos.hasNextPage == false {
@@ -125,7 +125,7 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
         } else if errorView.isHidden == false {
             announcement = errorView.messageLabel.text
         } else {
-            announcement = String.localizedStringWithFormat(NSLocalizedString("%d items", bundle: .core, comment: ""), todos.count)
+            announcement = String.localizedStringWithFormat(String(localized: "%d items", bundle: .core), todos.count)
         }
 
         if let announcement = announcement {
@@ -161,7 +161,7 @@ extension TodoListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let ignore = UIContextualAction(style: .destructive, title: NSLocalizedString("Done", bundle: .core, comment: "")) { [weak self] _, _, done in
+        let ignore = UIContextualAction(style: .destructive, title: String(localized: "Done", bundle: .core)) { [weak self] _, _, done in
             self?.ignoreTodo(at: indexPath)
             done(true)
         }

--- a/Core/Core/Todos/TodoListViewController.swift
+++ b/Core/Core/Todos/TodoListViewController.swift
@@ -55,17 +55,17 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("To Do", comment: "")
+        title = NSLocalizedString("To Do", bundle: .core, comment: "")
         navigationItem.leftBarButtonItem = profileButton
         navigationItem.titleView = Brand.shared.headerImageView()
 
-        emptyDescLabel.text = NSLocalizedString("Your to do list is empty. Time to recharge.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("Well Done!", comment: "")
+        emptyDescLabel.text = NSLocalizedString("Your to do list is empty. Time to recharge.", bundle: .core, comment: "")
+        emptyTitleLabel.text = NSLocalizedString("Well Done!", bundle: .core, comment: "")
         emptyView.accessibilityLabel = "\(emptyTitleLabel.text!) \(emptyDescLabel.text!)"
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading items to do. Pull to refresh to try again.", comment: "")
+        errorView.messageLabel.text = NSLocalizedString("There was an error loading items to do. Pull to refresh to try again.", bundle: .core, comment: "")
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
-        profileButton.accessibilityLabel = NSLocalizedString("Profile Menu", comment: "")
+        profileButton.accessibilityLabel = NSLocalizedString("Profile Menu", bundle: .core, comment: "")
 
         tableView.backgroundColor = .backgroundLightest
         tableView.refreshControl = CircleRefreshControl()
@@ -99,7 +99,7 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
     }
 
     @objc func refresh() {
-        UIAccessibility.post(notification: .announcement, argument: NSLocalizedString("Refreshing", comment: "Downloading new content has started"))
+        UIAccessibility.post(notification: .announcement, argument: NSLocalizedString("Refreshing", bundle: .core, comment: "Downloading new content has started"))
         lastVoiceoverAnnouncement = nil
         todos.exhaust(force: true) { [weak self] _ in
             if self?.todos.hasNextPage == false {
@@ -125,7 +125,7 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
         } else if errorView.isHidden == false {
             announcement = errorView.messageLabel.text
         } else {
-            announcement = String.localizedStringWithFormat(NSLocalizedString("%d items", comment: ""), todos.count)
+            announcement = String.localizedStringWithFormat(NSLocalizedString("%d items", bundle: .core, comment: ""), todos.count)
         }
 
         if let announcement = announcement {
@@ -161,7 +161,7 @@ extension TodoListViewController: UITableViewDataSource, UITableViewDelegate {
     }
 
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
-        let ignore = UIContextualAction(style: .destructive, title: NSLocalizedString("Done", comment: "")) { [weak self] _, _, done in
+        let ignore = UIContextualAction(style: .destructive, title: NSLocalizedString("Done", bundle: .core, comment: "")) { [weak self] _, _, done in
             self?.ignoreTodo(at: indexPath)
             done(true)
         }

--- a/Core/Core/UIViews/AccessIconView.swift
+++ b/Core/Core/UIViews/AccessIconView.swift
@@ -59,15 +59,15 @@ open class AccessIconView: UIView {
             case .published:
                 statusIconView.image = .publishSolid
                 statusIconView.tintColor = UIColor.textSuccess
-                accessibilityLabel = NSLocalizedString("Published", bundle: .core, comment: "")
+                accessibilityLabel = String(localized: "Published", bundle: .core)
             case .restricted:
                 statusIconView.image = .cloudLockLine
                 statusIconView.tintColor = UIColor.textDark
-                accessibilityLabel = NSLocalizedString("Restricted", bundle: .core, comment: "")
+                accessibilityLabel = String(localized: "Restricted", bundle: .core)
             case .unpublished:
                 statusIconView.image = .noSolid
                 statusIconView.tintColor = UIColor.textDark
-                accessibilityLabel = NSLocalizedString("Not Published", bundle: .core, comment: "")
+                accessibilityLabel = String(localized: "Not Published", bundle: .core)
             case .none:
                 statusIconView.isHidden = true
                 accessibilityLabel = nil

--- a/Core/Core/UIViews/BottomSheetTransitioning.swift
+++ b/Core/Core/UIViews/BottomSheetTransitioning.swift
@@ -75,7 +75,7 @@ class BottomSheetPresentationController: UIPresentationController {
         containerView.addSubview(dimmer)
         dimmer.pin(inside: containerView)
         dimmer.addTarget(self, action: #selector(tapped), for: .primaryActionTriggered)
-        dimmer.accessibilityLabel = NSLocalizedString("Close", bundle: .core, comment: "")
+        dimmer.accessibilityLabel = String(localized: "Close", bundle: .core)
         dimmer.accessibilityFrame = CGRect(x: 0, y: 0, width: containerView.bounds.width, height: containerView.bounds.height - presentedViewController.view.frame.height)
 
         presentingViewController.transitionCoordinator?.animate(alongsideTransition: { _ in

--- a/Core/Core/UIViews/FilterHeaderView.swift
+++ b/Core/Core/UIViews/FilterHeaderView.swift
@@ -40,7 +40,7 @@ public class FilterHeaderView: UITableViewHeaderFooterView {
         titleLabel.numberOfLines = 2
         contentView.addSubview(titleLabel)
         titleLabel.pin(inside: contentView, leading: 16, trailing: nil, top: 16, bottom: 8)
-        filterButton.setTitle(NSLocalizedString("Filter", bundle: .core, comment: ""), for: .normal)
+        filterButton.setTitle(String(localized: "Filter", bundle: .core), for: .normal)
         filterButton.setTitleColor(Brand.shared.linkColor, for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.medium16)
         filterButton.translatesAutoresizingMaskIntoConstraints = false

--- a/Core/Core/UIViews/GradeCircleView.swift
+++ b/Core/Core/UIViews/GradeCircleView.swift
@@ -146,7 +146,7 @@ public class GradeCircleView: UIView {
             circleComplete.isHidden = false
             gradeCircle?.progress = 1
             displayGrade.isHidden = false
-            displayGrade.text = NSLocalizedString("Excused", bundle: .core, comment: "")
+            displayGrade.text = String(localized: "Excused", bundle: .core)
         }
 
         // Update for hidden quantitative data

--- a/Core/Core/UIViews/GradeStatisticGraphView.swift
+++ b/Core/Core/UIViews/GradeStatisticGraphView.swift
@@ -111,15 +111,15 @@ public class GradeStatisticGraphView: UIView {
         formatter.maximumFractionDigits = 1
 
         minLabel.text = String.localizedStringWithFormat(
-            NSLocalizedString("Low: %@", bundle: .core, comment: ""),
+            String(localized: "Low: %@", bundle: .core),
             formatter.string(from: NSNumber(value: stats.min)) ?? ""
         )
         averageLabel.text = String.localizedStringWithFormat(
-            NSLocalizedString("Mean: %@", bundle: .core, comment: ""),
+            String(localized: "Mean: %@", bundle: .core),
             formatter.string(from: NSNumber(value: stats.mean)) ?? ""
         )
         maxLabel.text = String.localizedStringWithFormat(
-            NSLocalizedString("High: %@", bundle: .core, comment: ""),
+            String(localized: "High: %@", bundle: .core),
             formatter.string(from: NSNumber(value: stats.max)) ?? ""
         )
 

--- a/Core/Core/UIViews/ListErrorView.swift
+++ b/Core/Core/UIViews/ListErrorView.swift
@@ -34,7 +34,7 @@ public class ListErrorView: UIView {
 
     func commonInit() {
         loadFromXib()
-        retryButton.setTitle(NSLocalizedString("Retry", bundle: .core, comment: ""), for: .normal)
+        retryButton.setTitle(String(localized: "Retry", bundle: .core), for: .normal)
         retryButton.layer.borderColor = UIColor.borderDark.cgColor
     }
 }

--- a/Core/Core/UIViews/ScannerViewController.swift
+++ b/Core/Core/UIViews/ScannerViewController.swift
@@ -93,7 +93,7 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
         ])
 
         let prompt = UILabel()
-        prompt.text = NSLocalizedString("Find a code to scan", bundle: .core, comment: "")
+        prompt.text = String(localized: "Find a code to scan", bundle: .core)
         prompt.font = .scaledNamedFont(.semibold16)
         prompt.textColor = .textLightest
         promptContainer.addSubview(prompt)
@@ -127,11 +127,11 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
 
     func failed() {
         let alert = UIAlertController(
-            title: NSLocalizedString("Scanning not supported", bundle: .core, comment: ""),
-            message: NSLocalizedString("Make sure you enable camera permissions in Settings", bundle: .core, comment: ""),
+            title: String(localized: "Scanning not supported", bundle: .core),
+            message: String(localized: "Make sure you enable camera permissions in Settings", bundle: .core),
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .default) { [weak self] _ in
+        alert.addAction(UIAlertAction(title: String(localized: "OK", bundle: .core), style: .default) { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
         })
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) {

--- a/Core/Core/WrongApp/WrongAppViewController.swift
+++ b/Core/Core/WrongApp/WrongAppViewController.swift
@@ -38,26 +38,26 @@ public class WrongAppViewController: UIViewController {
     public override func viewDidLoad() {
         view.backgroundColor = .backgroundLightest
         navigationController?.setNavigationBarHidden(true, animated: false)
-        messageTitle?.text = NSLocalizedString("Whoops!", bundle: .core, comment: "")
+        messageTitle?.text = String(localized: "Whoops!", bundle: .core)
         messageDescription?.text = String.localizedStringWithFormat(
-            NSLocalizedString("It looks like you aren’t enrolled in any courses as %@. One of our other apps might be a better fit. Tap one to visit the App Store.", bundle: .core, comment: ""), (
-            Bundle.main.isParentApp ? NSLocalizedString("a parent", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'") :
-            Bundle.main.isTeacherApp ? NSLocalizedString("a teacher", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'") :
-            NSLocalizedString("a student", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'")
+            String(localized: "It looks like you aren’t enrolled in any courses as %@. One of our other apps might be a better fit. Tap one to visit the App Store.", bundle: .core), (
+            Bundle.main.isParentApp ? String(localized: "a parent", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'") :
+            Bundle.main.isTeacherApp ? String(localized: "a teacher", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'") :
+            String(localized: "a student", bundle: .core, comment: "Embedded in 'enrolled in any courses as %@'")
         ))
 
-        loginButton?.setTitle(NSLocalizedString("Log In Again", bundle: .core, comment: "").localizedUppercase, for: .normal)
-        canvasGuidesButton?.setTitle(NSLocalizedString("Canvas Guides", bundle: .core, comment: "").localizedUppercase, for: .normal)
+        loginButton?.setTitle(String(localized: "Log In Again", bundle: .core).localizedUppercase, for: .normal)
+        canvasGuidesButton?.setTitle(String(localized: "Canvas Guides", bundle: .core).localizedUppercase, for: .normal)
         canvasGuidesButton?.isHidden = !Bundle.main.isParentApp
 
         parentButton?.isHidden = Bundle.main.isParentApp
-        parentButton?.accessibilityLabel = NSLocalizedString("Canvas Parent", bundle: .core, comment: "")
+        parentButton?.accessibilityLabel = String(localized: "Canvas Parent", bundle: .core)
 
         studentButton?.isHidden = Bundle.main.isStudentApp
-        studentButton?.accessibilityLabel = NSLocalizedString("Canvas Student", bundle: .core, comment: "")
+        studentButton?.accessibilityLabel = String(localized: "Canvas Student", bundle: .core)
 
         teacherButton?.isHidden = Bundle.main.isTeacherApp
-        teacherButton?.accessibilityLabel = NSLocalizedString("Canvas Teacher", bundle: .core, comment: "")
+        teacherButton?.accessibilityLabel = String(localized: "Canvas Teacher", bundle: .core)
     }
 
     @IBAction func loginAgainButtonPressed(_ sender: UIButton) {

--- a/Core/CoreTests/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
@@ -22,11 +22,11 @@ import XCTest
 class CourseHomePropertiesTests: XCTestCase {
 
     func testHomeSubLabel() {
-        XCTAssertEqual(CourseDefaultView.assignments.homeSubLabel, NSLocalizedString("Assignments", bundle: .core, comment: ""))
-        XCTAssertEqual(CourseDefaultView.feed.homeSubLabel, NSLocalizedString("Recent Activity", bundle: .core, comment: ""))
-        XCTAssertEqual(CourseDefaultView.modules.homeSubLabel, NSLocalizedString("Course Modules", bundle: .core, comment: ""))
-        XCTAssertEqual(CourseDefaultView.syllabus.homeSubLabel, NSLocalizedString("Syllabus", bundle: .core, comment: ""))
-        XCTAssertEqual(CourseDefaultView.wiki.homeSubLabel, NSLocalizedString("Front Page", bundle: .core, comment: ""))
+        XCTAssertEqual(CourseDefaultView.assignments.homeSubLabel, String(localized: "Assignments", bundle: .core))
+        XCTAssertEqual(CourseDefaultView.feed.homeSubLabel, String(localized: "Recent Activity", bundle: .core))
+        XCTAssertEqual(CourseDefaultView.modules.homeSubLabel, String(localized: "Course Modules", bundle: .core))
+        XCTAssertEqual(CourseDefaultView.syllabus.homeSubLabel, String(localized: "Syllabus", bundle: .core))
+        XCTAssertEqual(CourseDefaultView.wiki.homeSubLabel, String(localized: "Front Page", bundle: .core))
     }
 
     func testHomeRoute() {

--- a/Core/CoreTests/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
@@ -22,11 +22,11 @@ import XCTest
 class CourseHomePropertiesTests: XCTestCase {
 
     func testHomeSubLabel() {
-        XCTAssertEqual(CourseDefaultView.assignments.homeSubLabel, NSLocalizedString("Assignments", comment: ""))
-        XCTAssertEqual(CourseDefaultView.feed.homeSubLabel, NSLocalizedString("Recent Activity", comment: ""))
-        XCTAssertEqual(CourseDefaultView.modules.homeSubLabel, NSLocalizedString("Course Modules", comment: ""))
-        XCTAssertEqual(CourseDefaultView.syllabus.homeSubLabel, NSLocalizedString("Syllabus", comment: ""))
-        XCTAssertEqual(CourseDefaultView.wiki.homeSubLabel, NSLocalizedString("Front Page", comment: ""))
+        XCTAssertEqual(CourseDefaultView.assignments.homeSubLabel, NSLocalizedString("Assignments", bundle: .core, comment: ""))
+        XCTAssertEqual(CourseDefaultView.feed.homeSubLabel, NSLocalizedString("Recent Activity", bundle: .core, comment: ""))
+        XCTAssertEqual(CourseDefaultView.modules.homeSubLabel, NSLocalizedString("Course Modules", bundle: .core, comment: ""))
+        XCTAssertEqual(CourseDefaultView.syllabus.homeSubLabel, NSLocalizedString("Syllabus", bundle: .core, comment: ""))
+        XCTAssertEqual(CourseDefaultView.wiki.homeSubLabel, NSLocalizedString("Front Page", bundle: .core, comment: ""))
     }
 
     func testHomeRoute() {

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModelTests.swift
@@ -26,8 +26,8 @@ class StudentViewCellViewModelTests: CoreTestCase {
         let testee = StudentViewCellViewModel(course: course)
 
         XCTAssertEqual(testee.iconImage, .userLine)
-        XCTAssertEqual(testee.label, NSLocalizedString("Student View", bundle: .core, comment: ""))
-        XCTAssertEqual(testee.subtitle, NSLocalizedString("Opens in Canvas Student", bundle: .core, comment: ""))
+        XCTAssertEqual(testee.label, String(localized: "Student View", bundle: .core))
+        XCTAssertEqual(testee.subtitle, String(localized: "Opens in Canvas Student", bundle: .core))
         XCTAssertEqual(testee.accessoryIconType, .externalLink)
         XCTAssertEqual(testee.tabID, "student_view")
     }

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/Cells/StudentViewCellViewModelTests.swift
@@ -26,8 +26,8 @@ class StudentViewCellViewModelTests: CoreTestCase {
         let testee = StudentViewCellViewModel(course: course)
 
         XCTAssertEqual(testee.iconImage, .userLine)
-        XCTAssertEqual(testee.label, NSLocalizedString("Student View", comment: ""))
-        XCTAssertEqual(testee.subtitle, NSLocalizedString("Opens in Canvas Student", comment: ""))
+        XCTAssertEqual(testee.label, NSLocalizedString("Student View", bundle: .core, comment: ""))
+        XCTAssertEqual(testee.subtitle, NSLocalizedString("Opens in Canvas Student", bundle: .core, comment: ""))
         XCTAssertEqual(testee.accessoryIconType, .externalLink)
         XCTAssertEqual(testee.tabID, "student_view")
     }

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseSettingsViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseSettingsViewModelTests.swift
@@ -53,11 +53,11 @@ class CourseSettingsViewModelTests: CoreTestCase {
         XCTAssertNil(section.title)
         XCTAssertEqual(picker.selected, IndexPath(row: 3, section: 0))
         XCTAssertEqual(section.items, [
-            ItemPickerItem(title: NSLocalizedString("Assignments List", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Course Activity Stream", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Course Modules", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Syllabus", bundle: .core, comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Pages Front Page", bundle: .core, comment: "")),
+            ItemPickerItem(title: String(localized: "Assignments List", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Course Activity Stream", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Course Modules", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Syllabus", bundle: .core)),
+            ItemPickerItem(title: String(localized: "Pages Front Page", bundle: .core)),
         ])
 
         XCTAssertEqual(testee.newDefaultView, .syllabus)

--- a/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseSettingsViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseDetails/ViewModel/CourseSettingsViewModelTests.swift
@@ -53,11 +53,11 @@ class CourseSettingsViewModelTests: CoreTestCase {
         XCTAssertNil(section.title)
         XCTAssertEqual(picker.selected, IndexPath(row: 3, section: 0))
         XCTAssertEqual(section.items, [
-            ItemPickerItem(title: NSLocalizedString("Assignments List", comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Course Activity Stream", comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Course Modules", comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Syllabus", comment: "")),
-            ItemPickerItem(title: NSLocalizedString("Pages Front Page", comment: "")),
+            ItemPickerItem(title: NSLocalizedString("Assignments List", bundle: .core, comment: "")),
+            ItemPickerItem(title: NSLocalizedString("Course Activity Stream", bundle: .core, comment: "")),
+            ItemPickerItem(title: NSLocalizedString("Course Modules", bundle: .core, comment: "")),
+            ItemPickerItem(title: NSLocalizedString("Syllabus", bundle: .core, comment: "")),
+            ItemPickerItem(title: NSLocalizedString("Pages Front Page", bundle: .core, comment: "")),
         ])
 
         XCTAssertEqual(testee.newDefaultView, .syllabus)

--- a/Core/CoreTests/Courses/CourseList/ViewModel/AllCoursesCellViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseList/ViewModel/AllCoursesCellViewModelTests.swift
@@ -218,7 +218,7 @@ class AllCoursesCellViewModelTests: CoreTestCase {
                                              router: environment.router,
                                              scheduler: .immediate)
 
-        XCTAssertEqual(testee.favoriteButtonAccessibilityText, NSLocalizedString("Favorite", bundle: .core, comment: ""))
+        XCTAssertEqual(testee.favoriteButtonAccessibilityText, String(localized: "Favorite", bundle: .core))
     }
 
     func testDetailsRoute() {

--- a/Core/CoreTests/Courses/CourseList/ViewModel/AllCoursesCellViewModelTests.swift
+++ b/Core/CoreTests/Courses/CourseList/ViewModel/AllCoursesCellViewModelTests.swift
@@ -218,7 +218,7 @@ class AllCoursesCellViewModelTests: CoreTestCase {
                                              router: environment.router,
                                              scheduler: .immediate)
 
-        XCTAssertEqual(testee.favoriteButtonAccessibilityText, NSLocalizedString("Favorite", comment: ""))
+        XCTAssertEqual(testee.favoriteButtonAccessibilityText, NSLocalizedString("Favorite", bundle: .core, comment: ""))
     }
 
     func testDetailsRoute() {

--- a/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
+++ b/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
@@ -24,15 +24,15 @@ class K5ScheduleItemInfoTests: CoreTestCase {
 
     func testSubmittedLabelAvailableOnlyForNonLateSubmissions() {
         let containsSubmittedLabel: ([(text: String, color: Color)]) -> Bool = { labels in
-            return labels.contains { $0.text == NSLocalizedString("Submitted", bundle: .core, comment: "") }
+            return labels.contains { $0.text == String(localized: "Submitted", bundle: .core) }
         }
         XCTAssertTrue(containsSubmittedLabel(APIPlannable.make(submissions: .make(submitted: true, late: false)).k5ScheduleLabels))
         XCTAssertFalse(containsSubmittedLabel(APIPlannable.make(submissions: .make(submitted: true, late: true)).k5ScheduleLabels))
     }
 
     func testScheduleSubjectName() {
-        XCTAssertEqual(APIPlannable.make(plannable_type: "calendar_event").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", bundle: .core, comment: ""))
-        XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: nil).k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", bundle: .core, comment: ""))
+        XCTAssertEqual(APIPlannable.make(plannable_type: "calendar_event").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, String(localized: "To Do", bundle: .core))
+        XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: nil).k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, String(localized: "To Do", bundle: .core))
         XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: "testName").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, "testName")
     }
 
@@ -77,7 +77,7 @@ class K5ScheduleItemInfoTests: CoreTestCase {
 
     func testDueText() {
         let allDayTestee = APIPlannable.make(plannable: .init(all_day: true, details: nil, end_at: nil, points_possible: nil, start_at: nil, title: nil))
-        XCTAssertEqual(allDayTestee.k5ScheduleDueText, NSLocalizedString("All Day", bundle: .core, comment: ""))
+        XCTAssertEqual(allDayTestee.k5ScheduleDueText, String(localized: "All Day", bundle: .core))
 
         let intervalTestee = APIPlannable.make(plannable: .init(all_day: nil, details: nil, end_at: Date().add(.hour, number: 1), points_possible: nil, start_at: Date(), title: nil))
         XCTAssertTrue(intervalTestee.k5ScheduleDueText.contains(" – "))

--- a/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
+++ b/Core/CoreTests/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
@@ -24,15 +24,15 @@ class K5ScheduleItemInfoTests: CoreTestCase {
 
     func testSubmittedLabelAvailableOnlyForNonLateSubmissions() {
         let containsSubmittedLabel: ([(text: String, color: Color)]) -> Bool = { labels in
-            return labels.contains { $0.text == NSLocalizedString("Submitted", comment: "") }
+            return labels.contains { $0.text == NSLocalizedString("Submitted", bundle: .core, comment: "") }
         }
         XCTAssertTrue(containsSubmittedLabel(APIPlannable.make(submissions: .make(submitted: true, late: false)).k5ScheduleLabels))
         XCTAssertFalse(containsSubmittedLabel(APIPlannable.make(submissions: .make(submitted: true, late: true)).k5ScheduleLabels))
     }
 
     func testScheduleSubjectName() {
-        XCTAssertEqual(APIPlannable.make(plannable_type: "calendar_event").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", comment: ""))
-        XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: nil).k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", comment: ""))
+        XCTAssertEqual(APIPlannable.make(plannable_type: "calendar_event").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", bundle: .core, comment: ""))
+        XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: nil).k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, NSLocalizedString("To Do", bundle: .core, comment: ""))
         XCTAssertEqual(APIPlannable.make(plannable_type: "other", context_name: "testName").k5ScheduleSubject(courseInfoByCourseIDs: [:]).name, "testName")
     }
 
@@ -77,7 +77,7 @@ class K5ScheduleItemInfoTests: CoreTestCase {
 
     func testDueText() {
         let allDayTestee = APIPlannable.make(plannable: .init(all_day: true, details: nil, end_at: nil, points_possible: nil, start_at: nil, title: nil))
-        XCTAssertEqual(allDayTestee.k5ScheduleDueText, NSLocalizedString("All Day", comment: ""))
+        XCTAssertEqual(allDayTestee.k5ScheduleDueText, NSLocalizedString("All Day", bundle: .core, comment: ""))
 
         let intervalTestee = APIPlannable.make(plannable: .init(all_day: nil, details: nil, end_at: Date().add(.hour, number: 1), points_possible: nil, start_at: Date(), title: nil))
         XCTAssertTrue(intervalTestee.k5ScheduleDueText.contains(" – "))

--- a/Core/CoreTests/Quizzes/QuizDetails/QuizAttributesTests.swift
+++ b/Core/CoreTests/Quizzes/QuizDetails/QuizAttributesTests.swift
@@ -124,7 +124,7 @@ class QuizAttributesTests: CoreTestCase {
         let testee = QuizAttributes(quiz: quiz, assignment: nil)
 
         let quizAttribute = testee.attributes.first(where: {$0.id == "Show Correct Answers:"})
-        let template = NSLocalizedString("After %@", bundle: .core, comment: "e.g. After 01.02.2022")
+        let template = String(localized: "After %@", bundle: .core, comment: "e.g. After 01.02.2022")
         let expected = String.localizedStringWithFormat(template, date.relativeDateTimeString)
         XCTAssertEqual(quizAttribute?.value, expected)
     }
@@ -139,7 +139,7 @@ class QuizAttributesTests: CoreTestCase {
         let testee = QuizAttributes(quiz: quiz, assignment: nil)
 
         let quizAttribute = testee.attributes.first(where: {$0.id == "Show Correct Answers:"})
-        let template = NSLocalizedString("Until %@", bundle: .core, comment: "e.g. Until 01.02.2022")
+        let template = String(localized: "Until %@", bundle: .core, comment: "e.g. Until 01.02.2022")
         let expected = String.localizedStringWithFormat(template, date.relativeDateTimeString)
         XCTAssertEqual(quizAttribute?.value, expected)
     }
@@ -157,7 +157,7 @@ class QuizAttributesTests: CoreTestCase {
         let testee = QuizAttributes(quiz: quiz, assignment: nil)
 
         let quizAttribute = testee.attributes.first(where: {$0.id == "Show Correct Answers:"})
-        let template = NSLocalizedString("%@ to %@", bundle: .core, comment: "e.g 01.02.2022 to 01.03.2022")
+        let template = String(localized: "%@ to %@", bundle: .core, comment: "e.g 01.02.2022 to 01.03.2022")
         let expected = String.localizedStringWithFormat(template, date1.relativeDateTimeString, date2.relativeDateTimeString)
         XCTAssertEqual(quizAttribute?.value, expected)
     }

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentCopyServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentCopyServiceTests.swift
@@ -41,7 +41,7 @@ class AttachmentCopyServiceTests: CoreTestCase {
             return
         }
 
-        XCTAssertEqual(error.localizedDescription, NSLocalizedString("No supported files to submit", comment: ""))
+        XCTAssertEqual(error.localizedDescription, NSLocalizedString("No supported files to submit", bundle: .core, comment: ""))
     }
 
     // Upload fails in this test because AttachmentCopyService can't create the destination url for the CoreTester bundle
@@ -67,7 +67,7 @@ class AttachmentCopyServiceTests: CoreTestCase {
             return
         }
 
-        XCTAssertEqual(error.localizedDescription, NSLocalizedString("Internal Error", comment: ""))
+        XCTAssertEqual(error.localizedDescription, NSLocalizedString("Internal Error", bundle: .core, comment: ""))
     }
 }
 

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentCopyServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentCopyServiceTests.swift
@@ -41,7 +41,7 @@ class AttachmentCopyServiceTests: CoreTestCase {
             return
         }
 
-        XCTAssertEqual(error.localizedDescription, NSLocalizedString("No supported files to submit", bundle: .core, comment: ""))
+        XCTAssertEqual(error.localizedDescription, String(localized: "No supported files to submit", bundle: .core))
     }
 
     // Upload fails in this test because AttachmentCopyService can't create the destination url for the CoreTester bundle
@@ -67,7 +67,7 @@ class AttachmentCopyServiceTests: CoreTestCase {
             return
         }
 
-        XCTAssertEqual(error.localizedDescription, NSLocalizedString("Internal Error", bundle: .core, comment: ""))
+        XCTAssertEqual(error.localizedDescription, String(localized: "Internal Error", bundle: .core))
     }
 }
 

--- a/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
+++ b/Parent/Parent/AccountNotifications/AccountNotificationDetailsViewController.swift
@@ -45,7 +45,7 @@ class AccountNotificationDetailsViewController: UIViewController, CoreWebViewLin
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Announcement", comment: "")
+        title = String(localized: "Announcement", bundle: .parent)
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
         webView.autoresizesHeight = true

--- a/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/AssignmentDetailsViewController.swift
@@ -72,7 +72,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Assignment Details", comment: "")
+        title = String(localized: "Assignment Details", bundle: .parent)
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
         webView.autoresizesHeight = true
@@ -82,20 +82,20 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
         scrollView.refreshControl = refreshControl
 
-        composeButton.accessibilityLabel = NSLocalizedString("Compose message to teachers", comment: "")
+        composeButton.accessibilityLabel = String(localized: "Compose message to teachers", bundle: .parent)
         composeButton.backgroundColor = ColorScheme.observee(studentID).color.darkenToEnsureContrast(against: .white)
         composeButton.isHidden = true
 
-        dateHeadingLabel.text = NSLocalizedString("Due", comment: "")
+        dateHeadingLabel.text = String(localized: "Due", bundle: .parent)
         dateLabel.text = ""
-        descriptionHeadingLabel.text = NSLocalizedString("Description", comment: "")
+        descriptionHeadingLabel.text = String(localized: "Description", bundle: .parent)
         titleLabel.text = ""
 
         pointsLabel.text = ""
 
-        reminderHeadingLabel.text = NSLocalizedString("Remind Me", comment: "")
-        reminderMessageLabel.text = NSLocalizedString("Set a date and time to be notified of this event.", comment: "")
-        reminderSwitch.accessibilityLabel = NSLocalizedString("Remind Me", comment: "")
+        reminderHeadingLabel.text = String(localized: "Remind Me", bundle: .parent)
+        reminderMessageLabel.text = String(localized: "Set a date and time to be notified of this event.", bundle: .parent)
+        reminderSwitch.accessibilityLabel = String(localized: "Remind Me", bundle: .parent)
         reminderSwitch.isEnabled = false
         reminderDateButton.isEnabled = false
         reminderDateButton.isHidden = true
@@ -143,7 +143,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     func update() {
         guard let assignment = assignment.first else { return }
         let status = assignment.submissions?.first(where: { $0.userID == studentID })?.status ?? .notSubmitted
-        title = course.first?.name ?? NSLocalizedString("Assignment Details", comment: "")
+        title = course.first?.name ?? String(localized: "Assignment Details", bundle: .parent)
 
         titleLabel.text = assignment.name
         pointsLabel.text = {
@@ -158,7 +158,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         statusLabel.isHidden = assignment.submissionStatusIsHidden
         statusLabel.textColor = status.color
         statusLabel.text = status.text
-        dateLabel.text = assignment.dueAt?.dateTimeString ?? NSLocalizedString("No Due Date", comment: "")
+        dateLabel.text = assignment.dueAt?.dateTimeString ?? String(localized: "No Due Date", bundle: .parent)
         reminderSwitch.isEnabled = true
         reminderDateButton.isEnabled = true
         if let html = assignment.details, !html.isEmpty {
@@ -221,12 +221,12 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     @IBAction func compose() {
         guard let assignment = assignment.first, let name = student.first?.fullName else { return }
         let subject = String.localizedStringWithFormat(
-            NSLocalizedString("Regarding: %@, Assignment - %@", comment: "Regarding <Name>, Assignment - <Assignment Name>"),
+            String(localized: "Regarding: %@, Assignment - %@", bundle: .parent, comment: "Regarding <Name>, Assignment - <Assignment Name>"),
             name,
             assignment.name
         )
         let hiddenMessage = String.localizedStringWithFormat(
-            NSLocalizedString("Regarding: %@, %@", comment: "Regarding <Name>, <URL>"),
+            String(localized: "Regarding: %@, %@", bundle: .parent, comment: "Regarding <Name>, <URL>"),
             name,
             assignment.htmlURL?.absoluteString ?? ""
         )

--- a/Parent/Parent/Conversations/ParentConversationListViewController.swift
+++ b/Parent/Parent/Conversations/ParentConversationListViewController.swift
@@ -40,17 +40,17 @@ class ParentConversationListViewController: UIViewController, ConversationCourse
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Inbox", comment: "")
+        title = String(localized: "Inbox", bundle: .parent)
 
-        composeButton.accessibilityLabel = NSLocalizedString("Compose new message", comment: "")
+        composeButton.accessibilityLabel = String(localized: "Compose new message", bundle: .parent)
         composeButton.layer.shadowColor = UIColor.backgroundDarkest.cgColor
 
-        emptyView.titleText = NSLocalizedString("Inbox Zero", comment: "")
-        emptyView.bodyText = NSLocalizedString("You’re all caught up", comment: "")
+        emptyView.titleText = String(localized: "Inbox Zero", bundle: .parent)
+        emptyView.bodyText = String(localized: "You’re all caught up", bundle: .parent)
         emptyView.isHidden = true
 
         errorView.isHidden = true
-        retryButton.setTitle(NSLocalizedString("Retry", comment: ""), for: .normal)
+        retryButton.setTitle(String(localized: "Retry", bundle: .parent), for: .normal)
         retryButton.layer.borderColor = UIColor.borderDark.cgColor
 
         tableView.refreshControl = CircleRefreshControl()
@@ -103,7 +103,7 @@ class ParentConversationListViewController: UIViewController, ConversationCourse
             observeeID: user.id,
             subject: course.name,
             hiddenMessage: String.localizedStringWithFormat(
-                NSLocalizedString("Regarding: %@", bundle: .parent, comment: ""),
+                String(localized: "Regarding: %@", bundle: .parent),
                 user.name
             )
         )

--- a/Parent/Parent/Courses/CourseDetailsViewController.swift
+++ b/Parent/Parent/Courses/CourseDetailsViewController.swift
@@ -74,7 +74,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
         colorScheme = ColorScheme.observee(studentID)
         navigationController?.setNavigationBarHidden(false, animated: true)
         navigationController?.navigationBar.useContextColor(colorScheme?.color)
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Back", comment: ""), style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: String(localized: "Back", bundle: .parent), style: .plain, target: nil, action: nil)
 
         delegate = self
         courses.refresh(force: true)
@@ -129,7 +129,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
 
         replyButton = FloatingButton(frame: CGRect(x: 0, y: 0, width: buttonSize, height: buttonSize))
         replyButton?.configuration = UIButton.Configuration.plain()
-        replyButton?.accessibilityLabel = NSLocalizedString("Compose Message", comment: "")
+        replyButton?.accessibilityLabel = String(localized: "Compose Message", bundle: .parent)
         replyButton?.accessibilityIdentifier = "Grades.composeMessageButton"
         replyButton?.accessibilityTraits.insert(.header)
         replyButton?.setImage(UIImage.commentSolid, for: .normal)
@@ -177,10 +177,10 @@ class CourseDetailsViewController: HorizontalMenuViewController {
         if !pending && replyStarted {
             let name = student.first?.fullName ?? ""
             var tabTitle = titleForSelectedTab() ?? ""
-            tabTitle = tabTitle.replacingOccurrences(of: NSLocalizedString("Summary", comment: ""), with: NSLocalizedString("Syllabus", comment: ""))
-            var template = NSLocalizedString("Regarding: %@, %@", comment: "Regarding <John Doe>, <Grades | Syllabus>")
+            tabTitle = tabTitle.replacingOccurrences(of: String(localized: "Summary", bundle: .parent), with: String(localized: "Syllabus", bundle: .parent))
+            var template = String(localized: "Regarding: %@, %@", bundle: .parent, comment: "Regarding <John Doe>, <Grades | Syllabus>")
             let subject = String.localizedStringWithFormat(template, name, tabTitle)
-            template = NSLocalizedString("Regarding: %@, %@", comment: "Regarding <John Doe>, [link to grades or syllabus]")
+            template = String(localized: "Regarding: %@, %@", bundle: .parent, comment: "Regarding <John Doe>, [link to grades or syllabus]")
             let compose = ComposeViewController.create(
                 context: .course(courseID),
                 observeeID: studentID,
@@ -194,7 +194,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
     }
 
     private func associatedTabConversationLink() -> String {
-        let na = NSLocalizedString("n/a", comment: "")
+        let na = String(localized: "n/a", bundle: .parent)
         guard let menuItem = MenuItem(rawValue: selectedIndexPath.row) else { return na }
         guard let baseURL = env.currentSession?.baseURL, var components = URLComponents(url: baseURL, resolvingAgainstBaseURL: true) else { return na }
         switch menuItem {
@@ -245,18 +245,18 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
         guard let menuItem = MenuItem(rawValue: at.row) else { return "" }
         switch menuItem {
         case .grades:
-            return NSLocalizedString("Grades", comment: "")
+            return String(localized: "Grades", bundle: .parent)
         case .syllabus:
             switch courses.first?.defaultView {
             case .wiki:
-                return NSLocalizedString("Front Page", comment: "")
+                return String(localized: "Front Page", bundle: .parent)
             case .syllabus:
-                return NSLocalizedString("Syllabus", comment: "")
+                return String(localized: "Syllabus", bundle: .parent)
             default:
-                return NSLocalizedString("Syllabus", comment: "")
+                return String(localized: "Syllabus", bundle: .parent)
             }
         case .summary:
-            return NSLocalizedString("Summary", comment: "")
+            return String(localized: "Summary", bundle: .parent)
         }
     }
 }

--- a/Parent/Parent/Courses/CourseListViewController.swift
+++ b/Parent/Parent/Courses/CourseListViewController.swift
@@ -45,9 +45,9 @@ class CourseListViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        emptyMessageLabel.text = NSLocalizedString("Your child’s courses might not be published yet.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Courses", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading courses. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = String(localized: "Your child’s courses might not be published yet.", bundle: .parent)
+        emptyTitleLabel.text = String(localized: "No Courses", bundle: .parent)
+        errorView.messageLabel.text = String(localized: "There was an error loading courses. Pull to refresh to try again.", bundle: .parent)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         spinnerView.color = nil
@@ -129,7 +129,7 @@ class CourseListCell: UITableViewCell {
 
         if course.hideTotalGrade {
             // this condition also triggers when multipleGradingPeriodsEnabled is true, currentGradingPeriodID is nil and totalsForAllGradingPeriodsOption is false
-            return course.hideFinalGrades ? "" : NSLocalizedString("N/A", comment: "")
+            return course.hideFinalGrades ? "" : String(localized: "N/A", bundle: .parent)
         }
 
         var grade = enrollment.computedCurrentGrade
@@ -152,12 +152,12 @@ class CourseListCell: UITableViewCell {
                 return enrollment.convertedLetterGrade(gradingPeriodID: enrollment.currentGradingPeriodID,
                                                        gradingScheme: course.gradingScheme)
             } else {
-                return NSLocalizedString("No Grade", comment: "")
+                return String(localized: "No Grade", bundle: .parent)
             }
         }
 
         guard let scoreNoNil = score, let scoreString = Course.scoreFormatter.string(from: NSNumber(value: scoreNoNil)) else {
-            return grade ?? NSLocalizedString("No Grade", comment: "")
+            return grade ?? String(localized: "No Grade", bundle: .parent)
         }
 
         if let grade = grade {

--- a/Parent/Parent/Dashboard/Admin/AdminViewController.swift
+++ b/Parent/Parent/Dashboard/Admin/AdminViewController.swift
@@ -31,7 +31,7 @@ class AdminViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        directionsLabel.text = NSLocalizedString("Add students at the top or visit the global menu to masquerade as a student.", comment: "")
-        welcomeLabel.text = NSLocalizedString("Welcome, Admin!", comment: "")
+        directionsLabel.text = String(localized: "Add students at the top or visit the global menu to masquerade as a student.", bundle: .parent)
+        welcomeLabel.text = String(localized: "Welcome, Admin!", bundle: .parent)
     }
 }

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -140,10 +140,10 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
 
     func updateBadgeCount() {
         profileButton.addBadge(number: badgeCount, color: currentColor)
-        profileButton.accessibilityLabel = NSLocalizedString("Settings", comment: "")
+        profileButton.accessibilityLabel = String(localized: "Settings", bundle: .parent)
         if badgeCount > 0 {
             profileButton.accessibilityHint = String.localizedStringWithFormat(
-                NSLocalizedString("conversation_unread_messages", bundle: .core, comment: ""),
+                String(localized: "conversation_unread_messages", bundle: .parent),
                 badgeCount
             )
         }
@@ -172,13 +172,13 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
             let displayName = Core.User.displayName(student.shortName, pronouns: student.pronouns)
             titleLabel.text = displayName
             dropdownButton.accessibilityLabel = String.localizedStringWithFormat(
-                NSLocalizedString("Current student: %@. Tap to switch students", comment: ""),
+                String(localized: "Current student: %@. Tap to switch students", bundle: .parent),
                 displayName
             )
         } else {
             avatarView.isHidden = true
-            titleLabel.text = NSLocalizedString("Add Student", comment: "")
-            dropdownButton.accessibilityLabel = NSLocalizedString("Add Student", comment: "")
+            titleLabel.text = String(localized: "Add Student", bundle: .parent)
+            dropdownButton.accessibilityLabel = String(localized: "Add Student", bundle: .parent)
         }
     }
 
@@ -223,7 +223,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         let courses = currentStudentID.flatMap {
             CourseListViewController.create(studentID: $0)
         } ?? AdminViewController.create()
-        courses.tabBarItem.title = NSLocalizedString("Courses", comment: "Courses Tab")
+        courses.tabBarItem.title = String(localized: "Courses", bundle: .parent, comment: "Courses Tab")
         courses.tabBarItem.image = .coursesTab
         courses.tabBarItem.selectedImage = .coursesTabActive
         courses.tabBarItem.accessibilityIdentifier = "TabBar.coursesTab"
@@ -235,7 +235,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         let calendar = currentStudentID.flatMap {
             PlannerViewController.create(studentID: $0, selectedDate: selectedDate)
         } ?? AdminViewController.create()
-        calendar.tabBarItem.title = NSLocalizedString("Calendar", comment: "Calendar Tab")
+        calendar.tabBarItem.title = String(localized: "Calendar", bundle: .parent, comment: "Calendar Tab")
         calendar.tabBarItem.image = .calendarTab
         calendar.tabBarItem.selectedImage = .calendarTabActive
         calendar.tabBarItem.accessibilityIdentifier = "TabBar.calendarTab"
@@ -243,7 +243,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         let alerts = currentStudentID.flatMap {
             ObserverAlertListViewController.create(studentID: $0)
         } ?? AdminViewController.create()
-        alerts.tabBarItem.title = NSLocalizedString("Alerts", comment: "Alerts Tab")
+        alerts.tabBarItem.title = String(localized: "Alerts", bundle: .parent, comment: "Alerts Tab")
         alerts.tabBarItem.image = .alertsTab
         alerts.tabBarItem.selectedImage = .alertsTabActive
         alerts.tabBarItem.accessibilityIdentifier = "TabBar.alertsTab"
@@ -331,7 +331,7 @@ class AddStudentButton: UIButton {
         }
         configuration = config
 
-        setTitle(NSLocalizedString("Add Student", comment: ""), for: .normal)
+        setTitle(String(localized: "Add Student", bundle: .parent), for: .normal)
         setTitleColor(.textDarkest, for: .normal)
         titleLabel?.numberOfLines = 1
 

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -143,7 +143,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         profileButton.accessibilityLabel = String(localized: "Settings", bundle: .parent)
         if badgeCount > 0 {
             profileButton.accessibilityHint = String.localizedStringWithFormat(
-                String(localized: "conversation_unread_messages", bundle: .parent),
+                String(localized: "conversation_unread_messages", bundle: .core),
                 badgeCount
             )
         }

--- a/Parent/Parent/Extensions/UserNotificationReminder.swift
+++ b/Parent/Parent/Extensions/UserNotificationReminder.swift
@@ -25,9 +25,9 @@ let RemindableActionURLKey = "RemindableActionURL"
 extension NotificationManager {
     func setReminder(for event: CalendarEvent, at date: Date, studentID: String, callback: @escaping (Error?) -> Void) {
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString("Event reminder", comment: "")
+        content.title = String(localized: "Event reminder", bundle: .parent)
         content.body = String.localizedStringWithFormat(
-            NSLocalizedString("%@ will begin at %@", comment: ""),
+            String(localized: "%@ will begin at %@", bundle: .parent),
             event.title,
             event.startAt!.dateTimeString
         )
@@ -40,9 +40,9 @@ extension NotificationManager {
 
     func setReminder(for assignment: Assignment, at date: Date, studentID: String, callback: @escaping (Error?) -> Void) {
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString("Assignment reminder", comment: "")
+        content.title = String(localized: "Assignment reminder", bundle: .parent)
         content.body = assignment.dueAt.map { String.localizedStringWithFormat(
-            NSLocalizedString("%@ is due at %@", comment: ""),
+            String(localized: "%@ is due at %@", bundle: .parent),
             assignment.name,
             $0.dateTimeString
         ) } ?? assignment.name

--- a/Parent/Parent/Localizable.xcstrings
+++ b/Parent/Parent/Localizable.xcstrings
@@ -12449,7 +12449,7 @@
       }
     },
     "Regarding: %@, %@" : {
-      "comment" : "Regarding <Name>, <URL>\nRegarding <John Doe>, [link to grades or syllabus]\n   Regarding <John Doe>, <Grades | Syllabus>",
+      "comment" : "Regarding <Name>, <URL>\nRegarding <John Doe>, <Grades | Syllabus>",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
+++ b/Parent/Parent/ObserverAlerts/ObserverAlertListViewController.swift
@@ -49,9 +49,9 @@ class ObserverAlertListViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        emptyMessageLabel.text = NSLocalizedString("There's nothing to be notified of yet.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Alerts", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading alerts. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = String(localized: "There's nothing to be notified of yet.", bundle: .parent)
+        emptyTitleLabel.text = String(localized: "No Alerts", bundle: .parent)
+        errorView.messageLabel.text = String(localized: "There was an error loading alerts. Pull to refresh to try again.", bundle: .parent)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         tableView.backgroundColor = .backgroundLightest
@@ -94,11 +94,11 @@ class ObserverAlertListViewController: UIViewController {
 
     private func showItemLockedMessage() {
         let alert = UIAlertController(
-            title: NSLocalizedString("Locked", bundle: .core, comment: ""),
-            message: NSLocalizedString("The linked item is no longer available.", bundle: .core, comment: ""),
+            title: String(localized: "Locked", bundle: .parent),
+            message: String(localized: "The linked item is no longer available.", bundle: .parent),
             preferredStyle: .alert
         )
-        alert.addAction(AlertAction(NSLocalizedString("OK", bundle: .core, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .parent), style: .cancel))
         env.router.show(alert, from: self, options: .modal())
     }
 }
@@ -140,7 +140,7 @@ extension ObserverAlertListViewController: UITableViewDataSource, UITableViewDel
     func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {
         guard let id = alerts[indexPath.row]?.id else { return nil }
         return UISwipeActionsConfiguration(actions: [
-            UIContextualAction(style: .destructive, title: NSLocalizedString("Dismiss", comment: "")) { (_, _, completed) in
+            UIContextualAction(style: .destructive, title: String(localized: "Dismiss", bundle: .parent)) { (_, _, completed) in
                 DismissObserverAlert(alertID: id).fetch { (_, _, error) in
                     completed(error == nil)
                 }
@@ -159,7 +159,7 @@ class ObserverAlertListCell: UITableViewCell {
     func update(alert: ObserverAlert?, threshold: UInt?) {
         backgroundColor = .backgroundLightest
         unreadView.isHidden = alert?.workflowState != .unread
-        unreadView.accessibilityLabel = NSLocalizedString("Unread", comment: "")
+        unreadView.accessibilityLabel = String(localized: "Unread", bundle: .parent)
         typeLabel.text = alert?.alertType.title(for: threshold)
         titleLabel.text = alert?.title
         dateLabel.text = alert?.actionDate?.dateTimeString
@@ -186,7 +186,7 @@ class ObserverAlertListCell: UITableViewCell {
 
     private func updateTitleToLockedState() {
         var newTypeText = typeLabel.text ?? ""
-        let lockedText = NSLocalizedString("Locked", bundle: .core, comment: "")
+        let lockedText = String(localized: "Locked", bundle: .parent)
 
         if newTypeText.isEmpty {
             newTypeText = lockedText

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -156,7 +156,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 
 extension ParentAppDelegate: LoginDelegate {
     var supportsCanvasNetwork: Bool { false }
-    var findSchoolButtonTitle: String { NSLocalizedString("Find School", bundle: .core, comment: "") }
+    var findSchoolButtonTitle: String { String(localized: "Find School", bundle: .parent) }
 
     func changeUser() {
         guard let window = window, !(window.rootViewController is LoginNavigationController) else { return }
@@ -224,10 +224,10 @@ extension ParentAppDelegate: LoginDelegate {
 
     func handleDeepLink(url: URL) {
         if url.host == "create-account" {
-            let title = NSLocalizedString("Login required", comment: "")
-            let message = NSLocalizedString("It looks like you’re trying to add a student. Try adding this student after you’ve logged in", comment: "")
+            let title = String(localized: "Login required", bundle: .parent)
+            let message = String(localized: "It looks like you’re trying to add a student. Try adding this student after you’ve logged in", bundle: .parent)
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", bundle: .core, comment: ""), style: .default))
+            alert.addAction(UIAlertAction(title: String(localized: "OK", bundle: .parent), style: .default))
             guard let vc = topMostViewController() else { return }
             AppEnvironment.shared.router.show(alert, from: vc, options: .modal())
         }

--- a/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
+++ b/Parent/Parent/Planner/CalendarEventDetailsViewController.swift
@@ -64,7 +64,7 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Event Details", comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Event Details", bundle: .parent))
         updateNavBar(subtitle: nil, color: ColorScheme.observee(studentID).color)
         webViewContainer.addSubview(webView)
         webView.pinWithThemeSwitchButton(inside: webViewContainer)
@@ -75,16 +75,16 @@ class CalendarEventDetailsViewController: UIViewController, ColoredNavViewProtoc
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
         scrollView.refreshControl = refreshControl
 
-        dateHeadingLabel.text = NSLocalizedString("Date", comment: "")
+        dateHeadingLabel.text = String(localized: "Date", bundle: .parent)
         dateLabel.text = ""
-        descriptionHeadingLabel.text = NSLocalizedString("Description", comment: "")
-        locationHeadingLabel.text = NSLocalizedString("Location", comment: "")
+        descriptionHeadingLabel.text = String(localized: "Description", bundle: .parent)
+        locationHeadingLabel.text = String(localized: "Location", bundle: .parent)
         locationView.isHidden = true
         titleLabel.text = ""
 
-        reminderHeadingLabel.text = NSLocalizedString("Remind Me", comment: "")
-        reminderMessageLabel.text = NSLocalizedString("Set a date and time to be notified of this event.", comment: "")
-        reminderSwitch.accessibilityLabel = NSLocalizedString("Remind Me", comment: "")
+        reminderHeadingLabel.text = String(localized: "Remind Me", bundle: .parent)
+        reminderMessageLabel.text = String(localized: "Set a date and time to be notified of this event.", bundle: .parent)
+        reminderSwitch.accessibilityLabel = String(localized: "Remind Me", bundle: .parent)
         reminderSwitch.isEnabled = false
         reminderDateButton.isEnabled = false
         reminderDateButton.isHidden = true

--- a/Parent/Parent/Students/AddStudentController.swift
+++ b/Parent/Parent/Students/AddStudentController.swift
@@ -35,14 +35,14 @@ class AddStudentController {
         let picker = BottomSheetPickerViewController.create()
         picker.addAction(
             image: nil,
-            title: NSLocalizedString("QR Code", comment: ""),
+            title: String(localized: "QR Code", bundle: .parent),
             accessibilityIdentifier: "DashboardViewController.addStudent.qrCode"
         ) { [weak self] in
             self?.scanQRCode()
         }
         picker.addAction(
             image: nil,
-            title: NSLocalizedString("Pairing Code", comment: ""),
+            title: String(localized: "Pairing Code", bundle: .parent),
             accessibilityIdentifier: "DashboardViewController.addStudent.pairingCode"
         ) { [weak self] in
             self?.useInput()
@@ -51,14 +51,14 @@ class AddStudentController {
     }
 
     func useInput() {
-        let title = NSLocalizedString("Add Student", comment: "")
-        let message = NSLocalizedString("Input the student pairing code provided to you.", comment: "")
+        let title = String(localized: "Add Student", bundle: .parent)
+        let message = String(localized: "Input the student pairing code provided to you.", bundle: .parent)
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alert.addTextField { tf in
-            tf.placeholder = NSLocalizedString("Pairing Code", comment: "")
+            tf.placeholder = String(localized: "Pairing Code", bundle: .parent)
         }
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
-        alert.addAction(AlertAction(NSLocalizedString("Add", comment: ""), style: .default, handler: { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .parent), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Add", bundle: .parent), style: .default, handler: { [weak self] _ in
             guard let textField = alert.textFields?.first, let code = textField.text else { return }
             self?.pair(with: code)
         }))
@@ -73,7 +73,7 @@ class AddStudentController {
             performUIUpdate {
                 if let error = error {
                     let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-                    alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default, handler: { _ in }))
+                    alert.addAction(UIAlertAction(title: String(localized: "OK", bundle: .parent), style: .default, handler: { _ in }))
                     self.env.router.show(alert, from: vc, options: .modal())
                 }
                 self.handler(error)
@@ -97,19 +97,18 @@ extension AddStudentController: ScannerDelegate {
                 let host = components.host,
                 let pairingCode = components.queryItems?.first(where: { $0.name == "code" })?.value
             else {
-                let error = NSError.instructureError(NSLocalizedString("Could not parse QR code, QR code invalid", comment: ""))
+                let error = NSError.instructureError(String(localized: "Could not parse QR code, QR code invalid", bundle: .parent))
                 (self.presentingViewController as? ErrorViewController)?.showError(error)
                 return
             }
 
             guard host == self.env.currentSession?.baseURL.host else {
-                let title = NSLocalizedString("Domain mismatch", comment: "")
-                let msg = NSLocalizedString(
+                let title = String(localized: "Domain mismatch", bundle: .parent)
+                let msg = String(localized:
                     """
                     The student you are trying to add is at a different Canvas institution.
                     Sign in or create an account with that institution to add this student.
-                    """,
-                    comment: "")
+                    """, bundle: .parent)
                 (self.presentingViewController as? ErrorViewController)?.showAlert(title: title, message: msg)
                 return
             }

--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -73,7 +73,7 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
         super.viewDidLoad()
         view.backgroundColor = .backgroundGrouped
 
-        alertHeaderLabel.text = NSLocalizedString("Alert me when:", comment: "")
+        alertHeaderLabel.text = String(localized: "Alert me when:", bundle: .parent)
         for label in alertLabels {
             label.text = AlertThresholdType.allCases[label.tag].name
         }
@@ -158,8 +158,8 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
         guard let value = formatter.number(from: text)?.uintValue, value >= 1, value <= 100 else {
             updateThresholds()
             return showAlert(
-                title: NSLocalizedString("Invalid Threshold", comment: ""),
-                message: NSLocalizedString("The value must a number between 0 and 100", comment: "")
+                title: String(localized: "Invalid Threshold", bundle: .parent),
+                message: String(localized: "The value must a number between 0 and 100", bundle: .parent)
             )
         }
 
@@ -180,15 +180,15 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
         if let low = low, low >= value {
             updateThresholds()
             return showAlert(
-                title: NSLocalizedString("Invalid Threshold", comment: ""),
-                message: NSLocalizedString("You cannot set a high threshold that is lower or equal to a previously set low threshold.", comment: "")
+                title: String(localized: "Invalid Threshold", bundle: .parent),
+                message: String(localized: "You cannot set a high threshold that is lower or equal to a previously set low threshold.", bundle: .parent)
             )
         }
         if let high = high, high <= value {
             updateThresholds()
             return showAlert(
-                title: NSLocalizedString("Invalid Threshold", comment: ""),
-                message: NSLocalizedString("You cannot set a low threshold that is higher or equal to a previously set high threshold.", comment: "")
+                title: String(localized: "Invalid Threshold", bundle: .parent),
+                message: String(localized: "You cannot set a low threshold that is higher or equal to a previously set high threshold.", bundle: .parent)
             )
         }
 

--- a/Parent/Parent/Students/StudentListViewController.swift
+++ b/Parent/Parent/Students/StudentListViewController.swift
@@ -52,12 +52,12 @@ class StudentListViewController: ScreenViewTrackableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Manage Students", comment: "")
+        title = String(localized: "Manage Students", bundle: .parent)
         navigationItem.rightBarButtonItem = addStudentButton
 
-        emptyMessageLabel.text = NSLocalizedString("Add students at the top.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Students", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading students. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = String(localized: "Add students at the top.", bundle: .parent)
+        emptyTitleLabel.text = String(localized: "No Students", bundle: .parent)
+        errorView.messageLabel.text = String(localized: "There was an error loading students. Pull to refresh to try again.", bundle: .parent)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsPresenter.swift
@@ -106,10 +106,10 @@ class AssignmentDetailsPresenter {
         switch assignment.lockStatus {
         case .before:
             guard let unlockAt = assignment.unlockAt else { return "" }
-            return String.localizedStringWithFormat(NSLocalizedString("This assignment is locked until %@", comment: ""), unlockAt.dateTimeString)
+            return String.localizedStringWithFormat(String(localized: "This assignment is locked until %@", bundle: .student), unlockAt.dateTimeString)
         case .after:
             guard let lockAt = assignment.lockAt else { return "" }
-            return String.localizedStringWithFormat(NSLocalizedString("This assignment was locked %@", comment: ""), lockAt.dateTimeString)
+            return String.localizedStringWithFormat(String(localized: "This assignment was locked %@", bundle: .student), lockAt.dateTimeString)
         default:
             return assignment.lockExplanation ?? ""
         }
@@ -219,7 +219,7 @@ class AssignmentDetailsPresenter {
             guard isActive else { return [] }
             return validSubmissions.map { submission in
                 let attemptNumber = String.localizedStringWithFormat(
-                    NSLocalizedString("Attempt %d", bundle: .core, comment: ""),
+                    String(localized: "Attempt %d", bundle: .student),
                     submission.attempt
                 )
                 let date = submission.submittedAt?.dateTimeString ?? ""
@@ -236,7 +236,7 @@ class AssignmentDetailsPresenter {
 
     private func updateAttemptInfo(submission: Submission) {
         let attemptNumber = String.localizedStringWithFormat(
-            NSLocalizedString("Attempt %d", bundle: .core, comment: ""),
+            String(localized: "Attempt %d", bundle: .student),
             submission.attempt
         )
         view?.updateAttemptInfo(attemptNumber: attemptNumber)
@@ -405,6 +405,6 @@ class AssignmentDetailsPresenter {
 
     func assignmentDescription() -> String {
         if let desc = assignments.first?.descriptionHTML, !desc.isEmpty { return desc }
-        return NSLocalizedString("No Content", comment: "")
+        return String(localized: "No Content", bundle: .student)
     }
 }

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -88,7 +88,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     @IBOutlet weak var submissionRubricButton: UIButton? {
         didSet {
             var buttonConfig = UIButton.Configuration.plain()
-            buttonConfig.title = String(localized: "Submission & Rubric")
+            buttonConfig.title = String(localized: "Submission & Rubric", bundle: .student)
             buttonConfig.baseForegroundColor = Brand.shared.linkColor
             buttonConfig.imagePlacement = .trailing
             buttonConfig.imagePadding = 4
@@ -171,7 +171,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         // Navigation Bar
         navigationItem.titleView = titleSubtitleView
-        titleSubtitleView.title = NSLocalizedString("Assignment Details", bundle: .student, comment: "")
+        titleSubtitleView.title = String(localized: "Assignment Details", bundle: .student)
 
         // Loading
         scrollView?.isHidden = true
@@ -190,21 +190,21 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         submissionTypesSection?.subHeader.accessibilityIdentifier = "AssignmentDetails.submissionTypes"
 
         // Localization
-        dueSection?.header.text = NSLocalizedString("Due", bundle: .student, comment: "")
-        submissionTypesSection?.header.text = NSLocalizedString("Submission Types", bundle: .student, comment: "")
-        fileTypesSection?.header.text = NSLocalizedString("File Types", bundle: .student, comment: "")
-        gradeHeadingLabel?.text = NSLocalizedString("Grade", bundle: .student, comment: "")
-        descriptionHeadingLabel?.text = NSLocalizedString("Description", bundle: .student, comment: "")
-        quizAttemptsLabel?.text = NSLocalizedString("Allowed Attempts:", bundle: .student, comment: "")
-        quizHeadingLabel?.text = NSLocalizedString("Settings", bundle: .student, comment: "")
-        quizQuestionsLabel?.text = NSLocalizedString("Questions:", bundle: .student, comment: "")
-        quizTimeLimitLabel?.text = NSLocalizedString("Time Limit:", bundle: .student, comment: "")
-        submittedLabel?.text = NSLocalizedString("Successfully submitted!", bundle: .student, comment: "")
-        submittedDetailsLabel?.text = NSLocalizedString("Your submission is now waiting to be graded.", bundle: .student, comment: "")
-        submissionButton?.setTitle(NSLocalizedString("Submission & Rubric", bundle: .student, comment: ""), for: .normal)
-        attemptsHeadingLabel.text = NSLocalizedString("Attempts", comment: "")
-        attemptsAllowedLabel.text = NSLocalizedString("Attempts Allowed:", comment: "")
-        attemptsUsedLabel.text = NSLocalizedString("Attempts Used:", comment: "")
+        dueSection?.header.text = String(localized: "Due", bundle: .student)
+        submissionTypesSection?.header.text = String(localized: "Submission Types", bundle: .student)
+        fileTypesSection?.header.text = String(localized: "File Types", bundle: .student)
+        gradeHeadingLabel?.text = String(localized: "Grade", bundle: .student)
+        descriptionHeadingLabel?.text = String(localized: "Description", bundle: .student)
+        quizAttemptsLabel?.text = String(localized: "Allowed Attempts:", bundle: .student)
+        quizHeadingLabel?.text = String(localized: "Settings", bundle: .student)
+        quizQuestionsLabel?.text = String(localized: "Questions:", bundle: .student)
+        quizTimeLimitLabel?.text = String(localized: "Time Limit:", bundle: .student)
+        submittedLabel?.text = String(localized: "Successfully submitted!", bundle: .student)
+        submittedDetailsLabel?.text = String(localized: "Your submission is now waiting to be graded.", bundle: .student)
+        submissionButton?.setTitle(String(localized: "Submission & Rubric", bundle: .student), for: .normal)
+        attemptsHeadingLabel.text = String(localized: "Attempts", bundle: .student)
+        attemptsAllowedLabel.text = String(localized: "Attempts Allowed:", bundle: .student)
+        attemptsUsedLabel.text = String(localized: "Attempts Used:", bundle: .student)
         attemptsAllowedValueLabel.text = nil
         attemptsUsedValueLabel.text = nil
 
@@ -304,7 +304,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
 
         submissionRubricButtonSection?.isHidden = true
         submittedLabel?.textColor = .textDarkest
-        submittedLabel?.text = NSLocalizedString("Successfully submitted!", bundle: .student, comment: "")
+        submittedLabel?.text = String(localized: "Successfully submitted!", bundle: .student)
         submittedDetailsLabel?.isHidden = false
         changeSubmittedIconVisibility(to: true)
 
@@ -344,31 +344,31 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
     func updateSubmissionLabels(state: OnlineUploadState) {
         switch state {
         case .reSubmissionFailed:
-            submittedLabel?.text = NSLocalizedString("Resubmission Failed", bundle: .core, comment: "")
+            submittedLabel?.text = String(localized: "Resubmission Failed", bundle: .student)
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
             submittedDetailsLabel?.isHidden = true
-            fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
+            fileSubmissionButton?.setTitle(String(localized: "Tap to view details", bundle: .student), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .failed:
-            submittedLabel?.text = NSLocalizedString("Submission Failed", bundle: .core, comment: "")
+            submittedLabel?.text = String(localized: "Submission Failed", bundle: .student)
             submittedLabel?.textColor = UIColor.textDanger.ensureContrast(against: .white)
             submittedDetailsLabel?.isHidden = true
-            fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view details", bundle: .core, comment: ""), for: .normal)
+            fileSubmissionButton?.setTitle(String(localized: "Tap to view details", bundle: .student), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .uploading:
-            submittedLabel?.text = NSLocalizedString("Submission Uploading...", bundle: .core, comment: "")
+            submittedLabel?.text = String(localized: "Submission Uploading...", bundle: .student)
             submittedLabel?.textColor = .textDarkest
             submittedDetailsLabel?.isHidden = true
-            fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
+            fileSubmissionButton?.setTitle(String(localized: "Tap to view progress", bundle: .student), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .staged:
-            submittedLabel?.text = NSLocalizedString("Submission In Progress...", bundle: .core, comment: "")
+            submittedLabel?.text = String(localized: "Submission In Progress...", bundle: .student)
             submittedLabel?.textColor = .textDarkest
             submittedDetailsLabel?.isHidden = true
-            fileSubmissionButton?.setTitle(NSLocalizedString("Tap to view progress", bundle: .core, comment: ""), for: .normal)
+            fileSubmissionButton?.setTitle(String(localized: "Tap to view progress", bundle: .student), for: .normal)
             changeSubmittedIconVisibility(to: false)
             return
         case .completed:
@@ -397,17 +397,17 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         statusLabel?.text = status.text
         dueSection?.subHeader.text = assignment.dueAt.flatMap {
             $0.dateTimeString
-        } ?? NSLocalizedString("No Due Date", bundle: .core, comment: "")
+        } ?? String(localized: "No Due Date", bundle: .student)
         submissionTypesSection?.subHeader.text = assignment.submissionTypeText
         fileTypesSection?.subHeader.text = assignment.fileTypeText
         fileTypesSection?.isHidden = !assignment.hasFileTypes
         attemptsAllowedValueLabel.text = assignment.allowedAttempts > 0
             ? NumberFormatter.localizedString(from: NSNumber(value: assignment.allowedAttempts), number: .none)
-            : NSLocalizedString("Unlimited", comment: "")
+            : String(localized: "Unlimited", bundle: .student)
         attemptsUsedValueLabel.text = NumberFormatter.localizedString(from: NSNumber(value: assignment.usedAttempts), number: .none)
         descriptionHeadingLabel?.text = quiz == nil
-            ? NSLocalizedString("Description", bundle: .student, comment: "")
-            : NSLocalizedString("Instructions", bundle: .student, comment: "")
+            ? String(localized: "Description", bundle: .student)
+            : String(localized: "Instructions", bundle: .student)
 
         let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
             sessionId: env.currentSession?.uniqueID ?? "",

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/Model/AssignmentReminderTimeFormatter.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/Model/AssignmentReminderTimeFormatter.swift
@@ -34,6 +34,6 @@ class AssignmentReminderTimeFormatter: DateComponentsFormatter {
             return nil
         }
 
-        return String(localized: "\(formatted) before", comment: "10 minutes before")
+        return String(localized: "\(formatted) before", bundle: .student, comment: "10 minutes before")
     }
 }

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/Model/AssignmentReminderTimeMetric.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/Model/AssignmentReminderTimeMetric.swift
@@ -24,10 +24,10 @@ public enum AssignmentReminderTimeMetric: CaseIterable, Identifiable, Hashable {
     public var id: String { pickerTitle }
     public var pickerTitle: String {
         switch self {
-        case .minutes: return String(localized: "Minutes Before")
-        case .hours: return String(localized: "Hours Before")
-        case .days: return String(localized: "Days Before")
-        case .weeks: return String(localized: "Weeks Before")
+        case .minutes: return String(localized: "Minutes Before", bundle: .student)
+        case .hours: return String(localized: "Hours Before", bundle: .student)
+        case .days: return String(localized: "Days Before", bundle: .student)
+        case .weeks: return String(localized: "Weeks Before", bundle: .student)
         }
     }
 }

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/Model/Notifications/AssignmentNotificationContent.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/Model/Notifications/AssignmentNotificationContent.swift
@@ -29,8 +29,8 @@ extension UNNotificationContent {
         let dueText = formatter.string(from: beforeTime) ?? ""
 
         let result = UNMutableNotificationContent()
-        result.title = String(localized: "Due Date Reminder")
-        result.body = String(localized: "This assignment is due in \(dueText)", comment: "Due in 5 minutes") + ": \(context.assignmentName)"
+        result.title = String(localized: "Due Date Reminder", bundle: .student)
+        result.body = String(localized: "This assignment is due in \(dueText)", bundle: .student, comment: "Due in 5 minutes") + ": \(context.assignmentName)"
         result.sound = .default
         result.userInfo = [
             AssignmentReminderKeys.courseId.rawValue: context.courseId,

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentReminderDatePickerView.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentReminderDatePickerView.swift
@@ -43,7 +43,7 @@ public struct AssignmentReminderDatePickerView: View {
             .animation(.default, value: viewModel.customPickerVisible)
         }
         .background(Color.backgroundLightest)
-        .navigationTitle(Text("Reminder"))
+        .navigationTitle(Text("Reminder", bundle: .student))
         .navBarItems(leading: cancelButton, trailing: doneButton)
     }
 
@@ -106,7 +106,7 @@ public struct AssignmentReminderDatePickerView: View {
         Button {
             viewController.value.dismiss(animated: true)
         } label: {
-            Text("Cancel")
+            Text("Cancel", bundle: .student)
                 .font(.regular16)
                 .foregroundStyle(Color(Brand.shared.primary))
         }
@@ -116,7 +116,7 @@ public struct AssignmentReminderDatePickerView: View {
         Button {
             viewModel.doneButtonDidTap(host: viewController.value)
         } label: {
-            Text("Done")
+            Text("Done", bundle: .student)
                 .font(.regular16)
                 .foregroundStyle(Color(Brand.shared.primary))
                 .opacity(viewModel.doneButtonActive ? 1 : 0.3)

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentReminderItemView.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentReminderItemView.swift
@@ -40,8 +40,8 @@ struct AssignmentReminderItemView: View {
         .accessibilityAction {
             deleteDidTap()
         }
-        .accessibilityLabel(Text("Reminder") + Text(verbatim: ",\(viewModel.title)"))
-        .accessibilityHint(Text("Activate to delete"))
+        .accessibilityLabel(Text("Reminder", bundle: .student) + Text(verbatim: ",\(viewModel.title)"))
+        .accessibilityHint(Text("Activate to delete", bundle: .student))
     }
 
     private var bellIcon: some View {

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentRemindersView.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/View/AssignmentRemindersView.swift
@@ -70,8 +70,8 @@ public struct AssignmentRemindersView: View {
 
     @ViewBuilder
     private var header: some View {
-        let title = String(localized: "Reminder")
-        let description = String(localized: "Add due date reminder notifications about this assignment on this device.")
+        let title = String(localized: "Reminder", bundle: .student)
+        let description = String(localized: "Add due date reminder notifications about this assignment on this device.", bundle: .student)
         HStack(spacing: 0) {
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/ViewModel/AssignmentReminderDatePickerViewModel.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/ViewModel/AssignmentReminderDatePickerViewModel.swift
@@ -47,7 +47,7 @@ class AssignmentReminderDatePickerViewModel: ObservableObject {
         buttonTitles = {
             let formatter = AssignmentReminderTimeFormatter()
             var result = Self.predefinedIntervals.map { formatter.string(from: $0)?.capitalized ?? "" }
-            result.append(String(localized: "Custom"))
+            result.append(String(localized: "Custom", bundle: .student))
             return result
         }()
     }

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/ViewModel/AssignmentRemindersViewModel.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/ViewModel/AssignmentRemindersViewModel.swift
@@ -26,13 +26,13 @@ public class AssignmentRemindersViewModel: ObservableObject {
     @Published public private(set) var isReminderSectionVisible = false
     @Published public var showingDeleteConfirmDialog = false
     public let confirmAlert = ConfirmationAlertViewModel(
-        title: NSLocalizedString("Delete Reminder", comment: ""),
-        message: NSLocalizedString(
+        title: String(localized: "Delete Reminder", bundle: .student),
+        message: String(localized:
            """
            Are you sure you would like to delete this reminder?
-           """, comment: ""),
-        cancelButtonTitle: NSLocalizedString("No", comment: ""),
-        confirmButtonTitle: NSLocalizedString("Yes", comment: ""),
+           """, bundle: .student),
+        cancelButtonTitle: String(localized: "No", bundle: .student),
+        confirmButtonTitle: String(localized: "Yes", bundle: .student),
         isDestructive: true
     )
 
@@ -71,7 +71,7 @@ public class AssignmentRemindersViewModel: ObservableObject {
             .sink { [weak interactor] in
                 // We can't use subscribe because userConfirmation() finishes and
                 // the stream would finish the publisher in the interactor as well
-                UIAccessibility.announce(String(localized: "Reminder Deleted"))
+                UIAccessibility.announce(String(localized: "Reminder Deleted", bundle: .student))
                 interactor?.reminderDidDelete.send(reminder)
             }
             .store(in: &subscriptions)
@@ -116,17 +116,17 @@ public class AssignmentRemindersViewModel: ObservableObject {
 
                     switch $0 {
                     case .reminderInPast:
-                        message = String(localized: "Please choose a future time for your reminder!")
+                        message = String(localized: "Please choose a future time for your reminder!", bundle: .student)
                     case .duplicate:
-                        message = String(localized: "You have already set a reminder for this time.")
+                        message = String(localized: "You have already set a reminder for this time.", bundle: .student)
                     case .application, .scheduleFailed, .noPermission:
-                        message = String(localized: "An unknown error occurred.")
+                        message = String(localized: "An unknown error occurred.", bundle: .student)
                     }
 
-                    let alert = UIAlertController(title: String(localized: "Reminder Creation Failed"),
+                    let alert = UIAlertController(title: String(localized: "Reminder Creation Failed", bundle: .student),
                                                   message: message,
                                                   preferredStyle: .alert)
-                    alert.addAction(.init(title: String(localized: "OK"), style: .default))
+                    alert.addAction(.init(title: String(localized: "OK", bundle: .student), style: .default))
 
                     if let self, let reminderView = self.newReminderView {
                         self.router.show(alert, from: reminderView)

--- a/Student/Student/Notifications/ActivityStreamViewController.swift
+++ b/Student/Student/Notifications/ActivityStreamViewController.swift
@@ -67,12 +67,12 @@ class ActivityStreamViewController: ScreenViewTrackableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Notifications", comment: "Notifications tab title")
+        title = String(localized: "Notifications", bundle: .student, comment: "Notifications tab title")
         navigationItem.titleView = Brand.shared.headerImageView()
         view.backgroundColor = .backgroundLightest
         setupTableView()
-        emptyStateHeader.text = NSLocalizedString("No Notifications", comment: "")
-        emptyStateSubHeader.text = NSLocalizedString("There's nothing to be notified of yet.", comment: "")
+        emptyStateHeader.text = String(localized: "No Notifications", bundle: .student)
+        emptyStateSubHeader.text = String(localized: "There's nothing to be notified of yet.", bundle: .student)
         refreshData()
     }
 
@@ -166,7 +166,7 @@ class ActivityCell: UITableViewCell {
     func update(_ activity: Activity, courseCache: [String: ActivityStreamViewController.Info] ) {
         backgroundColor = .backgroundLightest
         if activity.type == ActivityType.conversation {
-            titleLabel.setText(NSLocalizedString("New Message", comment: ""), style: .textCellTitle)
+            titleLabel.setText(String(localized: "New Message", bundle: .student), style: .textCellTitle)
         } else {
             titleLabel.setText(activity.title, style: .textCellTitle)
         }

--- a/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizDetailsViewController.swift
@@ -76,14 +76,14 @@ class QuizDetailsViewController: ScreenViewTrackableViewController, ColoredNavVi
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Quiz Details", comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Quiz Details", bundle: .student))
 
-        attemptsLabel.text = NSLocalizedString("Allowed Attempts:", comment: "")
-        dueHeadingLabel.text = NSLocalizedString("Due", comment: "")
-        instructionsHeadingLabel.text = NSLocalizedString("Instructions", comment: "")
-        questionsLabel.text = NSLocalizedString("Questions:", comment: "")
-        settingsHeadingLabel.text = NSLocalizedString("Settings", comment: "")
-        timeLimitLabel.text = NSLocalizedString("Time Limit:", comment: "")
+        attemptsLabel.text = String(localized: "Allowed Attempts:", bundle: .student)
+        dueHeadingLabel.text = String(localized: "Due", bundle: .student)
+        instructionsHeadingLabel.text = String(localized: "Instructions", bundle: .student)
+        questionsLabel.text = String(localized: "Questions:", bundle: .student)
+        settingsHeadingLabel.text = String(localized: "Settings", bundle: .student)
+        timeLimitLabel.text = String(localized: "Time Limit:", bundle: .student)
 
         instructionsContainer.addSubview(instructionsWebView)
         instructionsWebView.pinWithThemeSwitchButton(inside: instructionsContainer)
@@ -139,29 +139,29 @@ class QuizDetailsViewController: ScreenViewTrackableViewController, ColoredNavVi
             statusIconView.tintColor = .textSuccess
             statusLabel.textColor = .textSuccess
             statusLabel.text = String.localizedStringWithFormat(
-                NSLocalizedString("Submitted %@", comment: "Submitted date"),
+                String(localized: "Submitted %@", bundle: .student, comment: "Submitted date"),
                 finishedAt.dateTimeString
             )
         } else if submission?.attempt ?? 0 > 1 {
             statusIconView.image = .completeSolid
             statusIconView.tintColor = .textSuccess
             statusLabel.textColor = .textSuccess
-            statusLabel.text = NSLocalizedString("Submitted", comment: "")
+            statusLabel.text = String(localized: "Submitted", bundle: .student)
         } else {
             statusIconView.image = .noSolid
             statusIconView.tintColor = .textDark
             statusLabel.textColor = .textDark
-            statusLabel.text = NSLocalizedString("Not Submitted", comment: "")
+            statusLabel.text = String(localized: "Not Submitted", bundle: .student)
         }
         dueLabel.text = quiz?.dueText
         attemptsValueLabel.text = quiz?.allowedAttemptsText
         questionsValueLabel.text = quiz?.questionCountText
         timeLimitValueLabel.text = quiz?.timeLimitText
         instructionsHeadingLabel.text = quiz?.lockedForUser == true
-            ? NSLocalizedString("Locked", comment: "")
-            : NSLocalizedString("Instructions", comment: "")
+            ? String(localized: "Locked", bundle: .student)
+            : String(localized: "Instructions", bundle: .student)
         var html = quiz?.lockExplanation ?? quiz?.details ?? ""
-        if html.isEmpty { html = NSLocalizedString("No Content", comment: "") }
+        if html.isEmpty { html = String(localized: "No Content", bundle: .student) }
 
         let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
             sessionId: env.currentSession?.uniqueID ?? "",
@@ -193,16 +193,16 @@ class QuizDetailsViewController: ScreenViewTrackableViewController, ColoredNavVi
         guard let quiz = quizzes.first, !quizzes.pending else { return nil }
         if quiz.canTake {
             guard let submission = quiz.submission else {
-                return NSLocalizedString("Take Quiz", comment: "")
+                return String(localized: "Take Quiz", bundle: .student)
             }
             if submission.canResume {
-                return NSLocalizedString("Resume Quiz", comment: "")
+                return String(localized: "Resume Quiz", bundle: .student)
             }
             return submission.finishedAt != nil || submission.attempt > 1
-                ? NSLocalizedString("Retake Quiz", comment: "")
-                : NSLocalizedString("Take Quiz", comment: "")
+                ? String(localized: "Retake Quiz", bundle: .student)
+                : String(localized: "Take Quiz", bundle: .student)
         } else if quiz.resultsURL != nil {
-            return NSLocalizedString("View Results", comment: "")
+            return String(localized: "View Results", bundle: .student)
         }
         return nil
     }

--- a/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
+++ b/Student/Student/Quizzes/QuizDetails/QuizWebViewController.swift
@@ -44,9 +44,9 @@ class QuizWebViewController: UIViewController {
         webView.linkDelegate = self
         webView.uiDelegate = self
 
-        title = NSLocalizedString("Take Quiz", comment: "")
+        title = String(localized: "Take Quiz", bundle: .student)
         navigationItem.rightBarButtonItem = UIBarButtonItem(
-            title: NSLocalizedString("Exit", comment: "Exit button to leave the quiz"),
+            title: String(localized: "Exit", bundle: .student, comment: "Exit button to leave the quiz"),
             style: .plain, target: self, action: #selector(exitQuiz)
         )
 
@@ -64,9 +64,9 @@ class QuizWebViewController: UIViewController {
 
     @objc func exitQuiz() {
         if webView.url?.path.contains("/take") == true {
-            let areYouSure = NSLocalizedString("Are you sure you want to leave this quiz?", comment: "")
-            let stay = NSLocalizedString("Stay", comment: "Stay on the quiz view")
-            let leave = NSLocalizedString("Leave", comment: "Leave the quiz")
+            let areYouSure = String(localized: "Are you sure you want to leave this quiz?", bundle: .student)
+            let stay = String(localized: "Stay", bundle: .student, comment: "Stay on the quiz view")
+            let leave = String(localized: "Leave", bundle: .student, comment: "Leave the quiz")
 
             let alert = UIAlertController(title: nil, message: areYouSure, preferredStyle: .alert)
             alert.addAction(AlertAction(stay, style: .cancel))
@@ -91,10 +91,10 @@ class QuizWebViewController: UIViewController {
 extension QuizWebViewController: WKUIDelegate {
     func webView(_ webView: WKWebView, runJavaScriptConfirmPanelWithMessage message: String, initiatedByFrame frame: WKFrameInfo, completionHandler: @escaping (Bool) -> Void) {
         let alert = UIAlertController(title: nil, message: message, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel) { _ in
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .student), style: .cancel) { _ in
             completionHandler(false)
         })
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .student), style: .default) { _ in
             completionHandler(true)
         })
         env.router.show(alert, from: self, options: .modal())

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -72,7 +72,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
             dashboard.interactivePopGestureRecognizer?.isEnabled = false
             result = dashboard
 
-            tabBarTitle = NSLocalizedString("Homeroom", comment: "Homeroom tab title")
+            tabBarTitle = String(localized: "Homeroom", bundle: .student, comment: "Homeroom tab title")
             tabBarImage =  .homeroomTab
             tabBarImageSelected = .homeroomTabActive
         } else {
@@ -80,7 +80,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
                                                                     showOnlyTeacherEnrollment: false))
             result = DashboardContainerViewController(rootViewController: dashboard) { HelmSplitViewController() }
 
-            tabBarTitle = NSLocalizedString("Dashboard", comment: "dashboard page title")
+            tabBarTitle = String(localized: "Dashboard", bundle: .student, comment: "dashboard page title")
             tabBarImage = .dashboardTab
             tabBarImageSelected = .dashboardTabActive
         }
@@ -100,7 +100,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
             HelmNavigationController(rootViewController: EmptyViewController()),
         ]
         split.view.tintColor = Brand.shared.primary
-        split.tabBarItem.title = NSLocalizedString("Calendar", comment: "Calendar page title")
+        split.tabBarItem.title = String(localized: "Calendar", bundle: .student, comment: "Calendar page title")
         split.tabBarItem.image = .calendarTab
         split.tabBarItem.selectedImage = .calendarTabActive
         split.tabBarItem.accessibilityIdentifier = "TabBar.calendarTab"
@@ -116,7 +116,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
             HelmNavigationController(rootViewController: todoController),
             HelmNavigationController(rootViewController: EmptyViewController()),
         ]
-        todo.tabBarItem.title = NSLocalizedString("To Do", comment: "Title of the Todo screen")
+        todo.tabBarItem.title = String(localized: "To Do", bundle: .student, comment: "Title of the Todo screen")
         todo.tabBarItem.image = .todoTab
         todo.tabBarItem.selectedImage = .todoTabActive
         todo.tabBarItem.accessibilityIdentifier = "TabBar.todoTab"
@@ -133,7 +133,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
             HelmNavigationController(rootViewController: ActivityStreamViewController.create()),
             HelmNavigationController(rootViewController: EmptyViewController()),
         ]
-        split.tabBarItem.title = NSLocalizedString("Notifications", comment: "Notifications tab title")
+        split.tabBarItem.title = String(localized: "Notifications", bundle: .student, comment: "Notifications tab title")
         split.tabBarItem.image = .alertsTab
         split.tabBarItem.selectedImage = .alertsTabActive
         split.tabBarItem.accessibilityIdentifier = "TabBar.notificationsTab"
@@ -160,7 +160,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         empty.navigationBar.useGlobalNavStyle()
 
         inboxSplit.viewControllers = [inboxController, empty]
-        let title = NSLocalizedString("Inbox", comment: "Inbox tab title")
+        let title = String(localized: "Inbox", bundle: .student, comment: "Inbox tab title")
         inboxSplit.tabBarItem = UITabBarItem(title: title, image: .inboxTab, selectedImage: .inboxTabActive)
         inboxSplit.tabBarItem.accessibilityIdentifier = "TabBar.inboxTab"
         inboxSplit.tabBarItem.makeUnavailableInOfflineMode()

--- a/Student/Student/Submissions/ArcSubmission/ArcSubmissionViewController.swift
+++ b/Student/Student/Submissions/ArcSubmission/ArcSubmissionViewController.swift
@@ -66,7 +66,7 @@ class ArcSubmissionViewController: UIViewController, ArcSubmissionView {
                         self?.showError(error)
                         return
                     }
-                    let alert = UIAlertController(title: NSLocalizedString("Successfully submitted!", bundle: .student, comment: ""), message: nil, preferredStyle: .alert)
+                    let alert = UIAlertController(title: String(localized: "Successfully submitted!", bundle: .student), message: nil, preferredStyle: .alert)
                     self?.present(alert, animated: true) {
                         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
                             alert.dismiss(animated: true) {

--- a/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModel.swift
+++ b/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModel.swift
@@ -32,10 +32,10 @@ public class StudentAnnotationSubmissionViewModel: ObservableObject {
 
     public init(documentURL: URL, courseID: String, assignmentID: String, userID: String, annotatableAttachmentID: String?, assignmentName: String, courseColor: UIColor) {
         self.documentURL = documentURL
-        self.navBar = (title: NSLocalizedString("Student Annotation", comment: ""),
+        self.navBar = (title: String(localized: "Student Annotation", bundle: .student),
                        subtitle: assignmentName,
                        color: courseColor,
-                       closeButtonTitle: NSLocalizedString("Close", bundle: .core, comment: ""))
+                       closeButtonTitle: String(localized: "Close", bundle: .student))
         self.submissionUseCase = CreateSubmission(context: .course(courseID),
                                                   assignmentID: assignmentID,
                                                   userID: userID,
@@ -52,7 +52,7 @@ public class StudentAnnotationSubmissionViewModel: ObservableObject {
             if submission != nil {
                 self.dismissView.send()
             } else {
-                self.error = .init(title: NSLocalizedString("Submission Failed", comment: ""), message: error?.localizedDescription ?? NSLocalizedString("Unknown Error", bundle: .core, comment: ""))
+                self.error = .init(title: String(localized: "Submission Failed", bundle: .student), message: error?.localizedDescription ?? String(localized: "Unknown Error", bundle: .student))
             }
         }}
     }
@@ -62,7 +62,7 @@ public class StudentAnnotationSubmissionViewModel: ObservableObject {
     }
 
     private static func makeDoneButton(isSaving: Bool) -> (title: String, isDisabled: Bool, opacity: Double) {
-        (title: isSaving ? NSLocalizedString("Submitting...", comment: "") : NSLocalizedString("Submit", bundle: .core, comment: ""), isDisabled: isSaving, opacity: isSaving ? 0.5 : 1)
+        (title: isSaving ? String(localized: "Submitting...", bundle: .student) : String(localized: "Submit", bundle: .student), isDisabled: isSaving, opacity: isSaving ? 0.5 : 1)
     }
 }
 

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
@@ -31,11 +31,11 @@ enum SubmissionButtonAlertView {
             alert.addAction(action)
         }
         if arc {
-            alert.addAction(UIAlertAction(title: NSLocalizedString("Studio", bundle: .student, comment: ""), style: .default) { [weak presenter] _ in
+            alert.addAction(UIAlertAction(title: String(localized: "Studio", bundle: .student), style: .default) { [weak presenter] _ in
                 presenter?.submitArc(assignment: assignment)
             })
         }
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", bundle: .student, comment: ""), style: .cancel))
+        alert.addAction(UIAlertAction(title: String(localized: "Cancel", bundle: .student), style: .cancel))
         // set ipad properties to display modal
         alert.popoverPresentationController?.sourceView = button
         alert.popoverPresentationController?.sourceRect =  CGRect(origin: button.center, size: .zero)
@@ -44,8 +44,8 @@ enum SubmissionButtonAlertView {
     }
 
     static func uploadingAlert(_ mediaUploader: UploadMedia) -> UIAlertController {
-        let uploading = UIAlertController(title: NSLocalizedString("Uploading", bundle: .student, comment: ""), message: nil, preferredStyle: .alert)
-        uploading.addAction(UIAlertAction(title: NSLocalizedString("Cancel", bundle: .student, comment: ""), style: .destructive) { _ in
+        let uploading = UIAlertController(title: String(localized: "Uploading", bundle: .student), message: nil, preferredStyle: .alert)
+        uploading.addAction(UIAlertAction(title: String(localized: "Cancel", bundle: .student), style: .destructive) { _ in
             mediaUploader.cancel()
         })
         return uploading

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -59,11 +59,11 @@ class SubmissionButtonPresenter: NSObject {
 
     func buttonText(course: Course, assignment: Assignment, quiz: Quiz?, onlineUpload: OnlineUploadState?) -> String? {
         if assignment.isDiscussion {
-            return NSLocalizedString("View Discussion", bundle: .student, comment: "")
+            return String(localized: "View Discussion", bundle: .student)
         }
 
         if assignment.isLTIAssignment {
-            return NSLocalizedString("Launch External Tool", bundle: .student, comment: "")
+            return String(localized: "Launch External Tool", bundle: .student)
         }
 
         if arcID == .pending {
@@ -86,18 +86,18 @@ class SubmissionButtonPresenter: NSObject {
         guard canSubmit else { return nil }
 
         if quiz?.submission?.canResume == true {
-            return NSLocalizedString("Resume Quiz", bundle: .student, comment: "")
+            return String(localized: "Resume Quiz", bundle: .student)
         }
         if quiz?.submission?.attemptsLeft == 0 { return nil }
         if assignment.quizID != nil {
             return assignment.submission?.submittedAt == nil
-                ? NSLocalizedString("Take Quiz", bundle: .student, comment: "")
-                : NSLocalizedString("Retake Quiz", bundle: .student, comment: "")
+                ? String(localized: "Take Quiz", bundle: .student)
+                : String(localized: "Retake Quiz", bundle: .student)
         }
 
         return assignment.submission?.workflowState == .unsubmitted || assignment.submission?.submittedAt == nil
-            ? NSLocalizedString("Submit Assignment", bundle: .student, comment: "")
-            : NSLocalizedString("Resubmit Assignment", bundle: .student, comment: "")
+            ? String(localized: "Submit Assignment", bundle: .student)
+            : String(localized: "Resubmit Assignment", bundle: .student)
     }
 
     func submitAssignment(_ assignment: Assignment, button: UIView) {
@@ -218,8 +218,8 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
         self.assignment = assignment
         self.selectedSubmissionTypes = selectedSubmissionTypes
         let filePicker = FilePickerViewController.create(batchID: isMediaRecording ? UUID.string : batchID)
-        filePicker.title = NSLocalizedString("Submission", bundle: .student, comment: "")
-        filePicker.cancelButtonTitle = NSLocalizedString("Cancel Submission", bundle: .student, comment: "")
+        filePicker.title = String(localized: "Submission", bundle: .student)
+        filePicker.cancelButtonTitle = String(localized: "Cancel Submission", bundle: .student)
         let allowedUTIs = selectedSubmissionTypes.allowedUTIs( allowedExtensions: assignment.allowedExtensions )
         let mediaTypes = selectedSubmissionTypes.allowedMediaTypes
         filePicker.sources = [.files]
@@ -311,15 +311,15 @@ extension SubmissionButtonPresenter: AudioRecorderDelegate, UIImagePickerControl
         let mediaUploader = UploadMedia(type: type, url: url)
         let uploading = SubmissionButtonAlertView.uploadingAlert(mediaUploader)
         let reportError = { [weak self] (error: Error) -> Void in
-            let failure = UIAlertController(title: NSLocalizedString("Submission Failed", bundle: .student, comment: ""), message: error.localizedDescription, preferredStyle: .alert)
-            failure.addAction(UIAlertAction(title: NSLocalizedString("Retry", bundle: .student, comment: ""), style: .default) { _ in
+            let failure = UIAlertController(title: String(localized: "Submission Failed", bundle: .student), message: error.localizedDescription, preferredStyle: .alert)
+            failure.addAction(UIAlertAction(title: String(localized: "Retry", bundle: .student), style: .default) { _ in
                 self?.submitMediaType(type, url: url, callback: callback)
             })
-            failure.addAction(UIAlertAction(title: NSLocalizedString("Cancel", bundle: .student, comment: ""), style: .cancel))
+            failure.addAction(UIAlertAction(title: String(localized: "Cancel", bundle: .student), style: .cancel))
             self?.show(failure)
         }
         let reportSuccess = { [weak self] in
-            let success = UIAlertController(title: NSLocalizedString("Successfully submitted!", bundle: .student, comment: ""), message: nil, preferredStyle: .alert)
+            let success = UIAlertController(title: String(localized: "Successfully submitted!", bundle: .student), message: nil, preferredStyle: .alert)
             self?.show(success) {
                 DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .seconds(1)) {
                     env.router.dismiss(success)

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
@@ -32,7 +32,7 @@ class SubmissionCommentAttemptCell: UITableViewCell {
     func update(comment: SubmissionComment, submission: Submission?, onFileTap: @escaping (Submission?, File?) -> Void) {
         accessibilityIdentifier = "SubmissionComments.attemptCell.\(comment.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("On %@ %@ submitted the following", bundle: .student, comment: ""),
+            String(localized: "On %@ %@ submitted the following", bundle: .student),
             comment.createdAtLocalizedString,
             comment.authorName
         )

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentAudioCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentAudioCell.swift
@@ -33,7 +33,7 @@ class SubmissionCommentAudioCell: UITableViewCell {
     func update(comment: SubmissionComment, parent: UIViewController) {
         accessibilityIdentifier = "SubmissionComments.audioCell.\(comment.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("On %@ %@ left an audio comment", bundle: .student, comment: ""),
+            String(localized: "On %@ %@ left an audio comment", bundle: .student),
             comment.createdAtLocalizedString,
             comment.authorName
         )

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
@@ -38,7 +38,7 @@ class SubmissionCommentFileView: UIControl {
         let id = file.id ?? ""
         accessibilityIdentifier = "SubmissionComments.fileView.\(id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("View file %@ %@", bundle: .student, comment: ""),
+            String(localized: "View file %@ %@", bundle: .student),
             file.displayName ?? "",
             file.size.humanReadableFileSize
         )
@@ -50,7 +50,7 @@ class SubmissionCommentFileView: UIControl {
     func update(submission: Submission) {
         accessibilityIdentifier = "SubmissionComments.attemptView.\(submission.attempt)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("View submission attempt %d. %@", bundle: .student, comment: ""),
+            String(localized: "View submission attempt %d. %@", bundle: .student),
             submission.attempt,
             submission.type?.localizedString ?? ""
         )

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
@@ -37,7 +37,7 @@ class SubmissionCommentTextCell: UITableViewCell {
         self.comment = comment
         accessibilityIdentifier = "SubmissionComments.textCell.\(comment.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("On %@ %@ commented \"%@\"", bundle: .student, comment: ""),
+            String(localized: "On %@ %@ commented \"%@\"", bundle: .student),
             comment.createdAtLocalizedString,
             comment.authorName,
             comment.comment

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentVideoCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentVideoCell.swift
@@ -41,7 +41,7 @@ class SubmissionCommentVideoCell: UITableViewCell {
     func update(comment: SubmissionComment, parent: UIViewController) {
         accessibilityIdentifier = "SubmissionComments.videoCell.\(comment.id)"
         accessibilityLabel = String.localizedStringWithFormat(
-            NSLocalizedString("On %@ %@ left a video comment", bundle: .student, comment: ""),
+            String(localized: "On %@ %@ left a video comment", bundle: .student),
             comment.createdAtLocalizedString,
             comment.authorName
         )

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsPresenter.swift
@@ -95,7 +95,7 @@ class SubmissionCommentsPresenter: SubmissionCommentAttemptDelegate {
             attempt: attempt
         ).fetch { [weak self] comment, error in
             if error != nil || comment == nil {
-                self?.view?.showError(error ?? NSError.instructureError(NSLocalizedString("Could not save the comment", bundle: .student, comment: "")))
+                self?.view?.showError(error ?? NSError.instructureError(String(localized: "Could not save the comment", bundle: .student)))
             }
         }
     }
@@ -111,7 +111,7 @@ class SubmissionCommentsPresenter: SubmissionCommentAttemptDelegate {
             attempt: attempt
         ).fetch { [weak self] comment, error in
             if error != nil || comment == nil {
-                self?.view?.showError(error ?? NSError.instructureError(NSLocalizedString("Could not save the comment", bundle: .student, comment: "")))
+                self?.view?.showError(error ?? NSError.instructureError(String(localized: "Could not save the comment", bundle: .student)))
             }
         }
     }
@@ -126,7 +126,7 @@ class SubmissionCommentsPresenter: SubmissionCommentAttemptDelegate {
             attempt: attempt
         ).fetch { [weak self] comment, error in
             if error != nil || comment == nil {
-                self?.view?.showError(error ?? NSError.instructureError(NSLocalizedString("Could not save the comment", bundle: .student, comment: "")))
+                self?.view?.showError(error ?? NSError.instructureError(String(localized: "Could not save the comment", bundle: .student)))
             }
         }
     }

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -63,20 +63,20 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         addCommentBorderView.backgroundColor = .backgroundLightest
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale
-        addCommentButton.accessibilityLabel = NSLocalizedString("Send comment", bundle: .student, comment: "")
-        addCommentTextView.accessibilityLabel = NSLocalizedString("Add a comment or reply to previous comments", bundle: .student, comment: "")
-        addCommentTextView.placeholder = NSLocalizedString("Comment", bundle: .student, comment: "")
+        addCommentButton.accessibilityLabel = String(localized: "Send comment", bundle: .student)
+        addCommentTextView.accessibilityLabel = String(localized: "Add a comment or reply to previous comments", bundle: .student)
+        addCommentTextView.placeholder = String(localized: "Comment", bundle: .student)
         addCommentTextView.placeholderColor = .textDark
         addCommentTextView.font(.scaledNamedFont(.regular16), lineHeight: .body)
         addCommentTextView.adjustsFontForContentSizeCategory = true
         addCommentTextView.textColor = .textDarkest
         addCommentView.backgroundColor = .backgroundLightest
         emptyContainer.isHidden = true
-        emptyLabel.text = NSLocalizedString("Have questions about your assignment?\nMessage your instructor.", bundle: .student, comment: "")
+        emptyLabel.text = String(localized: "Have questions about your assignment?\nMessage your instructor.", bundle: .student)
         emptyImageView.image = UIImage(named: Panda.NoComments.name, in: .core, compatibleWith: nil)
         tableView.transform = CGAffineTransform(scaleX: 1, y: -1)
         tableView.keyboardDismissMode = .onDrag
-        addMediaButton.accessibilityLabel = NSLocalizedString("Add media attachment", bundle: .student, comment: "")
+        addMediaButton.accessibilityLabel = String(localized: "Add media attachment", bundle: .student)
 
         presenter?.viewIsReady()
     }
@@ -95,7 +95,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
 
     @IBAction func addMediaButtonPressed(_ sender: UIButton) {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.addAction(AlertAction(NSLocalizedString("Record Audio", bundle: .student, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "Record Audio", bundle: .student), style: .default) { _ in
             AudioRecorderViewController.requestPermission { [weak self] allowed in
                 guard let self = self else { return }
                 guard allowed else {
@@ -107,7 +107,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
                 self.showMediaController(controller)
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Record Video", bundle: .student, comment: ""), style: .default) { _ in
+        alert.addAction(AlertAction(String(localized: "Record Video", bundle: .student), style: .default) { _ in
             VideoRecorder.requestPermission { [weak self] allowed in
                 guard let self = self else { return }
                 guard allowed else {
@@ -129,15 +129,15 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
                 }
             }
         })
-        alert.addAction(AlertAction(NSLocalizedString("Choose File", bundle: .student, comment: ""), style: .default) { [weak self] _ in
+        alert.addAction(AlertAction(String(localized: "Choose File", bundle: .student), style: .default) { [weak self] _ in
             let picker = FilePickerViewController.create()
             picker.delegate = self
-            picker.title = NSLocalizedString("Attachments", bundle: .student, comment: "")
-            picker.submitButtonTitle = NSLocalizedString("Send", bundle: .student, comment: "")
+            picker.title = String(localized: "Attachments", bundle: .student)
+            picker.submitButtonTitle = String(localized: "Send", bundle: .student)
             let nav = UINavigationController(rootViewController: picker)
             self?.present(nav, animated: true, completion: nil)
         })
-        alert.addAction(AlertAction(NSLocalizedString("Cancel", bundle: .student, comment: ""), style: .cancel))
+        alert.addAction(AlertAction(String(localized: "Cancel", bundle: .student), style: .cancel))
         alert.popoverPresentationController?.sourceView = sender
         alert.popoverPresentationController?.sourceRect = sender.bounds
         present(alert, animated: true)

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -333,6 +333,6 @@ class SubmissionDetailsPresenter {
     }
 
     func lockedEmptyViewHeader() -> String {
-        return assignment.first?.quizID != nil ? NSLocalizedString("Quiz Locked", comment: "") : NSLocalizedString("Assignment Locked", comment: "")
+        return assignment.first?.quizID != nil ? String(localized: "Quiz Locked", bundle: .student) : String(localized: "Assignment Locked", bundle: .student)
     }
 }

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -60,7 +60,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        setupTitleViewInNavbar(title: NSLocalizedString("Submission", bundle: .student, comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Submission", bundle: .student))
         drawer?.tabs?.addTarget(self, action: #selector(drawerTabChanged), for: .valueChanged)
         emptyView?.submitCallback = { [weak self] button in
             self?.presenter?.submit(button: button)
@@ -117,7 +117,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
             let title = DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short)
             updateAttemptPickerButton(isActive: presenter.pickerSubmissions.count > 1, title: title)
             attemptLabel.isEnabled = presenter.pickerSubmissions.count > 1
-            let format = NSLocalizedString("Attempt %d", bundle: .core, comment: "")
+            let format = String(localized: "Attempt %d", bundle: .student)
             attemptLabel?.text = String.localizedStringWithFormat(format, attempt)
         }
         if presenter.pickerSubmissions.count <= 1 || assignment.isExternalToolAssignment {
@@ -257,7 +257,7 @@ extension SubmissionDetailsViewController: UIPickerViewDataSource, UIPickerViewD
     private func text(forRow row: Int) -> NSAttributedString {
         let submissionDateText: String = {
             guard let submittedAt = presenter?.pickerSubmissions[row].submittedAt else {
-                return NSLocalizedString("No Submission Date", bundle: .student, comment: "")
+                return String(localized: "No Submission Date", bundle: .student)
             }
 
             return DateFormatter.localizedString(from: submittedAt, dateStyle: .medium, timeStyle: .short)
@@ -267,7 +267,7 @@ extension SubmissionDetailsViewController: UIPickerViewDataSource, UIPickerViewD
                 return ""
             }
 
-            let format = NSLocalizedString("Attempt %d", bundle: .core, comment: "")
+            let format = String(localized: "Attempt %d", bundle: .student)
             return String.localizedStringWithFormat(format, attempt)
         }()
 

--- a/Student/Student/Submissions/SubmissionDetails/Views/Drawer.swift
+++ b/Student/Student/Submissions/SubmissionDetails/Views/Drawer.swift
@@ -50,7 +50,7 @@ class Drawer: UIView {
 
     var fileCount: Int = 0 {
         didSet {
-            let title = String.localizedStringWithFormat(NSLocalizedString("Files (%d)", bundle: .student, comment: ""), fileCount)
+            let title = String.localizedStringWithFormat(String(localized: "Files (%d)", bundle: .student), fileCount)
             tabs?.setTitle(title, forSegmentAt: Tab.files.rawValue)
         }
     }
@@ -71,9 +71,9 @@ class Drawer: UIView {
 
         gripper?.layer.cornerRadius = 2
         updateGripperLabel(height: height)
-        tabs?.setTitle(NSLocalizedString("Comments", bundle: .student, comment: ""), forSegmentAt: Tab.comments.rawValue)
-        tabs?.setTitle(NSLocalizedString("Files", bundle: .student, comment: ""), forSegmentAt: Tab.files.rawValue)
-        tabs?.setTitle(NSLocalizedString("Rubric", bundle: .student, comment: ""), forSegmentAt: Tab.rubric.rawValue)
+        tabs?.setTitle(String(localized: "Comments", bundle: .student), forSegmentAt: Tab.comments.rawValue)
+        tabs?.setTitle(String(localized: "Files", bundle: .student), forSegmentAt: Tab.files.rawValue)
+        tabs?.setTitle(String(localized: "Rubric", bundle: .student), forSegmentAt: Tab.rubric.rawValue)
         tabs?.layer.cornerRadius = 0
         tabs?.layer.masksToBounds = false
     }
@@ -98,11 +98,11 @@ class Drawer: UIView {
 
     func updateGripperLabel(height: CGFloat) {
         if height == 2 {
-            gripper?.accessibilityLabel = NSLocalizedString("Drawer closed", bundle: .student, comment: "")
+            gripper?.accessibilityLabel = String(localized: "Drawer closed", bundle: .student)
         } else if height == midDrawerHeight {
-            gripper?.accessibilityLabel = NSLocalizedString("Drawer partially opened", bundle: .student, comment: "")
+            gripper?.accessibilityLabel = String(localized: "Drawer partially opened", bundle: .student)
         } else if height == maxDrawerHeight {
-            gripper?.accessibilityLabel = NSLocalizedString("Drawer fully open", bundle: .student, comment: "")
+            gripper?.accessibilityLabel = String(localized: "Drawer fully open", bundle: .student)
         }
     }
 

--- a/Student/Student/Submissions/SubmissionDetails/Views/SubmissionDetailsEmptyView.swift
+++ b/Student/Student/Submissions/SubmissionDetails/Views/SubmissionDetailsEmptyView.swift
@@ -43,7 +43,7 @@ class SubmissionDetailsEmptyView: UIView {
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         loadFromXib()
-        headingLabel?.text = NSLocalizedString("No Submission", bundle: .student, comment: "")
-        submitButtonTitle = NSLocalizedString("Submit Assignment", bundle: .student, comment: "")
+        headingLabel?.text = String(localized: "No Submission", bundle: .student)
+        submitButtonTitle = String(localized: "Submit Assignment", bundle: .student)
     }
 }

--- a/Student/Student/Submissions/SubmissionDetails/Views/SubmissionDetailsLockedEmptyView.swift
+++ b/Student/Student/Submissions/SubmissionDetails/Views/SubmissionDetailsLockedEmptyView.swift
@@ -28,6 +28,6 @@ class SubmissionDetailsLockedEmptyView: UIView {
         super.init(coder: aDecoder)
         loadFromXib()
         imageView.image = UIImage(named: Panda.Locked.name, in: .core, compatibleWith: nil)
-        headerLabel.text = NSLocalizedString("Quiz Locked", comment: "")
+        headerLabel.text = String(localized: "Quiz Locked", bundle: .student)
     }
 }

--- a/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
+++ b/Student/Student/Submissions/SubmissionFiles/SubmissionFilesViewController.swift
@@ -39,7 +39,7 @@ class SubmissionFilesViewController: UIViewController {
         view.backgroundColor = .backgroundLightest
         tableView?.separatorColor = .borderMedium
         tableView?.tintColor = .textInfo
-        emptyLabel?.text = NSLocalizedString("There are no files for this assignment.", bundle: .student, comment: "")
+        emptyLabel?.text = String(localized: "There are no files for this assignment.", bundle: .student)
         emptyContainer?.isHidden = !files.isEmpty
         emptyImageView?.image = UIImage(named: Panda.Papers.name, in: .core, compatibleWith: nil)
     }

--- a/Student/Student/Submissions/SubmissionRubric/RubricCircleView.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricCircleView.swift
@@ -80,7 +80,7 @@ class RubricCircleView: UIView {
             let font: UIFont
             let color: UIColor
             let bgColor: UIColor
-            let format = NSLocalizedString("g_points", bundle: .core, comment: "")
+            let format = String(localized: "g_points", bundle: .student)
             var a11yLabel: String = String.localizedStringWithFormat(format, Double(Int(r)))
             a11yLabel += " " + description
 

--- a/Student/Student/Submissions/SubmissionRubric/RubricCircleView.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricCircleView.swift
@@ -80,7 +80,7 @@ class RubricCircleView: UIView {
             let font: UIFont
             let color: UIColor
             let bgColor: UIColor
-            let format = String(localized: "g_points", bundle: .student)
+            let format = String(localized: "g_points", bundle: .core)
             var a11yLabel: String = String.localizedStringWithFormat(format, Double(Int(r)))
             a11yLabel += " " + description
 

--- a/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricPresenter.swift
@@ -40,7 +40,7 @@ struct RubricViewModel: Hashable, Equatable {
 
     func ratingBlurb(_ atIndex: Int) -> (header: String, subHeader: String) {
         let isCustom = isCustomAssessment && atIndex >= rubricRatings.count
-        let header = isCustom ? NSLocalizedString("Custom Grade", comment: "") : rubricRatings[atIndex].desc
+        let header = isCustom ? String(localized: "Custom Grade", bundle: .student) : rubricRatings[atIndex].desc
         let subHeader = isCustom ? "" : rubricRatings[atIndex].longDesc
         return (header, subHeader)
     }
@@ -124,7 +124,7 @@ class RubricPresenter {
                 //  this is a custom assesment
                 allRatings.append(points)
                 selectedIndex = allRatings.count - 1
-                description = NSLocalizedString("Custom Grade", comment: "")
+                description = String(localized: "Custom Grade", bundle: .student)
                 allDescriptions.append(description)
                 isCustomAssessment = true
             }

--- a/Student/Student/Submissions/SubmissionRubric/RubricViewController.swift
+++ b/Student/Student/Submissions/SubmissionRubric/RubricViewController.swift
@@ -52,7 +52,7 @@ class RubricViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        emptyViewLabel.text = NSLocalizedString("There is no rubric for this assignment", comment: "")
+        emptyViewLabel.text = String(localized: "There is no rubric for this assignment", bundle: .student)
 
         emptyImageView.image = UIImage(named: Panda.NoRubric.name, in: .core, compatibleWith: nil)
         presenter.viewIsReady()

--- a/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
+++ b/Student/Student/Submissions/TextSubmission/TextSubmissionViewController.swift
@@ -42,17 +42,17 @@ class TextSubmissionViewController: UIViewController, ErrorViewController, RichC
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Text Entry", bundle: .student, comment: "")
+        title = String(localized: "Text Entry", bundle: .student)
 
         navigationController?.navigationBar.useModalStyle()
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Submit", bundle: .student, comment: ""), style: .plain, target: self, action: #selector(submit))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Submit", bundle: .student), style: .plain, target: self, action: #selector(submit))
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = "TextSubmission.submitButton"
         navigationItem.rightBarButtonItem?.isEnabled = false
         addCancelButton(side: .left)
 
         editor.delegate = self
-        editor.placeholder = NSLocalizedString("Write...", bundle: .student, comment: "Text submission editor placeholder")
-        editor.a11yLabel = NSLocalizedString("Submission text", bundle: .student, comment: "Text submission editor accessibility label")
+        editor.placeholder = String(localized: "Write...", bundle: .student, comment: "Text submission editor placeholder")
+        editor.a11yLabel = String(localized: "Submission text", bundle: .student, comment: "Text submission editor accessibility label")
         editor.webView.scrollView.layer.masksToBounds = false
         embed(editor, in: contentView)
     }

--- a/Student/Student/Submissions/urlSubmission/UrlSubmissionPresenter.swift
+++ b/Student/Student/Submissions/urlSubmission/UrlSubmissionPresenter.swift
@@ -69,7 +69,7 @@ class UrlSubmissionPresenter {
                 }
             }
         } else {
-            let error = NSError.instructureError(NSLocalizedString("Invalid url", comment: ""))
+            let error = NSError.instructureError(String(localized: "Invalid url", bundle: .student))
             view?.showError(error)
         }
     }

--- a/Student/Student/Submissions/urlSubmission/UrlSubmissionViewController.swift
+++ b/Student/Student/Submissions/urlSubmission/UrlSubmissionViewController.swift
@@ -40,10 +40,10 @@ class UrlSubmissionViewController: UIViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         loadingView?.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Website Address", comment: "")
+        title = String(localized: "Website Address", bundle: .student)
         textField.accessibilityLabel = title
 
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Submit", comment: ""), style: .plain, target: self, action: #selector(submit))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: String(localized: "Submit", bundle: .student), style: .plain, target: self, action: #selector(submit))
         navigationItem.rightBarButtonItem?.accessibilityIdentifier = "URLSubmission.submit"
         addCancelButton(side: .left)
     }

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPickerTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPickerTests.swift
@@ -52,7 +52,7 @@ class SubmissionDetailsPickerTests: StudentTestCase {
         testee.loadViewIfNeeded()
 
         XCTAssertEqual(testee.picker!.dataSource?.pickerView(testee.picker!, numberOfRowsInComponent: 0), 2)
-        let noSubmissionDateTitle = NSLocalizedString("No Submission Date", bundle: .student, comment: "")
+        let noSubmissionDateTitle = String(localized: "No Submission Date", bundle: .student)
         XCTAssertNotEqual(testee.picker!.delegate?.pickerView?(testee.picker!, titleForRow: 0, forComponent: 0), noSubmissionDateTitle)
         XCTAssertNotEqual(testee.picker!.delegate?.pickerView?(testee.picker!, titleForRow: 1, forComponent: 0), noSubmissionDateTitle)
     }

--- a/Student/Widgets/AnnouncementsWidget/AnnouncementsWidget.swift
+++ b/Student/Widgets/AnnouncementsWidget/AnnouncementsWidget.swift
@@ -26,7 +26,7 @@ struct AnnouncementsWidget: Widget {
         StaticConfiguration(kind: kind, provider: AnnouncementsProvider()) { entry in
             AnnouncementsWidgetView(entry: entry)
         }
-        .configurationDisplayName(NSLocalizedString("Announcements", comment: "Name of the announcements widget"))
-        .description(NSLocalizedString("View the latest announcements from your courses.", comment: "Description of the announcements widget"))
+        .configurationDisplayName(String(localized: "Announcements", comment: "Name of the announcements widget"))
+        .description(String(localized: "View the latest announcements from your courses.", comment: "Description of the announcements widget"))
     }
 }

--- a/Student/Widgets/AnnouncementsWidget/Model/AnnouncementsEntry.swift
+++ b/Student/Widgets/AnnouncementsWidget/Model/AnnouncementsEntry.swift
@@ -24,25 +24,25 @@ class AnnouncementsEntry: WidgetModel {
 
         return AnnouncementsEntry(announcementItems: [
             AnnouncementItem(
-                title: NSLocalizedString("Finals are moving to next week.", comment: "Example announcement title"),
+                title: String(localized: "Finals are moving to next week.", comment: "Example announcement title"),
                 date: Date(),
                 url: url,
-                authorName: NSLocalizedString("Thomas McKempis", comment: "Example author name"),
-                courseName: NSLocalizedString("Introduction to the Solar System", comment: "Example course name"),
+                authorName: String(localized: "Thomas McKempis", comment: "Example author name"),
+                courseName: String(localized: "Introduction to the Solar System", comment: "Example course name"),
                 courseColor: .electric),
             AnnouncementItem(
-                title: NSLocalizedString("Zoo Field Trip!", comment: "Example announcement title"),
+                title: String(localized: "Zoo Field Trip!", comment: "Example announcement title"),
                 date: Date().addDays(-1),
                 url: url,
-                authorName: NSLocalizedString("Susan Jorgenson", comment: "Example author name"),
-                courseName: NSLocalizedString("Biology 201", comment: "Example course name"),
+                authorName: String(localized: "Susan Jorgenson", comment: "Example author name"),
+                courseName: String(localized: "Biology 201", comment: "Example course name"),
                 courseColor: .barney),
             AnnouncementItem(
-                title: NSLocalizedString("Read Moby Dick by end of week.", comment: "Example announcement title"),
+                title: String(localized: "Read Moby Dick by end of week.", comment: "Example announcement title"),
                 date: Date().addDays(-5),
                 url: url,
-                authorName: NSLocalizedString("Janet Hammond", comment: "Example author name"),
-                courseName: NSLocalizedString("American literature IV", comment: "Example course name"),
+                authorName: String(localized: "Janet Hammond", comment: "Example author name"),
+                courseName: String(localized: "American literature IV", comment: "Example course name"),
                 courseColor: .shamrock),
         ])
     }

--- a/Student/Widgets/AnnouncementsWidget/View/MediumLarge/MediumLargeAnnouncementsView.swift
+++ b/Student/Widgets/AnnouncementsWidget/View/MediumLarge/MediumLargeAnnouncementsView.swift
@@ -29,7 +29,7 @@ struct MediumLargeAnnouncementsView: View {
     var body: some View {
         ZStack(alignment: Alignment(horizontal: .trailing, vertical: .top)) {
             HStack {
-                Text(NSLocalizedString("Announcements", comment: ""))
+                Text(String(localized: "Announcements"))
                     .font(.semibold12).foregroundColor(.textDark)
                     .frame(maxWidth: .infinity, alignment: .leading)
                 Image("student-logomark")

--- a/Student/Widgets/GradesWidget/GradesWidget.swift
+++ b/Student/Widgets/GradesWidget/GradesWidget.swift
@@ -26,7 +26,7 @@ struct GradesWidget: Widget {
         StaticConfiguration(kind: kind, provider: GradesWidgetProvider()) { model in
             GradesWidgetView(model: model)
         }
-        .configurationDisplayName(NSLocalizedString("Grades", comment: "Name of the grades widget"))
-        .description(NSLocalizedString("View the latest grades from assignments and your favorite courses.", comment: "Description of the grades widget"))
+        .configurationDisplayName(String(localized: "Grades", comment: "Name of the grades widget"))
+        .description(String(localized: "View the latest grades from assignments and your favorite courses.", comment: "Description of the grades widget"))
     }
 }

--- a/Student/Widgets/GradesWidget/Model/GradeModel.swift
+++ b/Student/Widgets/GradesWidget/Model/GradeModel.swift
@@ -21,12 +21,12 @@ import WidgetKit
 class GradeModel: WidgetModel {
     override class var publicPreview: GradeModel {
         GradeModel(assignmentGrades: [
-            GradeItem(name: NSLocalizedString("Essay #1: The Rocky Planets", comment: "Example exam name"), grade: "95 / 100", color: .electric),
-            GradeItem(name: NSLocalizedString("American Literature IV", comment: "Example exam name"), grade: "9.2 / 10", color: .shamrock),
-            GradeItem(name: NSLocalizedString("Biology Exam 2", comment: "Example exam name"), grade: "20 / 25", color: .barney),
+            GradeItem(name: String(localized: "Essay #1: The Rocky Planets", comment: "Example exam name"), grade: "95 / 100", color: .electric),
+            GradeItem(name: String(localized: "American Literature IV", comment: "Example exam name"), grade: "9.2 / 10", color: .shamrock),
+            GradeItem(name: String(localized: "Biology Exam 2", comment: "Example exam name"), grade: "20 / 25", color: .barney),
         ], courseGrades: [
-            GradeItem(name: NSLocalizedString("Introduction to the Solar System", comment: "Example course name"), grade: "A-", color: .electric),
-            GradeItem(name: NSLocalizedString("American Literature IV: All the Books", comment: "Example course name"), grade: "B", color: .shamrock),
+            GradeItem(name: String(localized: "Introduction to the Solar System", comment: "Example course name"), grade: "A-", color: .electric),
+            GradeItem(name: String(localized: "American Literature IV: All the Books", comment: "Example course name"), grade: "B", color: .shamrock),
         ])
     }
 

--- a/rn/Teacher/ios/Teacher/Attendance/AttendanceViewController.swift
+++ b/rn/Teacher/ios/Teacher/Attendance/AttendanceViewController.swift
@@ -73,13 +73,13 @@ class AttendanceViewController: ScreenViewTrackableViewController, ColoredNavVie
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        setupTitleViewInNavbar(title: NSLocalizedString("Attendance", comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Attendance", bundle: .teacher))
         titleSubtitleView.subtitle = AttendanceViewController.dateFormatter.string(from: date)
 
         let datePickerButton = UIButton(type: .custom)
         datePickerButton.accessibilityIdentifier = "Attendance.selectDateButton"
-        datePickerButton.accessibilityLabel = NSLocalizedString("Date picker", comment: "")
-        datePickerButton.accessibilityHint = NSLocalizedString("Select to change the roll call date", comment: "")
+        datePickerButton.accessibilityLabel = String(localized: "Date picker", bundle: .teacher)
+        datePickerButton.accessibilityHint = String(localized: "Select to change the roll call date", bundle: .teacher)
         datePickerButton.addSubview(calendarDayIconView)
         datePickerButton.addTarget(self, action: #selector(showDatePicker(_:)), for: .primaryActionTriggered)
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: datePickerButton)
@@ -102,7 +102,7 @@ class AttendanceViewController: ScreenViewTrackableViewController, ColoredNavVie
         changeSectionButton.translatesAutoresizingMaskIntoConstraints = false
         changeSectionButton.setContentHuggingPriority(UILayoutPriority.required, for: .horizontal)
         changeSectionButton.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
-        changeSectionButton.setTitle(NSLocalizedString("Change Section", comment: ""), for: .normal)
+        changeSectionButton.setTitle(String(localized: "Change Section", bundle: .teacher), for: .normal)
         changeSectionButton.sizeToFit()
         changeSectionButton.addTarget(self, action: #selector(changeSection(_:)), for: .primaryActionTriggered)
         changeSectionButton.tintColor = Core.Brand.shared.linkColor
@@ -201,8 +201,8 @@ class AttendanceViewController: ScreenViewTrackableViewController, ColoredNavVie
         let hasMarked = statuses.contains(where: { $0.status.attendance != nil })
 
         let title = hasMarked
-            ? NSLocalizedString("Mark Remaining as Present", comment: "")
-            : NSLocalizedString("Mark All as Present", comment: "")
+            ? String(localized: "Mark Remaining as Present", bundle: .teacher)
+            : String(localized: "Mark All as Present", bundle: .teacher)
         markAllButton.setTitle(title, for: .normal)
 
         if hasUnmarked, markAllButtonBottom.constant != 0 {
@@ -228,11 +228,11 @@ class AttendanceViewController: ScreenViewTrackableViewController, ColoredNavVie
     func alertError(_ error: Error) {
         print(error)
         let alert = UIAlertController(
-            title: NSLocalizedString("Attendance Error", comment: ""),
+            title: String(localized: "Attendance Error", bundle: .teacher),
             message: error.localizedDescription,
             preferredStyle: .alert
         )
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Dismiss", comment: ""), style: .default))
+        alert.addAction(UIAlertAction(title: String(localized: "Dismiss", bundle: .teacher), style: .default))
         env.router.show(alert, from: self, options: .modal())
     }
 
@@ -304,7 +304,7 @@ extension AttendanceViewController: UITableViewDataSource, UITableViewDelegate {
         let sc = statuses[indexPath.row]
         return UISwipeActionsConfiguration(actions: [ Attendance.present, Attendance.absent, Attendance.late, nil ].compactMap { (value: Attendance?) -> UIContextualAction? in
             guard sc.status.attendance != value else { return nil }
-            let action = UIContextualAction(style: .normal, title: value?.label ?? NSLocalizedString("Unmark", comment: "")) { [weak self] _, _, done in
+            let action = UIContextualAction(style: .normal, title: value?.label ?? String(localized: "Unmark", bundle: .teacher)) { [weak self] _, _, done in
                 sc.update(attendance: value)
                 self?.updateMarkAllButton()
                 done(true)
@@ -361,7 +361,7 @@ extension AttendanceViewController: DatePickerDelegate {
 extension AttendanceViewController {
     @objc func changeSection(_ sender: UIButton) {
         let alert = UIAlertController(
-            title: NSLocalizedString("Choose a Section", comment: ""),
+            title: String(localized: "Choose a Section", bundle: .teacher),
             message: nil,
             preferredStyle: .actionSheet
         )
@@ -371,7 +371,7 @@ extension AttendanceViewController {
                 self?.changeToSection(section)
             })
         }
-        alert.addAction(UIAlertAction(title: NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        alert.addAction(UIAlertAction(title: String(localized: "Cancel", bundle: .teacher), style: .cancel))
 
         alert.popoverPresentationController?.sourceRect = changeSectionButton.bounds
         alert.popoverPresentationController?.sourceView = changeSectionButton

--- a/rn/Teacher/ios/Teacher/Attendance/DatePickerViewController.swift
+++ b/rn/Teacher/ios/Teacher/Attendance/DatePickerViewController.swift
@@ -102,7 +102,7 @@ class DatePickerViewController: UIViewController {
 
         view.backgroundColor = .backgroundLightest
 
-        navigationItem.title = NSLocalizedString("Choose Date", comment: "")
+        navigationItem.title = String(localized: "Choose Date", bundle: .teacher)
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done(_:)))
 
         layout.minimumLineSpacing = 0.0

--- a/rn/Teacher/ios/Teacher/Attendance/RollCallSession.swift
+++ b/rn/Teacher/ios/Teacher/Attendance/RollCallSession.swift
@@ -83,7 +83,7 @@ class RollCallSession: NSObject, WKNavigationDelegate {
             if let url = url {
                 self.launch(url: url)
             } else {
-                self.state = .error(attendanceError(message: NSLocalizedString("Failed to launch rollcall LTI tool.", comment: ""), code: 1))
+                self.state = .error(attendanceError(message: String(localized: "Failed to launch rollcall LTI tool.", bundle: .teacher), code: 1))
             }
         }
     }
@@ -126,7 +126,7 @@ class RollCallSession: NSObject, WKNavigationDelegate {
             } else if let message = dict?["error"], !message.isEmpty {
                 self.state = .error(attendanceError(message: message, code: 2))
             } else {
-                self.state = .error(attendanceError(message: NSLocalizedString("Error: No data returned from the rollcall api.", comment: ""), code: 1))
+                self.state = .error(attendanceError(message: String(localized: "Error: No data returned from the rollcall api.", bundle: .teacher), code: 1))
             }
         }
     }
@@ -139,7 +139,7 @@ class RollCallSession: NSObject, WKNavigationDelegate {
         api.makeRequest(url) { [self] (data, _, error) in
             do {
                 guard let data = data else {
-                    return completed([], attendanceError(message: NSLocalizedString("Error: No data returned from the rollcall api.", comment: ""), code: 1))
+                    return completed([], attendanceError(message: String(localized: "Error: No data returned from the rollcall api.", bundle: .teacher), code: 1))
                 }
                 let statuses: [Status] = try decoder.decode([Status].self, from: data)
                 completed(statuses, nil)
@@ -172,7 +172,7 @@ class RollCallSession: NSObject, WKNavigationDelegate {
         api.makeRequest(request) { [self] (data, _, error) in
             guard let data = data else {
                 let error = NSError(domain: "com.instructure.rollcall", code: 1, userInfo: [
-                    NSLocalizedDescriptionKey: NSLocalizedString("Error: No data returned from the rollcall api.", comment: "rollcall status error"),
+                    NSLocalizedDescriptionKey: String(localized: "Error: No data returned from the rollcall api.", bundle: .teacher, comment: "rollcall status error"),
                 ])
                 return completed(nil, error)
             }

--- a/rn/Teacher/ios/Teacher/Attendance/Status.swift
+++ b/rn/Teacher/ios/Teacher/Attendance/Status.swift
@@ -24,9 +24,9 @@ public enum Attendance: String, Codable {
 
     var label: String {
         switch self {
-        case .present: return NSLocalizedString("Present", comment: "")
-        case .late: return NSLocalizedString("Late", comment: "")
-        case .absent: return NSLocalizedString("Absent", comment: "")
+        case .present: return String(localized: "Present", bundle: .teacher)
+        case .late: return String(localized: "Late", bundle: .teacher)
+        case .absent: return String(localized: "Absent", bundle: .teacher)
         }
     }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentEditor.swift
@@ -28,10 +28,10 @@ struct CommentEditor: View {
 
     var body: some View {
         HStack(alignment: .bottom) {
-            DynamicHeightTextEditor(text: $text, placeholder: NSLocalizedString("Comment", bundle: .core, comment: ""))
+            DynamicHeightTextEditor(text: $text, placeholder: String(localized: "Comment", bundle: .teacher))
                 .font(.regular16)
                 .lineLimit(10)
-                .accessibility(label: Text("Comment"))
+                .accessibility(label: Text("Comment", bundle: .teacher))
                 .identifier("SubmissionComments.commentTextView")
             Button(action: {
                 action()
@@ -48,7 +48,7 @@ struct CommentEditor: View {
             })
                 .opacity(text.isEmpty ? 0.5 : 1)
                 .disabled(text.isEmpty)
-                .accessibility(label: Text("Send"))
+                .accessibility(label: Text("Send", bundle: .teacher))
                 .identifier("SubmissionComments.addCommentButton")
         }
             .padding(EdgeInsets(top: 4, leading: 12, bottom: 4, trailing: 6))

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentLibraryList.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentLibraryList.swift
@@ -41,7 +41,7 @@ struct CommentLibraryList: View {
     private var emptyView: some View {
         VStack {
             Spacer()
-            Text("No suggestions available", bundle: .core)
+            Text("No suggestions available", bundle: .teacher)
                 .font(.regular17)
                 .foregroundColor(.textDarkest)
                 .frame(maxWidth: .infinity, alignment: .center)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/CommentLibrarySheet.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/CommentLibrarySheet.swift
@@ -47,14 +47,14 @@ struct CommentLibrarySheet: View {
     @ViewBuilder
     var headerView: some View {
         ZStack {
-            Text("Comment Library", bundle: .core).font(.semibold17).foregroundColor(.textDarkest)
+            Text("Comment Library", bundle: .teacher).font(.semibold17).foregroundColor(.textDarkest)
             Button(action: {
                 presentationMode.wrappedValue.dismiss()
             }, label: {
                 dismissView
             })
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                .accessibility(label: Text("Close", bundle: .core))
+                .accessibility(label: Text("Close", bundle: .teacher))
         }
         .padding()
         Divider()

--- a/rn/Teacher/ios/Teacher/SpeedGrader/Drawer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/Drawer.swift
@@ -98,9 +98,9 @@ struct Drawer<Content: View>: View {
 
     var buttonA11yText: Text {
         switch state {
-        case .min: return Text("Open Drawer half screen")
-        case .mid: return Text("Open Drawer full screen")
-        case .max: return Text("Close Drawer")
+        case .min: return Text("Open Drawer half screen", bundle: .teacher)
+        case .mid: return Text("Open Drawer full screen", bundle: .teacher)
+        case .max: return Text("Close Drawer", bundle: .teacher)
         }
     }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/GradeSlider.swift
@@ -36,7 +36,7 @@ struct GradeSlider: View {
                 }.onEnded { _ in
                     onEditingChanged(false)
                 })
-                .accessibility(label: Text("Grade Slider"))
+                .accessibility(label: Text("Grade Slider", bundle: .teacher))
                 .accessibility(value: tooltipText)
                 .overlay(!showTooltip ? nil : GeometryReader { geometry in
                     let x = CGFloat(score / max(possible, 0.01))

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -306,7 +306,7 @@ struct RubricAssessor: View {
     }
 
     private func promptCustomGrade(_ criteria: Rubric, assessment: APIRubricAssessment?) {
-        let format = String(localized: "out_of_g_pts", bundle: .teacher)
+        let format = String(localized: "out_of_g_pts", bundle: .core)
         let message = String.localizedStringWithFormat(format, criteria.points)
         let prompt = UIAlertController(title: String(localized: "Customize Grade", bundle: .teacher), message: message, preferredStyle: .alert)
         prompt.addTextField { field in

--- a/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/RubricAssessor.swift
@@ -37,9 +37,9 @@ struct RubricAssessor: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading, spacing: 0) {
-                Text("Rubric")
+                Text("Rubric", bundle: .teacher)
                     .font(.heavy24).foregroundColor(.textDarkest)
-                Text("\(currentScore, specifier: "%g") out of \(assignment.rubricPointsPossible ?? 0, specifier: "%g")")
+                Text("\(currentScore, specifier: "%g") out of \(assignment.rubricPointsPossible ?? 0, specifier: "%g")", bundle: .teacher)
                     .font(.medium14).foregroundColor(.textDark)
             }
             Spacer()
@@ -72,7 +72,7 @@ struct RubricAssessor: View {
         Text(criteria.desc)
             .font(.semibold16).foregroundColor(.textDarkest)
         if criteria.ignoreForScoring {
-            Text("This criterion will not impact the score.")
+            Text("This criterion will not impact the score.", bundle: .teacher)
                 .font(.regular12).foregroundColor(.textDark)
                 .padding(.top, 2)
         }
@@ -152,7 +152,7 @@ struct RubricAssessor: View {
                 Image.addSolid
             }
         }
-        .accessibility(label: Text("Customize Grade"))
+        .accessibility(label: Text("Customize Grade", bundle: .teacher))
         .alignmentGuide(.leading, computeValue: leading)
         .alignmentGuide(.top, computeValue: top)
     }
@@ -173,7 +173,7 @@ struct RubricAssessor: View {
                         }
                     },
                     label: {
-                        Text("Add Comment")
+                        Text("Add Comment", bundle: .teacher)
                             .font(.medium14)
                             .foregroundColor(.accentColor)
                     }
@@ -195,7 +195,7 @@ struct RubricAssessor: View {
                         env.router.show(web, from: controller, options: .modal(embedInNav: true))
                     },
                     label: {
-                        Text("View Long Description")
+                        Text("View Long Description", bundle: .teacher)
                             .font(.medium14)
                             .foregroundColor(.accentColor)
                     }
@@ -220,7 +220,7 @@ struct RubricAssessor: View {
                 self.comment = comment
                 commentID = criteriaID
             } }, label: {
-                Text("Edit")
+                Text("Edit", bundle: .teacher)
                     .font(.medium14).foregroundColor(.accentColor)
             })
         }
@@ -306,23 +306,23 @@ struct RubricAssessor: View {
     }
 
     private func promptCustomGrade(_ criteria: Rubric, assessment: APIRubricAssessment?) {
-        let format = NSLocalizedString("out_of_g_pts", bundle: .core, comment: "")
+        let format = String(localized: "out_of_g_pts", bundle: .teacher)
         let message = String.localizedStringWithFormat(format, criteria.points)
-        let prompt = UIAlertController(title: NSLocalizedString("Customize Grade", comment: ""), message: message, preferredStyle: .alert)
+        let prompt = UIAlertController(title: String(localized: "Customize Grade", bundle: .teacher), message: message, preferredStyle: .alert)
         prompt.addTextField { field in
             field.placeholder = ""
             field.returnKeyType = .done
             field.addTarget(prompt, action: #selector(UIAlertController.performOKAlertAction), for: .editingDidEndOnExit)
-            field.accessibilityLabel = NSLocalizedString("Grade", comment: "")
+            field.accessibilityLabel = String(localized: "Grade", bundle: .teacher)
         }
-        prompt.addAction(AlertAction(NSLocalizedString("OK", comment: "")) { _ in
+        prompt.addAction(AlertAction(String(localized: "OK", bundle: .teacher)) { _ in
             let text = prompt.textFields?[0].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             assessments[criteria.id] = APIRubricAssessment(
                 comments: assessment?.comments,
                 points: DoubleFieldRow.formatter.number(from: text)?.doubleValue
             )
         })
-        prompt.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        prompt.addAction(AlertAction(String(localized: "Cancel", bundle: .teacher), style: .cancel))
         env.router.show(prompt, from: controller, options: .modal())
     }
 
@@ -376,7 +376,7 @@ struct RubricAssessor: View {
 
     private func showError(_ error: Error) {
         let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .teacher), style: .default))
         env.router.show(alert, from: controller, options: .modal())
     }
 }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SimilarityScore.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SimilarityScore.swift
@@ -40,7 +40,7 @@ struct SimilarityScore: View {
 
     var body: some View {
         let content = HStack(spacing: 0) {
-            Text("Similarity Score")
+            Text("Similarity Score", bundle: .teacher)
                 .font(.semibold14).foregroundColor(.textDarkest)
             Spacer()
             switch status {
@@ -60,12 +60,12 @@ struct SimilarityScore: View {
                 Image.clockLine
                     .size(18).foregroundColor(.white)
                     .padding(4).background(Color.backgroundDark).cornerRadius(4)
-                    .accessibility(label: Text("Pending"))
+                    .accessibility(label: Text("Pending", bundle: .teacher))
             default:
                 Image.warningLine
                     .size(18).foregroundColor(.white)
                     .padding(4).background(Color.backgroundDanger).cornerRadius(4)
-                    .accessibility(label: Text("Error"))
+                    .accessibility(label: Text("Error", bundle: .teacher))
             }
             if url != nil {
                 Spacer().frame(width: 8)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -132,7 +132,7 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
     lazy var loadingView: UIViewController = CoreHostingController(
         ProgressView()
             .progressViewStyle(.indeterminateCircle())
-            .accessibility(label: Text("Loading"))
+            .accessibility(label: Text("Loading", bundle: .teacher))
             .identifier("SpeedGrader.spinner")
     )
 
@@ -149,8 +149,8 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
                     .identifier("SpeedGrader.emptyCloseButton")
             }
             EmptyPanda(.Space,
-                title: Text("No Submissions"),
-                message: Text("It seems there aren't any valid submissions to grade.")
+                title: Text("No Submissions", bundle: .teacher),
+                message: Text("It seems there aren't any valid submissions to grade.", bundle: .teacher)
             )
         }
     )

--- a/rn/Teacher/ios/Teacher/SpeedGrader/StudentAnnotationSubmissionViewerViewModel.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/StudentAnnotationSubmissionViewerViewModel.swift
@@ -48,7 +48,7 @@ class StudentAnnotationSubmissionViewerViewModel: ObservableObject {
             if let session = session?.canvadocs_session_url?.rawValue {
                 result = .success(session)
             } else {
-                let errorResult = error ?? NSError.instructureError(NSLocalizedString("Unknown Error", bundle: .core, comment: ""))
+                let errorResult = error ?? NSError.instructureError(String(localized: "Unknown Error", bundle: .teacher))
                 result = .failure(errorResult)
             }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -80,7 +80,7 @@ struct SubmissionCommentList: View {
                         }
                     // Assume already loaded by parent, so skip loading & error
                     case .loading, .empty, .error:
-                        EmptyPanda(.NoComments, message: Text("There are no messages yet."))
+                        EmptyPanda(.NoComments, message: Text("There are no messages yet.", bundle: .teacher))
                             .frame(minWidth: geometry.size.width, minHeight: geometry.size.height - 40)
                     }
                 }
@@ -110,11 +110,11 @@ struct SubmissionCommentList: View {
                         .onTapGesture {
                             showCommentLibrary = commentLibrary.shouldShow
                         }
-                        .accessibilityAction(named: Text("Open comment library", bundle: .core)) {
+                        .accessibilityAction(named: Text("Open comment library", bundle: .teacher)) {
                             if commentLibrary.shouldShow {
                                 showCommentLibrary = true
                             } else {
-                                UIAccessibility.post(notification: .screenChanged, argument: NSLocalizedString("Comment library is not available", bundle: .teacher, comment: ""))
+                                UIAccessibility.post(notification: .screenChanged, argument: String(localized: "Comment library is not available", bundle: .teacher))
                             }
                         }
                 }
@@ -151,13 +151,13 @@ struct SubmissionCommentList: View {
                     .foregroundColor(.textDark)
                     .padding(EdgeInsets(top: 11, leading: 11, bottom: 11, trailing: 11))
             })
-                .accessibility(label: Text("Add Attachment"))
+                .accessibility(label: Text("Add Attachment", bundle: .teacher))
                 .identifier("SubmissionComments.addMediaButton")
                 .actionSheet(isPresented: $showMediaOptions) {
-                    ActionSheet(title: Text("Add Attachment"), buttons: [
-                        .default(Text("Record Audio"), action: recordAudio),
-                        .default(Text("Record Video"), action: recordVideo),
-                        .default(Text("Choose Files"), action: chooseFile),
+                    ActionSheet(title: Text("Add Attachment", bundle: .teacher), buttons: [
+                        .default(Text("Record Audio", bundle: .teacher), action: recordAudio),
+                        .default(Text("Record Video", bundle: .teacher), action: recordVideo),
+                        .default(Text("Choose Files", bundle: .teacher), action: chooseFile),
                         .cancel(),
                     ])
                 }
@@ -188,7 +188,7 @@ struct SubmissionCommentList: View {
         ).fetch { comment, error in
             if error != nil || comment == nil {
                 self.comment = text
-                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.")
+                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.", bundle: .teacher)
             }
         }
     }
@@ -237,7 +237,7 @@ struct SubmissionCommentList: View {
             attempt: commentAttempt
         ).fetch { comment, error in
             if error != nil || comment == nil {
-                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.")
+                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.", bundle: .teacher)
             }
         }
     }
@@ -264,7 +264,7 @@ struct SubmissionCommentList: View {
             attempt: commentAttempt
         ).fetch { comment, error in
             if error != nil || comment == nil {
-                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.")
+                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.", bundle: .teacher)
             }
         }
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListCell.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionCommentListCell.swift
@@ -156,7 +156,7 @@ struct SubmissionCommentFile: View {
                 .frame(width: 300)
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
         })
-            .accessibility(label: Text("View file \(file.displayName ?? file.filename) \(file.size.humanReadableFileSize)"))
+            .accessibility(label: Text("View file \(file.displayName ?? file.filename) \(file.size.humanReadableFileSize)", bundle: .teacher))
             .identifier("SubmissionComments.fileView.\(file.id ?? "")")
     }
 }
@@ -205,7 +205,7 @@ struct SubmissionAttempt: View {
                 .frame(width: 300)
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
         })
-            .accessibility(label: Text("View submission attempt \(submission.attempt). \(submission.type?.localizedString ?? "")"))
+            .accessibility(label: Text("View submission attempt \(submission.attempt). \(submission.type?.localizedString ?? "")", bundle: .teacher))
     }
 }
 

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionFileList.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionFileList.swift
@@ -34,7 +34,7 @@ struct SubmissionFileList: View {
         GeometryReader { geometry in
             ScrollView {
                 if submission.type != .online_upload || files.isEmpty {
-                    EmptyPanda(.Papers, message: Text("This submission has no files."))
+                    EmptyPanda(.Papers, message: Text("This submission has no files.", bundle: .teacher))
                         .frame(minWidth: geometry.size.width, minHeight: geometry.size.height)
                 } else if #available(iOS 14, *) {
                     LazyVStack(alignment: .leading, spacing: 0) { list }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -182,7 +182,7 @@ struct SubmissionGrader: View {
     var attemptToggle: some View {
         if let first = attempts.first, attempts.count == 1 {
             HStack {
-                Text("Attempt \(attempt ?? 1)").font(.regular14)
+                Text("Attempt \(attempt ?? 1)", bundle: .teacher).font(.regular14)
                 Spacer()
                 Text(first.submittedAt?.dateTimeString ?? "")
                     .font(.regular14)
@@ -196,7 +196,7 @@ struct SubmissionGrader: View {
                 showAttempts.toggle()
             }, label: {
                 HStack {
-                    Text("Attempt \(attempt ?? 1)").font(.regular14)
+                    Text("Attempt \(attempt ?? 1)", bundle: .teacher).font(.regular14)
                     Spacer()
                     Text(selected.submittedAt?.dateTimeString ?? "")
                         .font(.regular14)
@@ -242,14 +242,14 @@ struct SubmissionGrader: View {
     private func segmentedTitles() -> [String] {
         let filesString: String!
         if selected.type == .online_upload, let count = selected.attachments?.count, count > 0 {
-            filesString = String(localized: "Files (\(count))")
+            filesString = String(localized: "Files (\(count))", bundle: .teacher)
         } else {
-            filesString = NSLocalizedString("Files", comment: "")
+            filesString = String(localized: "Files", bundle: .teacher)
         }
 
         return [
-            NSLocalizedString("Grades", comment: ""),
-            NSLocalizedString("Comments", comment: ""),
+            String(localized: "Grades", bundle: .teacher),
+            String(localized: "Comments", bundle: .teacher),
             filesString,
         ]
     }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -111,7 +111,7 @@ struct SubmissionGrades: View {
                         HStack {
                             Text("Late", bundle: .teacher)
                             Spacer()
-                            Text("\(-deducted, specifier: "%g") pts", bundle: .teacher)
+                            Text("\(-deducted, specifier: "%g") pts", bundle: .core)
                         }
                         .font(.medium14).foregroundColor(.textWarning)
                         .padding(EdgeInsets(top: -10, leading: 16, bottom: -4, trailing: 16))

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -66,7 +66,7 @@ struct SubmissionGrades: View {
         if assignment.moderatedGrading {
             GeometryReader { geometry in
                 ScrollView {
-                    EmptyPanda(.Unsupported, message: Text("Moderated Grading Unsupported"))
+                    EmptyPanda(.Unsupported, message: Text("Moderated Grading Unsupported", bundle: .teacher))
                         .frame(minWidth: geometry.size.width, minHeight: geometry.size.height)
                 }
             }
@@ -74,17 +74,17 @@ struct SubmissionGrades: View {
             GeometryReader { geometry in ScrollView {
                 VStack(spacing: 0) {
                     HStack(spacing: 0) {
-                        Text("Grade")
+                        Text("Grade", bundle: .teacher)
                         Spacer()
                         if isSaving {
                             ProgressView()
                                 .progressViewStyle(.indeterminateCircle(size: 24))
                         } else if assignment.gradingType == .not_graded {
-                            Text("Not Graded")
+                            Text("Not Graded", bundle: .teacher)
                         } else {
                             Button(action: promptNewGrade, label: {
                                 if submission.excused == true {
-                                    Text("Excused")
+                                    Text("Excused", bundle: .teacher)
                                 } else if submission.grade?.isEmpty == false {
                                     Text(GradeFormatter.longString(
                                         for: assignment,
@@ -96,7 +96,7 @@ struct SubmissionGrades: View {
                                     Image.addSolid.foregroundColor(Color(Brand.shared.linkColor))
                                 }
                             })
-                            .accessibility(hint: Text("Prompts for an updated grade"))
+                            .accessibility(hint: Text("Prompts for an updated grade", bundle: .teacher))
                             .identifier("SpeedGrader.gradeButton")
                         }
                         if submission.grade?.isEmpty == false, submission.postedAt == nil {
@@ -109,14 +109,14 @@ struct SubmissionGrades: View {
                     .padding(.horizontal, 16).padding(.vertical, 12)
                     if hasLateDeduction, let deducted = submission.pointsDeducted {
                         HStack {
-                            Text("Late")
+                            Text("Late", bundle: .teacher)
                             Spacer()
-                            Text("\(-deducted, specifier: "%g") pts", bundle: .core)
+                            Text("\(-deducted, specifier: "%g") pts", bundle: .teacher)
                         }
                         .font(.medium14).foregroundColor(.textWarning)
                         .padding(EdgeInsets(top: -10, leading: 16, bottom: -4, trailing: 16))
                         HStack {
-                            Text("Final Grade")
+                            Text("Final Grade", bundle: .teacher)
                             Spacer()
                             Text(GradeFormatter.longString(for: assignment, submission: submission, final: true))
                         }
@@ -174,8 +174,8 @@ struct SubmissionGrades: View {
         let score = sliderValue ?? submission.enteredScore ?? submission.score ?? 0
         let possible = assignment.pointsPossible ?? 0
         let tooltipText =
-            sliderCleared ? Text("No Grade") :
-            sliderExcused ? Text("Excused") :
+            sliderCleared ? Text("No Grade", bundle: .teacher) :
+            sliderExcused ? Text("Excused", bundle: .teacher) :
             assignment.gradingType == .percent ? Text(round(score / max(possible, 0.01) * 100) / 100, number: .percent) :
             Text(score)
         let maxScore = assignment.gradingType == .percent ? 100 : possible
@@ -285,47 +285,47 @@ struct SubmissionGrades: View {
         var message: String?
         switch assignment.gradingType {
         case .gpa_scale:
-            message = NSLocalizedString("GPA", comment: "")
+            message = String(localized: "GPA", bundle: .teacher)
         case .letter_grade:
-            message = NSLocalizedString("Letter grade", comment: "")
+            message = String(localized: "Letter grade", bundle: .teacher)
         case .not_graded, .pass_fail:
             message = nil
         case .percent:
-            message = NSLocalizedString("Percent (%)", comment: "")
+            message = String(localized: "Percent (%)", bundle: .teacher)
         case .points:
             message = assignment.outOfText
         }
-        let prompt = UIAlertController(title: NSLocalizedString("Customize Grade", comment: ""), message: message, preferredStyle: .alert)
+        let prompt = UIAlertController(title: String(localized: "Customize Grade", bundle: .teacher), message: message, preferredStyle: .alert)
         if assignment.gradingType == .pass_fail {
-            prompt.addAction(AlertAction(NSLocalizedString("Complete", comment: "")) { _ in saveGrade("complete") })
-            prompt.addAction(AlertAction(NSLocalizedString("Incomplete", comment: "")) { _ in saveGrade("incomplete") })
+            prompt.addAction(AlertAction(String(localized: "Complete", bundle: .teacher)) { _ in saveGrade("complete") })
+            prompt.addAction(AlertAction(String(localized: "Incomplete", bundle: .teacher)) { _ in saveGrade("incomplete") })
         } else {
             prompt.addTextField { field in
                 field.placeholder = ""
                 field.returnKeyType = .done
-                field.text = submission.excused == true ? NSLocalizedString("Excused", comment: "") :
+                field.text = submission.excused == true ? String(localized: "Excused", bundle: .teacher) :
                     hasLateDeduction ? submission.enteredGrade : submission.grade
                 field.addTarget(prompt, action: #selector(UIAlertController.performOKAlertAction), for: .editingDidEndOnExit)
-                field.accessibilityLabel = NSLocalizedString("Grade", comment: "")
+                field.accessibilityLabel = String(localized: "Grade", bundle: .teacher)
             }
         }
-        prompt.addAction(AlertAction(NSLocalizedString("No Grade", comment: "")) { _ in saveGrade("") })
+        prompt.addAction(AlertAction(String(localized: "No Grade", bundle: .teacher)) { _ in saveGrade("") })
         if submission.excused != true {
-            prompt.addAction(AlertAction(NSLocalizedString("Excuse Student", comment: "")) { _ in saveGrade(excused: true) })
+            prompt.addAction(AlertAction(String(localized: "Excuse Student", bundle: .teacher)) { _ in saveGrade(excused: true) })
         }
         if assignment.gradingType != .pass_fail {
-            prompt.addAction(AlertAction(NSLocalizedString("OK", comment: "")) { _ in
+            prompt.addAction(AlertAction(String(localized: "OK", bundle: .teacher)) { _ in
                 saveGrade(prompt.textFields?[0].text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? "")
             })
         }
-        prompt.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
+        prompt.addAction(AlertAction(String(localized: "Cancel", bundle: .teacher), style: .cancel))
         env.router.show(prompt, from: controller, options: .modal())
     }
 
     // MARK: Save
 
     func saveGrade(excused: Bool? = nil, _ grade: String? = nil) {
-        guard !(submission.excused == true && grade == NSLocalizedString("Excused", comment: "")) else { return }
+        guard !(submission.excused == true && grade == String(localized: "Excused", bundle: .teacher)) else { return }
         var grade = grade
         if assignment.gradingType == .percent, let percent = grade, !percent.hasSuffix("%") {
             grade = "\(percent)%"
@@ -346,14 +346,14 @@ struct SubmissionGrades: View {
 
     func showError(_ error: Error) {
         let alert = UIAlertController(title: nil, message: error.localizedDescription, preferredStyle: .alert)
-        alert.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default))
+        alert.addAction(AlertAction(String(localized: "OK", bundle: .teacher), style: .default))
         env.router.show(alert, from: controller, options: .modal())
     }
 }
 
 extension UIAlertController: UITextFieldDelegate {
     @objc public func performOKAlertAction() {
-        if let ok = actions.first(where: { $0.title == NSLocalizedString("OK", comment: "") }) as? AlertAction {
+        if let ok = actions.first(where: { $0.title == String(localized: "OK", bundle: .teacher) }) as? AlertAction {
             ok.handler?(ok)
             AppEnvironment.shared.router.dismiss(self)
         }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionHeader.swift
@@ -63,10 +63,10 @@ struct SubmissionHeader: View {
                     .padding(16)
             })
                 .identifier("SpeedGrader.postPolicyButton")
-                .accessibility(label: Text("Post settings"))
+                .accessibility(label: Text("Post settings", bundle: .teacher))
 
             Button(action: dismiss, label: {
-                Text("Done")
+                Text("Done", bundle: .teacher)
                     .font(.semibold16).foregroundColor(Color(Brand.shared.linkColor))
                     .padding(EdgeInsets(top: 16, leading: 0, bottom: 16, trailing: 16))
             })
@@ -86,7 +86,7 @@ struct SubmissionHeader: View {
 
     var nameText: Text {
         if assignment.anonymizeStudents {
-            return isGroupSubmission ? Text("Group") : Text("Student")
+            return isGroupSubmission ? Text("Group", bundle: .teacher) : Text("Student", bundle: .teacher)
         }
         return Text(groupName ?? submission.user.flatMap {
             User.displayName($0.name, pronouns: $0.pronouns)

--- a/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/SubmissionViewer.swift
@@ -61,7 +61,7 @@ struct SubmissionViewer: View {
                 VStack {
                     Spacer()
                     HStack { Spacer() }
-                    Text("This student's responses are hidden because this assignment is anonymous.", bundle: .core)
+                    Text("This student's responses are hidden because this assignment is anonymous.", bundle: .teacher)
                     Spacer()
                 }
                 .font(.regular16).foregroundColor(.textDarkest)
@@ -95,13 +95,13 @@ struct SubmissionViewer: View {
             case .failure(let error):
                 VStack(alignment: .center, spacing: 0) {
                     Spacer()
-                    Text("Failed to load submission data!")
+                    Text("Failed to load submission data!", bundle: .teacher)
                         .font(.regular16).foregroundColor(.textDarkest)
                     Text(error.localizedDescription)
                         .font(.regular16).foregroundColor(.textDarkest)
                         .padding(.bottom, 10)
                     Button(action: studentAnnotationViewModel.retry, label: {
-                        Text("Retry", bundle: .core)
+                        Text("Retry", bundle: .teacher)
                             .foregroundColor(Color(Brand.shared.primary))
                     })
                     Spacer()
@@ -121,13 +121,13 @@ struct SubmissionViewer: View {
                 Spacer()
                 HStack { Spacer() }
                 if assignment.submissionTypes.contains(.on_paper) {
-                    Text("This assignment only allows on-paper submissions.", bundle: .core)
+                    Text("This assignment only allows on-paper submissions.", bundle: .teacher)
                 } else if assignment.submissionTypes.contains(.none) {
-                    Text("This assignment does not allow submissions.", bundle: .core)
+                    Text("This assignment does not allow submissions.", bundle: .teacher)
                 } else if submission.groupID != nil {
-                    Text("This group does not have a submission for this assignment.", bundle: .core)
+                    Text("This group does not have a submission for this assignment.", bundle: .teacher)
                 } else {
-                    Text("This student does not have a submission for this assignment.", bundle: .core)
+                    Text("This student does not have a submission for this assignment.", bundle: .teacher)
                 }
                 Spacer()
             }

--- a/rn/Teacher/ios/Teacher/SpeedGrader/URLSubmissionViewer.swift
+++ b/rn/Teacher/ios/Teacher/SpeedGrader/URLSubmissionViewer.swift
@@ -33,7 +33,7 @@ struct URLSubmissionViewer: View {
         ScrollView {
             VStack(spacing: 0) {
                 HStack {
-                    Text("This submission is a URL to an external page. We've included a snapshot of what the page looked like when it was submitted.")
+                    Text("This submission is a URL to an external page. We've included a snapshot of what the page looked like when it was submitted.", bundle: .teacher)
                         .font(.regular16).foregroundColor(.textDarkest)
                     Spacer()
                 }
@@ -60,7 +60,7 @@ struct URLSubmissionViewer: View {
                             Image(uiImage: image)
                                 .resizable()
                                 .aspectRatio(image.size, contentMode: .fill)
-                                .accessibility(label: Text("URL Preview Image"))
+                                .accessibility(label: Text("URL Preview Image", bundle: .teacher))
                         })
                             .padding(.horizontal, -16)
                     } else {
@@ -76,7 +76,7 @@ struct URLSubmissionViewer: View {
                         }
                     }
                 } else {
-                    Text("Preview Unavailable")
+                    Text("Preview Unavailable", bundle: .teacher)
                         .font(.regular16).foregroundColor(.textDark)
                 }
             }

--- a/rn/Teacher/ios/Teacher/Submissions/HideGradesViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/HideGradesViewController.swift
@@ -46,10 +46,10 @@ class HideGradesViewController: UIViewController {
         view.backgroundColor = .backgroundLightest
         allGradesHiddenView.backgroundColor = .backgroundLightest
         allGradesHiddenView.isHidden = true
-        allHiddenLabel.text = NSLocalizedString("All Hidden", comment: "")
-        allHiddenSubHeader.text = NSLocalizedString("All grades are currently hidden.", comment: "")
+        allHiddenLabel.text = String(localized: "All Hidden", bundle: .teacher)
+        allHiddenSubHeader.text = String(localized: "All grades are currently hidden.", bundle: .teacher)
 
-        hideGradesButton.setTitle(NSLocalizedString("Hide Grades", comment: ""), for: .normal)
+        hideGradesButton.setTitle(String(localized: "Hide Grades", bundle: .teacher), for: .normal)
 
         presenter.viewIsReady()
     }
@@ -80,7 +80,7 @@ extension HideGradesViewController: UITableViewDelegate, UITableViewDataSource {
         cell.toggle.onTintColor = Brand.shared.buttonPrimaryBackground
 
         if indexPath.row == 0 {
-            cell.textLabel?.text = NSLocalizedString("Specific Sections", comment: "")
+            cell.textLabel?.text = String(localized: "Specific Sections", bundle: .teacher)
             cell.selectionStyle = .none
             cell.toggle.isOn = showSections
             cell.toggle.accessibilityIdentifier = "PostPolicy.toggleHideGradeSections"
@@ -100,7 +100,7 @@ extension HideGradesViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if section == 0 {
-            let localizedFormat = NSLocalizedString("grades_currently_posted", comment: "number of grades hidden")
+            let localizedFormat = String(localized: "grades_currently_posted", bundle: .teacher, comment: "number of grades hidden")
             return String(format: localizedFormat, viewModel?.submissions.postedCount ?? 0)
         }
         return nil

--- a/rn/Teacher/ios/Teacher/Submissions/PostGradesViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/PostGradesViewController.swift
@@ -49,12 +49,12 @@ class PostGradesViewController: UIViewController {
         setupSections()
 
         view.backgroundColor = .backgroundLightest
-        postGradesButton.setTitle(NSLocalizedString("Post Grades", comment: ""), for: .normal)
+        postGradesButton.setTitle(String(localized: "Post Grades", bundle: .teacher), for: .normal)
 
         allGradesPostedView.backgroundColor = .backgroundLightest
         allGradesPostedView.isHidden = true
-        allGradesPostedLabel.text = NSLocalizedString("All Posted", comment: "")
-        allGradesPostedSubheader.text = NSLocalizedString("All grades are currently posted.", comment: "")
+        allGradesPostedLabel.text = String(localized: "All Posted", bundle: .teacher)
+        allGradesPostedSubheader.text = String(localized: "All grades are currently posted.", bundle: .teacher)
         presenter.viewIsReady()
     }
 
@@ -92,14 +92,14 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
         if let row = Row(rawValue: indexPath.row) {
             switch row {
             case .postTo:
-                cell.textLabel?.text = NSLocalizedString("Post to...", comment: "")
+                cell.textLabel?.text = String(localized: "Post to...", bundle: .teacher)
                 cell.detailTextLabel?.text = postPolicy.title
                 cell.detailTextLabel?.accessibilityIdentifier = "PostPolicy.postToValue"
                 cell.accessoryType = .disclosureIndicator
                 cell.selectionStyle = .default
                 cell.accessibilityIdentifier = "PostPolicy.postTo"
             case .section:
-                cell.textLabel?.text = NSLocalizedString("Specific Sections", comment: "")
+                cell.textLabel?.text = String(localized: "Specific Sections", bundle: .teacher)
                 cell.selectionStyle = .none
                 if let cell = cell as? SectionCell {
                     cell.toggle.isOn = showSections
@@ -126,7 +126,7 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
         if section == 0 {
-            let localizedFormat = NSLocalizedString("grades_currently_hidden", comment: "number of grades hidden")
+            let localizedFormat = String(localized: "grades_currently_hidden", bundle: .teacher, comment: "number of grades hidden")
             return String(format: localizedFormat, viewModel?.submissions.hiddenCount ?? 0)
         }
         return nil
@@ -137,7 +137,7 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
 
         if let row = Row(rawValue: indexPath.row), row == .postTo {
             show(ItemPickerViewController.create(
-                title: NSLocalizedString("Post to...", comment: ""),
+                title: String(localized: "Post to...", bundle: .teacher),
                 sections: [ ItemPickerSection(items: PostGradePolicy.allCases.map {
                     ItemPickerItem(title: $0.title, subtitle: $0.subtitle, accessibilityIdentifier: "PostToSelection.\($0.rawValue)")
                 }), ],
@@ -224,18 +224,18 @@ extension PostGradePolicy {
     var title: String {
         switch self {
         case .everyone:
-            return NSLocalizedString("Everyone", comment: "")
+            return String(localized: "Everyone", bundle: .teacher)
         case .graded:
-            return NSLocalizedString("Graded", comment: "")
+            return String(localized: "Graded", bundle: .teacher)
         }
     }
 
     var subtitle: String {
         switch self {
         case .everyone:
-            return NSLocalizedString("Grades will be made visible to all students", comment: "")
+            return String(localized: "Grades will be made visible to all students", bundle: .teacher)
         case .graded:
-            return NSLocalizedString("Grades will be made visible to students with graded submissions", comment: "")
+            return String(localized: "Grades will be made visible to students with graded submissions", bundle: .teacher)
         }
     }
 }

--- a/rn/Teacher/ios/Teacher/Submissions/PostSettingsViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/PostSettingsViewController.swift
@@ -40,7 +40,7 @@ class PostSettingsViewController: HorizontalMenuViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        title = NSLocalizedString("Post Settings", comment: "")
+        title = String(localized: "Post Settings", bundle: .teacher)
 
         delegate = self
         configurePost()
@@ -48,7 +48,7 @@ class PostSettingsViewController: HorizontalMenuViewController {
 
         navigationController?.navigationBar.useModalStyle()
 
-        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: NSLocalizedString("Back", comment: ""), style: .plain, target: nil, action: nil)
+        self.navigationItem.backBarButtonItem = UIBarButtonItem(title: String(localized: "Back", bundle: .teacher), style: .plain, target: nil, action: nil)
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -90,9 +90,9 @@ extension PostSettingsViewController: HorizontalPagedMenuDelegate {
         guard let menuItem = MenuItem(rawValue: at.row) else { return "" }
         switch menuItem {
         case .post:
-            return NSLocalizedString("Post Grades", comment: "")
+            return String(localized: "Post Grades", bundle: .teacher)
         case .hide:
-            return NSLocalizedString("Hide Grades", comment: "")
+            return String(localized: "Hide Grades", bundle: .teacher)
         }
     }
 }

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListFilter.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListFilter.swift
@@ -23,9 +23,9 @@ public enum QuizSubmissionListFilter: String, CaseIterable, Hashable {
 
     public var localizedName: String {
         switch self {
-        case .all: return NSLocalizedString("All Submissions", comment: "")
-        case .submitted: return NSLocalizedString("Submitted", comment: "")
-        case .notSubmitted: return NSLocalizedString("Not Submitted", comment: "")
+        case .all: return String(localized: "All Submissions", bundle: .teacher)
+        case .submitted: return String(localized: "Submitted", bundle: .teacher)
+        case .notSubmitted: return String(localized: "Not Submitted", bundle: .teacher)
         }
     }
 

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/Model/Entities/QuizSubmissionListItem.swift
@@ -47,7 +47,7 @@ public struct QuizSubmissionListItem: Equatable {
             let name: String?
 
             if isAnonymous {
-                displayName = String(localized: "Student \(index + 1)")
+                displayName = String(localized: "Student \(index + 1)", bundle: .teacher)
                 avatarURL = nil
                 name = nil
             } else {

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/View/QuizSubmissionListView.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/View/QuizSubmissionListView.swift
@@ -47,7 +47,7 @@ public struct QuizSubmissionListView: View, ScreenViewTrackable {
                         case .empty:
                             emptyView(height: 0.9 * geometry.size.height)
                         case .error:
-                            Text("There was an error loading submissions. Pull to refresh to try again.")
+                            Text("There was an error loading submissions. Pull to refresh to try again.", bundle: .teacher)
                         case .loading:
                             SwiftUI.EmptyView()
                         }
@@ -68,15 +68,15 @@ public struct QuizSubmissionListView: View, ScreenViewTrackable {
         .navigationTitle(model.title, subtitle: model.subTitle)
         .navigationBarItems(trailing: messageUsersButton)
         .alert(isPresented: $model.showError) {
-            Alert(title: Text("Practice quizzes & surveys do not have detail views."))
+            Alert(title: Text("Practice quizzes & surveys do not have detail views.", bundle: .teacher))
         }
     }
 
     private func emptyView(height: CGFloat) -> some View {
         InteractivePanda(
             scene: ConferencesPanda(),
-            title: Text("No Submissions"),
-            subtitle: Text("It seems there aren't any valid submissions to grade."))
+            title: Text("No Submissions", bundle: .teacher),
+            subtitle: Text("It seems there aren't any valid submissions to grade.", bundle: .teacher))
         .frame(maxWidth: .infinity, minHeight: height, alignment: .center)
         .listRowBackground(SwiftUI.EmptyView())
         .listRowSeparator(.hidden)
@@ -100,13 +100,13 @@ public struct QuizSubmissionListView: View, ScreenViewTrackable {
             .foregroundColor(.textDarkest)
         }
         .actionSheet(isPresented: $model.isShowingFilterSelector) {
-            ActionSheet(title: Text("Filter by"), buttons: filterButtons)
+            ActionSheet(title: Text("Filter by", bundle: .teacher), buttons: filterButtons)
         }
         .frame(height: 81)
         .padding(.leading, 16)
         .padding(.trailing, 19)
         .background(Color.backgroundLightest)
-        .accessibilityLabel(Text("Filter submissions"))
+        .accessibilityLabel(Text("Filter submissions", bundle: .teacher))
         .accessibilityHint(Text(model.filter.localizedName))
     }
 
@@ -116,7 +116,7 @@ public struct QuizSubmissionListView: View, ScreenViewTrackable {
                 model.filterDidChange.send(filter)
             }
         }
-        let cancelButton = ActionSheet.Button.cancel(Text("Cancel"))
+        let cancelButton = ActionSheet.Button.cancel(Text("Cancel", bundle: .teacher))
         return filterButtons + [cancelButton]
     }
 
@@ -151,7 +151,7 @@ public struct QuizSubmissionListView: View, ScreenViewTrackable {
                 .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
         }
         .frame(width: 44, height: 44).padding(.leading, -6)
-        .accessibility(label: Text("Send message to users"))
+        .accessibility(label: Text("Send message to users", bundle: .teacher))
     }
 }
 

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListItemViewModel.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListItemViewModel.swift
@@ -33,10 +33,10 @@ public struct QuizSubmissionListItemViewModel: Identifiable, Equatable {
         self.displayName = item.displayName
         self.name = item.name
         if item.status == .untaken {
-            self.status = NSLocalizedString("Not Submitted", comment: "")
+            self.status = String(localized: "Not Submitted", bundle: .teacher)
             self.statusColor = .textDarkest
         } else {
-            self.status = NSLocalizedString("Submitted", comment: "")
+            self.status = String(localized: "Submitted", bundle: .teacher)
             self.statusColor = .textSuccess
 
         }

--- a/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListViewModel.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/QuizSubmissionList/ViewModel/QuizSubmissionListViewModel.swift
@@ -30,7 +30,7 @@ class QuizSubmissionListViewModel: ObservableObject {
     @Published public var courseID: String = ""
     @Published public var quizID: String = ""
 
-    public let title = NSLocalizedString("Submissions", comment: "")
+    public let title = String(localized: "Submissions", bundle: .teacher)
     public let filters = QuizSubmissionListFilter.allCases
 
     // MARK: - Inputs

--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionFilterPickerViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionFilterPickerViewController.swift
@@ -21,8 +21,8 @@ import Core
 
 class SubmissionFilterPickerViewController: UIViewController {
     let tableView = UITableView(frame: .zero, style: .plain)
-    lazy var resetButton = UIBarButtonItem(title: NSLocalizedString("Reset", comment: ""), style: .plain, target: self, action: #selector(resetFilter))
-    lazy var doneButton = UIBarButtonItem(title: NSLocalizedString("Done", comment: ""), style: .done, target: self, action: #selector(done))
+    lazy var resetButton = UIBarButtonItem(title: String(localized: "Reset", bundle: .teacher), style: .plain, target: self, action: #selector(resetFilter))
+    lazy var doneButton = UIBarButtonItem(title: String(localized: "Done", bundle: .teacher), style: .done, target: self, action: #selector(done))
 
     var assignmentID = ""
     var context = Context.currentUser
@@ -63,7 +63,7 @@ class SubmissionFilterPickerViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = NSLocalizedString("Filter by", comment: "")
+        title = String(localized: "Filter by", bundle: .teacher)
         navigationItem.leftBarButtonItem = resetButton
         navigationItem.rightBarButtonItem = doneButton
 
@@ -120,21 +120,21 @@ extension SubmissionFilterPickerViewController: UITableViewDataSource, UITableVi
         var isSelected = false
         switch (indexPath.section, indexPath.row) {
         case (0, let row):
-            cell.textLabel?.text = staticFilters[row]?.name ?? NSLocalizedString("All submissions", comment: "")
+            cell.textLabel?.text = staticFilters[row]?.name ?? String(localized: "All submissions", bundle: .teacher)
             isSelected = filter == staticFilters[row]
         case (1, 0):
             if case .scoreBelow = filter {
                 cell.textLabel?.text = filter?.name
                 isSelected = true
             } else {
-                cell.textLabel?.text = NSLocalizedString("Scored below...", comment: "")
+                cell.textLabel?.text = String(localized: "Scored below...", bundle: .teacher)
             }
         case (1, 1):
             if case .scoreAbove = filter {
                 cell.textLabel?.text = filter?.name
                 isSelected = true
             } else {
-                cell.textLabel?.text = NSLocalizedString("Scored above...", comment: "")
+                cell.textLabel?.text = String(localized: "Scored above...", bundle: .teacher)
             }
         case (_, let row):
             cell.textLabel?.text = sections[row]?.name
@@ -161,16 +161,16 @@ extension SubmissionFilterPickerViewController: UITableViewDataSource, UITableVi
             filter = staticFilters[row]
         case (1, let row):
             let prompt = UIAlertController(
-                title: row == 0 ? NSLocalizedString("Scored below...", comment: "") : NSLocalizedString("Scored above...", comment: ""),
+                title: row == 0 ? String(localized: "Scored below...", bundle: .teacher) : String(localized: "Scored above...", bundle: .teacher),
                 message: outOfText,
                 preferredStyle: .alert
             )
             prompt.addTextField { field in
                 field.keyboardType = .decimalPad
-                field.accessibilityLabel = NSLocalizedString("Points", comment: "")
+                field.accessibilityLabel = String(localized: "Points", bundle: .teacher)
             }
-            prompt.addAction(AlertAction(NSLocalizedString("Cancel", comment: ""), style: .cancel))
-            prompt.addAction(AlertAction(NSLocalizedString("OK", comment: ""), style: .default) { [weak self] _ in
+            prompt.addAction(AlertAction(String(localized: "Cancel", bundle: .teacher), style: .cancel))
+            prompt.addAction(AlertAction(String(localized: "OK", bundle: .teacher), style: .default) { [weak self] _ in
                 let text = prompt.textFields?[0].text?.trimmingCharacters(in: .whitespacesAndNewlines)
                 guard let score = text.flatMap({ NumberFormatter().number(from: $0) })?.doubleValue else { return }
                 self?.filter = row == 0 ? .scoreBelow(score) : .scoreAbove(score)

--- a/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
+++ b/rn/Teacher/ios/Teacher/Submissions/SubmissionListViewController.swift
@@ -72,16 +72,16 @@ class SubmissionListViewController: ScreenViewTrackableViewController, ColoredNa
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
-        setupTitleViewInNavbar(title: NSLocalizedString("Submissions", comment: ""))
+        setupTitleViewInNavbar(title: String(localized: "Submissions", bundle: .teacher))
 
-        emptyMessageLabel.text = NSLocalizedString("It seems there aren't any valid submissions to grade.", comment: "")
-        emptyTitleLabel.text = NSLocalizedString("No Submissions", comment: "")
-        errorView.messageLabel.text = NSLocalizedString("There was an error loading submissions. Pull to refresh to try again.", comment: "")
+        emptyMessageLabel.text = String(localized: "It seems there aren't any valid submissions to grade.", bundle: .teacher)
+        emptyTitleLabel.text = String(localized: "No Submissions", bundle: .teacher)
+        errorView.messageLabel.text = String(localized: "There was an error loading submissions. Pull to refresh to try again.", bundle: .teacher)
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         postPolicyButton.accessibilityIdentifier = "SubmissionsList.postPolicyButton"
-        postPolicyButton.accessibilityLabel = NSLocalizedString("Grade post policy", comment: "")
-        messageUsersButton.accessibilityLabel = NSLocalizedString("Send message to users", comment: "")
+        postPolicyButton.accessibilityLabel = String(localized: "Grade post policy", bundle: .teacher)
+        messageUsersButton.accessibilityLabel = String(localized: "Send message to users", bundle: .teacher)
 
         tableView.backgroundColor = .backgroundLightest
         refreshControl.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
@@ -180,13 +180,13 @@ class SubmissionListViewController: ScreenViewTrackableViewController, ColoredNa
 extension SubmissionListViewController: UITableViewDataSource, UITableViewDelegate {
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header: FilterHeaderView = tableView.dequeueHeaderFooter()
-        header.titleLabel.text = filter.isEmpty ? NSLocalizedString("All submissions", comment: "") :
+        header.titleLabel.text = filter.isEmpty ? String(localized: "All submissions", bundle: .teacher) :
             filter.compactMap { $0.name } .joined(separator: " - ")
         header.filterButton.removeTarget(self, action: nil, for: .primaryActionTriggered)
         header.filterButton.addTarget(self, action: #selector(showFilters), for: .primaryActionTriggered)
         header.filterButton.setTitle(
-            filter.isEmpty ? NSLocalizedString("Filter", comment: "") :
-                String.localizedStringWithFormat(NSLocalizedString("Filter (%d)", comment: ""), filter.count),
+            filter.isEmpty ? String(localized: "Filter", bundle: .teacher) :
+                String.localizedStringWithFormat(String(localized: "Filter (%d)", bundle: .teacher), filter.count),
             for: .normal
         )
         header.filterButton.setTitleColor(Brand.shared.linkColor, for: .normal)
@@ -226,7 +226,7 @@ class SubmissionListCell: UITableViewCell {
 
     override func awakeFromNib() {
         super.awakeFromNib()
-        needsGradingLabel.text = NSLocalizedString("Needs Grading", comment: "").localizedUppercase
+        needsGradingLabel.text = String(localized: "Needs Grading", bundle: .teacher).localizedUppercase
         needsGradingView.layer.borderColor = UIColor.borderInfo.cgColor
         needsGradingView.layer.borderWidth = 1
         needsGradingView.layer.cornerRadius = needsGradingView.frame.height / 2
@@ -238,10 +238,10 @@ class SubmissionListCell: UITableViewCell {
         if assignment?.anonymizeStudents != false {
             if submission?.groupID != nil {
                 avatarView.icon = .groupLine
-                nameLabel.text = String(localized: "Group \(row)")
+                nameLabel.text = String(localized: "Group \(row)", bundle: .teacher)
             } else {
                 avatarView.icon = .userLine
-                nameLabel.text = String(localized: "Student \(row)")
+                nameLabel.text = String(localized: "Student \(row)", bundle: .teacher)
             }
         } else if let name = submission?.groupName {
             avatarView.name = name

--- a/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
+++ b/rn/Teacher/ios/Teacher/Syllabus/TeacherSyllabusTabViewController.swift
@@ -39,7 +39,7 @@ class TeacherSyllabusTabViewController: SyllabusTabViewController {
     }
 
     lazy var editButton = UIBarButtonItem(
-        title: NSLocalizedString("Edit", bundle: .core, comment: ""), style: .plain,
+        title: String(localized: "Edit", bundle: .teacher), style: .plain,
         target: self, action: #selector(edit)
     )
 

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -375,7 +375,7 @@ extension TeacherAppDelegate: LoginDelegate, NativeLoginManagerDelegate {
             refreshToken: session.refreshToken,
             userAvatarURL: nil,
             userID: fakeStudentID,
-            userName: NSLocalizedString("Test Student", comment: ""),
+            userName: String(localized: "Test Student", bundle: .teacher),
             userEmail: session.userEmail,
             clientID: session.clientID,
             clientSecret: session.clientSecret

--- a/rn/Teacher/ios/Teacher/TeacherTabBarController.swift
+++ b/rn/Teacher/ios/Teacher/TeacherTabBarController.swift
@@ -60,7 +60,7 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
         let cardView = CoreHostingController(DashboardContainerView(shouldShowGroupList: false,
                                                                showOnlyTeacherEnrollment: true))
         let dashboard = DashboardContainerViewController(rootViewController: cardView) { HelmSplitViewController() }
-        dashboard.tabBarItem.title = NSLocalizedString("Courses", comment: "")
+        dashboard.tabBarItem.title = String(localized: "Courses", bundle: .teacher)
         dashboard.tabBarItem.image = .coursesTab
         dashboard.tabBarItem.selectedImage = .coursesTabActive
         dashboard.tabBarItem.accessibilityIdentifier = "TabBar.dashboardTab"
@@ -74,7 +74,7 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
             HelmNavigationController(rootViewController: EmptyViewController()),
         ]
         split.view.tintColor = Brand.shared.primary
-        split.tabBarItem.title = NSLocalizedString("Calendar", comment: "Calendar page title")
+        split.tabBarItem.title = String(localized: "Calendar", bundle: .teacher, comment: "Calendar page title")
         split.tabBarItem.image = .calendarTab
         split.tabBarItem.selectedImage = .calendarTabActive
         split.tabBarItem.accessibilityIdentifier = "TabBar.calendarTab"
@@ -85,7 +85,7 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
 
     func toDoTab() -> UIViewController {
         let todo = HelmNavigationController(rootViewController: TodoListViewController.create())
-        todo.tabBarItem.title = NSLocalizedString("To Do", comment: "")
+        todo.tabBarItem.title = String(localized: "To Do", bundle: .teacher)
         todo.tabBarItem.image = .todoTab
         todo.tabBarItem.selectedImage = .todoTabActive
         todo.tabBarItem.accessibilityIdentifier = "TabBar.todoTab"
@@ -112,7 +112,7 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
         empty.navigationBar.useGlobalNavStyle()
 
         inboxSplit.viewControllers = [inboxController, empty]
-        let title = NSLocalizedString("Inbox", comment: "Inbox tab title")
+        let title = String(localized: "Inbox", bundle: .teacher, comment: "Inbox tab title")
         inboxSplit.tabBarItem = UITabBarItem(title: title, image: .inboxTab, selectedImage: .inboxTabActive)
         inboxSplit.tabBarItem.accessibilityIdentifier = "TabBar.inboxTab"
         inboxSplit.extendedLayoutIncludesOpaqueBars = true

--- a/rn/Teacher/ios/TeacherTests/SpeedGrader/StudentAnnotationSubmissionViewerViewModelTests.swift
+++ b/rn/Teacher/ios/TeacherTests/SpeedGrader/StudentAnnotationSubmissionViewerViewModelTests.swift
@@ -42,7 +42,7 @@ class StudentAnnotationSubmissionViewerViewModelTests: TeacherTestCase {
             testee.viewDidAppear()
         }, withExpectedUpdates: [
             nil,
-            .failure(NSError.instructureError(NSLocalizedString("Unknown Error", bundle: .core, comment: ""))),
+            .failure(NSError.instructureError(String(localized: "Unknown Error", bundle: .teacher))),
         ])
     }
 


### PR DESCRIPTION
refs: [MBL-17518](https://instructure.atlassian.net/browse/MBL-17518)
affects: All
release note: Fixed missing localizations.

## Problem
`bundle: .core` needs to be added for all `NSLocalizedString()`, `String(localized:)`, `Text()` method calls in `Core` module.
Otherwise all of these will fall back to the apps module.

## What's new
- Added `bundle: .core` in all places in Core
- Added `bundle: .canvas` in all places in CanvasCore
- Added `bundle: .student/teacher/parent` in all places in app modules (to save us from mistakes when we move code around modules)
- Changed (almost) all `NSLocalizedString()` usages to `String(localized:)`
- Fixed some misc issues

## What's not changed
- Backend driven texts are not fixed (ie.: Assignment List section headers)

## Test plan
See ticket and use already setup account described there.
Smoke test all apps.

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet

[MBL-17518]: https://instructure.atlassian.net/browse/MBL-17518?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ