### PR TITLE
Automation - Student - Test for Based On Graded Assignments feature

### DIFF
--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -301,6 +301,7 @@ public struct GradeListView: View, ScreenViewTrackable {
             .toggleStyle(SwitchToggleStyle(tint: Color(Brand.shared.primary)))
             .frame(minHeight: 51)
             .padding(.horizontal, 16)
+            .accessibilityIdentifier("BasedOnGradedToggle")
 
             if viewModel.isWhatIfScoreFlagEnabled {
                 Divider()

--- a/Core/TestsFoundation/Helpers/GradesHelper.swift
+++ b/Core/TestsFoundation/Helpers/GradesHelper.swift
@@ -22,6 +22,7 @@ public class GradesHelper: BaseHelper {
     public static var totalGrade: XCUIElement { app.find(id: "CourseTotalGrade") }
     public static var filterButton: XCUIElement { app.find(type: .popUpButton) }
     public static var lockIcon: XCUIElement { app.find(id: "lockIcon") }
+    public static var basedOnGradedSwitch: XCUIElement { app.find(id: "BasedOnGradedToggle").find(type: .switch) }
 
     public static func labelOfAG(assignmentGroup: DSAssignmentGroup) -> XCUIElement {
         return app.find(label: assignmentGroup.name, type: .staticText)

--- a/Student/StudentE2ETests/Grades/GradesTests.swift
+++ b/Student/StudentE2ETests/Grades/GradesTests.swift
@@ -383,7 +383,7 @@ class GradesTests: E2ETestCase {
         XCTAssertTrue(totalGrade.isVisible)
         XCTAssertTrue(totalGrade.hasLabel(label: basedOnGradedExpected, strict: false))
 
-        // MARK: Toggle switch and check changes
+        // MARK: Toggle switch, check Total Grade again
         basedOnGradedSwitch.hit()
         XCTAssertTrue(basedOnGradedSwitch.waitUntil(.value(expected: "0")).hasValue(value: "0"))
         XCTAssertTrue(totalGrade.isVisible)


### PR DESCRIPTION
### Student - Grades - New E2E test case

#### testBasedOnGradedAssignments
- DataSeeder creates 4 assignments
- DataSeeder creates submissions for all 4 assignments
- DataSeeder gets 2 assignments graded (other 2 stays ungraded)
- Logs in with the student
- Navigates to grades screen
- Checks Based On Graded Assignments toggle (by default it should be switched on)
- Checks Total Grade
- Taps the toggle (should get switched off)
- Checks Total Grade again