### PR TITLE
Offline modules refinement

### DIFF
--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -57,11 +57,21 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
     ) -> AnyPublisher<[ModuleItem], Error> {
         moduleItems.publisher
             .flatMap {
-                ReactiveStore(
+                let assetType: GetModuleItemSequenceRequest.AssetType
+                let assetID: String
+
+                if $0.indent == 1 {
+                    assetType = $0.type?.assetType ?? .moduleItem
+                    assetID = $0.pageId ?? $0.id
+                } else {
+                    assetType = .moduleItem
+                    assetID = $0.id
+                }
+                return ReactiveStore(
                     useCase: GetModuleItemSequence(
                         courseID: courseID,
-                        assetType: .moduleItem,
-                        assetID: $0.id
+                        assetType: assetType,
+                        assetID: assetID
                     )
                 )
                 .getEntities(ignoreCache: true)

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -57,21 +57,11 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
     ) -> AnyPublisher<[ModuleItem], Error> {
         moduleItems.publisher
             .flatMap {
-                let assetType: GetModuleItemSequenceRequest.AssetType
-                let assetID: String
-
-                if $0.indent == 1 {
-                    assetType = $0.type?.assetType ?? .moduleItem
-                    assetID = $0.pageId ?? $0.id
-                } else {
-                    assetType = .moduleItem
-                    assetID = $0.id
-                }
-                return ReactiveStore(
+                ReactiveStore(
                     useCase: GetModuleItemSequence(
                         courseID: courseID,
-                        assetType: assetType,
-                        assetID: assetID
+                        assetType: .moduleItem,
+                        assetID: $0.id
                     )
                 )
                 .getEntities(ignoreCache: true)

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -696,6 +696,7 @@
         <attribute name="lockExplanation" optional="YES" attributeType="String"/>
         <attribute name="minScoreRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="moduleID" attributeType="String"/>
+        <attribute name="pageId" optional="YES" attributeType="String"/>
         <attribute name="pointsPossibleRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="position" attributeType="Double" usesScalarValueType="YES"/>
         <attribute name="publishedRaw" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Core/Core/Modules/APIModule.swift
+++ b/Core/Core/Modules/APIModule.swift
@@ -42,6 +42,7 @@ public struct APIModuleItem: Codable, Equatable {
         public let hidden: Bool?
         public let unlock_at: Date?
         public let lock_at: Date?
+        public let page_url: String?
     }
 
     public let id: ID
@@ -58,6 +59,8 @@ public struct APIModuleItem: Codable, Equatable {
     /// (Optional) link to the Canvas API object, if applicable
     /// eg: "https://canvas.example.edu/api/v1/courses/222/assignments/987"
     public let url: URL?
+    /// (Only for 'Page' type) unique locator for the linked wiki page
+    public let pageId: String?
     /// Only present if the caller has permission to view unpublished items
     public let published: Bool?
     /// Indicates whether the item is allowed to be unpublished. This could be false e.g. when related assignment already has submissions.
@@ -75,6 +78,7 @@ public struct APIModuleItem: Codable, Equatable {
         content: ModuleItemType?,
         html_url: URL?,
         url: URL?,
+        pageId: String?,
         published: Bool?,
         unpublishable: Bool?,
         content_details: ContentDetails?,
@@ -89,6 +93,7 @@ public struct APIModuleItem: Codable, Equatable {
         self.content = content
         self.html_url = html_url
         self.url = url
+        self.pageId = pageId
         self.published = published
         self.unpublishable = unpublishable
         self.content_details = content_details
@@ -104,6 +109,7 @@ public struct APIModuleItem: Codable, Equatable {
         case indent
         case html_url
         case url
+        case page_url
         case published
         case unpublishable
         case content
@@ -121,6 +127,7 @@ public struct APIModuleItem: Codable, Equatable {
         indent = try container.decodeIfPresent(Int.self, forKey: .indent) ?? 0
         html_url = try container.decodeIfPresent(URL.self, forKey: .html_url)
         url = try container.decodeIfPresent(URL.self, forKey: .url)
+        pageId = try container.decodeIfPresent(String.self, forKey: .page_url)
         published = try container.decodeIfPresent(Bool.self, forKey: .published)
         unpublishable = try container.decodeIfPresent(Bool.self, forKey: .unpublishable)
         content = try ModuleItemType?(from: decoder)
@@ -138,6 +145,7 @@ public struct APIModuleItem: Codable, Equatable {
         try container.encode(indent, forKey: .indent)
         try container.encode(html_url, forKey: .html_url)
         try container.encode(url, forKey: .url)
+        try container.encode(pageId, forKey: .page_url)
         try container.encode(published, forKey: .published)
         try container.encodeIfPresent(content_details, forKey: .content_details)
         try container.encode(completion_requirement, forKey: .completion_requirement)
@@ -223,6 +231,7 @@ extension APIModuleItem {
         content: ModuleItemType = .assignment("1"),
         html_url: URL? = URL(string: "https://canvas.example.edu/courses/222/modules/items/768"),
         url: URL? = URL(string: "https://canvas.example.edu/api/v1/courses/222/assignments/987"),
+        pageId: String? = nil,
         published: Bool? = nil,
         unpublishable: Bool? = nil,
         content_details: ContentDetails? = nil,
@@ -238,6 +247,7 @@ extension APIModuleItem {
             content: content,
             html_url: html_url,
             url: url,
+            pageId: pageId,
             published: published,
             unpublishable: unpublishable,
             content_details: content_details,
@@ -255,7 +265,8 @@ extension APIModuleItem.ContentDetails {
         lock_explanation: String? = nil,
         hidden: Bool? = nil,
         unlock_at: Date? = nil,
-        lock_at: Date? = nil
+        lock_at: Date? = nil,
+        page_url: String? = nil
     ) -> APIModuleItem.ContentDetails {
         return APIModuleItem.ContentDetails(
             due_at: due_at,
@@ -264,7 +275,8 @@ extension APIModuleItem.ContentDetails {
             lock_explanation: lock_explanation,
             hidden: hidden,
             unlock_at: unlock_at,
-            lock_at: lock_at
+            lock_at: lock_at,
+            page_url: page_url
         )
     }
 }

--- a/Core/Core/Modules/ModuleItem.swift
+++ b/Core/Core/Modules/ModuleItem.swift
@@ -31,6 +31,7 @@ public class ModuleItem: NSManagedObject {
     @NSManaged public var indent: Int
     @NSManaged public var htmlURL: URL?
     @NSManaged public var url: URL?
+    @NSManaged public var pageId: String?
     @NSManaged public var publishedRaw: NSNumber?
     @NSManaged public var canBeUnpublished: Bool
     @NSManaged public var typeRaw: Data?
@@ -164,6 +165,7 @@ public class ModuleItem: NSManagedObject {
         model.indent = item.indent
         model.htmlURL = item.html_url
         model.url = item.url
+        model.pageId = item.pageId
         model.published = item.published
         model.canBeUnpublished = item.unpublishable ?? true
         model.type = item.content

--- a/Core/Core/Modules/ModuleItemType.swift
+++ b/Core/Core/Modules/ModuleItemType.swift
@@ -138,6 +138,19 @@ public enum ModuleItemType: Equatable, Codable {
             return String(localized: "external tool", bundle: .core)
         }
     }
+
+    var assetType: GetModuleItemSequenceRequest.AssetType {
+        switch self {
+        case .file: return .file
+        case .discussion: return .discussion
+        case .assignment: return .assignment
+        case .quiz: return .quiz
+        case .externalURL: return .moduleItem
+        case .externalTool: return .externalTool
+        case .page: return .page
+        case .subHeader: return .moduleItem
+        }
+    }
 }
 
 public extension Optional where Wrapped == ModuleItemType {

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -70,6 +70,17 @@ public final class ModuleItemSequenceViewController: UIViewController {
         nextButton.titleLabel?.transform = transform
         nextButton.imageView?.transform = transform
 
+        // Sometimes module links within Pages are referenced by their pageId ("/pages/my-module") instead of their id.
+        // When downloading module item sequences for offline usage, we always download with the id field so we need to
+        // find the matching `ModuleItem` and replace the assetID for the `GetModuleItemSequence` request. 
+        if OfflineModeAssembly.make().isNetworkOffline() {
+            if Int(assetID) == nil, let model: ModuleItem = env.database.viewContext.fetch(scope: .where(#keyPath(ModuleItem.pageId), equals: assetID)).first {
+                store = env.subscribe(GetModuleItemSequence(courseID: courseID, assetType: .moduleItem, assetID: model.id)) { [weak self] in
+                    self?.update(embed: true)
+                }
+            }
+        }
+
         // force refresh because we don't provide a refresh control
         store.refresh(force: true)
     }

--- a/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -37,6 +37,7 @@ public final class ModuleItemSequenceViewController: UIViewController {
     private var assetType: AssetType!
     private var assetID: String!
     private var url: URLComponents!
+    private var offlineModeInteractor: OfflineModeInteractor!
 
     let pages = PagesViewController()
     private var observations: [NSKeyValueObservation]?
@@ -46,12 +47,19 @@ public final class ModuleItemSequenceViewController: UIViewController {
     }
     private var sequence: ModuleItemSequence? { store.first }
 
-    public static func create(courseID: String, assetType: AssetType, assetID: String, url: URLComponents) -> Self {
+    public static func create(
+        courseID: String,
+        assetType: AssetType,
+        assetID: String,
+        url: URLComponents,
+        offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()
+    ) -> Self {
         let controller = loadFromStoryboard()
         controller.courseID = courseID
         controller.assetType = assetType
         controller.assetID = assetID
         controller.url = url
+        controller.offlineModeInteractor = offlineModeInteractor
         return controller
     }
 
@@ -73,7 +81,7 @@ public final class ModuleItemSequenceViewController: UIViewController {
         // Sometimes module links within Pages are referenced by their pageId ("/pages/my-module") instead of their id.
         // When downloading module item sequences for offline usage, we always download with the id field so we need to
         // find the matching `ModuleItem` and replace the assetID for the `GetModuleItemSequence` request. 
-        if OfflineModeAssembly.make().isNetworkOffline() {
+        if offlineModeInteractor.isOfflineModeEnabled() {
             if Int(assetID) == nil, let model: ModuleItem = env.database.viewContext.fetch(scope: .where(#keyPath(ModuleItem.pageId), equals: assetID)).first {
                 store = env.subscribe(GetModuleItemSequence(courseID: courseID, assetType: .moduleItem, assetID: model.id)) { [weak self] in
                     self?.update(embed: true)

--- a/Core/CoreTests/Modules/ModuleItemTests.swift
+++ b/Core/CoreTests/Modules/ModuleItemTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class ModuleItemTests: CoreTestCase {
     func testSave() {
-        let item = APIModuleItem.make()
+        let item = APIModuleItem.make(pageId: "pageId")
         let model = ModuleItem.save(item, forCourse: "1", in: databaseClient)
         XCTAssertEqual(model.id, item.id.value)
         XCTAssertEqual(model.title, item.title)
@@ -34,6 +34,7 @@ class ModuleItemTests: CoreTestCase {
         XCTAssertEqual(model.type, item.content)
         XCTAssertEqual(model.courseID, "1")
         XCTAssertEqual(model.dueAt, item.content_details?.due_at)
+        XCTAssertEqual(model.pageId, item.pageId)
     }
 
     func testSaveDueAt() {

--- a/Core/CoreTests/Modules/ModuleItemTypeTests.swift
+++ b/Core/CoreTests/Modules/ModuleItemTypeTests.swift
@@ -81,4 +81,27 @@ class ModuleItemTypeTests: XCTestCase {
         let type = try! decoder.decode(ModuleItemType.self, from: data)
         XCTAssertEqual(type, .externalTool("1", URL(string: url)!))
     }
+
+    func testMapping() {
+        let discussion = ModuleItemType.discussion("")
+        XCTAssertEqual(discussion.assetType, .discussion)
+
+        let assignement = ModuleItemType.assignment("")
+        XCTAssertEqual(assignement.assetType, .assignment)
+
+        let quiz = ModuleItemType.quiz("")
+        XCTAssertEqual(quiz.assetType, .quiz)
+
+        let externalURL = ModuleItemType.externalURL(URL(string: "/foo")!)
+        XCTAssertEqual(externalURL.assetType, .moduleItem)
+
+        let externalTool = ModuleItemType.externalTool("", URL(string: "/foo")!)
+        XCTAssertEqual(externalTool.assetType, .externalTool)
+
+        let page = ModuleItemType.page("")
+        XCTAssertEqual(page.assetType, .page)
+
+        let subHeader = ModuleItemType.subHeader
+        XCTAssertEqual(subHeader.assetType, .moduleItem)
+    }
 }

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
@@ -126,4 +126,39 @@ class ModuleItemSequenceViewControllerTests: CoreTestCase {
         XCTAssertEqual(details.courseID, "1")
         XCTAssertTrue(details.authenticate)
     }
+
+    func testOfflineMode() {
+        _ = ModuleItem.save(.make(id: "item-id", pageId: "my-page"), forCourse: "1", in: databaseClient)
+        let prev = APIModuleItem.make(id: "item-id", module_id: "1", html_url: URL(string: "/prev"), pageId: "my-page")
+        let current = APIModuleItem.make(id: "2", module_id: "1", html_url: URL(string: "/current"))
+        let next = APIModuleItem.make(id: "3", module_id: "2", html_url: URL(string: "/next"))
+        api.mock(
+            GetModuleItemSequenceRequest(courseID: "1", assetType: .moduleItem, assetID: prev.id.value),
+            value: .make(items: [.make(prev: nil, current: prev, next: current)])
+        )
+        api.mock(
+            GetModuleItemSequenceRequest(courseID: "1", assetType: .moduleItem, assetID: current.id.value),
+            value: .make(items: [.make(prev: prev, current: current, next: next)])
+        )
+        api.mock(
+            GetModuleItemSequenceRequest(courseID: "1", assetType: .moduleItem, assetID: next.id.value),
+            value: .make(items: [.make(prev: current, current: next, next: nil)])
+        )
+
+        let offlineModeInteractorMock = OfflineModeInteractorMock(mockIsInOfflineMode: true)
+        let controller = ModuleItemSequenceViewController.create(
+            courseID: "1",
+            assetType: .page,
+            assetID: "my-page",
+            url: URLComponents(string: "")!,
+            offlineModeInteractor: offlineModeInteractorMock
+        )
+        controller.view.layoutIfNeeded()
+        let details = controller.pages.currentPage as! ModuleItemDetailsViewController
+        XCTAssertEqual(details.courseID, "1")
+        XCTAssertEqual(details.moduleID, "1")
+        XCTAssertEqual(details.itemID, "item-id")
+        XCTAssertTrue(controller.previousButton.isHidden)
+        XCTAssertFalse(controller.nextButton.isHidden)
+    }
 }


### PR DESCRIPTION
refs: MBL-17545
affects: Students
release note: none
test plan: Check regular module sequences, modules linked in pages. 

### What's new
- Module sequence wasn't handled correctly if a module was referenced within a page. 
- When opening a page from the `Pages` course navigation menu where the page is part of a module sequence and is locked now show up as a locked page instead of a white page. 

### Test areas 
Check Tamas' offline account 
- Onboarding/Modules
- Onboarding 
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/133c276d-9fc3-4f2b-8662-1a1258df96bb" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/614a2ac3-6a90-4a6b-ba07-0df241569099" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/cac2700e-764d-4fa6-ac28-c7be354920c8" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/3931f254-a022-4bc7-97ce-5756ac3101fa" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet
