### PR TITLE
Update code to ignore forbidden API errors

### DIFF
--- a/Core/Core/Notifications/PushNotificationsInteractor.swift
+++ b/Core/Core/Notifications/PushNotificationsInteractor.swift
@@ -115,7 +115,7 @@ public class PushNotificationsInteractor {
             }
             guard let channelID = channel?.id.value, error == nil else {
                 // Hide error alert when "Users can edit their communication channels" setting is turned off
-                if let apiError = error as? APIError, case .unauthorized = apiError {
+                if error?.isForbidden == true {
                     return
                 } else if error.isPushNotConfigured {
                     return


### PR DESCRIPTION
refs: MBL-17774
affects: Student, Teacher
release note: none

test plan:
- Turn off "Users can edit their communication channels" account setting.
- Start the app.
- No "user not authorized to perform this action" popup should appear.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet
