### PR TITLE
Fix fullscreen video crash

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebViewFullScreenVideoSupport.swift
+++ b/Core/Core/CoreWebView/View/CoreWebViewFullScreenVideoSupport.swift
@@ -70,6 +70,25 @@ extension CoreWebView {
         }
 
         private func restoreOriginalConstraints(_ webView: WKWebView) {
+            /// Sometimes the webview exits full screen before being placed back into its original superview.
+            /// In this case the theme switcher and the webview will have different super views and
+            /// if we want to activate a constraint affecting both views it will crash the app.
+            let isWebViewAndThemeSwitcherInDifferentViews = originalConstraints.contains { constraint in
+                guard let button = constraint.firstItem as? CoreWebViewThemeSwitcherButton else {
+                    return false
+                }
+
+                if button.superview != webView.superview {
+                    return true
+                }
+
+                return false
+            }
+
+            if isWebViewAndThemeSwitcherInDifferentViews {
+                return
+            }
+
             webView.translatesAutoresizingMaskIntoConstraints = false
             originalConstraints.forEach { $0.isActive = true }
             webView.superview?.layoutIfNeeded()

--- a/Core/CoreTests/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
+++ b/Core/CoreTests/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
@@ -54,6 +54,47 @@ class CoreWebViewFullScreenVideoSupportTests: XCTestCase {
         XCTAssertTrue(constraint.isActive)
         XCTAssertEqual(webView.backgroundColor, .purple)
     }
+
+    func testNotCrashesWhenWebViewHasNoParentAfterExitingFullScreen() {
+        let host = UIView(frame: .init(origin: .zero, size: .init(width: 123, height: 321)))
+        let webView = MockWebView()
+        host.addSubview(webView)
+        webView.pinWithThemeSwitchButton(
+            inside: host,
+            leading: 0,
+            trailing: nil,
+            top: nil,
+            bottom: nil
+        )
+        webView.mockedFullscreenState = .enteringFullscreen
+        webView.mockedFullscreenState = .inFullscreen
+
+        // WHEN
+        webView.removeFromSuperview()
+        webView.mockedFullscreenState = .notInFullscreen
+    }
+
+    func testNotCrashesWhenWebViewHasDifferentParentThanThemeSwitcherAfterExitingFullScreen() {
+        let host = UIView(frame: .init(origin: .zero, size: .init(width: 123, height: 321)))
+        let webView = MockWebView()
+        host.addSubview(webView)
+        webView.pinWithThemeSwitchButton(
+            inside: host,
+            leading: 0,
+            trailing: nil,
+            top: nil,
+            bottom: nil
+        )
+        webView.mockedFullscreenState = .enteringFullscreen
+        webView.mockedFullscreenState = .inFullscreen
+
+        let newHost = UIView(frame: .init(origin: .zero, size: .init(width: 123, height: 321)))
+        webView.removeFromSuperview()
+        newHost.addSubview(webView)
+
+        // WHEN
+        webView.mockedFullscreenState = .notInFullscreen
+    }
 }
 
 class MockWebView: CoreWebView {


### PR DESCRIPTION
I couldn't reproduce the crash on device but could set up multiple scenarios with unit tests that lead to this crash. Hope this will fix the crash we see.

refs: [MBL-17779](https://instructure.atlassian.net/browse/MBL-17779)
affects: Student, Teacher, Parent
release note: none

test plan:
- Test if full screen/pip video playback still works and you can exit these modes.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet


[MBL-17779]: https://instructure.atlassian.net/browse/MBL-17779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ