### PR TITLE
Enabled embedded videos on the front page to play

### DIFF
--- a/Parent/Parent/Courses/CourseDetailsViewController.swift
+++ b/Parent/Parent/Courses/CourseDetailsViewController.swift
@@ -118,7 +118,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
 
     func configureFrontPage() {
         let vc = CoreWebViewController()
-        vc.webView.loadHTMLString(frontPages.first?.body ?? "", baseURL: nil)
+        vc.webView.loadHTMLString(frontPages.first?.body ?? "", baseURL: frontPages.first?.htmlURL)
         viewControllers.append(vc)
     }
 


### PR DESCRIPTION
refs: MBL-17604
affects: Parent
release note: Enabled embedded videos on the front page to play.

test plan:
- Create a page that has a embedded Studio video in it.
- Set this page as the course home.
- Start the parent app and check if the embedded video loads.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/f057a26f-34c2-4894-aa23-ad7c2cd3c152" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/6f754ce5-1b2c-4826-9232-4a89172db3df" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
