### PR TITLE
Filter out concluded groups from calendar filter

### DIFF
--- a/Core/Core/Groups/APIGroup.swift
+++ b/Core/Core/Groups/APIGroup.swift
@@ -20,6 +20,11 @@ import Foundation
 
 // https://canvas.instructure.com/doc/api/groups.html#Group
 public struct APIGroup: Codable, Equatable {
+    public enum GroupType {
+        case account
+        case course(courseId: ID)
+    }
+
     public let id: ID
     let name: String
     let concluded: Bool
@@ -38,6 +43,14 @@ public struct APIGroup: Codable, Equatable {
     // let storage_quota_mb: String
     let permissions: Permissions?
     let is_favorite: Bool?
+
+    public var groupType: GroupType {
+        if let course_id {
+            return .course(courseId: course_id)
+        } else {
+            return .account
+        }
+    }
 
     public struct Permissions: Codable, Equatable {
         let create_announcement: Bool

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
@@ -74,10 +74,15 @@ class GetCalendarFilters: UseCase {
 
         Publishers
             .CombineLatest(coursesFetch, groupsFetch)
-            .map {
-                APIResponse(
-                    courses: $0.0,
-                    groups: $0.1.body
+            .map { (courses, groups) in
+                let validCourseIDs = courses.map { $0.id }
+                /// If a course's end date has passed and "Restrict students from viewing course after course end date" is checked
+                /// then fetching events for a group in this course will give 403 unauthorized.
+                /// To be on the safe side we drop all courses without a valid course.
+                let filteredGroups = groups.body.filterOutCourseGroupsWithoutValidCourses(validCourseIDs: validCourseIDs)
+                return APIResponse(
+                    courses: courses,
+                    groups: filteredGroups
                 )
             }
             .first()
@@ -121,5 +126,19 @@ class GetCalendarFilters: UseCase {
 
     func reset(context: NSManagedObjectContext) {
         context.delete(context.fetch(scope: scope) as [CDCalendarFilterEntry])
+    }
+}
+
+extension Array where Element == APIGroup {
+
+    func filterOutCourseGroupsWithoutValidCourses(validCourseIDs: [ID]) -> [Element] {
+        filter { group in
+            switch group.groupType {
+            case .account:
+                return true
+            case .course(let courseId):
+                return validCourseIDs.contains(courseId)
+            }
+        }
     }
 }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
@@ -79,7 +79,7 @@ class GetCalendarFilters: UseCase {
                 /// If a course's end date has passed and "Restrict students from viewing course after course end date" is checked
                 /// then fetching events for a group in this course will give 403 unauthorized.
                 /// To be on the safe side we drop all courses without a valid course.
-                let filteredGroups = groups.body.filterOutCourseGroupsWithoutValidCourses(validCourseIDs: validCourseIDs)
+                let filteredGroups = groups.body.dropCourseGroupsWithoutValidCourses(validCourseIDs: validCourseIDs)
                 return APIResponse(
                     courses: courses,
                     groups: filteredGroups
@@ -129,9 +129,9 @@ class GetCalendarFilters: UseCase {
     }
 }
 
-extension Array where Element == APIGroup {
+private extension Array where Element == APIGroup {
 
-    func filterOutCourseGroupsWithoutValidCourses(validCourseIDs: [ID]) -> [Element] {
+    func dropCourseGroupsWithoutValidCourses(validCourseIDs: [ID]) -> [Element] {
         filter { group in
             switch group.groupType {
             case .account:

--- a/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetCalendarFiltersTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetCalendarFiltersTests.swift
@@ -1,0 +1,57 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class GetCalendarFiltersTests: CoreTestCase {
+
+    /// If a course's end date has passed and "Restrict students from viewing course after course end date"
+    /// is checked then fetching events for a group in this course will give 403 unauthorized.
+    func testRemovesCourseGroupsWhereCourseIsUnavailable() {
+        let coursesRequest = GetCurrentUserCoursesRequest(
+            enrollmentState: .active,
+            state: [],
+            includes: []
+        )
+        api.mock(coursesRequest, value: [])
+
+        let groupsRequest = GetGroupsRequest(context: .currentUser)
+        api.mock(
+            groupsRequest,
+            value: [
+                .make(id: "LockedCourseGroup", course_id: "1"),
+                .make(id: "AccountGroup", course_id: nil),
+            ]
+        )
+
+        let testee = GetCalendarFilters(currentUserName: "",
+                                        currentUserId: "",
+                                        states: [],
+                                        filterUnpublishedCourses: true)
+        let requestCompleted = expectation(description: "requestCompleted")
+
+        testee.makeRequest(environment: environment) { response, _, _ in
+            XCTAssertEqual(response?.groups.count, 1)
+            XCTAssertEqual(response?.groups.first?.id, "AccountGroup")
+            requestCompleted.fulfill()
+        }
+
+        wait(for: [requestCompleted])
+    }
+}


### PR DESCRIPTION
refs: [MBL-17646](https://instructure.atlassian.net/browse/MBL-17646)
affects: Student
release note: Fixed calendar trying to load events for concluded groups.

test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/d8aa69f2-97aa-4a2d-a96e-c6b5717afed6" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/ed44a301-2ae5-460b-bf0f-ab0c9ec70f7f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-17646]: https://instructure.atlassian.net/browse/MBL-17646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ