### PR TITLE
Fix 403 API responses triggering a token renewal

### DIFF
--- a/Core/Core/API/APIError.swift
+++ b/Core/Core/API/APIError.swift
@@ -19,10 +19,10 @@
 import Foundation
 
 public enum HttpError {
-    static let unauthorized = 1000
-    static let forbidden = 1001
-    static let notFound = 1002
-    static let unexpected = 2000
+    public static let unauthorized = 1000
+    public static let forbidden = 1001
+    public static let notFound = 1002
+    public static let unexpected = 2000
 }
 
 public enum APIError: LocalizedError {

--- a/Core/Core/Extensions/ErrorExtensions.swift
+++ b/Core/Core/Extensions/ErrorExtensions.swift
@@ -19,9 +19,16 @@
 import Foundation
 
 public extension Error {
-
+    
     var isFrameLoadInterrupted: Bool {
-        let nsError = self as NSError
-        return nsError.domain == "WebKitErrorDomain" && nsError.code == 102
+        nsError.domain == "WebKitErrorDomain" && nsError.code == 102
+    }
+
+    var isForbidden: Bool {
+        nsError.domain == NSError.Constants.domain && nsError.code == HttpError.forbidden
+    }
+
+    private var nsError: NSError {
+        self as NSError
     }
 }

--- a/Core/Core/Extensions/ErrorExtensions.swift
+++ b/Core/Core/Extensions/ErrorExtensions.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 public extension Error {
-    
+
     var isFrameLoadInterrupted: Bool {
         nsError.domain == "WebKitErrorDomain" && nsError.code == 102
     }

--- a/Core/Core/Extensions/NSErrorExtensions.swift
+++ b/Core/Core/Extensions/NSErrorExtensions.swift
@@ -20,8 +20,8 @@ import Foundation
 
 extension NSError {
     public struct Constants {
-        static let domain = "com.instructure"
-        static let internalError = "Internal Error"
+        public static let domain = "com.instructure"
+        public static let internalError = "Internal Error"
     }
 
     public static func internalError(code: Int = 0) -> NSError {

--- a/Core/Core/Extensions/URLResponseExtensions.swift
+++ b/Core/Core/Extensions/URLResponseExtensions.swift
@@ -41,9 +41,7 @@ extension URLResponse {
     }
 
     public var isUnauthorized: Bool {
-        guard let statusCode = (self as? HTTPURLResponse)?.statusCode else { return false }
-        let unauthorizedCodes = [401, 403]
-        return unauthorizedCodes.contains(statusCode)
+        (self as? HTTPURLResponse)?.statusCode == 401
     }
 
     /**

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -169,8 +169,8 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
     func update() {
         guard let file = files.first, offlineFileInteractor?.isOffline == false else {
             if let error = files.error {
-                // If file download failed because of unauthorization error and we have a verifier token, then we modify the url and try to open the file in a webview.
-                if var url = originURL, url.containsVerifier, case .unauthorized = (error as? APIError) {
+                // If file download failed because of a forbidden error and we have a verifier token, then we modify the url and try to open the file in a webview.
+                if var url = originURL, url.containsVerifier, error.isForbidden {
                     if !url.path.hasSuffix("download") {
                         url.path.append("/download")
                         url.queryItems?.append(URLQueryItem(name: "download_frd", value: "1"))

--- a/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
@@ -22,7 +22,18 @@ import XCTest
 class ErrorExtensionsTests: XCTestCase {
 
     func testFrameLoadInterruptedError() {
-        let error: Error = NSError(domain: "WebKitErrorDomain", code: 102)
+        let error: Error = NSError(
+            domain: "WebKitErrorDomain",
+            code: 102
+        )
         XCTAssertTrue(error.isFrameLoadInterrupted)
+    }
+
+    func testForbiddenError() {
+        let error: Error = NSError(
+            domain: NSError.Constants.domain,
+            code: HttpError.forbidden
+        )
+        XCTAssertTrue(error.isForbidden)
     }
 }

--- a/Core/CoreTests/Extensions/URLResponseExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLResponseExtensionsTests.swift
@@ -40,10 +40,38 @@ class URLResponseExtensionsTests: XCTestCase {
         XCTAssertNil(response.links)
     }
 
-    func testUnauthenticated() {
-        XCTAssertTrue(HTTPURLResponse(url: URL(string: "/")!, statusCode: 401, httpVersion: nil, headerFields: nil)!.isUnauthorized)
-        XCTAssertFalse(HTTPURLResponse(url: URL(string: "/")!, statusCode: 201, httpVersion: nil, headerFields: nil)!.isUnauthorized)
-        XCTAssertFalse(URLResponse(url: URL(string: "/")!, mimeType: nil, expectedContentLength: 0, textEncodingName: nil).isUnauthorized)
+    func testUnauthorized() {
+        let unautorizedResponse = HTTPURLResponse(
+            url: URL(string: "/")!,
+            statusCode: 401,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        XCTAssertTrue(unautorizedResponse.isUnauthorized)
+
+        let forbiddenResponse = HTTPURLResponse(
+            url: URL(string: "/")!,
+            statusCode: 403,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        XCTAssertFalse(forbiddenResponse.isUnauthorized)
+
+        let createdResponse = HTTPURLResponse(
+            url: URL(string: "/")!,
+            statusCode: 201,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        XCTAssertFalse(createdResponse.isUnauthorized)
+
+        let nonHttpURLResponse = URLResponse(
+            url: URL(string: "/")!,
+            mimeType: nil,
+            expectedContentLength: 0,
+            textEncodingName: nil
+        )
+        XCTAssertFalse(nonHttpURLResponse.isUnauthorized)
     }
 
     func testExceededLimit() {


### PR DESCRIPTION
### What happened?
- Upon app start we initialize pandata that makes an API call to the backend to start a pandata session.
- In case an account has no pandata set up the API call is rejected with a 403 Developer key not registered.
- During a [bug fix](https://github.com/instructure/canvas-ios/pull/2216/files) in the past we mistakenly defined the 403 response code as unauthorised and thus eligible for a token refresh and retry.
- Upon logging into the no pandata account the app instantly renewed the access token.
- The old access token was invalidated since a new one was created and because of this in-flight API calls failed with error 401.
- These 401 API calls again renewed the access token causing another round of invalid access token API calls which renewed the token again.
- This cascade of token renewals quickly depleted the token refresh quota of the account so our requests automatically got rejected due to the frequent usage of this API.
- Our logic waits only 1 sec before retrying an API call that was rejected due to the quota being exhausted but this time wasn't enough for this account so the app tried to renew the token every 1 sec to infinity.

### Solutions
- There are multiple implementation quirks in the API.swift file that caused this event to happen. (For example API calls not being paused in case one was throttled down or the hardcoded 1 sec waiting time.) Fixing these would be much more complex and error prone than fixing the issue which triggered this event.
- I reverted the previous fix (linked above) and made the app not to renew the token in case a 403 was received. This broke the previous fix so I had to apply another -this time correct- fix.

refs: MBL-17768
affects: Student, Teacher, Parent
release note: none

test plan:
- See ticket for test account.
- Log in a few times and check if there multiple calls to `/login/oauth2/token` after you have logged in.
- Since this fix modifies the logic of how file downloads are re-tried also test if a user's personal file added as an URL to a page opens correctly when logged in with a different user.
- For this log in with my student.
- Go to Pages and open "Mary's page".
- This contains a link to an image uploaded by another user.
- Tapping the link should open the image (instead of giving a permission error).

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet
