### PR TITLE
Update codebase for the latest swiftlint

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,6 +10,7 @@ disabled_rules: # rule identifiers to exclude from running
   - function_parameter_count
   - multiple_closures_with_trailing_closure
   - inclusive_language
+  - non_optional_string_data_conversion # Can be re-enabled when https://github.com/realm/SwiftLint/pull/5601 is merged back.
 opt_in_rules: # some rules are only opt-in
   - yoda_condition
 included: # paths to include during linting. `--path` is ignored if present.
@@ -36,11 +37,5 @@ type_name:
   min_length: 3
   max_length: 50
 
-identifier_name:
-  allowed_symbols: "_"
-  min_length: 1 # only min_length
-  max_length: 50
-  excluded: # excluded via string array
-    - access_token
 trailing_comma:
   mandatory_comma: true

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -463,9 +463,9 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
     }
 
     private func focusOnNewReplyIfNecessary() {
-        if let newReplyIDFromCurrentUser = newReplyIDFromCurrentUser,
-           isContentLargerThanView // if the webview content is smaller than the screen then scrolling will trigger the pull to refresh icon
-        {
+        if let newReplyIDFromCurrentUser,
+           // if the webview content is smaller than the screen then scrolling will trigger the pull to refresh icon
+           isContentLargerThanView {
             webView.scrollIntoView(fragment: "entry-\(newReplyIDFromCurrentUser)")
         }
 

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -559,7 +559,7 @@ extension FileDetailsViewController: PDFViewControllerDelegate {
 
         let document = Document(url: url)
         document.annotationSaveMode = .embedded
-        let controller = PDFViewController(document: document, configuration: PDFConfiguration { (builder) -> Void in
+        let controller = PDFViewController(document: document, configuration: PDFConfiguration { builder in
             docViewerConfigurationBuilder(builder)
             builder.editableAnnotationTypes = [ .link, .highlight, .underline, .strikeOut, .squiggly, .freeText, .ink, .square, .circle, .line, .polygon, .eraser ]
             builder.propertiesForAnnotations[.square] = [["color"], ["lineWidth"]]

--- a/Core/Core/LTI/EmbeddedExternalTools.swift
+++ b/Core/Core/LTI/EmbeddedExternalTools.swift
@@ -22,14 +22,12 @@ import SafariServices
  This helper opens LTI launch urls that are not Canvas LTI launch urls in Safari.
  */
 enum EmbeddedExternalTools {
-    // swiftlint:disable opening_brace
     private static let externalToolChecks: [(URL) -> Bool] = [
         {
             $0.host?.contains("sharepoint.com") == true &&
             $0.path.contains("embed")
         },
     ]
-    // swiftlint:enable opening_brace
 
     /**
      - returns: `True` if the LTI launch was handled by this method.

--- a/Core/CoreTests/.swiftlint.yml
+++ b/Core/CoreTests/.swiftlint.yml
@@ -17,10 +17,5 @@ included: # paths to include during linting. `--path` is ignored if present.
 excluded: # paths to ignore during linting. Takes precedence over `included`.
   - Pods
 
-identifier_name:
-  min_length: 1 # only min_length
-  max_length: 50
-  excluded: # excluded via string array
-    - access_token
 trailing_comma:
   mandatory_comma: true

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -329,7 +329,7 @@ extension ParentAppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL, let login = GetSSOLogin(url: url, app: .parent) {
             window?.rootViewController = LoadingViewController.create()
-            login.fetch(environment: environment) { [weak self] (session, error) -> Void in
+            login.fetch(environment: environment) { [weak self] session, error in
                 guard let session = session, error == nil else {
                     self?.changeUser()
                     return

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -500,7 +500,7 @@ extension StudentAppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL, let login = GetSSOLogin(url: url, app: .student) {
             window?.rootViewController = LoadingViewController.create()
-            login.fetch(environment: environment) { [weak self] (session, error) -> Void in
+            login.fetch(environment: environment) { [weak self] session, error in
                 guard let session = session, error == nil else {
                     self?.changeUser()
                     return

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -310,7 +310,7 @@ extension SubmissionButtonPresenter: AudioRecorderDelegate, UIImagePickerControl
         let env = self.env
         let mediaUploader = UploadMedia(type: type, url: url)
         let uploading = SubmissionButtonAlertView.uploadingAlert(mediaUploader)
-        let reportError = { [weak self] (error: Error) -> Void in
+        let reportError = { [weak self] (error: Error) in
             let failure = UIAlertController(title: String(localized: "Submission Failed", bundle: .student), message: error.localizedDescription, preferredStyle: .alert)
             failure.addAction(UIAlertAction(title: String(localized: "Retry", bundle: .student), style: .default) { _ in
                 self?.submitMediaType(type, url: url, callback: callback)
@@ -326,13 +326,13 @@ extension SubmissionButtonPresenter: AudioRecorderDelegate, UIImagePickerControl
                 }
             }
         }
-        let doneUploading = { [weak self] (error: Error?) -> Void in
+        let doneUploading = { [weak self] (error: Error?) in
             performUIUpdate { self?.env.router.dismiss(uploading) {
                 if let error = error { return reportError(error) }
                 reportSuccess()
             } }
         }
-        let createSubmission = { (mediaID: String?, error: Error?) -> Void in
+        let createSubmission = { (mediaID: String?, error: Error?) in
             guard error == nil else { return doneUploading(error) }
             CreateSubmission(
                 context: .course(assignment.courseID),

--- a/Student/Widgets/AnnouncementsWidget/Model/GetWidgetAnnouncements.swift
+++ b/Student/Widgets/AnnouncementsWidget/Model/GetWidgetAnnouncements.swift
@@ -46,8 +46,8 @@ public class GetWidgetAnnouncements: CollectionUseCase {
         urlResponse: URLResponse?,
         to client: NSManagedObjectContext
     ) {
-        response?.enumerated().forEach {
-            CDWidgetAnnouncement.save($0.element, in: client)
+        response?.forEach {
+            CDWidgetAnnouncement.save($0, in: client)
         }
     }
 }

--- a/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
+++ b/rn/Teacher/ios/Teacher/TeacherAppDelegate.swift
@@ -468,7 +468,7 @@ extension TeacherAppDelegate {
     func application(_ application: UIApplication, continue userActivity: NSUserActivity, restorationHandler: @escaping ([UIUserActivityRestoring]?) -> Void) -> Bool {
         if userActivity.activityType == NSUserActivityTypeBrowsingWeb, let url = userActivity.webpageURL, let login = GetSSOLogin(url: url, app: .teacher) {
             window?.rootViewController = LoadingViewController.create()
-            login.fetch(environment: environment) { [weak self] (session, error) -> Void in
+            login.fetch(environment: environment) { [weak self] session, error in
                 guard let session = session, error == nil else {
                     self?.changeUser()
                     return

--- a/scripts/swift/.swiftlint.yml
+++ b/scripts/swift/.swiftlint.yml
@@ -23,11 +23,5 @@ type_name:
   min_length: 3
   max_length: 50
 
-identifier_name:
-  allowed_symbols: "_"
-  min_length: 1 # only min_length
-  max_length: 50
-  excluded: # excluded via string array
-    - access_token
 trailing_comma:
   mandatory_comma: true


### PR DESCRIPTION
### What changed?
- I disabled the `non_optional_string_data_conversion` rule since part of it will be reverted in the next swiftlint version.
- Removed the `identifier_name` rule configuration since it's disabled and now it generates a warning if we have it disabled but with an active config.
- Fixed misc new warnings.

[ignore-commit-lint]