### PR TITLE
Filter out threshold alerts for courses where quantitative data restriction is enabled

### DIFF
--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -139,14 +139,14 @@ public class CourseDetailsViewModel: ObservableObject {
     }
 
     private func updateCellOfflineSupport(on cells: [CourseDetailsCellViewModel]) {
-        guard var offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
+        guard let offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
             return
         }
 
         let wholeCourseSelected = offlineSelectionsForCourse.contains("courses/\(courseID)")
 
         if wholeCourseSelected {
-            var offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
+            let offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
 
             cells.forEach {
                 $0.isSupportedOffline = offlineTabs.contains($0.tabID)

--- a/Core/Core/Courses/CourseSettingsInteractor.swift
+++ b/Core/Core/Courses/CourseSettingsInteractor.swift
@@ -1,0 +1,66 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+
+public class CourseSettingsInteractor {
+
+    public init() {}
+
+    public func courseIDs(
+        where settingKey: KeyPath<CourseSettings, Bool>,
+        equals expectedValue: Bool,
+        fromCourseIDs courseIDs: [String],
+        ignoreCache: Bool = false
+    ) -> AnyPublisher<[String], Error> {
+        fetchCourseSettings(
+            courseIDs: courseIDs,
+            ignoreCache: ignoreCache
+        )
+        .map { settings in
+            courseIDs.filter { courseID in
+                guard let courseSettings = settings.first(where: { $0.courseID == courseID }) else {
+                    return false
+                }
+                return courseSettings[keyPath: settingKey] == expectedValue
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+
+    private func fetchCourseSettings(
+        courseIDs: [String],
+        ignoreCache: Bool = false
+    ) -> AnyPublisher<[CourseSettings], Error> {
+        return Publishers
+            .Sequence(sequence: courseIDs)
+            .setFailureType(to: Error.self)
+            .flatMap { courseID in
+                let courseSettingsUseCase = GetCourseSettings(
+                    courseID: courseID
+                )
+                return ReactiveStore(useCase: courseSettingsUseCase)
+                    .getEntities(ignoreCache: ignoreCache)
+            }
+            .collect()
+            .map { arrayOfSettings in
+                arrayOfSettings.flatMap { $0 }
+            }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -742,7 +742,7 @@
         <attribute name="actionDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="alertTypeRaw" attributeType="String"/>
         <attribute name="contextID" optional="YES" attributeType="String"/>
-        <attribute name="courseID" optional="YES" attributeType="String"/>
+        <attribute name="contextType" optional="YES" attributeType="String"/>
         <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>

--- a/Core/Core/ObserverAlerts/APIObserverAlert.swift
+++ b/Core/Core/ObserverAlerts/APIObserverAlert.swift
@@ -22,8 +22,8 @@ import Foundation
 public struct APIObserverAlert: Codable {
     let action_date: Date?
     let alert_type: AlertThresholdType
+    let context_type: String?
     let context_id: ID?
-    let course_id: ID?
     let html_url: APIURL?
     let id: ID
     let observer_id: ID
@@ -39,8 +39,8 @@ extension APIObserverAlert {
     public static func make(
         action_date: Date? = Clock.now,
         alert_type: AlertThresholdType = .institutionAnnouncement,
+        context_type: String? = "Course",
         context_id: String? = "1",
-        course_id: String? = nil,
         html_url: URL? = URL(string: "/accounts/self/account_notifications/1"),
         id: String = "1",
         observer_id: String = "1",
@@ -53,8 +53,8 @@ extension APIObserverAlert {
         return APIObserverAlert(
             action_date: action_date,
             alert_type: alert_type,
+            context_type: context_type,
             context_id: context_id.map { ID($0) },
-            course_id: course_id.map { ID($0) },
             html_url: APIURL(rawValue: html_url),
             id: ID(id),
             observer_id: ID(observer_id),

--- a/Core/CoreTests/Courses/CourseSettingsInteractorTests.swift
+++ b/Core/CoreTests/Courses/CourseSettingsInteractorTests.swift
@@ -1,0 +1,36 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class CourseSettingsInteractorTests: CoreTestCase {
+
+    func testFiltersCourseIDsBasedOnSettingsValue() {
+        api.mock(GetCourseSettingsRequest(courseID: "1"), value: .make(restrict_quantitative_data: true))
+        api.mock(GetCourseSettingsRequest(courseID: "2"), value: .make(restrict_quantitative_data: false))
+
+        let testee = CourseSettingsInteractor().courseIDs(
+            where: \.restrictQuantitativeData,
+            equals: false,
+            fromCourseIDs: ["1", "2", "3"]
+        )
+
+        XCTAssertSingleOutputEquals(testee, ["2"])
+    }
+}

--- a/Core/CoreTests/ObserverAlerts/ObserverAlertTests.swift
+++ b/Core/CoreTests/ObserverAlerts/ObserverAlertTests.swift
@@ -52,4 +52,32 @@ class ObserverAlertTests: CoreTestCase {
         ObserverAlert.save(.make(id: "testId", locked_for_user: true), in: databaseClient)
         XCTAssertEqual(alert.lockedForUser, true)
     }
+
+    func testCourseID() {
+        let alert: ObserverAlert = databaseClient.insert()
+        alert.contextID = "contextID"
+        alert.htmlURL = URL(string: "https://test.com/courses/courseID/assignments/1434231")!
+
+        alert.alertType = .courseGradeHigh
+        XCTAssertEqual(alert.courseID, "contextID")
+        alert.alertType = .courseGradeLow
+        XCTAssertEqual(alert.courseID, "contextID")
+
+        alert.alertType = .assignmentMissing
+        XCTAssertEqual(alert.courseID, nil)
+        alert.alertType = .courseAnnouncement
+        XCTAssertEqual(alert.courseID, nil)
+        alert.alertType = .institutionAnnouncement
+        XCTAssertEqual(alert.courseID, nil)
+
+        alert.alertType = .assignmentGradeHigh
+        XCTAssertEqual(alert.courseID, "courseID")
+        alert.alertType = .assignmentGradeLow
+        XCTAssertEqual(alert.courseID, "courseID")
+
+        // Invalid url scenarios
+        alert.alertType = .assignmentGradeLow
+        alert.htmlURL = URL(string: "https://test.com/courses")!
+        XCTAssertEqual(alert.courseID, nil)
+    }
 }

--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		B49725D3290C06050067B91E /* Heap in Frameworks */ = {isa = PBXBuildFile; productRef = B49725D2290C06050067B91E /* Heap */; };
 		CF04D3182BC572C4009D8C86 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CF04D3172BC572C4009D8C86 /* PrivacyInfo.xcprivacy */; };
 		CF20B5C42B1F9D5700C00B39 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = CF20B5C32B1F9D5700C00B39 /* LaunchScreen.storyboard */; };
+		CF34EC472C08C6700085EA33 /* ObserverAlertsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF34EC462C08C6700085EA33 /* ObserverAlertsInteractor.swift */; };
+		CF34EC4A2C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF34EC492C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift */; };
 		CFAA401D2AE26302002C7AAE /* PSPDFKit in Frameworks */ = {isa = PBXBuildFile; productRef = CFAA401C2AE26302002C7AAE /* PSPDFKit */; };
 		CFEE68D82B1A24ED00A04E43 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */; };
 		CFEE68DB2B1A251C00A04E43 /* LaunchScreen.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */; };
@@ -244,6 +246,8 @@
 		B59561D7E9F8B8ACA930A4E9 /* Pods-needs-pspdfkit-ParentUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-needs-pspdfkit-ParentUITests.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-needs-pspdfkit-ParentUITests/Pods-needs-pspdfkit-ParentUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		CF04D3172BC572C4009D8C86 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		CF20B5C32B1F9D5700C00B39 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
+		CF34EC462C08C6700085EA33 /* ObserverAlertsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverAlertsInteractor.swift; sourceTree = "<group>"; };
+		CF34EC492C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverAlertsInteractorTests.swift; sourceTree = "<group>"; };
 		CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = LaunchScreen.xcstrings; sourceTree = "<group>"; };
 		CFEE68DA2B1A251C00A04E43 /* Localizable.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -543,6 +547,7 @@
 		7DC7045B24AA8EA400CD1C46 /* ObserverAlerts */ = {
 			isa = PBXGroup;
 			children = (
+				CF34EC452C08C6660085EA33 /* Model */,
 				7DC7046624AA9F0F00CD1C46 /* ObserverAlertListViewController.storyboard */,
 				7DC7046424AA96C500CD1C46 /* ObserverAlertListViewController.swift */,
 			);
@@ -552,6 +557,7 @@
 		7DC7046B24ABBAD700CD1C46 /* ObserverAlerts */ = {
 			isa = PBXGroup;
 			children = (
+				CF34EC482C08C9C90085EA33 /* Model */,
 				7DC7046C24ABBB0400CD1C46 /* APIObserverAlertTests.swift */,
 				7DC7046E24ABBD2D00CD1C46 /* GetObserverAlertsTests.swift */,
 				7DC7047024ABC07300CD1C46 /* ObserverAlertListViewControllerTests.swift */,
@@ -726,6 +732,22 @@
 				B1AA55CF235785A200DFD184 /* StudentListViewControllerTests.swift */,
 			);
 			path = Students;
+			sourceTree = "<group>";
+		};
+		CF34EC452C08C6660085EA33 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CF34EC462C08C6700085EA33 /* ObserverAlertsInteractor.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		CF34EC482C08C9C90085EA33 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				CF34EC492C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		E2CB0046CD9881A39071A512 /* Pods */ = {
@@ -1153,6 +1175,7 @@
 				7DB92CB824C64D35004A6C16 /* CourseListViewControllerTests.swift in Sources */,
 				7DB92CAF24C61575004A6C16 /* AccountNotificationDetailsViewControllerTests.swift in Sources */,
 				7DFDB43223A3EDFB00B28DED /* ParentConversationListViewControllerTests.swift in Sources */,
+				CF34EC4A2C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift in Sources */,
 				CFFE286A27B3B8A90029A408 /* CourseListCellGradesTests.swift in Sources */,
 				B1AA55D0235785A200DFD184 /* StudentListViewControllerTests.swift in Sources */,
 				3B54E3592326F9B000D8D1D2 /* ParentTestCase.swift in Sources */,
@@ -1183,6 +1206,7 @@
 				5E4E20511C927EB100E7D709 /* ColorScheme.swift in Sources */,
 				7D1801B924C207B500A7F023 /* AssignmentDetailsViewController.swift in Sources */,
 				3BA9FF6D2332999900196A06 /* CourseDetailsViewController.swift in Sources */,
+				CF34EC472C08C6700085EA33 /* ObserverAlertsInteractor.swift in Sources */,
 				4948BE691F915D330035BAFD /* BundleExtensions.swift in Sources */,
 				7DB92CAA24C608E9004A6C16 /* DiscussionDetailsViewController.swift in Sources */,
 				7D33976C24534CD30074ED71 /* StudentListViewController.swift in Sources */,

--- a/Parent/Parent/ObserverAlerts/Model/ObserverAlertsInteractor.swift
+++ b/Parent/Parent/ObserverAlerts/Model/ObserverAlertsInteractor.swift
@@ -1,0 +1,67 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import Combine
+
+class ObserverAlertsInteractor {
+    private let studentID: String
+    private var courseSettingsInteractor: CourseSettingsInteractor
+
+    init(
+        studentID: String,
+        courseSettingsInteractor: CourseSettingsInteractor = CourseSettingsInteractor()
+    ) {
+        self.studentID = studentID
+        self.courseSettingsInteractor = courseSettingsInteractor
+    }
+
+    public func refresh(
+        ignoreCache: Bool = false
+    ) -> AnyPublisher<(alerts: [ObserverAlert], thresholds: [AlertThreshold]), Error> {
+        let alerts = ReactiveStore(useCase: GetObserverAlerts(studentID: studentID))
+            // Explicitly load all pages so the new alert badge count will be up-to-date
+            .getEntities(ignoreCache: ignoreCache, loadAllPages: true)
+            .flatMap { [courseSettingsInteractor] alerts in
+                let courseIDs = Array(Set(alerts.compactMap { $0.courseID }))
+                return courseSettingsInteractor.courseIDs(
+                    where: \.restrictQuantitativeData,
+                    equals: true,
+                    fromCourseIDs: courseIDs,
+                    ignoreCache: ignoreCache
+                )
+                .map { (alerts, $0) }
+            }
+            .map { (alerts, hiddenAlertCourses) in
+                alerts.filter { alert in
+                    guard let alertCourseID = alert.courseID else {
+                        // If the alert has no course we don't need to filter it out
+                        return true
+                    }
+                    return hiddenAlertCourses.contains(alertCourseID) == false
+                }
+            }
+        let thresholds = ReactiveStore(useCase: GetAlertThresholds(studentID: studentID))
+            .getEntities(ignoreCache: ignoreCache)
+
+        return Publishers
+            .CombineLatest(alerts, thresholds)
+            .map { (alerts: $0.0, thresholds: $0.1) }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Parent/ParentUnitTests/ObserverAlerts/Model/ObserverAlertsInteractorTests.swift
+++ b/Parent/ParentUnitTests/ObserverAlerts/Model/ObserverAlertsInteractorTests.swift
@@ -48,7 +48,7 @@ class ObserverAlertsInteractorTests: ParentTestCase {
         }
         XCTAssertEqual(mockSettingsInteractor.receivedSettingsKey, \.restrictQuantitativeData)
         XCTAssertEqual(mockSettingsInteractor.receivedExpectedValue, true)
-        XCTAssertEqual(mockSettingsInteractor.receivedCourseIDs, ["c1", "c2"])
+        XCTAssertEqual(Set(mockSettingsInteractor.receivedCourseIDs ?? []), Set(["c1", "c2"]))
     }
 }
 

--- a/Parent/ParentUnitTests/ObserverAlerts/Model/ObserverAlertsInteractorTests.swift
+++ b/Parent/ParentUnitTests/ObserverAlerts/Model/ObserverAlertsInteractorTests.swift
@@ -1,0 +1,76 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import Combine
+@testable import Parent
+import XCTest
+
+class ObserverAlertsInteractorTests: ParentTestCase {
+
+    func testLoadsAlertsWhereQuantitativeDataIsNotEnabled() {
+        api.mock(GetObserverAlerts(studentID: "testStudent"), value: [
+            .make(alert_type: .courseGradeLow, context_id: "c1", id: "a1", user_id: "testStudent"),
+            .make(alert_type: .courseGradeLow, context_id: "c2", id: "a2", user_id: "testStudent"),
+        ])
+        api.mock(GetAlertThresholds(studentID: "testStudent"), value: [])
+        let mockSettingsInteractor = MockCourseSettingsInteractor()
+        // course c2 has restrict quantitative data enabled
+        mockSettingsInteractor.mockedCourseIDsResponse = ["c2"]
+        let testee = ObserverAlertsInteractor(
+            studentID: "testStudent",
+            courseSettingsInteractor: mockSettingsInteractor
+        )
+
+        // WHEN
+        let resultPubliser = testee.refresh()
+
+        // THEN
+        XCTAssertFirstValueAndCompletion(resultPubliser, timeout: 1) { (alerts, thresholds) in
+            XCTAssertEqual(alerts.count, 1)
+            XCTAssertEqual(alerts.first?.id, "a1")
+            XCTAssertEqual(thresholds.isEmpty, true)
+        }
+        XCTAssertEqual(mockSettingsInteractor.receivedSettingsKey, \.restrictQuantitativeData)
+        XCTAssertEqual(mockSettingsInteractor.receivedExpectedValue, true)
+        XCTAssertEqual(mockSettingsInteractor.receivedCourseIDs, ["c1", "c2"])
+    }
+}
+
+class MockCourseSettingsInteractor: CourseSettingsInteractor {
+
+    var mockedCourseIDsResponse: [String] = []
+    var receivedSettingsKey: KeyPath<CourseSettings, Bool>?
+    var receivedExpectedValue: Bool?
+    var receivedCourseIDs: [String]?
+
+    public override func courseIDs(
+        where settingKey: KeyPath<CourseSettings, Bool>,
+        equals expectedValue: Bool,
+        fromCourseIDs courseIDs: [String],
+        ignoreCache: Bool = false
+    ) -> AnyPublisher<[String], Error> {
+        receivedSettingsKey = settingKey
+        receivedExpectedValue = expectedValue
+        receivedCourseIDs = courseIDs
+
+        return Just(mockedCourseIDsResponse)
+            .setFailureType(to: Error.self)
+            .eraseToAnyPublisher()
+    }
+}

--- a/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
+++ b/Parent/ParentUnitTests/ObserverAlerts/ObserverAlertListViewControllerTests.swift
@@ -27,7 +27,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
 
     override func setUp() {
         super.setUp()
-        api.mock(controller.alerts, value: [
+        api.mock(GetObserverAlerts(studentID: "1"), value: [
             .make(
                 action_date: DateComponents(calendar: .current, year: 2020, month: 6, day: 30).date,
                 alert_type: .courseGradeHigh,
@@ -49,7 +49,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
             .make(
                 action_date: DateComponents(calendar: .current, year: 2020, month: 6, day: 15).date,
                 alert_type: .assignmentGradeLow,
-                course_id: "1", html_url: URL(string: "/courses/1/assignments/1"),
+                html_url: URL(string: "/courses/1/assignments/1"),
                 id: "7", observer_alert_threshold_id: "7",
                 title: "Assignment graded: 46% on Practice Worksheet 3 in C1",
                 user_id: "1",
@@ -67,7 +67,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
                 locked_for_user: true
             ),
         ])
-        api.mock(controller.thresholds, value: [
+        api.mock(GetAlertThresholds(studentID: "1"), value: [
             .make(id: "1", user_id: "1", alert_type: .courseGradeHigh, threshold: 90),
             .make(id: "2", user_id: "1", alert_type: .courseGradeLow, threshold: 60),
             .make(id: "3", user_id: "1", alert_type: .institutionAnnouncement, threshold: nil),
@@ -78,6 +78,7 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
         let nav = UINavigationController(rootViewController: controller)
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
+        drainMainQueue()
         XCTAssertEqual(nav.navigationBar.barTintColor?.hexString, ColorScheme.observee("1").color.darkenToEnsureContrast(against: .white).hexString)
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 4)
@@ -138,13 +139,14 @@ class ObserverAlertListViewControllerTests: ParentTestCase {
             XCTAssertEqual(isSuccess, true)
         }
 
-        api.mock(controller.alerts, error: NSError.internalError())
+        api.mock(GetObserverAlerts(studentID: "1"), error: NSError.internalError())
         controller.tableView.refreshControl?.sendActions(for: .primaryActionTriggered)
         XCTAssertEqual(controller.errorView.isHidden, false)
         XCTAssertEqual(controller.errorView.messageLabel.text, "There was an error loading alerts. Pull to refresh to try again.")
 
-        api.mock(controller.alerts, value: [])
+        api.mock(GetObserverAlerts(studentID: "1"), value: [])
         controller.errorView.retryButton.sendActions(for: .primaryActionTriggered)
+        drainMainQueue()
         XCTAssertEqual(controller.emptyView.isHidden, false)
         XCTAssertEqual(controller.emptyTitleLabel.text, "No Alerts")
         XCTAssertEqual(controller.emptyMessageLabel.text, "There's nothing to be notified of yet.")


### PR DESCRIPTION
refs: MBL-17542
affects: Parent
release note: Threshold alerts are hidden now for courses where quantitative data restriction is enabled.

test plan:
- Have a course where restrict quantitative data is disabled.
- Set up alert threshold for a student in parent app.
- Grade a submission in a way to trigger the threshold.
- Open the parent app and check the alert.
- Turn on restrict quantitative data for the course.
- Refresh the alerts page and check if the alerts have disappeared.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/a19343fa-fe29-4ab2-8569-8b3b46986d25" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/ebc17913-f777-442c-b8de-f19fbfb32630" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet