### PR TITLE
Skip offline sync without courses

### DIFF
--- a/Core/Core/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractor.swift
+++ b/Core/Core/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractor.swift
@@ -32,6 +32,7 @@ public class OfflineSyncNextDateInteractor {
         let dates: [Date] = sessionUniqueIDs.compactMap { sessionID in
             let defaults = SessionDefaults(sessionID: sessionID)
             guard defaults.isOfflineAutoSyncEnabled == true,
+                  !defaults.offlineSyncSelections.isEmpty,
                   let nextSyncDate = defaults.offlineSyncNextDate
             else {
                 return nil

--- a/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
@@ -113,11 +113,7 @@ private extension Array where Element == CourseSyncEntry {
             }
     }
 
-    func setSelected(
-        selection: CourseEntrySelection,
-        filter _: CourseSyncListFilter,
-        sessionDefaults _: SessionDefaults
-    ) -> [CourseSyncEntry] {
+    func setSelected(selection: CourseEntrySelection) -> [CourseSyncEntry] {
         var entriesCpy = self
 
         switch selection {
@@ -141,19 +137,21 @@ private extension Array where Element == CourseSyncEntry {
             .compactMap { $0.toCourseEntrySelection(from: self) }
 
         for selection in selections {
-            let entriesWithSelection = entriesCpy.setSelected(selection: selection,
-                                                              filter: filter,
-                                                              sessionDefaults: sessionDefaults)
+            let entriesWithSelection = entriesCpy.setSelected(selection: selection)
             entriesCpy = entriesWithSelection
         }
 
-        let selectedIds = entriesCpy
-            .filter { $0.selectionState == .selected || $0.selectionState == .partiallySelected }
-            .map { $0.id }
+        // When constructing the full course list, we need to clean up previous course selection to
+        // remove outdated courses.
+        if filter == .all {
+            let selectedIds = entriesCpy
+                .filter { $0.selectionState == .selected || $0.selectionState == .partiallySelected }
+                .map { $0.id }
 
-        sessionDefaults.offlineSyncSelections.removeAll { selection in
-            !selectedIds.contains { id in
-                selection.starts(with: id)
+            sessionDefaults.offlineSyncSelections.removeAll { selection in
+                !selectedIds.contains { id in
+                    selection.starts(with: id)
+                }
             }
         }
 

--- a/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
+++ b/Core/Core/CourseSync/Common/Models/CourseSyncListerInteractor.swift
@@ -89,7 +89,7 @@ public class CourseSyncListInteractorLive: CourseSyncListInteractor {
             }
             .collect()
             .replaceEmpty(with: [])
-            .map { [unowned self] in
+            .map { [self] in
                 $0.applySelectionsFromPreviousSession(filter: filter,
                                                       sessionDefaults: &sessionDefaults)
             }

--- a/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncNotificationInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/Model/CourseSyncNotificationInteractor.swift
@@ -42,6 +42,7 @@ public class CourseSyncNotificationInteractor {
             .CombineLatest(itemCountPublisher, isSuccessfulSyncPublisher)
             .receive(on: RunLoop.main)
             .filter { _ in window.isSyncProgressNotOnScreen() }
+            .filter { itemCount, _ in itemCount > 0 } // We want to avoid sending notifications about courses that have already ended.
             .flatMap { [localNotifications] (itemCount, isSuccessful) in
                 if isSuccessful {
                     return localNotifications.sendOfflineSyncCompletedSuccessfullyNotification(syncedItemsCount: itemCount)

--- a/Core/CoreTests/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractorTests.swift
+++ b/Core/CoreTests/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractorTests.swift
@@ -47,7 +47,7 @@ class OfflineSyncNextDateInteractorTests: XCTestCase {
         XCTAssertEqual(result, date2)
     }
 
-    func testSyncSkippingWhithoutCourses() {
+    func testSyncSkippingWithoutCourses() {
         let date1 = Date()
         var defaults = SessionDefaults(sessionID: "test1")
         defaults = SessionDefaults(sessionID: "test")

--- a/Core/CoreTests/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractorTests.swift
+++ b/Core/CoreTests/CourseSync/BackgroundUpdates/Model/Helpers/OfflineSyncNextDateInteractorTests.swift
@@ -36,6 +36,7 @@ class OfflineSyncNextDateInteractorTests: XCTestCase {
         defaults.offlineSyncNextDate = date1
         defaults.isOfflineAutoSyncEnabled = true
         defaults = SessionDefaults(sessionID: "test2")
+        defaults.offlineSyncSelections = ["a1"]
         defaults.offlineSyncNextDate = date2
         defaults.isOfflineAutoSyncEnabled = true
 
@@ -44,6 +45,20 @@ class OfflineSyncNextDateInteractorTests: XCTestCase {
 
         // THEN
         XCTAssertEqual(result, date2)
+    }
+
+    func testSyncSkippingWhithoutCourses() {
+        let date1 = Date()
+        var defaults = SessionDefaults(sessionID: "test1")
+        defaults = SessionDefaults(sessionID: "test")
+        defaults.offlineSyncNextDate = date1
+        defaults.isOfflineAutoSyncEnabled = true
+
+        // WHEN
+        let result = OfflineSyncNextDateInteractor().calculate(sessionUniqueIDs: ["test1", "test2"])
+
+        // THEN
+        XCTAssertEqual(result, nil)
     }
 
     func testPicksNoDateIfAutoSyncIsDisabled() {

--- a/Core/CoreTests/CourseSync/Common/CourseSyncListInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/Common/CourseSyncListInteractorLiveTests.swift
@@ -143,11 +143,8 @@ class CourseSyncListInteractorLiveTests: CoreTestCase {
         )
         api.mock(mockAPIRequest, value: [.make(id: "1", name: "1")])
 
-        let subscription = testee.getCourseSyncEntries(filter: .all).sink(receiveCompletion: { _ in }) { _ in }
-
-        drainMainQueue()
+        XCTAssertFinish(testee.getCourseSyncEntries(filter: .all))
         XCTAssertEqual(environment.userDefaults?.offlineSyncSelections, ["courses/1"])
-        subscription.cancel()
     }
 }
 


### PR DESCRIPTION
Skip offline sync without selected courses.

refs: MBL-17204
affects: Student
release note: Offline sync skips cases when there are no courses selected
test plan: Build from Xcode to easily trigger a sync, check if sync only occurs when there are offline selected courses.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
