### PR TITLE
Student - Fix FeatureFlagOffline tests

### DIFF
--- a/Core/TestsFoundation/Helpers/BaseHelper.swift
+++ b/Core/TestsFoundation/Helpers/BaseHelper.swift
@@ -25,6 +25,8 @@ open class BaseHelper {
     public static var nextButton: XCUIElement { app.find(id: "nextButton", type: .button) }
     public static var openInSafariButton: XCUIElement { app.find(id: "OpenInSafariButton") }
 
+    static func tacticalSleep(_ seconds: TimeInterval = 0.5) { usleep(UInt32(seconds*1000000)) }
+
     public static func pullToRefresh() {
         let window = app.find(type: .window)
         window.relativeCoordinate(x: 0.5, y: 0.2)

--- a/Core/TestsFoundation/Helpers/DashboardHelper.swift
+++ b/Core/TestsFoundation/Helpers/DashboardHelper.swift
@@ -100,10 +100,14 @@ public class DashboardHelper: BaseHelper {
             public static var bigBlueButtonButton: XCUIElement { app.find(label: "BigBlueButton", type: .staticText) }
 
             // Functions
-            public static func courseButton(course: DSCourse) -> XCUIElement? {
-                let courseButtons = app.findAll(labelContaining: course.name, type: .button)
-                for b in courseButtons where b.hasLabel(label: "elected", strict: false) {
-                    return b
+            public static func courseButton(course: DSCourse, timeout: TimeInterval = 10) -> XCUIElement? {
+                let deadline = Date().addingTimeInterval(timeout)
+                while Date() < deadline {
+                    let courseButtons = app.findAll(labelContaining: course.name, type: .button)
+                    for b in courseButtons where b.hasLabel(label: "elected", strict: false) {
+                        return b
+                    }
+                    tacticalSleep(1)
                 }
                 return nil
             }

--- a/Core/TestsFoundation/UITests/E2ETestCase.swift
+++ b/Core/TestsFoundation/UITests/E2ETestCase.swift
@@ -31,6 +31,7 @@ open class E2ETestCase: CoreUITestCase {
     open override func setUp() {
         super.setUp()
 
+        setNetworkStateOnline()
         for canvasFeatureFlag in canvasFeatureFlags {
             let featureFlagResponse = seeder.setFeatureFlag(featureFlag: canvasFeatureFlag.featureFlag, state: canvasFeatureFlag.state)
             XCTAssertEqual(featureFlagResponse.state, canvasFeatureFlag.state.rawValue)

--- a/Student/StudentE2ETests/Offline/FeatureFlagOfflineTests.swift
+++ b/Student/StudentE2ETests/Offline/FeatureFlagOfflineTests.swift
@@ -32,11 +32,11 @@ class FeatureFlagOfflineTests: OfflineE2ETest {
         super.tearDown()
     }
 
-    func testDiscussionsButtonIsDisabledIfDiscussionRedesignIsEnabled() {
+    func testDiscussionsFallbackToOldIfDiscussionRedesignIsEnabled() {
         // MARK: Seed the usual stuff with discussion and announcement
         let student = seeder.createUser()
         let course = seeder.createCourse()
-        DiscussionsHelper.createDiscussion(course: course)
+        let discussion = DiscussionsHelper.createDiscussion(course: course)
         AnnouncementsHelper.createAnnouncement(course: course)
         seeder.enrollStudent(student, in: course)
 
@@ -92,20 +92,38 @@ class FeatureFlagOfflineTests: OfflineE2ETest {
         XCTAssertTrue(courseCard.isVisible)
 
         courseCard.hit()
-        let announcementsButton = CourseDetailsHelper.cell(type: .announcements).waitUntil(.visible)
+        let announcementsButton = CourseDetailsHelper.cell(type: .announcements).waitUntil(.visible, timeout: 60)
         let discussionButton = CourseDetailsHelper.cell(type: .discussions).waitUntil(.visible)
         XCTAssertTrue(announcementsButton.isVisible)
         XCTAssertTrue(discussionButton.isVisible)
 
         announcementsButton.hit()
-        let offlineWarning = DashboardHelper.Options.OfflineContent.notAvailableOfflineLabel.waitUntil(.visible)
-        let okButton = DashboardHelper.Options.OfflineContent.okButton.waitUntil(.visible)
-        XCTAssertTrue(offlineWarning.isVisible)
-        XCTAssertTrue(okButton.isVisible)
+        let announcementItem = AnnouncementsHelper.cell(index: 0).waitUntil(.visible)
+        XCTAssertTrue(announcementItem.isVisible)
 
-        okButton.hit()
+        announcementItem.hit()
+        let announcementTitleItem = AnnouncementsHelper.Details.title.waitUntil(.visible)
+        let announcementBodyItem = AnnouncementsHelper.Details.message.waitUntil(.visible)
+        let backButton = AnnouncementsHelper.backButton.waitUntil(.visible)
+        XCTAssertTrue(announcementTitleItem.isVisible)
+        XCTAssertTrue(announcementBodyItem.isVisible)
+        XCTAssertTrue(backButton.isVisible)
+
+        backButton.hit()
+        XCTAssertTrue(announcementItem.waitUntil(.visible).isVisible)
+        XCTAssertTrue(backButton.waitUntil(.visible).isVisible)
+
+        backButton.hit()
+        XCTAssertTrue(discussionButton.waitUntil(.visible).isVisible)
+
         discussionButton.hit()
-        XCTAssertTrue(offlineWarning.waitUntil(.visible).isVisible)
-        XCTAssertTrue(okButton.waitUntil(.visible).isVisible)
+        let discussionItem = DiscussionsHelper.discussionButton(discussion: discussion).waitUntil(.visible)
+        XCTAssertTrue(discussionItem.isVisible)
+
+        discussionItem.hit()
+        let discussionTitleItem = DiscussionsHelper.Details.titleLabel.waitUntil(.visible)
+        let discussionBodyItem = DiscussionsHelper.Details.messageLabel.waitUntil(.visible)
+        XCTAssertTrue(discussionTitleItem.isVisible)
+        XCTAssertTrue(discussionBodyItem.isVisible)
     }
 }


### PR DESCRIPTION
refs: MBL-17634
affects: None
release note: None
test plan: Tests to pass

Test started failing due to recent changes in feature behaviour.

Previous behaviour:
If new discussion feature flag is turned on then after syncing course for offline use and opening discussions a warning message appeared that it's not available offline.

Current behaviour:
Fallback to old discussions screen.

Test has been updated accordingly.