### PR TITLE
Fixed media not displaying in account notifications

### DIFF
--- a/Core/Core/Dashboard/Notification/View/NotificationCard.swift
+++ b/Core/Core/Dashboard/Notification/View/NotificationCard.swift
@@ -60,7 +60,7 @@ struct NotificationCard: View {
                         .identifier("AccountNotification.\(notification.id).toggleButton")
                 }
                 if isExpanded {
-                    WebView(html: notification.message)
+                    WebView(html: notification.message, baseURL: env.currentSession?.baseURL)
                         .onLink { url in
                             env.router.route(to: url, from: controller, options: .detail)
                             return true


### PR DESCRIPTION
refs: MBL-17738
affects: Student, Teacher
release note: Fixed media not displaying in account notifications.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/3b86d79a-a44a-4973-8bd7-caa0cc33cc53" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/e7b7ea16-5ab9-4179-88cb-40337ded2817" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet
