### PR TITLE
Clear failed offline progress upon dismissing dashboard notification

### DIFF
--- a/Core/Core/Dashboard/OfflineSync/DashboardOfflineSyncProgressCardAssembly.swift
+++ b/Core/Core/Dashboard/OfflineSync/DashboardOfflineSyncProgressCardAssembly.swift
@@ -25,17 +25,28 @@ public enum DashboardOfflineSyncProgressCardAssembly {
                               router: Router = AppEnvironment.shared.router)
     -> DashboardOfflineSyncProgressCardViewModel {
         let offlineModeInteractor = OfflineModeAssembly.make()
-        let interactor = CourseSyncProgressObserverInteractorLive(container: container)
-        return DashboardOfflineSyncProgressCardViewModel(interactor: interactor, offlineModeInteractor: offlineModeInteractor, router: router)
+        let progressObserverInteractor = CourseSyncProgressObserverInteractorLive(container: container)
+        let progressWriterInteractor = CourseSyncProgressWriterInteractorLive(container: container)
+        return DashboardOfflineSyncProgressCardViewModel(
+            progressObserverInteractor: progressObserverInteractor,
+            progressWriterInteractor: progressWriterInteractor,
+            offlineModeInteractor: offlineModeInteractor,
+            router: router
+        )
     }
 
 #if DEBUG
 
     static func makePreview() -> some View {
         let offlineModeInteractor = OfflineModeAssembly.make()
-        let interactor = DashboardOfflineSyncInteractorPreview()
-        let viewModel = DashboardOfflineSyncProgressCardViewModel(interactor: interactor, offlineModeInteractor: offlineModeInteractor,
-                                                                  router: AppEnvironment.shared.router)
+        let progressObserverInteractor = DashboardOfflineSyncInteractorPreview()
+        let progressWriterInteractor = DashboardOfflineSyncProgressWriterInteractorPreview()
+        let viewModel = DashboardOfflineSyncProgressCardViewModel(
+            progressObserverInteractor: progressObserverInteractor,
+            progressWriterInteractor: progressWriterInteractor,
+            offlineModeInteractor: offlineModeInteractor,
+            router: AppEnvironment.shared.router
+        )
         return DashboardOfflineSyncProgressCardView(viewModel: viewModel)
     }
 

--- a/Core/Core/Dashboard/OfflineSync/Model/DashboardOfflineSyncInteractorPreview.swift
+++ b/Core/Core/Dashboard/OfflineSync/Model/DashboardOfflineSyncInteractorPreview.swift
@@ -46,6 +46,7 @@ class DashboardOfflineSyncInteractorPreview: CourseSyncProgressObserverInteracto
     }
 }
 
+// swiftlint:disable:next type_name
 class DashboardOfflineSyncProgressWriterInteractorPreview: CourseSyncProgressWriterInteractor {
     func saveDownloadProgress(entries _: [CourseSyncEntry]) {}
 

--- a/Core/Core/Dashboard/OfflineSync/Model/DashboardOfflineSyncInteractorPreview.swift
+++ b/Core/Core/Dashboard/OfflineSync/Model/DashboardOfflineSyncInteractorPreview.swift
@@ -46,4 +46,18 @@ class DashboardOfflineSyncInteractorPreview: CourseSyncProgressObserverInteracto
     }
 }
 
+class DashboardOfflineSyncProgressWriterInteractorPreview: CourseSyncProgressWriterInteractor {
+    func saveDownloadProgress(entries _: [CourseSyncEntry]) {}
+
+    func saveDownloadResult(isFinished _: Bool, error _: String?) {}
+
+    func cleanUpPreviousDownloadProgress() {}
+
+    func markInProgressDownloadsAsFailed() {}
+
+    func setInitialLoadingState(entries _: [CourseSyncEntry]) {}
+
+    func saveStateProgress(id _: String, selection _: CourseEntrySelection, state _: CourseSyncEntry.State) {}
+}
+
 #endif

--- a/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
+++ b/Core/Core/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModel.swift
@@ -158,7 +158,7 @@ class DashboardOfflineSyncProgressCardViewModel: ObservableObject {
 
     private func handleDismissTap(_ interactor: CourseSyncProgressWriterInteractor) {
         dismissDidTap
-            .map { _ in interactor.cleanUpPreviousDownloadProgress() } 
+            .map { _ in interactor.cleanUpPreviousDownloadProgress() }
             .map { .hidden }
             .assign(to: &$state)
     }

--- a/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
+++ b/Core/CoreTests/Dashboard/OfflineSync/ViewModel/DashboardOfflineSyncProgressCardViewModelTests.swift
@@ -27,7 +27,8 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
@@ -47,7 +48,8 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
@@ -108,7 +110,8 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
@@ -130,7 +133,8 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         let testScheduler: TestSchedulerOf<DispatchQueue> = DispatchQueue.test
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient,
                                                                       progressToReport: 1)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: testScheduler.eraseToAnyScheduler())
@@ -158,7 +162,8 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient,
                                                                       progressToReport: 1)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
@@ -187,7 +192,10 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - GIVEN
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let expectation = expectation(description: "Function is called.")
+        let mockWriterInteractor = CourseSyncProgressWriterInteractorMock(expectation: expectation)
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: mockWriterInteractor,
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router,
                                                                scheduler: .immediate)
@@ -204,13 +212,15 @@ class DashboardOfflineSyncProgressCardViewModelTests: CoreTestCase {
         // MARK: - THEN
 
         XCTAssertTrue(testee.state.isHidden)
+        waitForExpectations(timeout: 0.1)
     }
 
     func testCardTapRoutesToProgressView() {
         // MARK: - GIVEN
 
         let mockInteractor = CourseSyncProgressObserverInteractorMock(context: databaseClient)
-        let testee = DashboardOfflineSyncProgressCardViewModel(interactor: mockInteractor,
+        let testee = DashboardOfflineSyncProgressCardViewModel(progressObserverInteractor: mockInteractor,
+                                                               progressWriterInteractor: CourseSyncProgressWriterInteractorMock(),
                                                                offlineModeInteractor: MockOfflineModeInteractorEnabled(),
                                                                router: router)
         let source = UIViewController()
@@ -299,6 +309,28 @@ private class CourseSyncProgressObserverInteractorMock: CourseSyncProgressObserv
     func mockStateProgress() {
         stateProgressPublisher.send(stateProgressMock)
     }
+}
+
+class CourseSyncProgressWriterInteractorMock: CourseSyncProgressWriterInteractor {
+    let expectation: XCTestExpectation?
+
+    init(expectation: XCTestExpectation? = nil) {
+        self.expectation = expectation
+    }
+
+    func saveDownloadProgress(entries _: [CourseSyncEntry]) {}
+
+    func saveDownloadResult(isFinished _: Bool, error _: String?) {}
+
+    func cleanUpPreviousDownloadProgress() {
+        expectation?.fulfill()
+    }
+
+    func markInProgressDownloadsAsFailed() {}
+
+    func setInitialLoadingState(entries _: [CourseSyncEntry]) {}
+
+    func saveStateProgress(id _: String, selection _: CourseEntrySelection, state _: CourseSyncEntry.State) {}
 }
 
 private class MockOfflineModeInteractorEnabled: OfflineModeInteractor {


### PR DESCRIPTION
refs: MBL-17224
affects: Student
release note: Failed offline sync banner on the dashboard won't reappear after closing it.
test plan: See ticket

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
