### PR TITLE
Change keep alive request method from GET to HEAD

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -495,10 +495,12 @@ extension CoreWebView {
             cookieKeepAliveTimer?.invalidate()
             let interval: TimeInterval = 10 * 60 // ten minutes
             cookieKeepAliveTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-                let request = GetWebSessionRequest(to: env.api.baseURL.appendingPathComponent("users/self"))
-                env.api.makeRequest(request) { data, _, _ in performUIUpdate {
+                let sessionTokenRequest = GetWebSessionRequest(to: env.api.baseURL.appendingPathComponent("users/self"))
+                env.api.makeRequest(sessionTokenRequest) { data, _, _ in performUIUpdate {
                     guard let url = data?.session_url else { return }
-                    cookieKeepAliveWebView.load(URLRequest(url: url))
+                    var keepAliveRequest = URLRequest(url: url)
+                    keepAliveRequest.httpMethod = "HEAD"
+                    cookieKeepAliveWebView.load(keepAliveRequest)
                 } }
             }
             cookieKeepAliveTimer?.fire()

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -490,12 +490,15 @@ extension CoreWebView {
     static var cookieKeepAliveWebView = CoreWebView()
 
     public static func keepCookieAlive(for env: AppEnvironment) {
-        guard env.api.loginSession?.accessToken != nil else { return }
+        guard env.api.loginSession?.accessToken != nil,
+              cookieKeepAliveTimer == nil
+        else { return }
+
         performUIUpdate {
             cookieKeepAliveTimer?.invalidate()
             let interval: TimeInterval = 10 * 60 // ten minutes
             cookieKeepAliveTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-                let sessionTokenRequest = GetWebSessionRequest(to: env.api.baseURL.appendingPathComponent("users/self"))
+                let sessionTokenRequest = GetWebSessionRequest(to: nil)
                 env.api.makeRequest(sessionTokenRequest) { data, _, _ in performUIUpdate {
                     guard let url = data?.session_url else { return }
                     var keepAliveRequest = URLRequest(url: url)

--- a/Core/CoreTests/CoreWebView/View/CoreWebViewTests.swift
+++ b/Core/CoreTests/CoreWebView/View/CoreWebViewTests.swift
@@ -204,7 +204,7 @@ class CoreWebViewTests: CoreTestCase {
 
         environment.api = API(.make(accessToken: "a"))
         let value = GetWebSessionRequest.Response(session_url: URL(string: "data:text/html,")!, requires_terms_acceptance: false)
-        api.mock(GetWebSessionRequest(to: environment.api.baseURL.appendingPathComponent("users/self")), value: value)
+        api.mock(GetWebSessionRequest(to: nil), value: value)
         CoreWebView.keepCookieAlive(for: environment)
         wait(for: [expectation(for: .all, evaluatedWith: api) { CoreWebView.cookieKeepAliveWebView.url != nil }], timeout: 10)
         XCTAssertEqual(CoreWebView.cookieKeepAliveWebView.url, URL(string: "data:text/html,"))


### PR DESCRIPTION
refs: [MBL-15465](https://instructure.atlassian.net/browse/MBL-15465)
affects: Student, Teacher, Parent
release note: none

## What's changed
- Changed keep alive request method from `GET` to `HEAD`
- Changed keep alive request path from `/users/self` to `/`
- Fixed initial request duplication

## Test plan
- Observe requests sent to `https://*.instructure.com/`
  - Make sure you are not filtering only for the given app, but for the domain
- Start the app
- Find the first `HEAD https://*.instructure.com/?session_token=...` request
  - Verify it's response code is `302`
  - Verify it's response header has `Set-Cookie` with `canvas_session`
- Verify it's followed by a `HEAD https://*.instructure.com/` request
  - Verify it's response code is `200`
  - Verify it's request header has `canvas_session` cookie matching the value set in the previous request
- Verify it doesn't cause any failing requests

[MBL-15465]: https://instructure.atlassian.net/browse/MBL-15465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ