### PR TITLE
Make disk info header collapse when scrolling the screen's content.

### DIFF
--- a/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -30,6 +30,8 @@ struct CourseSyncSelectorView: View {
         on: .main,
         in: .common
     ).autoconnect()
+    @State private var scrollOffset: CGFloat?
+    @State private var infoHeight: CGFloat?
 
     var body: some View {
         content
@@ -79,20 +81,41 @@ struct CourseSyncSelectorView: View {
             }
             .accessibilityElement(children: .combine)
         case .data:
-            VStack(spacing: 0) {
-                CourseSyncDiskSpaceInfoView(viewModel: diskSpaceViewModel)
-                    .padding(16)
-                Divider()
-                GeometryReader { geometry in
-                    ScrollView {
-                        if viewModel.cells.isEmpty {
-                            emptyList(geometry: geometry)
-                        } else {
-                            listCells
+            ZStack(alignment: .top) {
+                VStack(spacing: 0) {
+                    Divider()
+                    GeometryReader { geometry in
+                        ScrollView {
+                            if viewModel.cells.isEmpty {
+                                emptyList(geometry: geometry)
+                            } else {
+                                VStack(spacing: 0) {
+                                    // Applying the background to listCells that is a LazyVStack didn't work
+                                    Color.clear.frame(height: 0)
+                                        .bindTopPosition(
+                                            id: "scrollPosition",
+                                            coordinateSpaceName: "scroll",
+                                            to: $scrollOffset
+                                        )
+                                    listCells
+                                }
+                            }
                         }
+                        .coordinateSpace(name: "scroll")
+                    }
+                    syncButton
+                }
+
+                CourseSyncDiskSpaceInfoView(
+                    viewModel: diskSpaceViewModel,
+                    scrollOffset: scrollOffset ?? 0
+                )
+                .padding(16)
+                .onFrameChange(id: "infoViewHeight", coordinateSpace: .local) { newFrame in
+                    if infoHeight == nil {
+                        infoHeight = newFrame.height
                     }
                 }
-                syncButton
             }
             .confirmationAlert(
                 isPresented: $viewModel.isShowingSyncConfirmationDialog,
@@ -107,6 +130,7 @@ struct CourseSyncSelectorView: View {
 
     private var listCells: some View {
         LazyVStack(spacing: 0) {
+            Color.clear.frame(height: 0).padding(.top, infoHeight)
             ForEach(viewModel.cells) { cell in
                 let isListItem: Bool = {
                     if case let .item(item) = cell, item.cellStyle == .listItem {

--- a/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
+++ b/Core/Core/SwiftUIViews/ViewPreferences/Bounds.swift
@@ -58,6 +58,19 @@ public struct ViewBoundsKey: PreferenceKey {
     }
 }
 
+/**
+ This key allows one to save a view's frame by an ID to the preference store.
+ */
+public struct ViewFrameByID: PreferenceKey {
+    public typealias Value = [String: CGRect]
+
+    public static var defaultValue: [String: CGRect] = [:]
+
+    public static func reduce(value: inout [String: CGRect], nextValue: () -> [String: CGRect]) {
+        value.merge(nextValue(), uniquingKeysWith: { _, newValue in newValue })
+    }
+}
+
 // MARK: - Saving a Single View's Size
 
 /**

--- a/Core/Core/ViewModifiers/ViewFrameBinding.swift
+++ b/Core/Core/ViewModifiers/ViewFrameBinding.swift
@@ -1,0 +1,102 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public extension View {
+
+    func bindFrame(
+        id: String,
+        coordinateSpace: CoordinateSpace,
+        to binding: Binding<CGRect?>
+    ) -> some View {
+        self
+            .saveFrame(
+                id: id,
+                coordinateSpace: coordinateSpace
+            )
+            .onPreferenceChange(ViewFrameByID.self) { framesByIDs in
+                binding.wrappedValue = framesByIDs[id]
+            }
+    }
+
+    func bindFrame(
+        id: String,
+        coordinateSpaceName: String,
+        to binding: Binding<CGRect?>
+    ) -> some View {
+        self
+            .bindFrame(
+                id: id,
+                coordinateSpace: .named(coordinateSpaceName),
+                to: binding
+            )
+    }
+
+    func bindTopPosition(
+        id: String,
+        coordinateSpace: CoordinateSpace,
+        to binding: Binding<CGFloat?>
+    ) -> some View {
+        self
+            .saveFrame(id: id, coordinateSpace: coordinateSpace)
+            .onPreferenceChange(ViewFrameByID.self) { framesByIDs in
+                binding.wrappedValue = framesByIDs[id]?.minY
+            }
+    }
+
+    func bindTopPosition(
+        id: String,
+        coordinateSpaceName: String,
+        to binding: Binding<CGFloat?>
+    ) -> some View {
+        self
+            .bindTopPosition(
+                id: id,
+                coordinateSpace: .named(coordinateSpaceName),
+                to: binding
+            )
+    }
+
+    func onFrameChange(
+        id: String,
+        coordinateSpace: CoordinateSpace,
+        _ callback: @escaping (CGRect) -> Void
+    ) -> some View {
+        self
+            .saveFrame(id: id, coordinateSpace: coordinateSpace)
+            .onPreferenceChange(ViewFrameByID.self) { framesByIDs in
+                if let frame = framesByIDs[id] {
+                    callback(frame)
+                }
+            }
+    }
+
+    private func saveFrame(
+        id: String,
+        coordinateSpace: CoordinateSpace
+    ) -> some View {
+        self
+            .background(GeometryReader { geometry in
+                Color.clear.preference(
+                    key: ViewFrameByID.self,
+                    value: [id: geometry.frame(in: coordinateSpace)]
+                )
+            })
+    }
+}


### PR DESCRIPTION
refs: MBL-17148
affects: Student
release note: Disk space info header now collapses on the offline sync screen when scrolling.

test plan:
- Check if collapse works correctly without any glitches.
- Known issue: if dynamic text size is changed while on screen it could introduce glitches.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/163a1aa7-b2ab-4ae3-8558-c977ba37cd87" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/f93cacef-db3e-4733-9ebc-ef804ad8ceaf" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
