### PR TITLE
Add baseURL to webview content loads

### DIFF
--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -140,7 +140,7 @@ public final class PageDetailsViewController: UIViewController, ColoredNavViewPr
             isOffline: offlineModeInteractor?.isNetworkOffline(),
             filePath: offlinePath,
             content: page.body,
-            originalBaseURL: nil,
+            originalBaseURL: page.htmlURL,
             offlineBaseURL: rootURL
         )
     }

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -420,7 +420,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             isOffline: offlineModeInteractor?.isNetworkOffline(),
             filePath: offlinePath,
             content: presenter?.assignmentDescription(),
-            originalBaseURL: nil,
+            originalBaseURL: baseURL,
             offlineBaseURL: rootURL
         )
 


### PR DESCRIPTION
refs: MBL-17586
affects: Student, Teacher, Parent
release note: Fixed embedded Studio videos not loading on some screens.

test plan:
- Check if embedded Studio videos load on the assignment details and page details screens.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/5359acf4-a97f-4eec-bdf2-c941f468ee66" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/23ef005c-555e-4e22-a895-8e031ac771c0" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/f87fa9b8-4320-4944-b46b-28ad842be268" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/86415340-992c-4852-aa5d-e6c24de2001e" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Follow-up e2e test ticket created
- [ ] Tested on iOS 16.x
- [x] Tested on iOS 17.x
