### PR TITLE
Fix webview getting released after moving to full screen

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebViewFullScreenVideoSupport.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewFullScreenVideoSupport.swift
@@ -27,8 +27,11 @@ extension CoreWebView {
      */
     class FullScreenVideoSupport {
         private var fullScreenObservation: NSKeyValueObservation?
+        /// If no one is keeping a strong reference to the webview it will deallocate after moving to full screen.
+        private var webView: WKWebView?
         /// These are the constraints the webview had before entered fullscreen mode
         private var originalConstraints: [NSLayoutConstraint]
+        private var originalWebViewBackgroundColor: UIColor?
 
         public init(webView: WKWebView) {
             originalConstraints = (webView.superview?.constraintsAffecting(view: webView) ?? []) + webView.constraints
@@ -37,28 +40,48 @@ extension CoreWebView {
                 return
             }
 
-            let matchFullScreenContainerSize: (WKWebView, [NSLayoutConstraint]) -> Void = { webView, constraints in
-                constraints.forEach { $0.isActive = false }
-                webView.translatesAutoresizingMaskIntoConstraints = true
-                webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-                webView.frame = webView.superview?.frame ?? .zero
-            }
-            let restoreOriginalConstraints: (WKWebView, [NSLayoutConstraint]) -> Void = { webView, constraints in
-                webView.translatesAutoresizingMaskIntoConstraints = false
-                constraints.forEach { $0.isActive = true }
-                webView.superview?.layoutIfNeeded()
-            }
-            fullScreenObservation = webView.observe(\.fullscreenState, options: []) { [originalConstraints] webView, _  in
+            fullScreenObservation = webView.observe(\.fullscreenState, options: []) { [weak self] webView, _  in
+                guard let self else { return }
+
                 switch webView.fullscreenState {
                 case .enteringFullscreen:
-                    matchFullScreenContainerSize(webView, originalConstraints)
-                    // This is to make a11y elements below the fullscreen window hidden.
-                    webView.superview?.accessibilityViewIsModal = true
+                    matchFullScreenContainerSize(webView)
+                    hideA11yElementsBelowFullscreenWindow(webView)
+                    setupDarkBackground(webView)
+                    self.webView = webView
                 case .notInFullscreen:
-                    restoreOriginalConstraints(webView, originalConstraints)
+                    restoreOriginalConstraints(webView)
+                    restoreBackground(webView)
+                    self.webView = nil
                 default: break
                 }
             }
+        }
+
+        private func matchFullScreenContainerSize(_ webView: WKWebView) {
+            originalConstraints.forEach { $0.isActive = false }
+            webView.translatesAutoresizingMaskIntoConstraints = true
+            webView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+            webView.frame = webView.superview?.frame ?? .zero
+        }
+
+        private func hideA11yElementsBelowFullscreenWindow(_ webView: WKWebView) {
+            webView.superview?.accessibilityViewIsModal = true
+        }
+
+        private func setupDarkBackground(_ webView: WKWebView) {
+            originalWebViewBackgroundColor = webView.backgroundColor
+            webView.backgroundColor = .black
+        }
+
+        private func restoreOriginalConstraints(_ webView: WKWebView) {
+            webView.translatesAutoresizingMaskIntoConstraints = false
+            originalConstraints.forEach { $0.isActive = true }
+            webView.superview?.layoutIfNeeded()
+        }
+
+        private func restoreBackground(_ webView: WKWebView) {
+            webView.backgroundColor = originalWebViewBackgroundColor
         }
     }
 }

--- a/Core/CoreTests/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
+++ b/Core/CoreTests/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
@@ -26,6 +26,7 @@ class CoreWebViewFullScreenVideoSupportTests: XCTestCase {
     func testEnterFullScreenMode() {
         let host = UIView(frame: .init(origin: .zero, size: .init(width: 123, height: 321)))
         let webView = MockWebView()
+        webView.backgroundColor = .purple
         host.addSubview(webView)
         webView.pinWithThemeSwitchButton(
             inside: host,
@@ -43,6 +44,7 @@ class CoreWebViewFullScreenVideoSupportTests: XCTestCase {
         XCTAssertTrue(webView.translatesAutoresizingMaskIntoConstraints)
         XCTAssertEqual(webView.autoresizingMask, [.flexibleWidth, .flexibleHeight])
         XCTAssertEqual(webView.frame, host.frame)
+        XCTAssertEqual(webView.backgroundColor, .black)
 
         // WHEN
         constraint.isActive = false
@@ -51,6 +53,7 @@ class CoreWebViewFullScreenVideoSupportTests: XCTestCase {
         // THEN
         XCTAssertFalse(webView.translatesAutoresizingMaskIntoConstraints)
         XCTAssertTrue(constraint.isActive)
+        XCTAssertEqual(webView.backgroundColor, .purple)
     }
 }
 


### PR DESCRIPTION
### What happened?
- When moving a html video to full screen hosted from a webview embedded inside SwiftUI the webview got deallocated after moving to full screen.
- I solved this by keeping a strong reference (effectively a retain cycle) to the webview from the full screen handler until the webview is in fullscreen mode and release it after it exits.
- There might be animation / display glitches, like a white border during fullscreen playback. I couldn't get rid of them. Also the touch areas seem to be off sometimes in full screen.

refs: MBL-17645
affects: Student, Teacher
release note: Fixed full screen video playback in announcements and discussions not working.

test plan:
- Embed a studio video inside a discussion.
- Turn on new discussion feature flag.
- Go to the discussion inside the app and move the video to full screen.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/1251d0be-1901-42ea-9ef3-853fef0eb36e" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/72396990/aef18b04-f3c9-4f41-93a6-2eba7f5d2adf" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
