### PR TITLE
Fix group submission comment upload when using share extension

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22522" systemVersion="22G120" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23F79" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -522,6 +522,7 @@
         <attribute name="assignmentName" attributeType="String" defaultValueString=""/>
         <attribute name="comment" optional="YES" attributeType="String"/>
         <attribute name="courseID" attributeType="String"/>
+        <attribute name="isGroupComment" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isHiddenOnDashboard" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="isSubmitted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="submissionError" optional="YES" attributeType="String"/>

--- a/Core/Core/Files/FileSubmission/Model/Entities/FileSubmission.swift
+++ b/Core/Core/Files/FileSubmission/Model/Entities/FileSubmission.swift
@@ -28,6 +28,7 @@ public final class FileSubmission: NSManagedObject {
     @NSManaged public var assignmentName: String
     /** The user entered comment for the submission. **/
     @NSManaged public var comment: String?
+    @NSManaged public var isGroupComment: Bool
     @NSManaged public var files: Set<FileUploadItem>
     @NSManaged public var isHiddenOnDashboard: Bool
 

--- a/Core/Core/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposer.swift
+++ b/Core/Core/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposer.swift
@@ -31,7 +31,14 @@ public class FileSubmissionComposer {
     /**
      - returns: The `objectID` of the created `FileSubmission` object.
      */
-    public func makeNewSubmission(courseId: String, assignmentId: String, assignmentName: String, comment: String?, files: [URL]) -> NSManagedObjectID {
+    public func makeNewSubmission(
+        courseId: String,
+        assignmentId: String,
+        assignmentName: String,
+        comment: String?,
+        isGroupComment: Bool?,
+        files: [URL]
+    ) -> NSManagedObjectID {
         var result: NSManagedObjectID!
 
         context.performAndWait {
@@ -40,6 +47,7 @@ public class FileSubmissionComposer {
             fileSubmission.assignmentID = assignmentId
             fileSubmission.assignmentName = assignmentName
             fileSubmission.comment = comment
+            fileSubmission.isGroupComment = isGroupComment ?? false
             fileSubmission.files = Set(files.map {
                 let item: FileUploadItem = context.insert()
                 item.localFileURL = $0

--- a/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
+++ b/Core/Core/Files/FileSubmission/Model/Submission/FileSubmissionSubmitter.swift
@@ -40,9 +40,12 @@ public class FileSubmissionSubmitter {
         context.performAndWait {
             guard let submission = try? context.existingObject(with: fileSubmissionID) as? FileSubmission else { return }
             let fileIDs = submission.files.compactMap { $0.apiID }
-            let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: submission.comment,
-                                                                     submission_type: .online_upload,
-                                                                     file_ids: fileIDs)
+            let requestedSubmission = CreateSubmissionRequest.Body.Submission(
+                text_comment: submission.comment,
+                group_comment: submission.isGroupComment,
+                submission_type: .online_upload,
+                file_ids: fileIDs
+            )
             let request = CreateSubmissionRequest(context: .course(submission.courseID),
                                                       assignmentID: submission.assignmentID,
                                                       body: .init(submission: requestedSubmission))

--- a/Core/Core/Files/Model/UploadManager.swift
+++ b/Core/Core/Files/Model/UploadManager.swift
@@ -330,7 +330,7 @@ open class UploadManager: NSObject, URLSessionDelegate, URLSessionTaskDelegate, 
         }
         guard files.allSatisfy({ $0.isUploaded }) else { return }
         let fileIDs = files.compactMap { $0.id }
-        let submission = CreateSubmissionRequest.Body.Submission(text_comment: comment, submission_type: .online_upload, file_ids: fileIDs)
+        let submission = CreateSubmissionRequest.Body.Submission(text_comment: comment, group_comment: nil, submission_type: .online_upload, file_ids: fileIDs)
         let requestable = CreateSubmissionRequest(context: .course(courseID), assignmentID: assignmentID, body: .init(submission: submission))
         var task: APITask?
         // This is to make the background task wait until we receive the submission response from the API.

--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -424,7 +424,7 @@ public struct CreateSubmissionRequest: APIRequestable {
             ) {
                 self.annotatable_attachment_id = annotatable_attachment_id
                 self.comment = text_comment
-                self.group_comment = group_comment
+                self.group_comment = group_comment ?? false
                 self.submission_type = submission_type
                 self.body = body
                 self.url = url

--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -402,7 +402,8 @@ public struct CreateSubmissionRequest: APIRequestable {
     public struct Body: Codable, Equatable {
         public struct Submission: Codable, Equatable {
             let annotatable_attachment_id: String? // Required if submission_type is student_annotation
-            let text_comment: String?
+            fileprivate(set) var comment: String?
+            let group_comment: Bool?
             let submission_type: SubmissionType
             let body: String? // Requires submission_type of online_text_entry
             let url: URL? // Requires submission_type of online_url or basic_lti_launch
@@ -413,6 +414,7 @@ public struct CreateSubmissionRequest: APIRequestable {
             public init(
                 annotatable_attachment_id: String? = nil,
                 text_comment: String? = nil,
+                group_comment: Bool?,
                 submission_type: SubmissionType,
                 body: String? = nil,
                 url: URL? = nil,
@@ -421,7 +423,8 @@ public struct CreateSubmissionRequest: APIRequestable {
                 media_comment_type: MediaCommentType? = nil
             ) {
                 self.annotatable_attachment_id = annotatable_attachment_id
-                self.text_comment = text_comment
+                self.comment = text_comment
+                self.group_comment = group_comment
                 self.submission_type = submission_type
                 self.body = body
                 self.url = url
@@ -437,10 +440,18 @@ public struct CreateSubmissionRequest: APIRequestable {
 
         public init(submission: Submission) {
             self.submission = submission
-            self.comment = submission.text_comment.flatMap(Comment.init(text_comment:))
+
+            // For individually graded submissions, comment needs to be set as comment[text_comment].
+            // For group graded submissions, comment needs to be set as submission[comment].
+            if submission.group_comment == false {
+                self.comment = submission.comment.flatMap(Comment.init(text_comment:))
+                self.submission.comment = nil
+            } else {
+                self.comment = nil
+            }
         }
 
-        let submission: Submission
+        private(set) var submission: Submission
         let comment: Comment?
     }
 

--- a/Core/Core/Submissions/GetSubmissions.swift
+++ b/Core/Core/Submissions/GetSubmissions.swift
@@ -51,6 +51,7 @@ public class CreateSubmission: APIUseCase {
         userID: String,
         submissionType: SubmissionType,
         textComment: String? = nil,
+        isGroupComment: Bool? = nil,
         body: String? = nil,
         url: URL? = nil,
         fileIDs: [String]? = nil,
@@ -65,6 +66,7 @@ public class CreateSubmission: APIUseCase {
         let submission = CreateSubmissionRequest.Body.Submission(
             annotatable_attachment_id: annotatableAttachmentID,
             text_comment: textComment,
+            group_comment: isGroupComment,
             submission_type: submissionType,
             body: body,
             url: url,

--- a/Core/Core/SubmitAssignmentExtension/Model/API/APIAssignmentPickerListItem.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/APIAssignmentPickerListItem.swift
@@ -22,11 +22,13 @@ public struct APIAssignmentPickerListItem: Equatable {
     public let id: String
     public let name: String
     public let allowedExtensions: [String]
+    public let gradeAsGroup: Bool
 
-    public init(id: String, name: String, allowedExtensions: [String]) {
+    public init(id: String, name: String, allowedExtensions: [String], gradeAsGroup: Bool) {
         self.id = id
         self.name = name
         self.allowedExtensions = allowedExtensions
+        self.gradeAsGroup = gradeAsGroup
     }
 
     public func isFileAllowed(_ url: URL) -> Bool {

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListRequest.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListRequest.swift
@@ -30,6 +30,7 @@ public struct AssignmentPickerListRequest: APIGraphQLRequestable {
                 _id
                 allowedExtensions
                 submissionTypes
+                gradeAsGroup
                 lockInfo {
                   isLocked
                 }

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListResponse.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListResponse.swift
@@ -27,6 +27,7 @@ public struct AssignmentPickerListResponse: Codable, Equatable {
         let submissionTypes: [SubmissionType]
         let allowedExtensions: [String]?
         let lockInfo: LockInfo
+        let gradeAsGroup: Bool
 
         public var isLocked: Bool { lockInfo.isLocked }
     }

--- a/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/API/AssignmentPickerListService.swift
@@ -73,7 +73,12 @@ public class AssignmentPickerListService: AssignmentPickerListServiceProtocol {
     private static func filterAssignments(_ assignments: [AssignmentPickerListResponse.Assignment]) -> [APIAssignmentPickerListItem] {
         assignments.compactMap {
             guard $0.isLocked == false, $0.submissionTypes.contains(.online_upload) else { return nil }
-            return APIAssignmentPickerListItem(id: $0._id, name: $0.name, allowedExtensions: $0.allowedExtensions ?? [])
+            return APIAssignmentPickerListItem(
+                id: $0._id,
+                name: $0.name,
+                allowedExtensions: $0.allowedExtensions ?? [],
+                gradeAsGroup: $0.gradeAsGroup
+            )
         }
     }
 }

--- a/Core/Core/SubmitAssignmentExtension/Model/AttachmentSubmissionService.swift
+++ b/Core/Core/SubmitAssignmentExtension/Model/AttachmentSubmissionService.swift
@@ -29,12 +29,26 @@ public class AttachmentSubmissionService {
     /**
      - returns: The `FileSubmission` CoreData object for the newly created submission.
      */
-    public func submit(urls: [URL], courseID: String, assignmentID: String, assignmentName: String, comment: String?) -> NSManagedObjectID {
+    public func submit(
+        urls: [URL],
+        courseID: String,
+        assignmentID: String,
+        assignmentName: String,
+        comment: String?,
+        isGroupComment: Bool?
+    ) -> NSManagedObjectID {
         if let existingSubmissionID = existingSubmissionID {
             submissionAssembly.composer.deleteSubmission(submissionID: existingSubmissionID)
         }
 
-        let submissionID = submissionAssembly.composer.makeNewSubmission(courseId: courseID, assignmentId: assignmentID, assignmentName: assignmentName, comment: comment, files: urls)
+        let submissionID = submissionAssembly.composer.makeNewSubmission(
+            courseId: courseID,
+            assignmentId: assignmentID,
+            assignmentName: assignmentName,
+            comment: comment,
+            isGroupComment: isGroupComment,
+            files: urls
+        )
         existingSubmissionID = submissionID
         submissionAssembly.start(fileSubmissionID: submissionID)
         return submissionID

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/AssignmentPickerItem.swift
@@ -20,6 +20,7 @@ public struct AssignmentPickerItem: Equatable, Identifiable {
     public let id: String
     public let name: String
     public let notAvailableReason: String?
+    public let gradeAsGroup: Bool
 
     public init(apiItem: APIAssignmentPickerListItem, sharedFileExtensions: Set<String>) {
         let incompatibleExtensions = Array(sharedFileExtensions.subtracting(Set(apiItem.allowedExtensions))).sorted()
@@ -35,12 +36,18 @@ public struct AssignmentPickerItem: Equatable, Identifiable {
             notAvailableReason = "\(notCompatibleText)\n\(compatibleText)"
         }
 
-        self.init(id: apiItem.id, name: apiItem.name, notAvailableReason: notAvailableReason)
+        self.init(
+            id: apiItem.id,
+            name: apiItem.name,
+            notAvailableReason: notAvailableReason,
+            gradeAsGroup: apiItem.gradeAsGroup
+        )
     }
 
-    public init(id: String, name: String, notAvailableReason: String? = nil) {
+    public init(id: String, name: String, notAvailableReason: String? = nil, gradeAsGroup: Bool = false) {
         self.id = id
         self.name = name
         self.notAvailableReason = notAvailableReason
+        self.gradeAsGroup = gradeAsGroup
     }
 }

--- a/Core/Core/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModel.swift
+++ b/Core/Core/SubmitAssignmentExtension/ViewModel/SubmitAssignmentExtensionViewModel.swift
@@ -72,11 +72,14 @@ public class SubmitAssignmentExtensionViewModel: ObservableObject {
 
     public func submitTapped() {
         Analytics.shared.logEvent("submit_tapped")
-        let submissionID = submissionService.submit(urls: selectedFileURLs,
-                                                    courseID: coursePickerViewModel.selectedCourse!.id,
-                                                    assignmentID: assignmentPickerViewModel.selectedAssignment!.id,
-                                                    assignmentName: assignmentPickerViewModel.selectedAssignment!.name,
-                                                    comment: comment)
+        let submissionID = submissionService.submit(
+            urls: selectedFileURLs,
+            courseID: coursePickerViewModel.selectedCourse!.id,
+            assignmentID: assignmentPickerViewModel.selectedAssignment!.id,
+            assignmentName: assignmentPickerViewModel.selectedAssignment!.name,
+            comment: comment,
+            isGroupComment: assignmentPickerViewModel.selectedAssignment?.gradeAsGroup == true
+        )
         let fileProgressViewModel = FileProgressListViewModel(submissionID: submissionID, dismiss: { [shareCompleted] in
             shareCompleted()
         })

--- a/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
@@ -41,7 +41,14 @@ class FileSubmissionAssemblyTests: CoreTestCase {
         // MARK: - GIVEN
 
         let testee = FileSubmissionAssembly.makeShareExtensionAssembly()
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", isGroupComment: nil, files: [testFileURL])
+        let submissionID = testee.composer.makeNewSubmission(
+            courseId: "testCourse",
+            assignmentId: "testAssignment",
+            assignmentName: "testName",
+            comment: "testComment",
+            isGroupComment: nil,
+            files: [testFileURL]
+        )
         let submission = try! databaseClient.existingObject(with: submissionID) as! FileSubmission
         XCTAssertEqual(databaseClient.registeredObjects.count, 2) // submission + item
 

--- a/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
@@ -41,7 +41,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
         // MARK: - GIVEN
 
         let testee = FileSubmissionAssembly.makeShareExtensionAssembly()
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", files: [testFileURL])
+        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", isGroupComment: nil, files: [testFileURL])
         let submission = try! databaseClient.existingObject(with: submissionID) as! FileSubmission
         XCTAssertEqual(databaseClient.registeredObjects.count, 2) // submission + item
 
@@ -65,6 +65,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
         // MARK: Submission mock
 
         let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: "testComment",
+                                                                          group_comment: nil,
                                                                           submission_type: .online_upload,
                                                                           file_ids: ["apiID"])
         let submissionRequest = CreateSubmissionRequest(context: .course("testCourse"),
@@ -130,7 +131,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
 
     func testCancelDeletesSubmission() {
         let testee = FileSubmissionAssembly.makeShareExtensionAssembly()
-        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", files: [])
+        let submissionID = testee.composer.makeNewSubmission(courseId: "testCourse", assignmentId: "testAssignment", assignmentName: "testName", comment: "testComment", isGroupComment: nil, files: [])
         XCTAssertEqual(databaseClient.registeredObjects.count, 1)
         testee.cancel(submissionID: submissionID)
         drainMainQueue()

--- a/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
@@ -37,7 +37,8 @@ class FileSubmissionComposerTests: CoreTestCase {
         let submissionID = testee.makeNewSubmission(courseId: "testCourseID",
                                                     assignmentId: "testAssignmentID",
                                                     assignmentName: "testName",
-                                                    comment: "testComment",
+                                                    comment: "testComment", 
+                                                    isGroupComment: nil,
                                                     files: [
                                                         tempFileURL,
                                                         tempFileURL
@@ -71,6 +72,7 @@ class FileSubmissionComposerTests: CoreTestCase {
                                                     assignmentId: "testAssignmentID",
                                                     assignmentName: "testName",
                                                     comment: "testComment",
+                                                    isGroupComment: nil,
                                                     files: [
                                                         URL(string: "/test")!
                                                     ])
@@ -94,6 +96,7 @@ class FileSubmissionComposerTests: CoreTestCase {
                                                     assignmentId: "testAssignmentID",
                                                     assignmentName: "testName",
                                                     comment: "testComment",
+                                                    isGroupComment: nil,
                                                     files: [
                                                         URL(string: "/test")!
                                                     ])

--- a/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/PrepareUpload/FileSubmissionComposerTests.swift
@@ -37,7 +37,7 @@ class FileSubmissionComposerTests: CoreTestCase {
         let submissionID = testee.makeNewSubmission(courseId: "testCourseID",
                                                     assignmentId: "testAssignmentID",
                                                     assignmentName: "testName",
-                                                    comment: "testComment", 
+                                                    comment: "testComment",
                                                     isGroupComment: nil,
                                                     files: [
                                                         tempFileURL,

--- a/Core/CoreTests/Files/FileSubmission/Model/Submission/FileSubmissionSubmitterTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/Submission/FileSubmissionSubmitterTests.swift
@@ -80,7 +80,7 @@ class FileSubmissionSubmitterTests: CoreTestCase {
         item.fileSubmission = submission
 
         let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: "testComment",
-                                                                          group_comment: nil, 
+                                                                          group_comment: nil,
                                                                           submission_type: .online_upload,
                                                                           file_ids: ["itemAPIID"])
         let request = CreateSubmissionRequest(context: .course("testCourse"),

--- a/Core/CoreTests/Files/FileSubmission/Model/Submission/FileSubmissionSubmitterTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/Submission/FileSubmissionSubmitterTests.swift
@@ -36,8 +36,9 @@ class FileSubmissionSubmitterTests: CoreTestCase {
         item.fileSubmission = submission
 
         let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: "testComment",
-                                                                 submission_type: .online_upload,
-                                                                 file_ids: ["itemAPIID"])
+                                                                          group_comment: nil,
+                                                                          submission_type: .online_upload,
+                                                                          file_ids: ["itemAPIID"])
         let request = CreateSubmissionRequest(context: .course("testCourse"),
                                               assignmentID: "testAssignment",
                                               body: .init(submission: requestedSubmission))
@@ -79,8 +80,9 @@ class FileSubmissionSubmitterTests: CoreTestCase {
         item.fileSubmission = submission
 
         let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: "testComment",
-                                                                 submission_type: .online_upload,
-                                                                 file_ids: ["itemAPIID"])
+                                                                          group_comment: nil, 
+                                                                          submission_type: .online_upload,
+                                                                          file_ids: ["itemAPIID"])
         let request = CreateSubmissionRequest(context: .course("testCourse"),
                                               assignmentID: "testAssignment",
                                               body: .init(submission: requestedSubmission))
@@ -116,8 +118,9 @@ class FileSubmissionSubmitterTests: CoreTestCase {
         submission.assignmentID = "testAssignment"
 
         let requestedSubmission = CreateSubmissionRequest.Body.Submission(text_comment: "testComment",
-                                                                 submission_type: .online_upload,
-                                                                 file_ids: [])
+                                                                          group_comment: nil,
+                                                                          submission_type: .online_upload,
+                                                                          file_ids: [])
         let request = CreateSubmissionRequest(context: .course("testCourse"),
                                               assignmentID: "testAssignment",
                                               body: .init(submission: requestedSubmission))

--- a/Core/CoreTests/Files/UploadManagerTests.swift
+++ b/Core/CoreTests/Files/UploadManagerTests.swift
@@ -314,6 +314,7 @@ class UploadManagerTests: CoreTestCase {
     private func mockSubmission(courseID: String, assignmentID: String, fileIDs: [String], comment: String? = nil, taskID: String, accessToken: String? = nil) {
         let submission = CreateSubmissionRequest.Body.Submission(
             text_comment: comment,
+            group_comment: nil,
             submission_type: .online_upload,
             body: nil,
             url: nil,

--- a/Core/CoreTests/Submissions/APISubmissionTests.swift
+++ b/Core/CoreTests/Submissions/APISubmissionTests.swift
@@ -35,6 +35,7 @@ class APISubmissionTests: CoreTestCase {
     func testCreateSubmissionRequest() {
         let submission = CreateSubmissionRequest.Body.Submission(
             text_comment: "a comment",
+            group_comment: nil,
             submission_type: .online_text_entry,
             body: "yo",
             url: nil,
@@ -49,6 +50,30 @@ class APISubmissionTests: CoreTestCase {
         XCTAssertEqual(request.method, .post)
         XCTAssertEqual(request.body, body)
         XCTAssertEqual(request.body?.comment?.text_comment, "a comment")
+        XCTAssertEqual(request.body?.submission.group_comment, false)
+        XCTAssertEqual(request.body?.submission.comment, nil)
+    }
+
+    func testCreateGroupSubmissionRequest() {
+        let submission = CreateSubmissionRequest.Body.Submission(
+            text_comment: "a comment",
+            group_comment: true,
+            submission_type: .online_text_entry,
+            body: "yo",
+            url: nil,
+            file_ids: nil,
+            media_comment_id: nil,
+            media_comment_type: nil
+        )
+        let body = CreateSubmissionRequest.Body(submission: submission)
+        let request = CreateSubmissionRequest(context: .course("1"), assignmentID: "2", body: body)
+
+        XCTAssertEqual(request.path, "courses/1/assignments/2/submissions")
+        XCTAssertEqual(request.method, .post)
+        XCTAssertEqual(request.body, body)
+        XCTAssertEqual(request.body?.comment?.text_comment, nil)
+        XCTAssertEqual(request.body?.submission.group_comment, true)
+        XCTAssertEqual(request.body?.submission.comment, "a comment")
     }
 
     func testPutSubmissionGradeRequest() {

--- a/Core/CoreTests/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Submissions/GetSubmissionsTests.swift
@@ -89,7 +89,7 @@ class CreateSubmissionTests: CoreTestCase {
 
     func testItPostsModuleCompletedRequirement() {
         let context = Context(.course, id: "1")
-        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(submission_type: .online_text_entry)))
+        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(group_comment: nil, submission_type: .online_text_entry)))
         api.mock(request, value: nil)
         let expectation = XCTestExpectation(description: "notification")
         var notification: Notification?
@@ -109,7 +109,7 @@ class CreateSubmissionTests: CoreTestCase {
 
     func testItDoesNotPostModuleCompletedRequirementIfError() {
         let context = Context(.course, id: "1")
-        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(submission_type: .online_text_entry)))
+        let request = CreateSubmissionRequest(context: context, assignmentID: "2", body: .init(submission: .init(group_comment: nil, submission_type: .online_text_entry)))
         api.mock(request, error: NSError.instructureError("oops"))
         let expectation = XCTestExpectation(description: "notification")
         expectation.isInverted = true

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/API/AssignmentPickerListServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/API/AssignmentPickerListServiceTests.swift
@@ -64,7 +64,21 @@ class AssignmentPickerListServiceTests: CoreTestCase {
         testee.courseID = "successID"
         waitForExpectations(timeout: 0.1)
         XCTAssertEqual(receivedResult, .success([
-            .init(id: "A2", name: "online upload", allowedExtensions: [])
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
+        ]))
+    }
+
+    func testGroupGradedAssignmentFetchSuccessful() {
+        api.mock(AssignmentPickerListRequest(courseID: "successID"), value: mockAssignments([
+            mockAssignment(id: "A1", name: "unknown submission type"),
+            mockAssignment(id: "A2", name: "online upload", submission_types: [.online_upload], gradeAsGroup: true),
+            mockAssignment(id: "A3", isLocked: true, name: "online upload, locked", submission_types: [.online_upload]),
+            mockAssignment(id: "A4", name: "external tool", submission_types: [.external_tool])
+        ]))
+        testee.courseID = "successID"
+        waitForExpectations(timeout: 0.1)
+        XCTAssertEqual(receivedResult, .success([
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: true)
         ]))
     }
 
@@ -101,7 +115,7 @@ class AssignmentPickerListServiceTests: CoreTestCase {
         return AssignmentPickerListRequest.Response(data: .init(course: .init(assignmentsConnection: .init(nodes: assignments))))
     }
 
-    private func mockAssignment(id: String, isLocked: Bool = false, name: String, submission_types: [SubmissionType] = []) -> AssignmentPickerListResponse.Assignment {
-        .init(name: name, _id: id, submissionTypes: submission_types, allowedExtensions: [], lockInfo: .init(isLocked: isLocked))
+    private func mockAssignment(id: String, isLocked: Bool = false, name: String, submission_types: [SubmissionType] = [], gradeAsGroup: Bool = false) -> AssignmentPickerListResponse.Assignment {
+        .init(name: name, _id: id, submissionTypes: submission_types, allowedExtensions: [], lockInfo: .init(isLocked: isLocked), gradeAsGroup: gradeAsGroup)
     }
 }

--- a/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentSubmissionServiceTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/Model/AttachmentSubmissionServiceTests.swift
@@ -44,7 +44,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
 
         // MARK: - WHEN
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
 
         // MARK: - THEN
         XCTAssertEqual(mockAssembly.mockComposer.startedSubmissionID, submissionID)
@@ -56,13 +56,31 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
         XCTAssertEqual(mockAssembly.startedSubmission, submissionID)
     }
 
+    func testGroupCommentSubmit() {
+        // MARK: - GIVEN
+        let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
+
+        // MARK: - WHEN
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: true)
+
+        // MARK: - THEN
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmissionID, submissionID)
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.courseId, "testCourseID")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentId, "testAssignmentID")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.assignmentName, "testName")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.comment, "testComment")
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.isGroupComment, true)
+        XCTAssertEqual(mockAssembly.mockComposer.startedSubmission?.files, [fileURL])
+        XCTAssertEqual(mockAssembly.startedSubmission, submissionID)
+    }
+
     func testReSubmitDeletesPreviousSubmission() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
 
         // MARK: - WHEN
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
-        let submissionID2 = testee.submit(urls: [fileURL], courseID: "testCourseID2", assignmentID: "testAssignmentID2", assignmentName: "testName2", comment: "testComment2")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
+        let submissionID2 = testee.submit(urls: [fileURL], courseID: "testCourseID2", assignmentID: "testAssignmentID2", assignmentName: "testName2", comment: "testComment2", isGroupComment: nil)
 
         // MARK: - THEN
         XCTAssertEqual(mockAssembly.mockComposer.deletedSubmission, submissionID)
@@ -78,7 +96,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testCancel() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
 
         // MARK: - WHEN
         testee.fileProgressViewModelCancel(FileProgressListViewModel(submissionID: submissionID, dismiss: {}))
@@ -90,7 +108,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testRetry() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
 
         // MARK: - WHEN
         testee.fileProgressViewModelRetry(FileProgressListViewModel(submissionID: submissionID, dismiss: {}))
@@ -102,7 +120,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testItemDeletion() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
         let itemID = NSManagedObjectID()
 
         // MARK: - WHEN
@@ -115,7 +133,7 @@ class AttachmentSubmissionServiceTests: CoreTestCase {
     func testSuccess() {
         // MARK: - GIVEN
         let testee = AttachmentSubmissionService(submissionAssembly: mockAssembly)
-        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment")
+        let submissionID = testee.submit(urls: [fileURL], courseID: "testCourseID", assignmentID: "testAssignmentID", assignmentName: "testName", comment: "testComment", isGroupComment: nil)
 
         // MARK: - WHEN
         testee.fileProgressViewModel(FileProgressListViewModel(submissionID: submissionID, dismiss: {}), didAcknowledgeSuccess: submissionID)
@@ -156,6 +174,7 @@ class MockFileSubmissionComposer: FileSubmissionComposer {
         let assignmentId: String
         let assignmentName: String
         let comment: String?
+        let isGroupComment: Bool?
         let files: [URL]
     }
     var deletedSubmission: NSManagedObjectID?
@@ -163,11 +182,12 @@ class MockFileSubmissionComposer: FileSubmissionComposer {
     var startedSubmission: StartedSubmissionParams?
     var startedSubmissionID: NSManagedObjectID?
 
-    public override func makeNewSubmission(courseId: String, assignmentId: String, assignmentName: String, comment: String?, files: [URL]) -> NSManagedObjectID {
+    public override func makeNewSubmission(courseId: String, assignmentId: String, assignmentName: String, comment: String?, isGroupComment: Bool?, files: [URL]) -> NSManagedObjectID {
         startedSubmission = StartedSubmissionParams(courseId: courseId,
                                                     assignmentId: assignmentId,
                                                     assignmentName: assignmentName,
                                                     comment: comment,
+                                                    isGroupComment: isGroupComment,
                                                     files: files)
         let startedSubmissionID = NSManagedObjectID()
         self.startedSubmissionID = startedSubmissionID

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerItemTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerItemTests.swift
@@ -22,38 +22,47 @@ import XCTest
 class AssignmentPickerItemTests: XCTestCase {
 
     func testSetupFromAPIEntity() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>())
         XCTAssertEqual(testee.id, "1")
         XCTAssertEqual(testee.name, "n1")
+        XCTAssertEqual(testee.gradeAsGroup, false)
+    }
+
+    func testSetupFromGroupAPIEntity() {
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"], gradeAsGroup: true)
+        let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>())
+        XCTAssertEqual(testee.id, "1")
+        XCTAssertEqual(testee.name, "n1")
+        XCTAssertEqual(testee.gradeAsGroup, true)
     }
 
     func testNoReasonWhenAllFilesAllowed() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: [])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: [], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>(["jpg"]))
         XCTAssertNil(testee.notAvailableReason)
     }
 
     func testUnknownFileExtensionReason() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>())
         XCTAssertNil(testee.notAvailableReason)
     }
 
     func testCompatibleFileExtensionReason() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>(["jpg"]))
         XCTAssertNil(testee.notAvailableReason)
     }
 
     func testIncompatibleFileExtensionReason() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf"])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf"], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>(["xls"]))
         XCTAssertEqual(testee.notAvailableReason, "The xls file type in your submission is incompatible with the selected assignment.\nPlease use pdf file extension.")
     }
 
     func testIncompatibleFilesExtensionReason() {
-        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"])
+        let apiAssignment = APIAssignmentPickerListItem(id: "1", name: "n1", allowedExtensions: ["pdf", "jpg"], gradeAsGroup: false)
         let testee = AssignmentPickerItem(apiItem: apiAssignment, sharedFileExtensions: Set<String>(["xls", "docx", "pdf"]))
         XCTAssertEqual(testee.notAvailableReason, "The docx, xls file types in your submission are incompatible with the selected assignment.\nPlease use jpg, pdf file extensions.")
     }

--- a/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
+++ b/Core/CoreTests/SubmitAssignmentExtension/ViewModel/AssignmentPickerViewModelTests.swift
@@ -41,7 +41,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
 
     func testAssignmentFetchSuccessful() {
         mockService.mockResult = .success([
-            .init(id: "A2", name: "online upload", allowedExtensions: [])
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID"
         drainMainQueue()
@@ -51,10 +51,22 @@ class AssignmentPickerViewModelTests: CoreTestCase {
         ]))
     }
 
+    func testGroupAssignmentFetchSuccessful() {
+        mockService.mockResult = .success([
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: true)
+        ])
+        testee.courseID = "successID"
+        drainMainQueue()
+        XCTAssertNil(testee.selectedAssignment)
+        XCTAssertEqual(testee.state, .data([
+            .init(id: "A2", name: "online upload", gradeAsGroup: true)
+        ]))
+    }
+
     func testAssignmentFetchSuccessfulButSharedFilesArentReady() {
         testee.sharedFileExtensions.send(nil)
         mockService.mockResult = .success([
-            .init(id: "A2", name: "online upload", allowedExtensions: [])
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID"
         drainMainQueue()
@@ -64,7 +76,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
 
     func testSameCourseIdDoesntTriggerRefresh() {
         mockService.mockResult = .success([
-            .init(id: "A1", name: "online upload", allowedExtensions: [])
+            .init(id: "A1", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID"
         drainMainQueue()
@@ -85,7 +97,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
     func testDefaultAssignmentSelection() {
         environment.userDefaults?.submitAssignmentID = "A2"
         mockService.mockResult = .success([
-            .init(id: "A2", name: "online upload", allowedExtensions: [])
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID"
         drainMainQueue()
@@ -99,7 +111,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
 
     func testCourseChangeRefreshesState() {
         mockService.mockResult = .success([
-            .init(id: "A1", name: "online upload", allowedExtensions: [])
+            .init(id: "A1", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID"
         drainMainQueue()
@@ -109,7 +121,7 @@ class AssignmentPickerViewModelTests: CoreTestCase {
 
         testee.assignmentSelected(.init(id: "A1", name: "online upload"))
         mockService.mockResult = .success([
-            .init(id: "A2", name: "online upload", allowedExtensions: [])
+            .init(id: "A2", name: "online upload", allowedExtensions: [], gradeAsGroup: false)
         ])
         testee.courseID = "successID2"
         drainMainQueue()

--- a/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/ArcSubmission/ArcSubmissionPresenterTests.swift
@@ -52,6 +52,7 @@ class ArcSubmissionPresenterTests: StudentTestCase {
             assignmentID: "1",
             body: .init(submission: .init(
                 text_comment: nil,
+                group_comment: nil,
                 submission_type: .basic_lti_launch,
                 body: nil,
                 url: URL(string: "https://arc.com/media/1")!,
@@ -78,6 +79,7 @@ class ArcSubmissionPresenterTests: StudentTestCase {
             assignmentID: "2",
             body: .init(submission: .init(
                 text_comment: nil,
+                group_comment: nil,
                 submission_type: .basic_lti_launch,
                 body: nil,
                 url: URL(string: "https://arc.com/media/1")!,
@@ -104,6 +106,7 @@ class ArcSubmissionPresenterTests: StudentTestCase {
             assignmentID: "2",
             body: .init(submission: .init(
                 text_comment: nil,
+                group_comment: nil,
                 submission_type: .basic_lti_launch,
                 body: nil,
                 url: URL(string: "https://arc.com/media/1")!,

--- a/Student/StudentUnitTests/Submissions/TextSubmission/TextSubmissionViewControllerTests.swift
+++ b/Student/StudentUnitTests/Submissions/TextSubmission/TextSubmissionViewControllerTests.swift
@@ -26,8 +26,9 @@ class TextSubmissionViewControllerTests: StudentTestCase {
     var navigation: UINavigationController!
 
     let request = CreateSubmissionRequest(context: .course("1"), assignmentID: "1", body: .init(submission: .init(
-            submission_type: .online_text_entry,
-            body: "<b>submission</b>"
+        group_comment: nil,
+        submission_type: .online_text_entry,
+        body: "<b>submission</b>"
     )))
 
     class MockEditor: RichContentEditorViewController {

--- a/Student/StudentUnitTests/Submissions/UrlSubmissionPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/UrlSubmissionPresenterTests.swift
@@ -77,6 +77,7 @@ class UrlSubmissionPresenterTests: StudentTestCase {
             assignmentID: "1",
             body: .init(submission: .init(
                 text_comment: nil,
+                group_comment: nil,
                 submission_type: .online_url,
                 body: nil,
                 url: url,


### PR DESCRIPTION
refs: MBL-17690
affects: Student
release note: Fixed group submission comment not being uploaded when using share extension
test plan: See ticket but use *.beta.instructure.com environment by logging in on the web and generate QR code to log in on mobile. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet

