### PR TITLE
Fix invalid grade data in offline mode

### DIFF
--- a/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/CourseDetailsViewModel.swift
@@ -139,14 +139,14 @@ public class CourseDetailsViewModel: ObservableObject {
     }
 
     private func updateCellOfflineSupport(on cells: [CourseDetailsCellViewModel]) {
-        guard var offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
+        guard let offlineSelectionsForCourse = env.userDefaults?.offlineSyncSelections else {
             return
         }
 
         let wholeCourseSelected = offlineSelectionsForCourse.contains("courses/\(courseID)")
 
         if wholeCourseSelected {
-            var offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
+            let offlineTabs = TabName.OfflineSyncableTabs.map { $0.rawValue }
 
             cells.forEach {
                 $0.isSupportedOffline = offlineTabs.contains($0.tabID)

--- a/Core/Core/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Grades/Model/GradeListInteractor.swift
@@ -221,13 +221,13 @@ public final class GradeListInteractorLive: GradeListInteractor {
         var assignmentSections: [GradeListData.AssignmentSections] = []
         orderedAssignments.forEach { assignment in
             if let index = assignmentSections.firstIndex(where: { section in
-                section.title == assignment.assignmentGroupSectionName
+                section.id == assignment.assignmentGroupID ?? ""
             }) {
                 assignmentSections[index].assignments.append(assignment)
             } else {
                 assignmentSections.append(
                     GradeListData.AssignmentSections(
-                        id: UUID.string,
+                        id: assignment.assignmentGroupID ?? UUID.string,
                         title: assignment.assignmentGroupSectionName,
                         assignments: [assignment]
                     )

--- a/Core/Core/People/User.swift
+++ b/Core/Core/People/User.swift
@@ -49,7 +49,7 @@ extension User: WriteableModel {
         user.pronouns = item.pronouns
         if let enrollments = item.enrollments {
             for item in enrollments {
-                let entity: Enrollment = context.first(where: #keyPath(Enrollment.id), equals: item.id?.value) ?? context.insert() as Enrollment
+                let entity: Enrollment = context.first(where: #keyPath(Enrollment.id), equals: item.id?.value) ?? context.insert()
                 var course: Course?
                 if let courseID = item.course_id?.value {
                     course = context.first(where: #keyPath(Course.id), equals: courseID)

--- a/Core/Core/People/User.swift
+++ b/Core/Core/People/User.swift
@@ -49,12 +49,12 @@ extension User: WriteableModel {
         user.pronouns = item.pronouns
         if let enrollments = item.enrollments {
             for item in enrollments {
-                let enrollment = context.insert() as Enrollment
+                let entity: Enrollment = context.first(where: #keyPath(Enrollment.id), equals: item.id?.value) ?? context.insert() as Enrollment
                 var course: Course?
                 if let courseID = item.course_id?.value {
                     course = context.first(where: #keyPath(Course.id), equals: courseID)
                 }
-                enrollment.update(fromApiModel: item, course: course, in: context)
+                entity.update(fromApiModel: item, course: course, in: context)
             }
         }
         return user

--- a/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
+++ b/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
@@ -190,9 +190,12 @@ class GradeListInteractorLiveTests: CoreTestCase {
 
     func testGroupArrangement() {
         let assignmentGroups: [APIAssignmentGroup] = [
-            .make(id: "1", name: "Group A", assignments: [.make(id: "1")]),
-            .make(id: "2", name: "Group B", assignments: [.make(id: "2")]),
-            .make(id: "3", name: "Group C", assignments: [.make(id: "3"), .make(id: "4")]),
+            .make(id: "1", name: "Group A", assignments: [.make(assignment_group_id: "1", id: "1")]),
+            .make(id: "2", name: "Group B", assignments: [.make(assignment_group_id: "2", id: "2")]),
+            .make(id: "3", name: "Group C", assignments: [
+                .make(assignment_group_id: "3", id: "3"),
+                .make(assignment_group_id: "3", id: "4"),
+            ]),
         ]
         api.mock(GetAssignmentsByGroup(courseID: "1", gradingPeriodID: "1"), value: assignmentGroups)
         let testee = GradeListInteractorLive(courseID: "1", userID: currentSession.userID)

--- a/Core/CoreTests/People/UserTests.swift
+++ b/Core/CoreTests/People/UserTests.swift
@@ -45,12 +45,17 @@ class UserTests: CoreTestCase {
     }
 
     func testSaveDoesNotOverwriteEnrollments() {
+        let enrollment = Enrollment.make(from: .make(id: "1", user_id: "1"))
         let user = User.make(from: .make(id: "1", name: "A", enrollments: [.make(user_id: "1")]))
         let api = APIUser.make(id: "1", name: "B", enrollments: nil)
         User.save(api, in: databaseClient)
         databaseClient.refresh(user, mergeChanges: true)
+
+        let fetchedEnrollments: [Enrollment] = databaseClient.fetch()
         XCTAssertEqual(user.name, "B")
         XCTAssertEqual(user.enrollments.count, 1)
+        XCTAssertEqual(fetchedEnrollments.count, 1)
+        XCTAssertEqual(fetchedEnrollments[0].objectID, enrollment.objectID)
     }
 
     func testDisplayName() {

--- a/Student/Student/InfoPlist.xcstrings
+++ b/Student/Student/InfoPlist.xcstrings
@@ -265,6 +265,18 @@
         }
       }
     },
+    "CFBundleSpokenName" : {
+      "comment" : "Accessibility Bundle Name",
+      "extractionState" : "extracted_with_value",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Canvas Student"
+          }
+        }
+      }
+    },
     "NSCameraUsageDescription" : {
       "comment" : "Privacy - Camera Usage Description",
       "extractionState" : "extracted_with_value",


### PR DESCRIPTION
refs: MBL-17207
affects: Student
release note: Fixed an issue where visiting people screen corrupted grade information across the app in offline mode
test plan: See ticket

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet


[MBL-17205]: https://instructure.atlassian.net/browse/MBL-17205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ