### PR TITLE
Offline sync selector updates

### DIFF
--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -27,7 +27,6 @@ public protocol CourseSyncSelectorInteractor: AnyObject {
      */
     init(courseID: String?, courseSyncListInteractor: CourseSyncListInteractor, sessionDefaults: SessionDefaults)
     func getCourseSyncEntries() -> AnyPublisher<[CourseSyncEntry], Error>
-    func observeSelectedCount() -> AnyPublisher<Int, Never>
     func observeSelectedSize() -> AnyPublisher<Int, Never>
     func observeIsEverythingSelected() -> AnyPublisher<Bool, Never>
     func setSelected(selection: CourseEntrySelection, selectionState: ListCellView.SelectionState)
@@ -79,21 +78,6 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
                 }
             )
             .flatMap { _ in self.courseSyncEntries.eraseToAnyPublisher() }
-            .eraseToAnyPublisher()
-    }
-
-    func observeSelectedCount() -> AnyPublisher<Int, Never> {
-        courseSyncEntries
-            .replaceError(with: [])
-            .map { entries in
-                entries
-                    .filter {
-                        $0.selectionState == .selected ||
-                        $0.selectionState == .partiallySelected
-                    }
-                    .count
-            }
-            .replaceEmpty(with: 0)
             .eraseToAnyPublisher()
     }
 

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractor.swift
@@ -30,6 +30,7 @@ public protocol CourseSyncSelectorInteractor: AnyObject {
     func observeSelectedSize() -> AnyPublisher<Int, Never>
     func observeIsEverythingSelected() -> AnyPublisher<Bool, Never>
     func setSelected(selection: CourseEntrySelection, selectionState: ListCellView.SelectionState)
+    func saveSelection()
     func setCollapsed(selection: CourseEntrySelection, isCollapsed: Bool)
     func toggleAllCoursesSelection(isSelected: Bool)
     func getSelectedCourseEntries() -> AnyPublisher<[CourseSyncEntry], Never>
@@ -109,6 +110,12 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             entries[id: entryID]?.selectFile(id: fileID, selectionState: selectionState)
         }
 
+        courseSyncEntries.send(entries)
+    }
+
+    func saveSelection() {
+        let entries = courseSyncEntries.value
+
         if let courseID {
             // If we only show one course then we should keep other course selections intact
             var oldSelections = sessionDefaults.offlineSyncSelections
@@ -119,8 +126,6 @@ final class CourseSyncSelectorInteractorLive: CourseSyncSelectorInteractor {
             // If all courses are visible then it's safe to overwrite all course selections
             sessionDefaults.offlineSyncSelections = CourseSyncItemSelection.make(from: entries)
         }
-
-        courseSyncEntries.send(entries)
     }
 
     func setCollapsed(selection: CourseEntrySelection, isCollapsed: Bool) {

--- a/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorPreview.swift
@@ -104,6 +104,7 @@ class CourseSyncSelectorInteractorPreview: CourseSyncSelectorInteractor {
         mockData.accept(entries)
     }
 
+    func saveSelection() {}
     func toggleAllCoursesSelection(isSelected _: Bool) {}
     func setCollapsed(selection _: CourseEntrySelection, isCollapsed _: Bool) {}
 

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -180,9 +180,7 @@ struct CourseSyncSelectorView: View {
                 .font(.regular16, lineHeight: .fit)
                 .foregroundColor(.textLightest)
                 .background(Color(Brand.shared.primary))
-                .opacity(viewModel.syncButtonDisabled ? 0.42 : 1)
         }
-        .disabled(viewModel.syncButtonDisabled)
         .animation(.default, value: offlineModeViewModel.isOffline)
     }
 

--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -33,10 +33,10 @@ struct CourseSyncSelectorView: View {
 
     var body: some View {
         content
-        .background(Color.backgroundLightest)
-        .navigationTitleStyled(navBarTitleView)
-        .navigationBarItems(leading: leftNavBarButton, trailing: cancelButton)
-        .navigationBarStyle(.modal)
+            .background(Color.backgroundLightest)
+            .navigationTitleStyled(navBarTitleView)
+            .navigationBarItems(leading: leftNavBarButton, trailing: cancelButton)
+            .navigationBarStyle(.modal)
     }
 
     @ViewBuilder
@@ -46,7 +46,7 @@ struct CourseSyncSelectorView: View {
             InteractivePanda(scene: NoResultsPanda(),
                              title: Text(viewModel.labels.error.title),
                              subtitle: Text(viewModel.labels.error.message))
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
         case .loading:
             VStack(spacing: 12) {
                 Image("LoadingPanda", bundle: .core)
@@ -94,8 +94,14 @@ struct CourseSyncSelectorView: View {
                 }
                 syncButton
             }
-            .confirmationAlert(isPresented: $viewModel.isShowingConfirmationDialog,
-                               presenting: viewModel.confirmAlert)
+            .confirmationAlert(
+                isPresented: $viewModel.isShowingSyncConfirmationDialog,
+                presenting: viewModel.syncConfirmAlert
+            )
+            .confirmationAlert(
+                isPresented: $viewModel.isShowingCancelConfirmationDialog,
+                presenting: viewModel.cancelConfirmAlert
+            )
         }
     }
 
@@ -103,7 +109,7 @@ struct CourseSyncSelectorView: View {
         LazyVStack(spacing: 0) {
             ForEach(viewModel.cells) { cell in
                 let isListItem: Bool = {
-                    if case .item(let item) = cell, item.cellStyle == .listItem {
+                    if case let .item(item) = cell, item.cellStyle == .listItem {
                         return true
                     } else {
                         return false
@@ -112,7 +118,7 @@ struct CourseSyncSelectorView: View {
 
                 VStack(spacing: 0) {
                     switch cell {
-                    case .item(let item):
+                    case let .item(item):
                         ListCellView(ListCellViewModel(cellStyle: item.cellStyle,
                                                        title: item.title,
                                                        subtitle: item.subtitle,
@@ -136,17 +142,17 @@ struct CourseSyncSelectorView: View {
                          title: Text(viewModel.labels.noCourses.title),
                          subtitle: Text(viewModel.labels.noCourses.message))
 
-        .padding(16)
-        .frame(maxWidth: .infinity, minHeight: geometry.size.height)
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: geometry.size.height)
     }
 
     private var emptyCourse: some View {
         InteractivePanda(scene: SpacePanda(),
                          title: Text(viewModel.labels.noItems.title),
                          subtitle: Text(viewModel.labels.noItems.message))
-        .allowsHitTesting(false)
-        .padding(.horizontal, 16)
-        .padding(.vertical, 32)
+            .allowsHitTesting(false)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 32)
     }
 
     private var navBarTitleView: some View {

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -46,8 +46,14 @@ class CourseSyncSelectorViewModel: ObservableObject {
     )
 
     public let cancelConfirmAlert = ConfirmationAlertViewModel(
-        title: String(localized: "Cancel Offline Content Sync?", bundle: .core),
-        message: "Selection changes that you may had made won't be saved. Are you sure you want to cancel?",
+        title: String(
+            localized: "Cancel Offline Content Sync?",
+            bundle: .core
+        ),
+        message: String(
+            localized: "Selection changes that you may had made won't be saved. Are you sure you want to cancel?",
+            bundle: .core
+        ),
         cancelButtonTitle: String(localized: "No", bundle: .core),
         confirmButtonTitle: String(localized: "Yes", bundle: .core),
         isDestructive: true

--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -32,7 +32,6 @@ class CourseSyncSelectorViewModel: ObservableObject {
     @Published public private(set) var state = State.loading
     @Published public private(set) var cells: [Cell] = []
     @Published public private(set) var navBarSubtitle = ""
-    @Published public private(set) var syncButtonDisabled = true
     @Published public private(set) var leftNavBarTitle = ""
     @Published public private(set) var leftNavBarButtonVisible = false
     @Published public var isShowingConfirmationDialog = false
@@ -83,7 +82,6 @@ class CourseSyncSelectorViewModel: ObservableObject {
         self.router = router
 
         updateState(selectorInteractor)
-        updateSyncButtonState(selectorInteractor)
         updateConfirmationDialogMessage(selectorInteractor)
         updateSelectAllButtonTitle(selectorInteractor)
         updateNavBarSubtitle(selectorInteractor)
@@ -108,13 +106,6 @@ class CourseSyncSelectorViewModel: ObservableObject {
         interactor
             .getCourseName()
             .assign(to: &$navBarSubtitle)
-    }
-
-    private func updateSyncButtonState(_ interactor: CourseSyncSelectorInteractor) {
-        interactor
-            .observeSelectedCount()
-            .map { $0 == 0 }
-            .assign(to: &$syncButtonDisabled)
     }
 
     private func updateSelectAllButtonTitle(_ interactor: CourseSyncSelectorInteractor) {

--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -139,14 +139,14 @@ public class CourseDetailsViewModel: ObservableObject {
     }
 
     private func updateCellOfflineSupport(on cells: [CourseDetailsCellViewModel]) {
-        guard var offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
+        guard let offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
             return
         }
 
         let wholeCourseSelected = offlineSelectionsForCourse.contains("courses/\(courseID)")
 
         if wholeCourseSelected {
-            var offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
+            let offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
 
             cells.forEach {
                 $0.isSupportedOffline = offlineTabs.contains($0.tabID)

--- a/Core/Core/SwiftUIViews/ConfirmationAlert.swift
+++ b/Core/Core/SwiftUIViews/ConfirmationAlert.swift
@@ -97,7 +97,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
 
     class ConfirmDemoViewModel: ObservableObject {
         @Published var statusText = ""
-        @Published var isShowingConfirmationDialog = false
+        @Published var isShowingSyncConfirmationDialog = false
         let confirmDialog = ConfirmationAlertViewModel(title: "Confirm Selection",
                                                        message: "This action needs to be confirmed",
                                                        cancelButtonTitle: "Not Now",
@@ -110,7 +110,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
             showDidTap
                 .handleEvents(receiveOutput: {
                     unownedSelf.statusText = ""
-                    unownedSelf.isShowingConfirmationDialog = true
+                    unownedSelf.isShowingSyncConfirmationDialog = true
                 })
                 .flatMap { unownedSelf.confirmDialog.userConfirmation() }
                 .map { "Confirmed!" }
@@ -131,7 +131,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
                     } label: {
                         Text("Show dialog", bundle: .core)
                     }
-                    .alertConfirmation(isPresented: $viewModel.isShowingConfirmationDialog,
+                    .alertConfirmation(isPresented: $viewModel.isShowingSyncConfirmationDialog,
                                        presenting: viewModel.confirmDialog)
                     Spacer()
                 }

--- a/Core/Core/SwiftUIViews/ConfirmationAlert.swift
+++ b/Core/Core/SwiftUIViews/ConfirmationAlert.swift
@@ -97,7 +97,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
 
     class ConfirmDemoViewModel: ObservableObject {
         @Published var statusText = ""
-        @Published var isShowingSyncConfirmationDialog = false
+        @Published var isShowingConfirmationDialog = false
         let confirmDialog = ConfirmationAlertViewModel(title: "Confirm Selection",
                                                        message: "This action needs to be confirmed",
                                                        cancelButtonTitle: "Not Now",
@@ -110,7 +110,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
             showDidTap
                 .handleEvents(receiveOutput: {
                     unownedSelf.statusText = ""
-                    unownedSelf.isShowingSyncConfirmationDialog = true
+                    unownedSelf.isShowingConfirmationDialog = true
                 })
                 .flatMap { unownedSelf.confirmDialog.userConfirmation() }
                 .map { "Confirmed!" }
@@ -131,7 +131,7 @@ struct ConfirmationAlertPreview: PreviewProvider {
                     } label: {
                         Text("Show dialog", bundle: .core)
                     }
-                    .alertConfirmation(isPresented: $viewModel.isShowingSyncConfirmationDialog,
+                    .alertConfirmation(isPresented: $viewModel.isShowingConfirmationDialog,
                                        presenting: viewModel.confirmDialog)
                     Spacer()
                 }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/Model/CourseSyncSelectorInteractorLiveTests.swift
@@ -438,6 +438,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         // MARK: - WHEN
 
         testee.setSelected(selection: .course("courses/2"), selectionState: .selected)
+        testee.saveSelection()
 
         // MARK: - THEN
 
@@ -461,6 +462,7 @@ class CourseSyncSelectorInteractorLiveTests: CoreTestCase {
         // MARK: - WHEN
 
         testee.setSelected(selection: .course("courses/1"), selectionState: .selected)
+        testee.saveSelection()
 
         // MARK: - THEN
 

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -292,6 +292,8 @@ private class MockCourseSyncSelectorInteractor: CourseSyncSelectorInteractor {
         lastSelected = (selection: selection, isSelected: selectionState == .selected ? true : false)
     }
 
+    func saveSelection() {}
+
     func setCollapsed(selection: Core.CourseEntrySelection, isCollapsed: Bool) {
         lastCollapsed = (selection: selection, isCollapsed: isCollapsed)
     }

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -49,14 +49,14 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(testee.cells, [])
         XCTAssertTrue(testee.syncButtonDisabled)
         XCTAssertFalse(testee.leftNavBarButtonVisible)
-        XCTAssertFalse(testee.isShowingConfirmationDialog)
+        XCTAssertFalse(testee.isShowingSyncConfirmationDialog)
     }
 
     func testConfirmAlertProps() {
-        XCTAssertEqual(testee.confirmAlert.title, "Sync Offline Content?")
-        XCTAssertEqual(testee.confirmAlert.cancelButtonTitle, "Cancel")
-        XCTAssertEqual(testee.confirmAlert.confirmButtonTitle, "Sync")
-        XCTAssertNil(testee.confirmAlert.confirmButtonRole)
+        XCTAssertEqual(testee.syncConfirmAlert.title, "Sync Offline Content?")
+        XCTAssertEqual(testee.syncConfirmAlert.cancelButtonTitle, "Cancel")
+        XCTAssertEqual(testee.syncConfirmAlert.confirmButtonTitle, "Sync")
+        XCTAssertNil(testee.syncConfirmAlert.confirmButtonRole)
     }
 
     func testUpdateSyncButtonState() {
@@ -77,7 +77,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
 
     func testUpdateConfirmationDialogMessage() {
         mockSelectorInteractor.selectedSizeSubject.send(1024)
-        XCTAssertEqual(testee.confirmAlert.message, "This will sync ~1 KB content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.")
+        XCTAssertEqual(testee.syncConfirmAlert.message, "This will sync ~1 KB content. It may result in additional charges from your data provider if you are not connected to a Wi-Fi network.")
     }
 
     func testLeftNavBarTap() {
@@ -92,7 +92,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
 
     func testSyncButtonTap() {
         testee.syncButtonDidTap.accept(WeakViewController(UIViewController()))
-        XCTAssertTrue(testee.isShowingConfirmationDialog)
+        XCTAssertTrue(testee.isShowingSyncConfirmationDialog)
     }
 
     func testUpdateStateFails() {

--- a/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelTests.swift
@@ -63,7 +63,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(testee.cancelConfirmAlert.message, "Selection changes that you may had made won't be saved. Are you sure you want to cancel?")
         XCTAssertEqual(testee.cancelConfirmAlert.cancelButtonTitle, "No")
         XCTAssertEqual(testee.cancelConfirmAlert.confirmButtonTitle, "Yes")
-        XCTAssertNil(testee.cancelConfirmAlert.confirmButtonRole)
+        XCTAssertEqual(testee.cancelConfirmAlert.confirmButtonRole, .destructive)
     }
 
     func testUpdateSelectAllButtonTitle() {
@@ -139,6 +139,7 @@ class CourseSyncSelectorViewModelTests: XCTestCase {
         let controller = UIViewController()
         let weakController = WeakViewController(controller)
         testee.cancelButtonDidTap.accept(weakController)
+        testee.cancelConfirmAlert.notifyCompletion(isConfirmed: true)
         XCTAssertEqual(router.dismissed, controller)
     }
 }


### PR DESCRIPTION
Offline selector updates

refs: MBL-17104
affects: Student
release note: none
test plan: See ticket

## Screenshots

<table>
<tr><th>Dialog</th>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/110813321/49112bbb-5cdb-4a1a-9622-27b22fd7dd67" height=500></td>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product
