### PR TITLE
Fix discussion redesign unauthorized error when masquerading a user

### DIFF
--- a/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
+++ b/Core/Core/EmbeddedWebPage/View/EmbeddedWebPageView.swift
@@ -40,7 +40,12 @@ public struct EmbeddedWebPageView<ViewModel: EmbeddedWebPageViewModel>: View {
 
     public var body: some View {
         WebSession(url: viewModel.url) { sessionURL in
-            WebView(url: sessionURL, features: features, canToggleTheme: true)
+            WebView(
+                url: sessionURL,
+                features: features,
+                canToggleTheme: true,
+                configuration: viewModel.webViewConfig
+            )
         }
         .navigationTitle(viewModel.navTitle, subtitle: viewModel.subTitle)
         .navigationBarStyle(.color(viewModel.contextColor))

--- a/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModel.swift
+++ b/Core/Core/EmbeddedWebPage/ViewModel/EmbeddedWebPageViewModel.swift
@@ -17,10 +17,12 @@
 //
 
 import SwiftUI
+import WebKit
 
 public protocol EmbeddedWebPageViewModel: ObservableObject {
     var url: URL { get }
     var navTitle: String { get }
     var subTitle: String? { get }
     var contextColor: UIColor? { get }
+    var webViewConfig: WKWebViewConfiguration { get }
 }


### PR DESCRIPTION
refs: MBL-17520
affects: Student, Teacher
release note: Fixed discussion redesign unauthorized error when masquerading a user
test plan: See ticket

The issue is fixed by providing a webview configuration where the data source is `nonPersistent`. 
We might want to look into how `WKWebViewConfiguration` is used across the app and turn it into a `CoreWebViewFeature`, but I only fixed the issue locally now.  

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
