### PR TITLE
Empty panda for syllabus screen

### DIFF
--- a/Core/Core/Syllabus/SyllabusSummaryViewController.swift
+++ b/Core/Core/Syllabus/SyllabusSummaryViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 public protocol ColorDelegate: AnyObject {
     var iconColor: UIColor? { get }
@@ -43,6 +44,18 @@ public class SyllabusSummaryViewController: UITableViewController {
     lazy var color = env.subscribe(GetCustomColors()) { [weak self] in
         self?.update()
     }
+
+    private var emptyPandaViewController: CoreHostingController<InteractivePanda> = {
+        let vc = CoreHostingController(
+            InteractivePanda(
+                scene: SpacePanda(),
+                title: Text("No syllabus"),
+                subtitle: Text("There is no syllabus to display.")
+            )
+        )
+        vc.view.backgroundColor = .backgroundLightest
+        return vc
+    }()
 
     public lazy var summary: Store<LocalUseCase<CalendarEvent>> = {
         let contextPredicate = NSPredicate(format: "%K == %@", #keyPath(CalendarEvent.contextRaw), self.context.canvasContextID)
@@ -94,6 +107,21 @@ public class SyllabusSummaryViewController: UITableViewController {
         let pending = assignments.pending || events.pending
         if tableView.refreshControl?.isRefreshing == true, !pending {
             tableView.refreshControl?.endRefreshing()
+        }
+
+        if summary.isEmpty {
+            tableView.backgroundColor = .clear
+            addChild(emptyPandaViewController)
+            emptyPandaViewController.didMove(toParent: self)
+            tableView.addSubview(emptyPandaViewController.view)
+            emptyPandaViewController.view.pin(inside: tableView)
+            NSLayoutConstraint.activate([
+                emptyPandaViewController.view.heightAnchor.constraint(equalTo: view.heightAnchor),
+                emptyPandaViewController.view.widthAnchor.constraint(equalTo: view.widthAnchor)
+            ])
+        } else if emptyPandaViewController.parent != nil, emptyPandaViewController.view.superview != nil {
+            emptyPandaViewController.removeFromParent()
+            emptyPandaViewController.view.removeFromSuperview()
         }
         tableView.reloadData()
     }

--- a/Core/Core/Syllabus/SyllabusTabViewController.swift
+++ b/Core/Core/Syllabus/SyllabusTabViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewController, ColoredNavViewProtocol, CoreWebViewLinkDelegate {
     public let titleSubtitleView = TitleSubtitleView.create()
@@ -41,6 +42,18 @@ open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewContr
         self?.update()
     }
 
+    private var emptyPandaViewController: CoreHostingController<InteractivePanda> = {
+        let vc = CoreHostingController(
+            InteractivePanda(
+                scene: SpacePanda(),
+                title: Text("No syllabus"),
+                subtitle: Text("There is no syllabus to display.")
+            )
+        )
+        vc.view.backgroundColor = .backgroundLightest
+        return vc
+    }()
+
     public static func create(courseID: String) -> SyllabusTabViewController {
         let controller = SyllabusTabViewController(nibName: nil, bundle: nil)
         controller.courseID = courseID
@@ -52,7 +65,7 @@ open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewContr
         delegate = self
         setupTitleViewInNavbar(title: String(localized: "Course Syllabus", bundle: .core))
         view.backgroundColor = UIColor.backgroundLightest
-
+        emptyPandaViewController.view.backgroundColor = .backgroundLightest
         settings.refresh()
         colors.refresh()
         course.refresh()
@@ -74,6 +87,15 @@ open class SyllabusTabViewController: ScreenViewTrackableHorizontalMenuViewContr
         }
         if settings.first?.syllabusCourseSummary == true {
             viewControllers.append(summary)
+        }
+        if viewControllers.isEmpty {
+            addChild(emptyPandaViewController)
+            emptyPandaViewController.didMove(toParent: self)
+            view.addSubview(emptyPandaViewController.view)
+            emptyPandaViewController.view.pin(inside: view)
+        } else if emptyPandaViewController.parent != nil, emptyPandaViewController.view.superview != nil {
+            emptyPandaViewController.removeFromParent()
+            emptyPandaViewController.view.removeFromSuperview()
         }
         updateFrames()
         reload()

--- a/Core/Core/Syllabus/SyllabusViewController.swift
+++ b/Core/Core/Syllabus/SyllabusViewController.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import SwiftUI
 
 open class SyllabusViewController: UIViewController, CoreWebViewLinkDelegate {
     public var courseID = ""


### PR DESCRIPTION
refs: MBL-15392
affects: Student, Teacher
release note: Added empty panda image when syllabus is empty.
test plan: Test empty syllabus when course summary is enabled, disabled.

## Screenshots

<table>
<tr><th>When course summary is disabled</th><th>When it's enabled</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d7579d34-e990-4e87-b6a8-556cf53430f7" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/9cf22dc6-5010-4259-a4b4-660499f1bbd4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
