### PR TITLE
Fixed course's associated enrollment not being fetched properly.

### DIFF
--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncGradesInteractorLiveTests.swift
@@ -87,7 +87,8 @@ class CourseSyncGradesInteractorLiveTests: CoreTestCase {
     // MARK: Course
 
     private func mockCourse() {
-        let mockEnrollment = APIEnrollment.make(enrollment_state: .active,
+        let mockEnrollment = APIEnrollment.make(id: nil,
+                                                enrollment_state: .active,
                                                 type: "StudentEnrollment",
                                                 user_id: "testUser",
                                                 current_grading_period_id: "testGradingPeriod")

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -91,12 +91,13 @@ class CourseTests: CoreTestCase {
     }
 
     func testWidgetDisplayGradeScore() {
-        let c = Course.make(from: .make(enrollments: [.make(computed_current_score: 40.05)]))
+        let c = Course.make(from: .make(enrollments: [.make(id: nil, computed_current_score: 40.05)]))
         XCTAssertEqual(c.displayGrade, "40.05%")
     }
 
     func testWidgetDisplayGradeScoreAndGrade() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             computed_current_score: 40.05,
             computed_current_grade: "F-"
         ), ]))
@@ -105,6 +106,7 @@ class CourseTests: CoreTestCase {
 
     func testWidgetDisplayGradeNoScoreWithGrade() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             computed_current_score: nil,
             computed_current_grade: "B+"
         ), ]))
@@ -113,6 +115,7 @@ class CourseTests: CoreTestCase {
 
     func testWidgetDisplayGradeNoScoreNoGrade() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             computed_current_score: nil,
             computed_current_grade: nil
         ), ]))
@@ -121,6 +124,7 @@ class CourseTests: CoreTestCase {
 
     func testWidgetDisplayGradeInCurrentMGP() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             multiple_grading_periods_enabled: true,
             current_grading_period_id: "1",
             current_period_computed_current_score: 90,
@@ -131,6 +135,7 @@ class CourseTests: CoreTestCase {
 
     func testWidgetDisplayGradeNotInCurrentMGPWithTotals() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             computed_current_score: 90,
             computed_final_score: 85,
             computed_current_grade: "A",
@@ -144,6 +149,7 @@ class CourseTests: CoreTestCase {
 
     func testWidgetDisplayGradeNotInCurrentMGPWithoutTotals() {
         let c = Course.make(from: .make(enrollments: [ .make(
+            id: nil,
             multiple_grading_periods_enabled: true,
             totals_for_all_grading_periods_option: false,
             current_grading_period_id: nil
@@ -247,7 +253,8 @@ class CourseTests: CoreTestCase {
                                                   computed_current_grade: String?,
                                                   computed_current_letter_grade: String?) -> Course {
         Course.make(from: .make(enrollments: [
-                                    .make(computed_current_score: 40.05,
+                                    .make(id: nil,
+                                          computed_current_score: 40.05,
                                           computed_current_grade: computed_current_grade,
                                           computed_current_letter_grade: computed_current_letter_grade),
                                 ],


### PR DESCRIPTION
### What happened?
- When we downloaded a course we received an enrollment with grade fields in it. This enrollment was associated with the course but it had no ID.
- When we fetched all enrollments for the user we received another enrollment object with different fields and with an ID.
- The dashboard and the grade screen's grade calculation was based on the first enrollment that had no ID but this was not specified while looking up the enrollment from the DB and it was undefined which one we receive.
- The solution was to explicitly state that we want to work with the one without ID.

refs: MBL-17205
affects: Student
release note: Fixed dashboard displaying invalid grades sometimes.

test plan:
- Sync a course for offline mode.
- Go to people page, select your profile.
- Wait until the profile loads.
- Close the app and restart it in offline mode.
- Scroll dashboard up and down, grade should stay consistent and not switch to 0.
- Go to course grades and check if displayed grade matches web.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/85cd8b4b-2627-424c-accb-68a939982c22" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/758781f7-546e-4e81-b25e-5d9b3eda924a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet
