### PR TITLE
Filter out studio in case the assignment is not a video file type

### DIFF
--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -489,30 +489,21 @@ extension Array where Element == SubmissionType {
     public func isStudioAccepted(
         allowedExtensions: [String]
     ) -> Bool {
-        let studioTypes: [SubmissionType] = [
-            .external_tool,
-            .basic_lti_launch,
-            .media_recording
-        ]
+        guard self.contains(.online_upload) else {
+            return false
+        }
 
-        for studioType in studioTypes where self.contains(studioType) {
+        if allowedExtensions.isEmpty {
             return true
         }
 
-        if self.contains(.online_upload) {
-            if allowedExtensions.isEmpty {
+        for allowedExtension in allowedExtensions {
+            guard let fileType = UTType(filenameExtension: allowedExtension) else {
+                continue
+            }
+            if fileType.conforms(to: .audiovisualContent) {
                 return true
             }
-
-            for allowedExtension in allowedExtensions {
-                guard let fileType = UTType(filenameExtension: allowedExtension) else {
-                    continue
-                }
-                if fileType.conforms(to: .audiovisualContent) {
-                    return true
-                }
-            }
-
         }
 
         return false

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -500,6 +500,10 @@ extension Array where Element == SubmissionType {
         }
 
         if self.contains(.online_upload) {
+            if allowedExtensions.isEmpty {
+                return true
+            }
+
             for allowedExtension in allowedExtensions {
                 guard let fileType = UTType(filenameExtension: allowedExtension) else {
                     continue

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -395,7 +395,7 @@ public enum SubmissionStatus {
     }
 }
 
-public enum SubmissionType: String, Codable {
+public enum SubmissionType: String, Codable, CaseIterable {
     case discussion_topic
     case external_tool
     case media_recording
@@ -484,6 +484,34 @@ extension Array where Element == SubmissionType {
         }
 
         return utis
+    }
+
+    public func isStudioAccepted(
+        allowedExtensions: [String]
+    ) -> Bool {
+        let studioTypes: [SubmissionType] = [
+            .external_tool,
+            .basic_lti_launch,
+            .media_recording
+        ]
+
+        for studioType in studioTypes where self.contains(studioType) {
+            return true
+        }
+
+        if self.contains(.online_upload) {
+            for allowedExtension in allowedExtensions {
+                guard let fileType = UTType(filenameExtension: allowedExtension) else {
+                    continue
+                }
+                if fileType.conforms(to: .audiovisualContent) {
+                    return true
+                }
+            }
+
+        }
+
+        return false
     }
 }
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -378,19 +378,29 @@ class SubmissionTypeTests: XCTestCase {
                 let result = [submissionType].isStudioAccepted(allowedExtensions: [])
                 XCTAssertEqual(result, true)
             case .online_upload:
-                let acceptedTypes = ["mp4", "mov", "avi"]
+                let acceptedFileExtensions = ["mp4", "mov", "avi"]
 
-                for acceptedType in acceptedTypes {
-                    let result = [submissionType].isStudioAccepted(allowedExtensions: [acceptedType])
+                for acceptedFileExtension in acceptedFileExtensions {
+                    let result = [submissionType].isStudioAccepted(
+                        allowedExtensions: [acceptedFileExtension]
+                    )
                     XCTAssertEqual(result, true)
                 }
 
-                let notAcceptedTypes = ["pdf", "docx", "txt"]
+                let notAcceptedFileExtensions = ["pdf", "docx", "txt"]
 
-                for notAcceptedType in notAcceptedTypes {
-                    let result = [submissionType].isStudioAccepted(allowedExtensions: [notAcceptedType])
+                for notAcceptedFileExtension in notAcceptedFileExtensions {
+                    let result = [submissionType].isStudioAccepted(
+                        allowedExtensions: [notAcceptedFileExtension]
+                    )
                     XCTAssertEqual(result, false)
                 }
+
+                let noFileExtensionRestriction: [String] = []
+                let result = [submissionType].isStudioAccepted(
+                    allowedExtensions: noFileExtensionRestriction
+                )
+                XCTAssertEqual(result, true)
             }
         }
     }

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -369,14 +369,12 @@ class SubmissionTypeTests: XCTestCase {
                  .on_paper,
                  .wiki_page,
                  .student_annotation,
-                 .online_url:
+                 .online_url,
+                 .media_recording,
+                 .basic_lti_launch,
+                 .external_tool:
                 let result = [submissionType].isStudioAccepted(allowedExtensions: [])
                 XCTAssertEqual(result, false)
-            case .external_tool,
-                 .media_recording,
-                 .basic_lti_launch:
-                let result = [submissionType].isStudioAccepted(allowedExtensions: [])
-                XCTAssertEqual(result, true)
             case .online_upload:
                 let acceptedFileExtensions = ["mp4", "mov", "avi"]
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -356,4 +356,43 @@ class SubmissionTypeTests: XCTestCase {
         XCTAssertTrue(result.contains { $0.isImage })
         XCTAssertTrue(result.contains(.text))
     }
+
+    func testStudioSubmissionTypes() {
+        // The strange format is to make sure all cases are tested
+        for submissionType in SubmissionType.allCases {
+            switch submissionType {
+            case .discussion_topic,
+                 .none,
+                 .not_graded,
+                 .online_quiz,
+                 .online_text_entry,
+                 .on_paper,
+                 .wiki_page,
+                 .student_annotation,
+                 .online_url:
+                let result = [submissionType].isStudioAccepted(allowedExtensions: [])
+                XCTAssertEqual(result, false)
+            case .external_tool,
+                 .media_recording,
+                 .basic_lti_launch:
+                let result = [submissionType].isStudioAccepted(allowedExtensions: [])
+                XCTAssertEqual(result, true)
+            case .online_upload:
+                let acceptedTypes = ["mp4", "mov", "avi"]
+
+                for acceptedType in acceptedTypes {
+                    let result = [submissionType].isStudioAccepted(allowedExtensions: [acceptedType])
+                    XCTAssertEqual(result, true)
+                }
+
+                let notAcceptedTypes = ["pdf", "docx", "txt"]
+
+                for notAcceptedType in notAcceptedTypes {
+                    let result = [submissionType].isStudioAccepted(allowedExtensions: [notAcceptedType])
+                    XCTAssertEqual(result, false)
+                }
+            }
+        }
+    }
+
 }

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
@@ -30,7 +30,7 @@ enum SubmissionButtonAlertView {
             }
             alert.addAction(action)
         }
-        if arc {
+        if arc, assignment.submissionTypes.isStudioAccepted(allowedExtensions: assignment.allowedExtensions) {
             alert.addAction(UIAlertAction(title: String(localized: "Studio", bundle: .student), style: .default) { [weak presenter] _ in
                 presenter?.submitArc(assignment: assignment)
             })

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonAlertView.swift
@@ -30,7 +30,7 @@ enum SubmissionButtonAlertView {
             }
             alert.addAction(action)
         }
-        if arc, assignment.submissionTypes.isStudioAccepted(allowedExtensions: assignment.allowedExtensions) {
+        if arc {
             alert.addAction(UIAlertAction(title: String(localized: "Studio", bundle: .student), style: .default) { [weak presenter] _ in
                 presenter?.submitArc(assignment: assignment)
             })

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -104,7 +104,7 @@ class SubmissionButtonPresenter: NSObject {
         guard assignment.canMakeSubmissions else { return }
         self.assignment = assignment
         let types = assignment.submissionTypes
-        let arc = types.contains(.online_upload) && arcID != .pending && arcID != .none
+        let arc = arcID != .pending && arcID != .none && assignment.submissionTypes.isStudioAccepted(allowedExtensions: assignment.allowedExtensions)
         if !arc && types.count == 1, let type = types.first {
             return submitType(type, for: assignment, button: button)
         }


### PR DESCRIPTION
### What changed?
A file extension check was added to Online File Uploads submission types to only allow Studio submission in case:
- There is no file extension limitation.
- The file extension limit is a valid video mime type.

Previously we offered studio all the time in case the submission type was Online File Uploads.

refs: [MBL-17735](https://instructure.atlassian.net/browse/MBL-17735)
affects: Student
release note: Fixed Studio being allowed for submission on non video assignments.

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/e04c7719-86ab-4ad9-904e-f2d6f59c877a" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/2bddbdfc-fa07-4606-a196-527319c4e83d" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product


[MBL-17735]: https://instructure.atlassian.net/browse/MBL-17735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ