### PR TITLE
Exhaust all courses and groups for calendar filter

### DIFF
--- a/Core/Core/InstUI/Views/Cells/CheckboxCell.swift
+++ b/Core/Core/InstUI/Views/Cells/CheckboxCell.swift
@@ -52,7 +52,6 @@ extension InstUI {
                                    alignment: .leading)
                     }
                     .paddingStyle(set: .iconCell)
-
                 }
                 InstUI.Divider()
             }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
@@ -58,7 +58,7 @@ class GetCalendarFilters: UseCase {
             includes: []
         )
         let coursesFetch = environment.api
-            .makeRequest(coursesRequest)
+            .exhaust(coursesRequest)
             .map { [filterUnpublishedCourses] in
                 let courses = $0.body
 
@@ -70,7 +70,7 @@ class GetCalendarFilters: UseCase {
             }
 
         let groupsRequest = GetGroupsRequest(context: .currentUser)
-        let groupsFetch = environment.api.makeRequest(groupsRequest)
+        let groupsFetch = environment.api.exhaust(groupsRequest)
 
         Publishers
             .CombineLatest(coursesFetch, groupsFetch)

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
@@ -56,7 +56,7 @@ class GetParentCalendarFilters: UseCase {
             perPage: 100
         )
         let coursesFetch = environment.api
-            .makeRequest(coursesRequest)
+            .exhaust(coursesRequest)
             .map { [observedUserId] in
                 let courses = $0.body.filter {
                     $0.enrollments?.contains { $0.associated_user_id?.value == observedUserId } == true
@@ -65,7 +65,7 @@ class GetParentCalendarFilters: UseCase {
             }
 
         let groupsRequest = GetGroupsRequest(context: .currentUser)
-        let groupsFetch = environment.api.makeRequest(groupsRequest)
+        let groupsFetch = environment.api.exhaust(groupsRequest)
 
         Publishers
             .CombineLatest(coursesFetch, groupsFetch)


### PR DESCRIPTION
refs: MBL-17669
affects: Student, Parent
release note: Fixed not all courses and groups appearing in the calendar filter.

test plan: See ticket for test account.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet
