### PR TITLE
Change Pandata response parsing

### DIFF
--- a/Core/Core/PageViewAnalytics/PageViewEventRequestManager.swift
+++ b/Core/Core/PageViewAnalytics/PageViewEventRequestManager.swift
@@ -51,12 +51,13 @@ class PageViewEventRequestManager {
 
             let events = self.persistence.batchOfEvents(count, userID: userID)?.map { $0.apiEvent(token) } ?? []
 
-            self.env.api.makeRequest(PostPandataEventsRequest(token: token, events: events)) { (response, _, error) in
-                guard response?.lowercased() == "\"ok\"", error == nil else {
+            self.env.api.makeRequest(PostPandataEventsRequest(token: token, events: events)) { (_, _, error) in
+                guard error == nil else {
                     handler(error)
                     self.backgroundAppHelper?.endBackgroundTask(taskName: taskName)
                     return
                 }
+
                 self.persistence.dequeue(count, userID: userID, handler: {
                     handler(nil)
                     self.backgroundAppHelper?.endBackgroundTask(taskName: taskName)

--- a/Core/CoreTests/PageViewAnalytics/PageViewEventRequestManagerTests.swift
+++ b/Core/CoreTests/PageViewAnalytics/PageViewEventRequestManagerTests.swift
@@ -72,7 +72,7 @@ class PageViewEventRequestManagerTests: CoreTestCase {
         let pandataEvents = p.batchOfEvents(2, userID: userID)?.map { $0.apiEvent(tokenResponse) } ?? []
 
         // mock the send events req
-        api.mock(PostPandataEventsRequest(token: tokenResponse, events: pandataEvents), data: "\"ok\"".data(using: .utf8))
+        api.mock(PostPandataEventsRequest(token: tokenResponse, events: pandataEvents), data: "\"any kind of response body\"".data(using: .utf8))
 
         drainMainQueue()
         XCTAssertEqual(p.queueCount(for: userID), 2)


### PR DESCRIPTION
refs: [MBL-1031](https://instructure.atlassian.net/browse/MBL-17031)
affects: Student, Teacher, Parent
release note: none

## Test plan
- Enter a Course
- Background the app to send Pandata events
- Rewrite the `POST */pandata-event` response body to something different than `"OK"`
- Foreground the app, navigate to a different screen and background it again
- Verify that the events sent in the first request are not sent again in the second

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested