### PR TITLE
Calendar Delete ToDo

### DIFF
--- a/Core/Core/InstUI/Views/Cells/CheckboxCell.swift
+++ b/Core/Core/InstUI/Views/Cells/CheckboxCell.swift
@@ -23,12 +23,12 @@ extension InstUI {
     public struct CheckboxCell: View {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-        private let name: String
+        private let title: String
         @Binding private var isSelected: Bool
         private let color: Color
 
-        public init(name: String, isSelected: Binding<Bool>, color: Color) {
-            self.name = name
+        public init(title: String, isSelected: Binding<Bool>, color: Color) {
+            self.title = title
             self._isSelected = isSelected
             self.color = color
         }
@@ -44,7 +44,7 @@ extension InstUI {
                             color: color
                         )
                         .animation(.default, value: isSelected)
-                        Text(name)
+                        Text(title)
                             .font(.regular16, lineHeight: .fit)
                             .multilineTextAlignment(.leading)
                             .foregroundStyle(Color.textDarkest)
@@ -57,7 +57,7 @@ extension InstUI {
             }
             .accessibilityRepresentation {
                 Toggle(isOn: $isSelected) {
-                    Text(name)
+                    Text(title)
                 }
             }
         }
@@ -71,7 +71,7 @@ private struct Container: View {
 
     var body: some View {
         InstUI.CheckboxCell(
-            name: "Checkbox here",
+            title: "Checkbox here",
             isSelected: $isSelected,
             color: .orange
         )

--- a/Core/Core/InstUI/Views/Cells/RadioButtonCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RadioButtonCell.swift
@@ -23,7 +23,7 @@ extension InstUI {
     public struct RadioButtonCell<Value: Equatable>: View {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
         @Binding private var selectedValue: Value?
-        private let name: String
+        private let title: String
         private let value: Value
         private let color: Color
 
@@ -31,12 +31,12 @@ extension InstUI {
         ///   - value: The value represented by this cell that will be passed to the `selectedValue` binding upon tap.
         ///   - selectedValue: This binding holds the currently selected value belonging to the radio button group. The value is equatable so this cell can decide when to display the selected state.
         public init(
-            name: String,
+            title: String,
             value: Value,
             selectedValue: Binding<Value?>,
             color: Color
         ) {
-            self.name = name
+            self.title = title
             self.value = value
             self._selectedValue = selectedValue
             self.color = color
@@ -53,7 +53,7 @@ extension InstUI {
                             color: color
                         )
                         .animation(.default, value: selectedValue)
-                        Text(name)
+                        Text(title)
                             .font(.regular16, lineHeight: .fit)
                             .multilineTextAlignment(.leading)
                             .foregroundStyle(Color.textDarkest)
@@ -73,7 +73,7 @@ extension InstUI {
                 }
 
                 Toggle(isOn: binding) {
-                    Text(name)
+                    Text(title)
                 }
             }
         }
@@ -88,13 +88,13 @@ private struct Container: View {
     var body: some View {
         VStack(spacing: 0) {
             InstUI.RadioButtonCell(
-                name: "Value 1",
+                title: "Value 1",
                 value: 1,
                 selectedValue: $selectedValue,
                 color: .orange
             )
             InstUI.RadioButtonCell(
-                name: "Value 2",
+                title: "Value 2",
                 value: 2,
                 selectedValue: $selectedValue,
                 color: .red

--- a/Core/Core/InstUI/Views/DisclosureIndicator.swift
+++ b/Core/Core/InstUI/Views/DisclosureIndicator.swift
@@ -41,25 +41,25 @@ extension InstUI {
 #Preview {
     VStack(spacing: 0) {
         InstUI.Divider()
-        Cell(label: "InstUI: arrowOpenRightLine") { InstUI.DisclosureIndicator() }
-        Cell(label: "Legacy: arrowOpenRightSolid") { Core.InstDisclosureIndicator() }
-        Cell(label: "Legacy: iOS chevron.right") { Core.DisclosureIndicator() }
+        Cell(title: "InstUI: arrowOpenRightLine") { InstUI.DisclosureIndicator() }
+        Cell(title: "Legacy: arrowOpenRightSolid") { Core.InstDisclosureIndicator() }
+        Cell(title: "Legacy: iOS chevron.right") { Core.DisclosureIndicator() }
     }
 }
 
 private struct Cell<Content: View>: View {
-    private let label: String
+    private let title: String
     @ViewBuilder private let disclosure: Content
 
-    init(label: String, @ViewBuilder disclosure: () -> Content) {
-        self.label = label
+    init(title: String, @ViewBuilder disclosure: () -> Content) {
+        self.title = title
         self.disclosure = disclosure()
     }
 
     var body: some View {
         VStack(spacing: 0) {
             HStack(spacing: 0) {
-                Text(label).textStyle(.cellLabel)
+                Text(title).textStyle(.cellLabel)
                 Text(verbatim: "Some value").textStyle(.cellValue)
                     .frame(maxWidth: .infinity, alignment: .trailing)
                 disclosure

--- a/Core/Core/InstUI/Views/ListSectionHeader.swift
+++ b/Core/Core/InstUI/Views/ListSectionHeader.swift
@@ -23,17 +23,17 @@ extension InstUI {
     public struct ListSectionHeader: View {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
-        private let name: String?
+        private let title: String?
 
-        public init(name: String?) {
-            self.name = name
+        public init(title: String?) {
+            self.title = title
         }
 
         @ViewBuilder
         public var body: some View {
-            if let name {
+            if let title {
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(name)
+                    Text(title)
                         .font(.semibold14)
                         .foregroundStyle(Color.textDark)
                         .paddingStyle(.all, .standard)
@@ -52,7 +52,7 @@ extension InstUI {
 #if DEBUG
 
 #Preview {
-    InstUI.ListSectionHeader(name: "Section Header Cell")
+    InstUI.ListSectionHeader(title: "Section Header Cell")
 }
 
 #endif

--- a/Core/Core/InstUI/Views/MenuItem.swift
+++ b/Core/Core/InstUI/Views/MenuItem.swift
@@ -1,0 +1,85 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension InstUI {
+
+    public struct MenuItem: View {
+        @ScaledMetric private var uiScale: CGFloat = 1
+
+        private let label: String
+        private let image: Image?
+        private let action: () -> Void
+
+        public init(
+            label: String,
+            image: Image?,
+            action: @escaping () -> Void
+        ) {
+            self.label = label
+            self.image = image
+            self.action = action
+        }
+
+        public var body: some View {
+            Button(
+                action: action,
+                label: {
+                    HStack {
+                        Text(label)
+                            .font(.regular16, lineHeight: .fit)
+                        Spacer()
+                        image?
+                            .size(uiScale.iconScale * 24)
+                    }
+                    .foregroundStyle(Color.textDarkest)
+                }
+            )
+        }
+    }
+}
+
+extension InstUI.MenuItem {
+    public static func edit(action: @escaping () -> Void) -> Self {
+        .init(label: String(localized: "Edit", bundle: .core), image: .editLine, action: action)
+    }
+
+    public static func delete(action: @escaping () -> Void) -> Self {
+        .init(label: String(localized: "Delete", bundle: .core), image: .trashLine, action: action)
+    }
+}
+
+#if DEBUG
+
+#Preview {
+    Menu(
+        content: {
+            InstUI.MenuItem(label: "Text Only", image: nil) { }
+            InstUI.MenuItem(label: "Publish", image: .completeLine) { }
+            InstUI.MenuItem(label: "Unpublish", image: .noLine) { }
+            InstUI.MenuItem.edit { }
+            InstUI.MenuItem.delete { }
+        },
+        label: {
+            Text(verbatim: "Menu")
+        }
+    )
+}
+
+#endif

--- a/Core/Core/InstUI/Views/MenuItem.swift
+++ b/Core/Core/InstUI/Views/MenuItem.swift
@@ -20,19 +20,20 @@ import SwiftUI
 
 extension InstUI {
 
+    /// `MenuItem` is to be used in `SwiftUI.Menu` content. It is a pre-styled `Button` with a `title` and an optional `image` as it's label.
     public struct MenuItem: View {
         @ScaledMetric private var uiScale: CGFloat = 1
 
-        private let label: String
+        private let title: String
         private let image: Image?
         private let action: () -> Void
 
         public init(
-            label: String,
+            title: String,
             image: Image?,
             action: @escaping () -> Void
         ) {
-            self.label = label
+            self.title = title
             self.image = image
             self.action = action
         }
@@ -42,7 +43,7 @@ extension InstUI {
                 action: action,
                 label: {
                     HStack {
-                        Text(label)
+                        Text(title)
                             .font(.regular16, lineHeight: .fit)
                         Spacer()
                         image?
@@ -57,11 +58,11 @@ extension InstUI {
 
 extension InstUI.MenuItem {
     public static func edit(action: @escaping () -> Void) -> Self {
-        .init(label: String(localized: "Edit", bundle: .core), image: .editLine, action: action)
+        .init(title: String(localized: "Edit", bundle: .core), image: .editLine, action: action)
     }
 
     public static func delete(action: @escaping () -> Void) -> Self {
-        .init(label: String(localized: "Delete", bundle: .core), image: .trashLine, action: action)
+        .init(title: String(localized: "Delete", bundle: .core), image: .trashLine, action: action)
     }
 }
 
@@ -70,9 +71,9 @@ extension InstUI.MenuItem {
 #Preview {
     Menu(
         content: {
-            InstUI.MenuItem(label: "Text Only", image: nil) { }
-            InstUI.MenuItem(label: "Publish", image: .completeLine) { }
-            InstUI.MenuItem(label: "Unpublish", image: .noLine) { }
+            InstUI.MenuItem(title: "Text Only", image: nil) { }
+            InstUI.MenuItem(title: "Publish", image: .completeLine) { }
+            InstUI.MenuItem(title: "Unpublish", image: .noLine) { }
             InstUI.MenuItem.edit { }
             InstUI.MenuItem.delete { }
         },

--- a/Core/Core/InstUI/Views/NavigationBarButton.swift
+++ b/Core/Core/InstUI/Views/NavigationBarButton.swift
@@ -85,12 +85,12 @@ extension InstUI {
 }
 
 extension InstUI.NavigationBarButton {
-    /// Button with string label.
+    /// Button with text label.
     public init(
         isBackgroundContextColor: Bool = false,
         isEnabled isEnabledOverride: Bool? = nil,
         isAvailableOffline: Bool = true,
-        label: String,
+        title: String,
         action: @escaping () -> Void
     ) {
         self.init(
@@ -99,7 +99,7 @@ extension InstUI.NavigationBarButton {
             isAvailableOffline: isAvailableOffline,
             action: action
         ) {
-            AnyView(Text(label).font(.regular16, lineHeight: .fit))
+            AnyView(Text(title).font(.regular16, lineHeight: .fit))
         }
     }
 
@@ -122,12 +122,12 @@ extension InstUI.NavigationBarButton {
         }
     }
 
-    /// Menu with string label.
+    /// Menu with text label.
     public init<MenuContent: View>(
         isBackgroundContextColor: Bool = false,
         isEnabled isEnabledOverride: Bool? = nil,
         isAvailableOffline: Bool = true,
-        label: String,
+        title: String,
         @ViewBuilder menuContent: () -> MenuContent
     ) {
         self.init(
@@ -137,7 +137,7 @@ extension InstUI.NavigationBarButton {
             action: {},
             menuContent: AnyView(menuContent())
         ) {
-            AnyView(Text(label).font(.regular16, lineHeight: .fit))
+            AnyView(Text(title).font(.regular16, lineHeight: .fit))
         }
     }
 
@@ -174,7 +174,7 @@ extension InstUI.NavigationBarButton {
             isBackgroundContextColor: isBackgroundContextColor,
             isEnabled: isEnabledOverride,
             isAvailableOffline: isAvailableOffline,
-            label: String(localized: "Cancel", bundle: .core),
+            title: String(localized: "Cancel", bundle: .core),
             action: action
         )
     }
@@ -189,7 +189,7 @@ extension InstUI.NavigationBarButton {
             isBackgroundContextColor: isBackgroundContextColor,
             isEnabled: isEnabledOverride,
             isAvailableOffline: isAvailableOffline,
-            label: String(localized: "Done", bundle: .core),
+            title: String(localized: "Done", bundle: .core),
             action: action
         )
     }
@@ -204,7 +204,7 @@ extension InstUI.NavigationBarButton {
             isBackgroundContextColor: isBackgroundContextColor,
             isEnabled: isEnabledOverride,
             isAvailableOffline: isAvailableOffline,
-            label: String(localized: "Add", bundle: .core),
+            title: String(localized: "Add", bundle: .core),
             action: action
         )
     }
@@ -219,7 +219,7 @@ extension InstUI.NavigationBarButton {
             isBackgroundContextColor: isBackgroundContextColor,
             isEnabled: isEnabledOverride,
             isAvailableOffline: isAvailableOffline,
-            label: String(localized: "Save", bundle: .core),
+            title: String(localized: "Save", bundle: .core),
             action: action
         )
     }
@@ -252,9 +252,9 @@ private func previewsFactory(isContextBackground: Bool) -> some View {
 
         InstUI.NavigationBarButton.add(isBackgroundContextColor: isContextBackground, isEnabled: false) { }
 
-        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: true, label: "Enabled button") { }
+        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: true, title: "Enabled button") { }
 
-        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: false, label: "Disabled button") { }
+        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: false, title: "Disabled button") { }
             .disabled(false)
 
         InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: true, image: .settingsLine, accessibilityLabel: "Settings") { }

--- a/Core/Core/InstUI/Views/NavigationBarButton.swift
+++ b/Core/Core/InstUI/Views/NavigationBarButton.swift
@@ -69,6 +69,7 @@ extension InstUI {
             isEnabled isEnabledOverride: Bool? = nil,
             isAvailableOffline: Bool = true,
             image: Image,
+            accessibilityLabel: String,
             action: @escaping () -> Void
         ) {
             self.init(
@@ -77,7 +78,7 @@ extension InstUI {
                 isAvailableOffline: isAvailableOffline,
                 action: action
             ) {
-                AnyView(image)
+                AnyView(image.accessibilityLabel(accessibilityLabel))
             }
         }
 
@@ -185,7 +186,7 @@ private func previewsFactory(isContextBackground: Bool) -> some View {
         InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: false, label: "Disabled button") { }
             .disabled(false)
 
-        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: true, image: .settingsLine) { }
+        InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: true, image: .settingsLine, accessibilityLabel: "Settings") { }
 
         InstUI.NavigationBarButton(isBackgroundContextColor: isContextBackground, isEnabled: false, action: {}) {
             AnyView(Image.settingsLine)

--- a/Core/Core/LTI/EmbeddedExternalTools.swift
+++ b/Core/Core/LTI/EmbeddedExternalTools.swift
@@ -22,8 +22,7 @@ import SafariServices
  This helper opens LTI launch urls that are not Canvas LTI launch urls in Safari.
  */
 enum EmbeddedExternalTools {
-    private static let externalToolChecks: [(URL) -> Bool] = [
-        {
+    private static let externalToolChecks: [(URL) -> Bool] = [ {
             $0.host?.contains("sharepoint.com") == true &&
             $0.path.contains("embed")
         }

--- a/Core/Core/Offline/View/OfflineObservingMenu.swift
+++ b/Core/Core/Offline/View/OfflineObservingMenu.swift
@@ -18,32 +18,32 @@
 
 import SwiftUI
 
-public struct OfflineObservingButton<Label: View>: View {
+public struct OfflineObservingMenu<Content: View, Label: View>: View {
 
     @StateObject private var viewModel = OfflineModeAssembly.makeViewModel()
 
-    private let action: () -> Void
+    private let content: () -> Content
     private let label: () -> Label
 
     public init(
-        action: @escaping () -> Void,
+        @ViewBuilder content: @escaping () -> Content,
         @ViewBuilder label: @escaping () -> Label
     ) {
-        self.action = action
+        self.content = content
         self.label = label
     }
 
     public var body: some View {
-        Button(
-            action: {
-                if viewModel.isOffline {
+        if viewModel.isOffline {
+            Button(
+                action: {
                     UIAlertController.showItemNotAvailableInOfflineAlert()
-                } else {
-                    action()
-                }
-            },
-            label: label
-        )
-        .opacity(viewModel.isOffline ? UIButton.DisabledInOfflineAlpha : 1.0)
+                },
+                label: label
+            )
+            .opacity(UIButton.DisabledInOfflineAlpha)
+        } else {
+            Menu(content: content, label: label)
+        }
     }
 }

--- a/Core/Core/Planner/CalendarFilter/View/CalendarFilterScreen.swift
+++ b/Core/Core/Planner/CalendarFilter/View/CalendarFilterScreen.swift
@@ -102,7 +102,7 @@ public struct CalendarFilterScreen: View, ScreenViewTrackable {
     private var userFilter: some View {
         if let filter = viewModel.userFilter {
             InstUI.CheckboxCell(
-                name: filter.name,
+                title: filter.name,
                 isSelected: selectionBinding(context: filter.context),
                 color: filter.color
             )
@@ -115,13 +115,13 @@ public struct CalendarFilterScreen: View, ScreenViewTrackable {
             Section {
                 ForEach(viewModel.courseFilters) { filter in
                     InstUI.CheckboxCell(
-                        name: filter.name,
+                        title: filter.name,
                         isSelected: selectionBinding(context: filter.context),
                         color: filter.color
                     )
                 }
             } header: {
-                InstUI.ListSectionHeader(name: String(localized: "Courses", bundle: .core))
+                InstUI.ListSectionHeader(title: String(localized: "Courses", bundle: .core))
             }
         }
     }
@@ -132,13 +132,13 @@ public struct CalendarFilterScreen: View, ScreenViewTrackable {
             Section {
                 ForEach(viewModel.groupFilters) { filter in
                     InstUI.CheckboxCell(
-                        name: filter.name,
+                        title: filter.name,
                         isSelected: selectionBinding(context: filter.context),
                         color: filter.color
                     )
                 }
             } header: {
-                InstUI.ListSectionHeader(name: String(localized: "Groups", bundle: .core))
+                InstUI.ListSectionHeader(title: String(localized: "Groups", bundle: .core))
             }
         }
     }

--- a/Core/Core/Planner/CalendarSelector/View/SelectCalendarScreen.swift
+++ b/Core/Core/Planner/CalendarSelector/View/SelectCalendarScreen.swift
@@ -37,7 +37,7 @@ struct SelectCalendarScreen: View {
                                 itemCell(with: item)
                             }
                         } header: {
-                            InstUI.ListSectionHeader(name: section.title)
+                            InstUI.ListSectionHeader(title: section.title)
                         }
                     }
                 }
@@ -48,7 +48,7 @@ struct SelectCalendarScreen: View {
 
     private func itemCell(with item: CDCalendarFilterEntry) -> some View {
         InstUI.RadioButtonCell(
-            name: item.name,
+            title: item.name,
             value: item,
             selectedValue: $viewModel.selectedCalendar,
             color: item.color

--- a/Core/Core/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequest.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequest.swift
@@ -1,0 +1,29 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+// https://canvas.instructure.com/doc/api/planner.html#method.planner_notes.destroy
+struct DeletePlannerNoteRequest: APIRequestable {
+    typealias Response = APIPlannerNote
+
+    let method: APIMethod = .delete
+    var path: String { "planner_notes/\(id)" }
+
+    let id: String
+}

--- a/Core/Core/Planner/CalendarToDo/Model/CalendarToDoInteractor.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/CalendarToDoInteractor.swift
@@ -35,6 +35,8 @@ public protocol CalendarToDoInteractor: AnyObject {
         calendar: CDCalendarFilterEntry?,
         details: String?
     ) -> AnyPublisher<Void, Error>
+
+    func deleteToDo(id: String) -> AnyPublisher<Void, Error>
 }
 
 final class CalendarToDoInteractorLive: CalendarToDoInteractor {
@@ -82,6 +84,14 @@ final class CalendarToDoInteractorLive: CalendarToDoInteractor {
             courseID: calendar?.context.courseId,
             courseName: calendar?.courseName
         )
+        return ReactiveStore(useCase: useCase)
+            .getEntities()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    func deleteToDo(id: String) -> AnyPublisher<Void, Error> {
+        let useCase = DeletePlannerNote(id: id)
         return ReactiveStore(useCase: useCase)
             .getEntities()
             .mapToVoid()

--- a/Core/Core/Planner/CalendarToDo/Model/CalendarToDoInteractorPreview.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/CalendarToDoInteractorPreview.swift
@@ -80,6 +80,21 @@ final class CalendarToDoInteractorPreview: CalendarToDoInteractor {
             return Empty().eraseToAnyPublisher()
         }
     }
+
+    var deleteToDoCallsCount: Int = 0
+    var deleteToDoInput: String?
+    var deleteToDoResult: Result<Void, Error>? = .success
+
+    func deleteToDo(id: String) -> AnyPublisher<Void, Error> {
+        deleteToDoCallsCount += 1
+        deleteToDoInput = id
+
+        if let deleteToDoResult {
+            return deleteToDoResult.publisher.eraseToAnyPublisher()
+        } else {
+            return Empty().eraseToAnyPublisher()
+        }
+    }
 }
 
 #endif

--- a/Core/Core/Planner/CalendarToDo/Model/UseCase/DeletePlannerNote.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/UseCase/DeletePlannerNote.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import CoreData
+
+final class DeletePlannerNote: DeleteUseCase {
+    typealias Model = Plannable
+
+    var request: DeletePlannerNoteRequest { .init(id: id) }
+    let cacheKey: String? = nil
+    var scope: Scope { .where(#keyPath(Plannable.id), equals: id) }
+
+    private let id: String
+
+    init(id: String) {
+        self.id = id
+    }
+}

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -33,14 +33,13 @@ public struct CalendarToDoDetailsScreen: View {
         }
         .navigationTitle(viewModel.navigationTitle)
         .navBarItems(
-            trailing: .init(
+            trailing: .moreIcon(
                 isBackgroundContextColor: true,
                 isEnabled: viewModel.isMoreButtonEnabled,
                 isAvailableOffline: false,
-                image: .moreLine,
-                accessibilityLabel: String(localized: "More", bundle: .core),
-                action: {
-                    viewModel.didTapDelete.send(controller)
+                menuContent: {
+                    InstUI.MenuItem.edit { viewModel.didTapEdit.send(controller) }
+                    InstUI.MenuItem.delete { viewModel.didTapDelete.send(controller) }
                 }
             )
         )

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -40,6 +40,16 @@ public struct CalendarToDoDetailsScreen: View {
             viewModel.showEditScreen(env: env, from: controller)
         })
         .navigationBarStyle(.color(viewModel.navBarColor))
+        .errorAlert(
+            isPresented: $viewModel.shouldShowDeleteError,
+            presenting: .init(
+                title: String(localized: "Delete Unsuccessful!", bundle: .core),
+                message: String(localized: "Your To Do was not deleted, you can try it again.", bundle: .core),
+                buttonTitle: String(localized: "OK", bundle: .core)
+            )
+        ) {
+            viewModel.shouldShowDeleteError = false
+        }
     }
 
     @ViewBuilder

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -35,7 +35,8 @@ public struct CalendarToDoDetailsScreen: View {
         .navBarItems(trailing: .init(
             isBackgroundContextColor: true,
             isAvailableOffline: false,
-            image: .moreLine
+            image: .moreLine,
+            accessibilityLabel: String(localized: "More", bundle: .core)
         ) {
             viewModel.showEditScreen(env: env, from: controller)
         })

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -28,19 +28,27 @@ public struct CalendarToDoDetailsScreen: View {
     }
 
     public var body: some View {
-        InstUI.BaseScreen(state: .data, config: viewModel.screenConfig) { _ in
+        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { _ in
             eventContent
         }
         .navigationTitle(viewModel.navigationTitle)
-        .navBarItems(trailing: .init(
-            isBackgroundContextColor: true,
-            isAvailableOffline: false,
-            image: .moreLine,
-            accessibilityLabel: String(localized: "More", bundle: .core)
-        ) {
-            viewModel.showEditScreen(env: env, from: controller)
-        })
+        .navBarItems(
+            trailing: .init(
+                isBackgroundContextColor: true,
+                isEnabled: viewModel.isMoreButtonEnabled,
+                isAvailableOffline: false,
+                image: .moreLine,
+                accessibilityLabel: String(localized: "More", bundle: .core),
+                action: {
+                    viewModel.didTapDelete.send(controller)
+                }
+            )
+        )
         .navigationBarStyle(.color(viewModel.navBarColor))
+        .confirmationAlert(
+            isPresented: $viewModel.shouldShowDeleteConfirmation,
+            presenting: viewModel.deleteConfirmationAlert
+        )
         .errorAlert(
             isPresented: $viewModel.shouldShowDeleteError,
             presenting: .init(
@@ -48,9 +56,7 @@ public struct CalendarToDoDetailsScreen: View {
                 message: String(localized: "Your To Do was not deleted, you can try it again.", bundle: .core),
                 buttonTitle: String(localized: "OK", bundle: .core)
             )
-        ) {
-            viewModel.shouldShowDeleteError = false
-        }
+        )
     }
 
     @ViewBuilder

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -51,8 +51,8 @@ public struct CalendarToDoDetailsScreen: View {
         .errorAlert(
             isPresented: $viewModel.shouldShowDeleteError,
             presenting: .init(
-                title: String(localized: "Delete Unsuccessful!", bundle: .core),
-                message: String(localized: "Your To Do was not deleted, you can try it again.", bundle: .core),
+                title: String(localized: "Deletion not completed", bundle: .core),
+                message: String(localized: "We couldn't delete your To Do at this time. You can try it again.", bundle: .core),
                 buttonTitle: String(localized: "OK", bundle: .core)
             )
         )

--- a/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/CalendarToDoDetailsScreen.swift
@@ -19,7 +19,6 @@
 import SwiftUI
 
 public struct CalendarToDoDetailsScreen: View {
-    @Environment(\.appEnvironment) private var env
     @Environment(\.viewController) private var controller
     @ObservedObject private var viewModel: CalendarToDoDetailsViewModel
 

--- a/Core/Core/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -94,7 +94,7 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
             trailing: .init(
                 isEnabled: viewModel.isSaveButtonEnabled,
                 isAvailableOffline: false,
-                label: viewModel.saveButtonTitle,
+                title: viewModel.saveButtonTitle,
                 action: {
                     viewModel.didTapSave.send()
                 }

--- a/Core/Core/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -94,14 +94,13 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
             trailing: .init(
                 isEnabled: viewModel.isSaveButtonEnabled,
                 isAvailableOffline: false,
-                label: viewModel.saveButtonTitle
-            ) {
-                viewModel.didTapSave.send()
-            }
+                label: viewModel.saveButtonTitle,
+                action: {
+                    viewModel.didTapSave.send()
+                }
+            )
         )
-        .errorAlert(isPresented: $viewModel.shouldShowAlert, presenting: viewModel.alert) {
-            viewModel.shouldShowAlert = false
-        }
+        .errorAlert(isPresented: $viewModel.shouldShowAlert, presenting: viewModel.alert)
     }
 }
 

--- a/Core/Core/Planner/CalendarToDo/ViewModel/CalendarToDoDetailsViewModel.swift
+++ b/Core/Core/Planner/CalendarToDo/ViewModel/CalendarToDoDetailsViewModel.swift
@@ -43,7 +43,7 @@ public class CalendarToDoDetailsViewModel: ObservableObject {
         message: String(localized: "This will permanently delete your To Do item.", bundle: .core),
         cancelButtonTitle: String(localized: "Cancel", bundle: .core),
         confirmButtonTitle: String(localized: "Delete", bundle: .core),
-        isDestructive: false
+        isDestructive: true
     )
 
     // MARK: - Input

--- a/Core/Core/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModel.swift
+++ b/Core/Core/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModel.swift
@@ -177,6 +177,8 @@ final class EditCalendarToDoViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
+    // MARK: - Private methods
+
     private func subscribeIsFieldsTouched<T: Equatable>(to publisher: Published<T>.Publisher) {
         publisher
             .removeDuplicates()

--- a/Core/Core/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModel.swift
+++ b/Core/Core/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModel.swift
@@ -60,14 +60,14 @@ final class EditCalendarToDoViewModel: ObservableObject {
         .init(
             title: {
                 switch mode {
-                case .add: String(localized: "Unsuccessful Creation!", bundle: .core)
-                case .edit: String(localized: "Save Unsuccessful!", bundle: .core)
+                case .add: String(localized: "Creation not completed", bundle: .core)
+                case .edit: String(localized: "Saving not completed", bundle: .core)
                 }
             }(),
             message: {
                 switch mode {
-                case .add: String(localized: "Your To Do was not added, you can try it again.", bundle: .core)
-                case .edit: String(localized: "Your changes were not saved, you can try it again.", bundle: .core)
+                case .add: String(localized: "We couldn't add your To Do at this time. You can try it again.", bundle: .core)
+                case .edit: String(localized: "We couldn't save your To Do at this time. You can try it again.", bundle: .core)
                 }
             }(),
             buttonTitle: String(localized: "OK", bundle: .core)

--- a/Core/Core/Planner/PlannerAssembly.swift
+++ b/Core/Core/Planner/PlannerAssembly.swift
@@ -77,10 +77,11 @@ public enum PlannerAssembly {
         return host
     }
 
-    public static func makeToDoDetailsViewController(plannable: Plannable) -> UIViewController {
+    public static func makeToDoDetailsViewController(plannable: Plannable, env: AppEnvironment = .shared) -> UIViewController {
         let viewModel = CalendarToDoDetailsViewModel(
             plannable: plannable,
-            interactor: CalendarToDoInteractorLive()
+            interactor: CalendarToDoInteractorLive(),
+            router: env.router
         )
         let view = CalendarToDoDetailsScreen(viewModel: viewModel)
         return CoreHostingController(view)
@@ -97,10 +98,11 @@ public enum PlannerAssembly {
         return EditCalendarToDoScreen(viewModel: viewModel)
     }
 
-    public static func makeToDoDetailsScreenPreview(plannable: Plannable) -> some View {
+    public static func makeToDoDetailsScreenPreview(plannable: Plannable, env: AppEnvironment = .shared) -> some View {
         let viewModel = CalendarToDoDetailsViewModel(
             plannable: plannable,
-            interactor: CalendarToDoInteractorPreview()
+            interactor: CalendarToDoInteractorPreview(),
+            router: env.router
         )
         return CalendarToDoDetailsScreen(viewModel: viewModel)
     }

--- a/Core/Core/SwiftUIViews/ConfirmationAlert.swift
+++ b/Core/Core/SwiftUIViews/ConfirmationAlert.swift
@@ -50,6 +50,16 @@ public class ConfirmationAlertViewModel {
         return subject.eraseToAnyPublisher()
     }
 
+    /**
+     - returns: A Publisher that finishes when either of the confirmation dialog's button is pressed.
+     If the user confirmed the action the publisher will send a value before completing.
+     */
+    public func userConfirmation<T>(value: T) -> AnyPublisher<T, Never> {
+        userConfirmation()
+            .map { value }
+            .eraseToAnyPublisher()
+    }
+
     // Don't use this function outside of this class. Internal access level is required because of tests.
     internal func notifyCompletion(isConfirmed: Bool) {
         for subscriber in subscribers {

--- a/Core/Core/SwiftUIViews/ErrorAlert.swift
+++ b/Core/Core/SwiftUIViews/ErrorAlert.swift
@@ -39,7 +39,7 @@ public extension View {
     func errorAlert(
         isPresented: Binding<Bool>,
         presenting viewModel: ErrorAlertViewModel,
-        buttonAction: @escaping () -> Void
+        buttonAction: @escaping () -> Void = {}
     ) -> some View {
         alert(
             viewModel.title,

--- a/Core/CoreTests/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequestTests.swift
+++ b/Core/CoreTests/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequestTests.swift
@@ -1,0 +1,30 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+final class DeletePlannerNoteRequestTests: XCTestCase {
+
+    func testProperties() {
+        let testee = DeletePlannerNoteRequest(id: "42")
+
+        XCTAssertEqual(testee.method, .delete)
+        XCTAssertEqual(testee.path, "planner_notes/42")
+    }
+}

--- a/Core/CoreTests/Planner/CalendarToDo/Model/CalendarToDoInteractorTests.swift
+++ b/Core/CoreTests/Planner/CalendarToDo/Model/CalendarToDoInteractorTests.swift
@@ -158,21 +158,36 @@ final class CalendarToDoInteractorTests: CoreTestCase {
     }
 
     private func verifyUpdateToDo(
-        id: String = "",
         title: String = "",
         date: Date = Clock.now,
         calendar: CDCalendarFilterEntry? = nil,
         details: String? = nil,
         bodyHandler: @escaping (PutPlannerNoteRequest.Body) -> Void
     ) {
-        let request = PutPlannerNoteRequest(id: "", body: .make())
+        let request = PutPlannerNoteRequest(id: "42", body: .make())
         let expectation = XCTestExpectation(description: "Request was sent")
         mockRequest(request) { (body: PutPlannerNoteRequest.Body) in
             bodyHandler(body)
             expectation.fulfill()
         }
 
-        let publisher = testee.updateToDo(id: id, title: title, date: date, calendar: calendar, details: details)
+        let publisher = testee.updateToDo(id: "42", title: title, date: date, calendar: calendar, details: details)
+        XCTAssertFinish(publisher)
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    // MARK: - DeleteToDo
+
+    func testDeleteToDo() {
+        let request = DeletePlannerNoteRequest(id: "42")
+        let expectation = XCTestExpectation(description: "Request was sent")
+        api.mock(request) { _ in
+            expectation.fulfill()
+            return (nil, nil, nil)
+        }
+
+        let publisher = testee.deleteToDo(id: "42")
         XCTAssertFinish(publisher)
 
         wait(for: [expectation], timeout: 1)

--- a/Core/CoreTests/Planner/CalendarToDo/Model/UseCase/DeletePlannerNoteTests.swift
+++ b/Core/CoreTests/Planner/CalendarToDo/Model/UseCase/DeletePlannerNoteTests.swift
@@ -1,0 +1,44 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+final class DeletePlannerNoteTests: CoreTestCase {
+
+    func testRequest() {
+        let testee = DeletePlannerNote(id: "42")
+        XCTAssertEqual(testee.request.id, "42")
+    }
+
+    func testWrite() {
+        Plannable.save(.make(id: "1"), contextName: nil, in: databaseClient)
+        Plannable.save(.make(id: "2"), contextName: nil, in: databaseClient)
+        Plannable.save(.make(id: "3"), contextName: nil, in: databaseClient)
+        let testee = DeletePlannerNote(id: "2")
+
+        testee.write(response: .make(id: "3"), urlResponse: nil, to: databaseClient)
+
+        let plannable1: Plannable? = databaseClient.first(where: #keyPath(Plannable.id), equals: "1")
+        let plannable2: Plannable? = databaseClient.first(where: #keyPath(Plannable.id), equals: "2")
+        let plannable3: Plannable? = databaseClient.first(where: #keyPath(Plannable.id), equals: "3")
+        XCTAssertEqual(plannable1?.id, "1")
+        XCTAssertEqual(plannable2?.id, nil)
+        XCTAssertEqual(plannable3?.id, "3")
+    }
+}

--- a/Core/CoreTests/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModelTests.swift
@@ -232,8 +232,8 @@ final class EditCalendarToDoViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee.pageTitle, String(localized: "New To Do", bundle: .core))
         XCTAssertEqual(testee.saveButtonTitle, String(localized: "Add", bundle: .core))
-        XCTAssertEqual(testee.alert.title, String(localized: "Unsuccessful Creation!", bundle: .core))
-        XCTAssertEqual(testee.alert.message, String(localized: "Your To Do was not added, you can try it again.", bundle: .core))
+        XCTAssertEqual(testee.alert.title, String(localized: "Creation not completed", bundle: .core))
+        XCTAssertEqual(testee.alert.message, String(localized: "We couldn't add your To Do at this time. You can try it again.", bundle: .core))
         XCTAssertEqual(testee.alert.buttonTitle, String(localized: "OK", bundle: .core))
     }
 
@@ -242,8 +242,8 @@ final class EditCalendarToDoViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee.pageTitle, String(localized: "Edit To Do", bundle: .core))
         XCTAssertEqual(testee.saveButtonTitle, String(localized: "Save", bundle: .core))
-        XCTAssertEqual(testee.alert.title, String(localized: "Save Unsuccessful!", bundle: .core))
-        XCTAssertEqual(testee.alert.message, String(localized: "Your changes were not saved, you can try it again.", bundle: .core))
+        XCTAssertEqual(testee.alert.title, String(localized: "Saving not completed", bundle: .core))
+        XCTAssertEqual(testee.alert.message, String(localized: "We couldn't save your To Do at this time. You can try it again.", bundle: .core))
         XCTAssertEqual(testee.alert.buttonTitle, String(localized: "OK", bundle: .core))
     }
 

--- a/Core/TestsFoundation/Router/TestRouter.swift
+++ b/Core/TestsFoundation/Router/TestRouter.swift
@@ -38,6 +38,7 @@ public class TestRouter: Router {
     }
 
     public var dismissed: UIViewController?
+    public var popped: UIViewController?
     public var last: UIViewController? { viewControllerCalls.last?.0 }
     public var routes = [URLComponents: () -> UIViewController?]()
 
@@ -75,6 +76,7 @@ public class TestRouter: Router {
 
     public var popExpectation = XCTestExpectation(description: "pop")
     public override func pop(from: UIViewController) {
+        popped = from
         popExpectation.fulfill()
     }
 


### PR DESCRIPTION
refs: [MBL-17291](https://instructure.atlassian.net/browse/MBL-17291)
affects: Student
release note: Calendar To Dos are now deletable.

## What's changed
- Replaced kebab button with menu on ToDo Details screen, which now has Edit and Delete items
- Added delete confirmation dialog
- Updated PlannerList to retain selection on iPad after reappearance or refresh
- Updated Create/Edit/Delete error messages

### Chores
- Added to `InstUI.NavigationBarButton`
  - `menuItems` parameter
  - `accessibilityLabel` parameter for image init
- Added generic `userConfirmation` method to `ConfirmationAlert` to pass value downstream
- Added `InstUI.MenuItem`
- Added `OfflineObservingMenu`
- Unified `InstUI` String type name/label/title properties to `title`

## Test plan
- Verify Edit ToDo screen is reachable properly from ToDo Details screen
- Verify Delete ToDo works as expected
  - on iPad it should update both the Events list and replace the ToDo Details screen with an empty one
  - if you delete a ToDo on another client and pull-to-refresh the Events list in won't clear the ToDo Details screen (out of scope for now)

## Screenshots

<table>
<tr>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/e31b8abc-d664-4935-b820-9e873fa90ace" maxHeight=500></td>
<td><img src="https://github.com/instructure/canvas-ios/assets/15140172/c1b3e2bc-8704-4780-9306-236b6b08508c" maxHeight=500></td>
</tr>
</table>

## Checklist
- [x] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product

[MBL-17291]: https://instructure.atlassian.net/browse/MBL-17291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ