### PR TITLE
Student, Teacher | Automation - E2E test maintenance

### DIFF
--- a/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -81,6 +81,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
                         .foregroundColor(.textDarkest)
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
+                        .accessibilityIdentifier("ComposeMessage.recipient.\(recipient.ids != [] ? recipient.ids[0] : "all\(recipient.displayName)")")
                     Spacer()
                     Image.checkSolid
                         .resizable()
@@ -108,6 +109,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
                                 .font(.regular16)
                                 .foregroundColor(.textDarkest)
                                 .lineLimit(1)
+                                .accessibilityIdentifier("ComposeMessage.recipient.all\(viewModel.roleName)")
                             Text("\(viewModel.allRecipient.ids.count) People", bundle: .core)
                                 .font(.regular14)
                                 .foregroundColor(.textDark)

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -81,7 +81,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
                         .foregroundColor(.textDarkest)
                         .lineLimit(1)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .accessibilityIdentifier("ComposeMessage.recipient.\(recipient.ids != [] ? recipient.ids[0] : "all\(recipient.displayName)")")
+                        .accessibilityIdentifier("ComposeMessage.recipient.\(recipient.ids.first ?? "all\(recipient.displayName)")")
                     Spacer()
                     Image.checkSolid
                         .resizable()

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -57,6 +57,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
                 .font(.regular16)
                 .foregroundColor(.accentColor)
         }
+        .accessibilityIdentifier("Inbox.addRecipient.done")
     }
 
     private var peopleView: some View {

--- a/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
+++ b/Core/Core/Inbox/Addressbook/View/AddressbookRoleView.swift
@@ -83,6 +83,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
             Text("Done", bundle: .core)
                 .font(.regular16)
                 .foregroundColor(.accentColor)
+                .accessibilityIdentifier("Inbox.addRecipient.done")
         }
     }
 
@@ -142,6 +143,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
                             .font(.regular16)
                             .foregroundColor(.textDarkest)
                             .lineLimit(1)
+                            .accessibilityIdentifier("Inbox.addRecipient.all\(role)")
                         Text("\(viewModel.roleRecipients[role]?.count ?? 0) People", bundle: .core)
                             .font(.regular14)
                             .foregroundColor(.textDark)
@@ -178,6 +180,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
                             .font(.regular16)
                             .foregroundColor(.textDarkest)
                             .lineLimit(1)
+                            .accessibilityIdentifier("Inbox.addRecipient.allIn.\(viewModel.recipientContext.context.id)")
                         Text("\(viewModel.recipients.count) People", bundle: .core)
                             .font(.regular14)
                             .foregroundColor(.textDark)

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -139,6 +139,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             Text("Cancel", bundle: .core)
                 .font(.regular16)
                 .foregroundColor(.accentColor)
+                .accessibilityIdentifier("ComposeMessage.cancel")
         }
     }
 
@@ -151,6 +152,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         .accessibility(label: Text("Send", bundle: .core))
         .disabled(!model.sendButtonActive)
         .frame(maxHeight: .infinity, alignment: .top)
+        .accessibilityIdentifier("ComposeMessage.send")
 
     }
 
@@ -171,11 +173,13 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         }
         .accessibilityLabel(Text("Add recipient", bundle: .core))
         .accessibilityElement(children: .ignore)
+        .accessibilityIdentifier("ComposeMessage.addRecipient")
     }
 
     private var headerView: some View {
         HStack(alignment: .center) {
             Text(model.subject.isEmpty ? model.title : model.subject)
+                .accessibilityIdentifier("ComposeMessage.subjectLabel")
                 .multilineTextAlignment(.leading)
                 .font(.semibold22)
                 .foregroundColor(.textDarkest)
@@ -218,6 +222,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 Text("Course", bundle: .core)
                     .font(.regular16, lineHeight: .condensed)
                     .foregroundColor(.textDark)
+                    .accessibilityIdentifier("ComposeMessage.course")
                 if let context = model.selectedContext {
                     Text(context.name)
                         .font(.regular16, lineHeight: .condensed)
@@ -242,6 +247,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 .foregroundColor(.textDark)
                 .padding(.vertical, 12)
                 .accessibilitySortPriority(3)
+                .accessibilityIdentifier("ComposeMessage.to")
             if !model.recipients.isEmpty {
                 recipientsView
                     .accessibilitySortPriority(1)
@@ -282,6 +288,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 .focused($focusedInput, equals: .subject)
                 .submitLabel(.done)
                 .accessibility(label: Text("Subject", bundle: .core))
+                .accessibilityIdentifier("ComposeMessage.subjectInput")
         }
         .disabled(model.isSubjectDisabled)
         .opacity(model.isSubjectDisabled ? 0.6 : 1)
@@ -299,6 +306,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         .padding(.horizontal, defaultHorizontalPaddingValue)
         .padding(.vertical, defaultVerticalPaddingValue)
         .contentShape(Rectangle())
+        .accessibilityIdentifier("ComposeMessage.individual")
     }
 
     @ViewBuilder
@@ -324,6 +332,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                         .padding(.horizontal, defaultHorizontalPaddingValue)
                 }
                 .accessibility(label: Text("Add attachment", bundle: .core))
+                .accessibilityIdentifier("ComposeMessage.attachment")
             }
             .padding(.leading, defaultHorizontalPaddingValue)
             .padding(.top, defaultVerticalPaddingValue)
@@ -346,6 +355,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             .padding(.horizontal, defaultHorizontalPaddingValue)
             .frame(minHeight: 60)
             .accessibility(label: Text("Message", bundle: .core))
+            .accessibilityIdentifier("ComposeMessage.body")
         }
         .disabled(model.isMessageDisabled)
         .opacity(model.isMessageDisabled ? 0.6 : 1)

--- a/Core/Core/Inbox/ComposeMessage/View/RecipientPillView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/RecipientPillView.swift
@@ -41,7 +41,7 @@ public struct RecipientPillView: View {
                     .padding(.trailing, 10)
                     .truncationMode(.tail)
                     .lineLimit(1)
-                    .accessibilityIdentifier("ComposeMessage.recipientPill.\(recipient.ids != [] ? recipient.ids[0] : "all\(recipient.displayName)")")
+                    .accessibilityIdentifier("ComposeMessage.recipientPill.\(recipient.ids.first ?? "all\(recipient.displayName)")")
                 removeButton
                     .padding(.trailing, 10)
             }

--- a/Core/Core/Inbox/ComposeMessage/View/RecipientPillView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/RecipientPillView.swift
@@ -41,6 +41,7 @@ public struct RecipientPillView: View {
                     .padding(.trailing, 10)
                     .truncationMode(.tail)
                     .lineLimit(1)
+                    .accessibilityIdentifier("ComposeMessage.recipientPill.\(recipient.ids != [] ? recipient.ids[0] : "all\(recipient.displayName)")")
                 removeButton
                     .padding(.trailing, 10)
             }

--- a/Core/Core/Inbox/InboxCoursePicker/View/InboxCoursePickerView.swift
+++ b/Core/Core/Inbox/InboxCoursePicker/View/InboxCoursePickerView.swift
@@ -153,6 +153,7 @@ public struct InboxCoursePickerView: View {
             .padding(.vertical, 16)
             .background(.background)
             .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier("Inbox.course.\(course.id)")
 
             separator
         }
@@ -183,6 +184,7 @@ public struct InboxCoursePickerView: View {
             .padding(.vertical, 16)
             .background(.background)
             .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier("Inbox.group.\(group.id)")
 
             separator
         }

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -95,7 +95,7 @@ public struct MessageDetailsView: View {
                 .moreLine
                 .foregroundColor(Color(Brand.shared.navTextColor))
         })
-        .identifier("MessageDetails.more")
+        .accessibilityIdentifier("MessageDetails.more")
         .accessibility(label: Text("More options", bundle: .core))
     }
 

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -79,6 +79,7 @@ public struct MessageDetailsView: View {
         HStack {
             Text(model.subject)
                 .font(.semibold22)
+                .accessibilityIdentifier("MessageDetails.subject")
             Spacer()
             starButton
         }
@@ -94,7 +95,7 @@ public struct MessageDetailsView: View {
                 .moreLine
                 .foregroundColor(Color(Brand.shared.navTextColor))
         })
-        .identifier("MessageDetails.moreButton")
+        .identifier("MessageDetails.more")
         .accessibility(label: Text("More options", bundle: .core))
     }
 
@@ -108,6 +109,7 @@ public struct MessageDetailsView: View {
                     .foregroundColor(.textDark)
                     .padding(.leading, 6)
                     .accessibilityLabel(String(localized: "Mark as Unstarred", bundle: .core))
+                    .accessibilityIdentifier("MessageDetails.unstar")
             }
         } else {
             Button {
@@ -118,6 +120,7 @@ public struct MessageDetailsView: View {
                     .foregroundColor(.textDark)
                     .padding(.leading, 6)
                     .accessibilityLabel(String(localized: "Mark as Starred", bundle: .core))
+                    .accessibilityIdentifier("MessageDetails.star")
             }
         }
     }

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -44,6 +44,7 @@ public struct MessageView: View {
                 Text("Reply", bundle: .core)
                     .font(.regular16)
                     .foregroundColor(Color(Brand.shared.linkColor))
+                    .accessibilityIdentifier("MessageDetails.replyButton")
             }
         }
     }
@@ -56,10 +57,12 @@ public struct MessageView: View {
                     .font(.regular16)
                     .foregroundColor(.textDarkest)
                     .lineLimit(1)
+                    .accessibilityIdentifier("MessageDetails.author")
 
                 Text(model.date)
                     .foregroundColor(.textDark)
                     .font(.regular12)
+                    .accessibilityIdentifier("MessageDetails.date")
             }
             Spacer()
             Button {
@@ -71,6 +74,7 @@ public struct MessageView: View {
                     .foregroundColor(.textDark)
                     .padding(.leading, 6)
                     .accessibilityLabel(Text("Reply", bundle: .core))
+                    .accessibilityIdentifier("MessageDetails.replyImage")
             }
             Button {
                 moreDidTap()
@@ -81,6 +85,7 @@ public struct MessageView: View {
                     .foregroundColor(.textDark)
                     .padding(.horizontal, 6)
                     .accessibilityLabel(Text("Conversation options", bundle: .core))
+                    .accessibilityIdentifier("MessageDetails.options")
             }
         }
     }
@@ -90,6 +95,7 @@ public struct MessageView: View {
             Text(model.body.toAttributedStringWithLinks())
                 .font(.regular16)
                 .textSelection(.enabled)
+                .accessibilityIdentifier("MessageDetails.body")
             if model.showAttachments {
                 AttachmentsView(attachments: model.attachments, didSelectAttachment: model.handleFileNavigation)
             }

--- a/Core/Core/Inbox/View/InboxFilterBarView.swift
+++ b/Core/Core/Inbox/View/InboxFilterBarView.swift
@@ -66,6 +66,7 @@ public struct InboxFilterBarView: View {
         }
         .accessibilityLabel(Text("Filter messages by course", bundle: .core))
         .accessibilityHint(Text(model.course))
+        .accessibilityIdentifier("Inbox.filterByCourse")
     }
 
     private var scopeFilterButton: some View {
@@ -94,6 +95,7 @@ public struct InboxFilterBarView: View {
         }
         .accessibilityLabel(Text("Filter messages by type", bundle: .core))
         .accessibilityHint(Text(model.scope.localizedName))
+        .accessibilityIdentifier("Inbox.filterByType")
     }
 
     private var scopeFilterButtons: [ActionSheet.Button] {

--- a/Core/Core/Inbox/View/InboxMessageView.swift
+++ b/Core/Core/Inbox/View/InboxMessageView.swift
@@ -35,6 +35,7 @@ public struct InboxMessageView: View {
         }
         .buttonStyle(PlainButtonStyle())
         .accessibilityLabel(model.a11yLabel)
+        .accessibilityIdentifier("Conversation.\(model.id)")
     }
 
     private var cellContent: some View {
@@ -46,21 +47,25 @@ public struct InboxMessageView: View {
                         .font(.semibold16)
                         .foregroundColor(.textDarkest)
                         .lineLimit(1)
+                        .accessibilityIdentifier("Conversation.\(model.id).participantName")
                     Spacer()
                     Text(model.date)
                         .foregroundColor(.textDark)
                         .font(.regular12)
+                        .accessibilityIdentifier("Conversation.\(model.id).date")
                 }
                 Text(verbatim: model.title)
                     .font(.regular14)
                     .foregroundColor(.textDarkest)
                     .lineLimit(1)
+                    .accessibilityIdentifier("Conversation.\(model.id).title")
                 HStack(alignment: .bottom, spacing: 0) {
                     Text(verbatim: model.message)
                         .font(.regular14)
                         .foregroundColor(.textDark)
                         .lineLimit(1)
                         .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("Conversation.\(model.id).message")
                     Spacer(minLength: 0)
                     attachmentIndicator
                     starredIndicator

--- a/Core/Core/Inbox/View/InboxView.swift
+++ b/Core/Core/Inbox/View/InboxView.swift
@@ -195,7 +195,7 @@ public struct InboxView: View, ScreenViewTrackable {
                 .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
         }
         .frame(width: 44, height: 44).padding(.leading, -6)
-        .identifier("inbox.profileButton")
+        .identifier("Inbox.profileButton")
         .accessibility(label: Text("Profile Menu", bundle: .core))
     }
 
@@ -207,7 +207,7 @@ public struct InboxView: View, ScreenViewTrackable {
                 .foregroundColor(Color(Brand.shared.navTextColor.ensureContrast(against: Brand.shared.navBackground)))
         }
         .frame(width: 44, height: 44).padding(.trailing, -6)
-        .identifier("inbox.newMessageButton")
+        .identifier("Inbox.newMessageButton")
         .accessibility(label: Text("New Message", bundle: .core))
     }
 

--- a/Core/TestsFoundation/Helpers/InboxHelper.swift
+++ b/Core/TestsFoundation/Helpers/InboxHelper.swift
@@ -111,12 +111,16 @@ public class InboxHelper: BaseHelper {
             return app.find(id: "Inbox.course.\(course.id)")
         }
 
-        public static func recipientSelectionItem(course: DSCourse? = nil, courseId: String? = nil) -> XCUIElement {
-            return app.find(id: "branch_course_\(course?.id ?? courseId!)")
+        public static func recipientPillById(recipient: DSUser) -> XCUIElement {
+            return app.find(id: "ComposeMessage.recipientPill.\(recipient.id)", type: .button)
         }
 
-        public static func recipientLabel(recipient: DSUser) -> XCUIElement {
-            return app.find(id: "message-recipient.\(recipient.id).label", type: .staticText)
+        public static func recipientPillByRole(role: String) -> XCUIElement {
+            return app.find(id: "ComposeMessage.recipientPill.all\(role)", type: .button)
+        }
+
+        public static func recipient(user: DSUser) -> XCUIElement {
+            return app.find(id: "ComposeMessage.recipient.\(user.id)", type: .button)
         }
 
         public struct Attachments {
@@ -151,9 +155,9 @@ public class InboxHelper: BaseHelper {
     public static func sendMessage(course: DSCourse, student: DSUser, subject: String?, message: String?) {
         newMessageButton.hit()
         Composer.selectCourseButton.hit()
-        Composer.Recipients.allInCourse(course: course).hit()
+        Composer.courseItem(course: course).hit()
         Composer.addRecipientButton.hit()
-        Composer.recipientSelectionItem(course: course).hit()
+        Composer.Recipients.allInCourse(course: course).hit()
         Composer.subjectInput.hit().pasteText(text: subject ?? "Sample Subject of \(student.name)")
         Composer.bodyInput.hit().pasteText(text: message ?? "Sample Message of \(student.name)")
         Composer.sendButton.hit()

--- a/Core/TestsFoundation/Helpers/InboxHelper.swift
+++ b/Core/TestsFoundation/Helpers/InboxHelper.swift
@@ -17,15 +17,32 @@
 //
 
 public class InboxHelper: BaseHelper {
-    public static var navBar: XCUIElement { app.find(id: "CanvasCore.HelmView") }
-    public static var profileButton: XCUIElement { app.find(id: "Inbox.profileButton") }
-    public static var newMessageButton: XCUIElement { app.find(id: "inbox.new-message") }
+    public static var profileButton: XCUIElement { app.find(id: "Inbox.profileButton", type: .button) }
+    public static var newMessageButton: XCUIElement { app.find(id: "Inbox.newMessageButton", type: .button) }
+    public static var filterByCourseButton: XCUIElement { app.find(id: "Inbox.filterByCourse") }
+    public static var filterByTypeButton: XCUIElement { app.find(id: "Inbox.filterByType") }
 
-    public static func conversation(conversation: DSConversation? = nil, conversationId: String? = nil) -> XCUIElement {
-        return app.find(id: "inbox.conversation-\(conversation?.id ?? conversationId!)")
+    public static func conversation(conversation: DSConversation) -> XCUIElement {
+        return app.find(id: "Conversation.\(conversation.id)")
     }
 
-    public static var conversations: [XCUIElement] { app.findAll(idStartingWith: "inbox.conversation-") }
+    public static func conversationDateLabel(conversation: DSConversation) -> XCUIElement {
+        return app.find(id: "Conversation.\(conversation.id).date")
+    }
+
+    public static func conversationParticipantLabel(conversation: DSConversation) -> XCUIElement {
+        return app.find(id: "Conversation.\(conversation.id).participantName")
+    }
+
+    public static func conversationTitleLabel(conversation: DSConversation) -> XCUIElement {
+        return app.find(id: "Conversation.\(conversation.id).title")
+    }
+
+    public static func conversationMessageLabel(conversation: DSConversation) -> XCUIElement {
+        return app.find(id: "Conversation.\(conversation.id).message")
+    }
+
+    public static var conversations: [XCUIElement] { app.findAll(idStartingWith: "Conversation.") }
 
     public static func addDateToSubject(subject: String, unread: Bool) -> String {
         let date = Date()
@@ -36,62 +53,62 @@ public class InboxHelper: BaseHelper {
         return unread ? result + ", Unread" : result
     }
 
-    public static func conversationBySubject(subject: String, unread: Bool = true) -> XCUIElement {
-        let stringToFind = addDateToSubject(subject: subject, unread: unread)
-        return app.find(label: stringToFind)
+    public static func conversationBySubject(subject: String) -> XCUIElement {
+        return app.find(label: subject, type: .staticText)
     }
 
     public struct Filter {
-        public static var all: XCUIElement { app.find(id: "inbox.filter-btn-all") }
-        public static var unread: XCUIElement { app.find(id: "inbox.filter-btn-unread") }
-        public static var starred: XCUIElement { app.find(id: "inbox.filter-btn-starred") }
-        public static var sent: XCUIElement { app.find(id: "inbox.filter-btn-sent") }
-        public static var archived: XCUIElement { app.find(id: "inbox.filter-btn-archived") }
-        public static var byCourse: XCUIElement { app.find(id: "inbox.filterByCourse") }
+        public static var cancelButton: XCUIElement { app.find(label: "Cancel", type: .button) }
+
+        // Filter by course
+        public static var allCourses: XCUIElement { app.find(label: "All Courses", type: .button) }
+        public static func course(course: DSCourse) -> XCUIElement { app.find(label: course.name, type: .button) }
+
+        // Filter by type
+        public static var inbox: XCUIElement { app.find(label: "Inbox", type: .button) }
+        public static var unread: XCUIElement { app.find(label: "Unread", type: .button) }
+        public static var starred: XCUIElement { app.find(label: "Starred", type: .button) }
+        public static var sent: XCUIElement { app.find(label: "Sent", type: .button) }
+        public static var archived: XCUIElement { app.find(label: "Archived", type: .button) }
     }
 
     public struct Details {
-        public static var navBar: XCUIElement { app.find(id: "Message Details") }
-        public static var optionsButton: XCUIElement { app.find(id: "inbox.detail.options.button") }
-        public static var replyButton: XCUIElement { app.find(id: "inbox.conversation-message-row.reply-button") }
-        public static var starButton: XCUIElement { app.find(id: "inbox.detail.not-starred") }
-        public static var unStarButton: XCUIElement { app.find(id: "inbox.detail.starred") }
-        public static func subjectLabel(conversation: DSConversation) -> XCUIElement { app.find(label: conversation.subject) }
-
-        public static func message(conversation: DSConversation) -> XCUIElement {
-            return app.find(id: "inbox.conversation-message-\(conversation.messages[0].id)")
-        }
-
-        public static func bodyOfMessage(conversation: DSConversation) -> XCUIElement {
-            return app.find(label: conversation.last_authored_message)
-        }
-
-        public static func messageOptions(conversation: DSConversation) -> XCUIElement {
-            return app.find(id: "conversation-message.kabob-\(conversation.messages[0].id)")
-        }
+        public static var optionsButton: XCUIElement { app.find(id: "MessageDetails.options") }
+        public static var moreButton: XCUIElement { app.find(id: "MessageDetails.more", type: .button) }
+        public static var replyImage: XCUIElement { app.find(id: "MessageDetails.replyImage") }
+        public static var replyButton: XCUIElement { app.find(id: "MessageDetails.replyButton") }
+        public static var authorLabel: XCUIElement { app.find(id: "MessageDetails.author") }
+        public static var starButton: XCUIElement { app.find(id: "MessageDetails.star") }
+        public static var unstarButton: XCUIElement { app.find(id: "MessageDetails.unstar") }
+        public static var dateLabel: XCUIElement { app.find(id: "MessageDetails.date") }
+        public static var bodyLabel: XCUIElement { app.find(id: "MessageDetails.body") }
+        public static var subjectLabel: XCUIElement { app.find(id: "MessageDetails.subject") }
 
         public struct Options {
-            public static var replyButton: XCUIElement { app.find(label: "Reply", type: .button) }
-            public static var replyAllButton: XCUIElement { app.find(label: "Reply All", type: .button) }
-            public static var forwardButton: XCUIElement { app.find(label: "Forward", type: .button) }
-            public static var deleteButton: XCUIElement { app.find(label: "Delete", type: .button) }
-            public static var cancelButton: XCUIElement { app.find(label: "Cancel", type: .button) }
+            public static var replyButton: XCUIElement { app.find(id: "MessageDetails.reply") }
+            public static var replyAllButton: XCUIElement { app.find(id: "MessageDetails.replyAll") }
+            public static var forwardButton: XCUIElement { app.find(id: "MessageDetails.forward") }
+            public static var deleteButton: XCUIElement { app.find(id: "MessageDetails.delete") }
+            public static var markAsUnreadButton: XCUIElement { app.find(id: "MessageDetails.markAsUnread") }
+            public static var markAsReadButton: XCUIElement { app.find(id: "MessageDetails.markAsRead") }
+            public static var archiveButton: XCUIElement { app.find(id: "MessageDetails.archive") }
+            public static var unarchiveButton: XCUIElement { app.find(id: "MessageDetails.unarchive") }
         }
     }
 
     public struct Composer {
-        public static var cancelButton: XCUIElement { app.find(id: "compose-message.cancel") }
-        public static var attachButton: XCUIElement { app.find(id: "compose-message.attach") }
-        public static var sendButton: XCUIElement { app.find(id: "compose-message.send") }
-        public static var courseSelectButton: XCUIElement { app.find(id: "compose.course-select") }
-        public static var subjectInput: XCUIElement { app.find(id: "compose-message.subject-text-input") }
-        public static var messageInput: XCUIElement { app.find(id: "compose-message.body-text-input") }
-        public static var individualSwitch: XCUIElement { app.find(labelContaining: "individual", type: .switch) }
-        public static var recipientsLabel: XCUIElement { app.find(id: "compose.recipients-placeholder") }
-        public static var addRecipientButton: XCUIElement { app.find(id: "compose.add-recipient") }
+        public static var cancelButton: XCUIElement { app.find(id: "ComposeMessage.cancel") }
+        public static var subjectLabel: XCUIElement { app.find(id: "ComposeMessage.subjectLabel") }
+        public static var sendButton: XCUIElement { app.find(id: "ComposeMessage.send") }
+        public static var selectCourseButton: XCUIElement { app.find(id: "ComposeMessage.course", type: .button) }
+        public static var subjectInput: XCUIElement { app.find(id: "ComposeMessage.subjectInput") }
+        public static var individualToggle: XCUIElement { app.find(id: "ComposeMessage.individual").find(type: .switch) }
+        public static var addAttachmentButton: XCUIElement { app.find(id: "ComposeMessage.attachment") }
+        public static var addRecipientButton: XCUIElement { app.find(id: "ComposeMessage.addRecipient").find(type: .button) }
+        public static var bodyInput: XCUIElement { app.find(id: "ComposeMessage.body") }
 
-        public static func courseSelectionItem(course: DSCourse? = nil, courseId: String? = nil) -> XCUIElement {
-            return app.find(id: "inbox.course-select.course-\(course?.id ?? courseId!)")
+        public static func courseItem(course: DSCourse) -> XCUIElement {
+            return app.find(id: "Inbox.course.\(course.id)")
         }
 
         public static func recipientSelectionItem(course: DSCourse? = nil, courseId: String? = nil) -> XCUIElement {
@@ -108,9 +125,17 @@ public class InboxHelper: BaseHelper {
         }
 
         public struct Recipients {
-            public static func teachers(course: DSCourse) -> XCUIElement { return app.find(id: "course_\(course.id)_teachers") }
-            public static func students(course: DSCourse) -> XCUIElement { return app.find(id: "course_\(course.id)_students") }
-            public static func userItem(user: DSUser) -> XCUIElement { return app.find(id: user.id) }
+            public static var students: XCUIElement { app.find(id: "Inbox.addRecipient.allStudents", type: .button) }
+            public static var teachers: XCUIElement { app.find(id: "Inbox.addRecipient.allTeachers", type: .button) }
+            public static var doneButton: XCUIElement { app.find(id: "Inbox.addRecipient.done") }
+
+            public static func allInCourse(course: DSCourse) -> XCUIElement {
+                return app.find(id: "Inbox.addRecipient.allIn.\(course.id)", type: .button)
+            }
+
+            public static func userItem(user: DSUser) -> XCUIElement {
+                return app.find(id: user.id)
+            }
         }
     }
 
@@ -125,12 +150,12 @@ public class InboxHelper: BaseHelper {
 
     public static func sendMessage(course: DSCourse, student: DSUser, subject: String?, message: String?) {
         newMessageButton.hit()
-        Composer.courseSelectButton.hit()
-        Composer.courseSelectionItem(course: course).hit()
+        Composer.selectCourseButton.hit()
+        Composer.Recipients.allInCourse(course: course).hit()
         Composer.addRecipientButton.hit()
         Composer.recipientSelectionItem(course: course).hit()
         Composer.subjectInput.hit().pasteText(text: subject ?? "Sample Subject of \(student.name)")
-        Composer.messageInput.hit().pasteText(text: message ?? "Sample Message of \(student.name)")
+        Composer.bodyInput.hit().pasteText(text: message ?? "Sample Message of \(student.name)")
         Composer.sendButton.hit()
     }
 

--- a/Core/TestsFoundation/Helpers/InboxHelper.swift
+++ b/Core/TestsFoundation/Helpers/InboxHelper.swift
@@ -21,6 +21,7 @@ public class InboxHelper: BaseHelper {
     public static var newMessageButton: XCUIElement { app.find(id: "Inbox.newMessageButton", type: .button) }
     public static var filterByCourseButton: XCUIElement { app.find(id: "Inbox.filterByCourse") }
     public static var filterByTypeButton: XCUIElement { app.find(id: "Inbox.filterByType") }
+    public static var discardButton: XCUIElement { app.find(label: "Discard", type: .button) }
 
     public static func conversation(conversation: DSConversation) -> XCUIElement {
         return app.find(id: "Conversation.\(conversation.id)")
@@ -98,6 +99,7 @@ public class InboxHelper: BaseHelper {
 
     public struct Composer {
         public static var cancelButton: XCUIElement { app.find(id: "ComposeMessage.cancel") }
+        public static var dismissButton: XCUIElement { app.find(id: "screen.dismiss", type: .button) }
         public static var subjectLabel: XCUIElement { app.find(id: "ComposeMessage.subjectLabel") }
         public static var sendButton: XCUIElement { app.find(id: "ComposeMessage.send") }
         public static var selectCourseButton: XCUIElement { app.find(id: "ComposeMessage.course", type: .button) }
@@ -161,6 +163,13 @@ public class InboxHelper: BaseHelper {
         Composer.subjectInput.hit().pasteText(text: subject ?? "Sample Subject of \(student.name)")
         Composer.bodyInput.hit().pasteText(text: message ?? "Sample Message of \(student.name)")
         Composer.sendButton.hit()
+    }
+
+    public static func handleCancelAlert() {
+        let discardButton = discardButton.waitUntil(.visible, timeout: 5)
+        if discardButton.isVisible {
+            discardButton.hit()
+        }
     }
 
     @discardableResult

--- a/Student/StudentE2ETests/Help/HelpTests.swift
+++ b/Student/StudentE2ETests/Help/HelpTests.swift
@@ -61,18 +61,19 @@ class HelpTests: E2ETestCase {
 
         // MARK: Check "Report a Problem" button
         cancelButton.hit()
+        InboxHelper.handleCancelAlert()
         HelpHelper.navigateToHelpPage()
         let reportAProblemButton = HelpHelper.reportAProblem.waitUntil(.visible)
         XCTAssertTrue(reportAProblemButton.isVisible)
 
         reportAProblemButton.hit()
-        cancelButton.waitUntil(.visible)
+        let dismissButton = InboxHelper.Composer.dismissButton.waitUntil(.visible)
         let reportAProblemLabel = app.find(label: "Report a Problem").waitUntil(.visible)
         XCTAssertTrue(reportAProblemLabel.isVisible)
-        XCTAssertTrue(cancelButton.isVisible)
+        XCTAssertTrue(dismissButton.isVisible)
 
         // MARK: Check "Submit a Feature Idea" button
-        cancelButton.hit()
+        dismissButton.hit()
         HelpHelper.navigateToHelpPage()
         let submitAFeatureButton = HelpHelper.submitAFeatureIdea.waitUntil(.visible)
         XCTAssertTrue(submitAFeatureButton.isVisible)

--- a/Student/StudentE2ETests/Help/HelpTests.swift
+++ b/Student/StudentE2ETests/Help/HelpTests.swift
@@ -54,8 +54,8 @@ class HelpTests: E2ETestCase {
         XCTAssertTrue(askYourInstructorButton.isVisible)
 
         askYourInstructorButton.hit()
-        let sendButton = app.find(label: "Send", type: .button).waitUntil(.visible)
-        let cancelButton = app.find(label: "Cancel").waitUntil(.visible)
+        let sendButton = InboxHelper.Composer.sendButton.waitUntil(.visible)
+        let cancelButton = InboxHelper.Composer.cancelButton.waitUntil(.visible)
         XCTAssertTrue(sendButton.isVisible)
         XCTAssertTrue(cancelButton.isVisible)
 

--- a/Student/StudentE2ETests/Help/HelpTests.swift
+++ b/Student/StudentE2ETests/Help/HelpTests.swift
@@ -54,9 +54,9 @@ class HelpTests: E2ETestCase {
         XCTAssertTrue(askYourInstructorButton.isVisible)
 
         askYourInstructorButton.hit()
-        let newMessageLabel = app.find(label: "New Message").waitUntil(.visible)
+        let sendButton = app.find(label: "Send", type: .button).waitUntil(.visible)
         let cancelButton = app.find(label: "Cancel").waitUntil(.visible)
-        XCTAssertTrue(newMessageLabel.isVisible)
+        XCTAssertTrue(sendButton.isVisible)
         XCTAssertTrue(cancelButton.isVisible)
 
         // MARK: Check "Report a Problem" button

--- a/Student/StudentE2ETests/Inbox/InboxTests.swift
+++ b/Student/StudentE2ETests/Inbox/InboxTests.swift
@@ -23,6 +23,7 @@ class InboxTests: E2ETestCase {
     typealias ComposerHelper = Helper.Composer
     typealias FilterHelper = Helper.Filter
     typealias DetailsHelper = Helper.Details
+    typealias OptionsHelper = DetailsHelper.Options
 
     func testSendMessage() {
         // MARK: Seed the usual stuff
@@ -71,7 +72,7 @@ class InboxTests: E2ETestCase {
         courseItem.hit()
         XCTAssertTrue(addRecipientButton.waitUntil(.visible).isVisible)
 
-        // MARK: Add recipients
+        // MARK: Add "student2" as recipient
         addRecipientButton.hit()
         let allInCourseButton = ComposerHelper.Recipients.allInCourse(course: course).waitUntil(.visible)
         let studentsButton = ComposerHelper.Recipients.students.waitUntil(.visible)
@@ -80,8 +81,16 @@ class InboxTests: E2ETestCase {
         XCTAssertTrue(studentsButton.isVisible)
         XCTAssertTrue(doneButton.isVisible)
 
-        allInCourseButton.hit()
+        studentsButton.hit()
+        let recipientButton = ComposerHelper.recipient(user: student2).waitUntil(.visible)
+        XCTAssertTrue(recipientButton.isVisible)
+
+        recipientButton.hit()
+        XCTAssertTrue(recipientButton.hasLabel(label: "Selected", strict: false))
+
         doneButton.hit()
+        let recipientPill = ComposerHelper.recipientPillById(recipient: student2).waitUntil(.visible)
+        XCTAssertTrue(recipientPill.isVisible)
 
         // MARK: Fill "Subject" and "Message" inputs
         let subject = "Sample Subject of \(student1.name)"
@@ -161,17 +170,15 @@ class InboxTests: E2ETestCase {
     }
 
     func testMessageDetails() {
-        typealias OptionsHelper = DetailsHelper.Options
         // MARK: Seed the usual stuff with a conversation
-        let student1 = seeder.createUser()
-        let student2 = seeder.createUser()
+        let student = seeder.createUser()
         let course = seeder.createCourse()
-        seeder.enrollStudents([student1, student2], in: course)
+        seeder.enrollStudent(student, in: course)
 
-        let conversation = Helper.createConversation(course: course, recipients: [student1.id, student2.id])
+        let conversation = Helper.createConversation(course: course, recipients: [student.id])
 
         // MARK: Get the first student logged in
-        logInDSUser(student1)
+        logInDSUser(student)
         let inboxTab = Helper.TabBar.inboxTab.waitUntil(.visible)
         XCTAssertTrue(inboxTab.isVisible)
 

--- a/Student/StudentE2ETests/Inbox/InboxTests.swift
+++ b/Student/StudentE2ETests/Inbox/InboxTests.swift
@@ -36,12 +36,8 @@ class InboxTests: E2ETestCase {
         let inboxTab = Helper.TabBar.inboxTab.waitUntil(.visible)
         XCTAssertTrue(inboxTab.isVisible)
 
-        // MARK: Navigate to Inbox
+        // MARK: Navigate to Inbox, Tap on the "New Message" button
         inboxTab.hit()
-        let navBar = Helper.navBar.waitUntil(.visible)
-        XCTAssertTrue(navBar.isVisible)
-
-        // MARK: Tap on the "New Message" button
         let newMessageButton = Helper.newMessageButton.waitUntil(.visible)
         XCTAssertTrue(newMessageButton.isVisible)
 
@@ -49,75 +45,65 @@ class InboxTests: E2ETestCase {
 
         // MARK: Check visibility of elements
         let cancelButton = ComposerHelper.cancelButton.waitUntil(.visible)
-        XCTAssertTrue(cancelButton.isVisible)
-
-        let attachButton = ComposerHelper.attachButton.waitUntil(.visible)
-        XCTAssertTrue(attachButton.isVisible)
-
-        var sendButton = ComposerHelper.sendButton.waitUntil(.visible)
-        XCTAssertTrue(sendButton.isVisible)
-        XCTAssertTrue(sendButton.isDisabled)
-
-        let courseSelectButton = ComposerHelper.courseSelectButton.waitUntil(.visible)
-        XCTAssertTrue(courseSelectButton.isVisible)
-
-        var recipientsLabel = ComposerHelper.recipientsLabel.waitUntil(.vanish)
-        XCTAssertTrue(recipientsLabel.isVanished)
-
-        var addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.vanish)
-        XCTAssertTrue(addRecipientButton.isVanished)
-
+        let subjectLabel = ComposerHelper.subjectLabel.waitUntil(.visible)
         let subjectInput = ComposerHelper.subjectInput.waitUntil(.visible)
+        let sendButton = ComposerHelper.sendButton.waitUntil(.visible)
+        let selectCourseButton = ComposerHelper.selectCourseButton.waitUntil(.visible)
+        let individualToggle = ComposerHelper.individualToggle.waitUntil(.visible)
+        let addAttachmentButton = ComposerHelper.addAttachmentButton.waitUntil(.visible)
+        let bodyInput = ComposerHelper.bodyInput.waitUntil(.visible)
+        let addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.vanish)
+        XCTAssertTrue(cancelButton.isVisible)
+        XCTAssertTrue(subjectLabel.isVisible)
         XCTAssertTrue(subjectInput.isVisible)
-
-        let individualSwitch = ComposerHelper.individualSwitch.waitUntil(.visible)
-        XCTAssertTrue(individualSwitch.isVisible)
-        XCTAssertTrue(individualSwitch.labelHasSuffix("Off"))
-
-        let messageInput = ComposerHelper.messageInput.waitUntil(.visible)
-        XCTAssertTrue(messageInput.isVisible)
+        XCTAssertTrue(sendButton.isVisible)
+        XCTAssertTrue(selectCourseButton.isVisible)
+        XCTAssertTrue(individualToggle.isVisible)
+        XCTAssertTrue(addAttachmentButton.isVisible)
+        XCTAssertTrue(addRecipientButton.isVanished)
+        XCTAssertTrue(bodyInput.isVisible)
 
         // MARK: Select course from the list
-        courseSelectButton.hit()
-        let courseSelectionItem = ComposerHelper.courseSelectionItem(course: course).waitUntil(.visible)
-        XCTAssertTrue(courseSelectionItem.isVisible)
+        selectCourseButton.hit()
+        let courseItem = ComposerHelper.courseItem(course: course).waitUntil(.visible)
+        XCTAssertTrue(courseItem.isVisible)
 
-        courseSelectionItem.hit()
-
-        // MARK: Check if "Recipients" label and "Add recipients" button appeared
-        recipientsLabel = ComposerHelper.recipientsLabel.waitUntil(.visible)
-        XCTAssertTrue(recipientsLabel.isVisible)
-
-        addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.visible)
-        XCTAssertTrue(addRecipientButton.isVisible)
+        courseItem.hit()
+        XCTAssertTrue(addRecipientButton.waitUntil(.visible).isVisible)
 
         // MARK: Add recipients
         addRecipientButton.hit()
-        let recipientSelectionItem = ComposerHelper.recipientSelectionItem(course: course).waitUntil(.visible)
-        XCTAssertTrue(recipientSelectionItem.isVisible)
+        let allInCourseButton = ComposerHelper.Recipients.allInCourse(course: course).waitUntil(.visible)
+        let studentsButton = ComposerHelper.Recipients.students.waitUntil(.visible)
+        let doneButton = ComposerHelper.Recipients.doneButton.waitUntil(.visible)
+        XCTAssertTrue(allInCourseButton.isVisible)
+        XCTAssertTrue(studentsButton.isVisible)
+        XCTAssertTrue(doneButton.isVisible)
 
-        recipientSelectionItem.hit()
+        allInCourseButton.hit()
+        doneButton.hit()
 
         // MARK: Fill "Subject" and "Message" inputs
         let subject = "Sample Subject of \(student1.name)"
-        subjectInput.hit()
-        subjectInput.pasteText(text: subject)
-        messageInput.hit()
-        messageInput.pasteText(text: "Sample Message of \(student1.name)")
+        subjectInput.writeText(text: subject)
+        bodyInput.writeText(text: "Sample Message of \(student1.name)")
 
         // MARK: Tap "Send" button
-        sendButton = sendButton.waitUntil(.visible)
-        XCTAssertTrue(sendButton.isVisible)
+        XCTAssertTrue(sendButton.waitUntil(.visible).isVisible)
         XCTAssertTrue(sendButton.isEnabled)
 
         sendButton.hit()
 
         // MARK: Check message in "Sent" filter tab
+        let filterByTypeButton = Helper.filterByTypeButton.waitUntil(.visible)
+        XCTAssertTrue(filterByTypeButton.isVisible)
+
+        filterByTypeButton.hit()
         let filterBySentButton = FilterHelper.sent.waitUntil(.visible)
         XCTAssertTrue(filterBySentButton.isVisible)
 
         filterBySentButton.hit()
-        let sentMessage = Helper.conversationBySubject(subject: subject, unread: false).waitUntil(.visible)
+        let sentMessage = Helper.conversationBySubject(subject: subject).waitUntil(.visible)
         XCTAssertTrue(sentMessage.isVisible)
 
         // MARK: Check if message is recieved by the other student of the course
@@ -128,18 +114,12 @@ class InboxTests: E2ETestCase {
         XCTAssertTrue(freshMessage.isVisible)
     }
 
-    func testInboxFilterTabs() {
+    func testInboxFilterOptions() {
         // MARK: Seed the usual stuff with a conversation
         let student = seeder.createUser()
         let course = seeder.createCourse()
         seeder.enrollStudent(student, in: course)
-
-        let readConversation = Helper.createConversation(
-            course: course, subject: "Read Message", recipients: [student.id])
-        let unreadConversation = Helper.createConversation(
-            course: course, subject: "Unread Message", recipients: [student.id])
-        let starredConversation = Helper.createConversation(
-            course: course, subject: "Starred Message", recipients: [student.id])
+        Helper.createConversation(course: course, recipients: [student.id])
 
         // MARK: Get the user logged in
         logInDSUser(student)
@@ -148,105 +128,36 @@ class InboxTests: E2ETestCase {
 
         // MARK: Navigate to Inbox
         inboxTab.hit()
-        let navBar = Helper.navBar.waitUntil(.visible)
-        XCTAssertTrue(navBar.isVisible)
+        let newMessageButton = Helper.newMessageButton.waitUntil(.visible)
+        let filterByCourseButton = Helper.filterByCourseButton.waitUntil(.visible)
+        let filterByTypeButton = Helper.filterByTypeButton.waitUntil(.visible)
+        XCTAssertTrue(newMessageButton.isVisible)
+        XCTAssertTrue(filterByCourseButton.isVisible)
+        XCTAssertTrue(filterByTypeButton.isVisible)
 
-        // MARK: Check filter options
-        let allButton = FilterHelper.all.waitUntil(.visible)
-        XCTAssertTrue(allButton.isVisible)
-        XCTAssertTrue(allButton.isSelected)
+        // MARK: Check filter by course options
+        filterByCourseButton.hit()
+        let allCoursesOption = Helper.Filter.allCourses.waitUntil(.visible)
+        let courseOption = Helper.Filter.course(course: course).waitUntil(.visible)
+        let cancelButton = Helper.Filter.cancelButton.waitUntil(.visible)
+        XCTAssertTrue(allCoursesOption.isVisible)
+        XCTAssertTrue(courseOption.isVisible)
+        XCTAssertTrue(cancelButton.isVisible)
 
-        // MARK: Check if all is unread
-        var readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.visible)
-        var unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.visible)
-        var starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVisible)
-        XCTAssertTrue(readMessageButton.labelHasSuffix("Unread"))
-        XCTAssertTrue(unreadMessageButton.isVisible)
-        XCTAssertTrue(unreadMessageButton.labelHasSuffix("Unread"))
-        XCTAssertTrue(starredMessageButton.isVisible)
-        XCTAssertTrue(starredMessageButton.labelHasSuffix("Unread"))
-
-        // MARK: Tap on message and check if it becomes read
-        readMessageButton.hit()
-        let backButton = Helper.backButton.waitUntil(.visible, timeout: 5)
-        if backButton.isVisible { backButton.hit() }
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVisible)
-        XCTAssertFalse(readMessageButton.labelHasSuffix("Unread"))
-
-        // MARK: Check "Unread" filter button
-        let unreadButton = FilterHelper.unread.waitUntil(.visible)
-        XCTAssertTrue(unreadButton.isVisible)
-        XCTAssertTrue(unreadButton.isUnselected)
-
-        // MARK: Tap "Unread" filter button and check messages again
-        unreadButton.hit()
-        XCTAssertTrue(unreadButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.visible)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVisible)
-        XCTAssertTrue(starredMessageButton.isVisible)
-
-        // MARK: Tap on message and mark it as starred
-        starredMessageButton.hit()
-        let starMessageButton = DetailsHelper.starButton.waitUntil(.visible)
-        XCTAssertTrue(starMessageButton.isVisible)
-
-        starMessageButton.hit()
-        backButton.waitUntil(.visible, timeout: 5)
-        if backButton.isVisible { backButton.hit() }
-
-        // MARK: Check "Starred" filter button
-        let starredButton = FilterHelper.starred.waitUntil(.visible)
-        XCTAssertTrue(starredButton.isVisible)
-        XCTAssertTrue(starredButton.isUnselected)
-
-        // MARK: Tap "Starred" filter button and check messages again
-        starredButton.hit()
-        XCTAssertTrue(starredButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVisible)
-
-        // MARK: Check "Sent" filter button
-        let sentButton = FilterHelper.sent.waitUntil(.visible)
-        XCTAssertTrue(sentButton.isVisible)
-        XCTAssertTrue(sentButton.isUnselected)
-
-        // MARK: Tap "Sent" filter button and check messages again
-        sentButton.hit()
-        XCTAssertTrue(sentButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.vanish)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVanished)
-
-        // MARK: Check "Archived" filter button
-        let archivedButton = FilterHelper.archived.waitUntil(.visible)
-        XCTAssertTrue(archivedButton.isVisible)
-        XCTAssertTrue(archivedButton.isUnselected)
-
-        // MARK: Tap "Archived" filter button and check messages again
-        archivedButton.hit()
-        XCTAssertTrue(archivedButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.vanish)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVanished)
+        // MARK: Check filter by type options
+        cancelButton.hit()
+        filterByTypeButton.hit()
+        let inboxOption = Helper.Filter.inbox.waitUntil(.visible)
+        let unreadOption = Helper.Filter.unread.waitUntil(.visible)
+        let starredOption = Helper.Filter.starred.waitUntil(.visible)
+        let sentOption = Helper.Filter.sent.waitUntil(.visible)
+        let archivedOption = Helper.Filter.archived.waitUntil(.visible)
+        XCTAssertTrue(inboxOption.isVisible)
+        XCTAssertTrue(unreadOption.isVisible)
+        XCTAssertTrue(starredOption.isVisible)
+        XCTAssertTrue(sentOption.isVisible)
+        XCTAssertTrue(archivedOption.isVisible)
+        XCTAssertTrue(cancelButton.waitUntil(.visible).isVisible)
     }
 
     func testMessageDetails() {
@@ -268,80 +179,70 @@ class InboxTests: E2ETestCase {
 
         // MARK: Check message item
         let messageButton = Helper.conversation(conversation: conversation).waitUntil(.visible)
+        let messageParticipantLabel = Helper.conversationParticipantLabel(conversation: conversation).waitUntil(.visible)
+        let messageDateLabel = Helper.conversationDateLabel(conversation: conversation).waitUntil(.visible)
+        let messageTitleLabel = Helper.conversationTitleLabel(conversation: conversation).waitUntil(.visible)
+        let messageMessageLabel = Helper.conversationMessageLabel(conversation: conversation).waitUntil(.visible)
         XCTAssertTrue(messageButton.isVisible)
-        XCTAssertTrue(messageButton.hasLabel(label: Helper.addDateToSubject(subject: conversation.subject, unread: true)))
+        XCTAssertTrue(messageButton.hasLabel(label: "Unread", strict: false))
+        XCTAssertTrue(messageParticipantLabel.isVisible)
+        XCTAssertTrue(messageDateLabel.isVisible)
+        XCTAssertTrue(messageTitleLabel.isVisible)
+        XCTAssertTrue(messageTitleLabel.hasLabel(label: conversation.subject))
+        XCTAssertTrue(messageMessageLabel.isVisible)
+        XCTAssertTrue(messageMessageLabel.hasLabel(label: conversation.last_authored_message))
 
         messageButton.hit()
 
         // MARK: Check message details
-        let detailsNavBar = DetailsHelper.navBar.waitUntil(.visible)
-        XCTAssertTrue(detailsNavBar.isVisible)
-
-        let starButton = DetailsHelper.starButton.waitUntil(.visible)
-        XCTAssertTrue(starButton.isVisible)
-
-        let subjectLabel = DetailsHelper.subjectLabel(conversation: conversation).waitUntil(.visible)
-        XCTAssertTrue(subjectLabel.isVisible)
-
-        let messageLabel = DetailsHelper.message(conversation: conversation).waitUntil(.visible)
-        XCTAssertTrue(messageLabel.isVisible)
-
-        let messageBody = DetailsHelper.bodyOfMessage(conversation: conversation).waitUntil(.visible)
-        XCTAssertTrue(messageBody.isVisible)
-
-        let replyButton = DetailsHelper.replyButton.waitUntil(.visible)
-        XCTAssertTrue(replyButton.isVisible)
-
-        // MARK: Check options
         let optionsButton = DetailsHelper.optionsButton.waitUntil(.visible)
+        let moreButton = DetailsHelper.moreButton.waitUntil(.visible)
+        let replyButton = DetailsHelper.replyButton.waitUntil(.visible)
+        let replyImage = DetailsHelper.replyImage.waitUntil(.visible)
+        let authorLabel = DetailsHelper.authorLabel.waitUntil(.visible)
+        let starButton = DetailsHelper.starButton.waitUntil(.visible)
+        let dateLabel = DetailsHelper.dateLabel.waitUntil(.visible)
+        let bodyLabel = DetailsHelper.bodyLabel.waitUntil(.visible)
+        let subjectLabel = DetailsHelper.subjectLabel.waitUntil(.visible)
         XCTAssertTrue(optionsButton.isVisible)
-        optionsButton.hit()
+        XCTAssertTrue(moreButton.isVisible)
+        XCTAssertTrue(replyButton.isVisible)
+        XCTAssertTrue(replyImage.isVisible)
+        XCTAssertTrue(authorLabel.isVisible)
+        XCTAssertTrue(starButton.isVisible)
+        XCTAssertTrue(dateLabel.isVisible)
+        XCTAssertTrue(bodyLabel.isVisible)
+        XCTAssertTrue(subjectLabel.isVisible)
+        XCTAssertTrue(bodyLabel.hasLabel(label: conversation.last_authored_message))
+        XCTAssertTrue(subjectLabel.hasLabel(label: conversation.subject))
+
+        // MARK: Check "More options"
+        moreButton.hit()
 
         var replyOption = OptionsHelper.replyButton.waitUntil(.visible)
-        XCTAssertTrue(replyOption.isVisible)
-
         var replyAllOption = OptionsHelper.replyAllButton.waitUntil(.visible)
-        XCTAssertTrue(replyAllOption.isVisible)
-
         var forwardOption = OptionsHelper.forwardButton.waitUntil(.visible)
-        XCTAssertTrue(forwardOption.isVisible)
-
+        let markAsUnreadOption = OptionsHelper.markAsUnreadButton.waitUntil(.visible)
+        let archiveOption = OptionsHelper.archiveButton.waitUntil(.visible)
         var deleteOption = OptionsHelper.deleteButton.waitUntil(.visible)
-        XCTAssertTrue(deleteOption.isVisible)
-
-        // On iPhone: There is a cancel button to hit
-        // On iPad: No cancel button, need to tap somewhere outside the box
-        let cancelOption = OptionsHelper.cancelButton.waitUntil(.visible, timeout: 5)
-        if cancelOption.isVisible {
-            cancelOption.hit()
-        } else {
-            optionsButton.forceTap()
-        }
-
-        // MARK: Check message options
-        let messageOptions = DetailsHelper.messageOptions(conversation: conversation).waitUntil(.visible)
-        XCTAssertTrue(messageOptions.isVisible)
-
-        messageOptions.hit()
-        replyOption = OptionsHelper.replyButton.waitUntil(.visible)
         XCTAssertTrue(replyOption.isVisible)
-
-        replyAllOption = OptionsHelper.replyAllButton.waitUntil(.visible)
         XCTAssertTrue(replyAllOption.isVisible)
-
-        forwardOption = OptionsHelper.forwardButton.waitUntil(.visible)
         XCTAssertTrue(forwardOption.isVisible)
-
-        deleteOption = OptionsHelper.deleteButton.waitUntil(.visible)
+        XCTAssertTrue(markAsUnreadOption.isVisible)
+        XCTAssertTrue(archiveOption.isVisible)
         XCTAssertTrue(deleteOption.isVisible)
 
-        // On iPhone: There is a cancel button to hit
-        // On iPad: No cancel button, need to tap somewhere outside the box
-        cancelOption.waitUntil(.visible, timeout: 5)
-        if cancelOption.isVisible {
-            cancelOption.hit()
-        } else {
-            optionsButton.forceTap()
-        }
+        moreButton.forceTap()
+
+        // MARK: Check "Conversation options"
+        optionsButton.hit()
+        replyOption = OptionsHelper.replyButton.waitUntil(.visible)
+        replyAllOption = OptionsHelper.replyAllButton.waitUntil(.visible)
+        forwardOption = OptionsHelper.forwardButton.waitUntil(.visible)
+        deleteOption = OptionsHelper.deleteButton.waitUntil(.visible)
+        XCTAssertTrue(replyOption.isVisible)
+        XCTAssertTrue(replyAllOption.isVisible)
+        XCTAssertTrue(forwardOption.isVisible)
+        XCTAssertTrue(deleteOption.isVisible)
     }
 }

--- a/Student/StudentE2ETests/People/PeopleTests.swift
+++ b/Student/StudentE2ETests/People/PeopleTests.swift
@@ -247,36 +247,15 @@ class PeopleTests: E2ETestCase {
         let courseSelector = InboxHelper.Composer.selectCourseButton.waitUntil(.visible)
         let subjectInput = InboxHelper.Composer.subjectInput.waitUntil(.visible)
         let messageInput = InboxHelper.Composer.bodyInput.waitUntil(.visible)
+        let recipientPill = InboxHelper.Composer.recipientPillById(recipient: teacher)
         XCTAssertTrue(sendButton.isVisible)
-        XCTAssertTrue(sendButton.isDisabled)
         XCTAssertTrue(courseSelector.isVisible)
         XCTAssertTrue(subjectInput.isVisible)
         XCTAssertTrue(messageInput.isVisible)
-
-        // MARK: Select course
-        courseSelector.hit()
-        let courseItem = InboxHelper.Composer.Recipients.allInCourse(course: course).waitUntil(.visible)
-        XCTAssertTrue(courseItem.isVisible)
-
-        courseItem.hit()
-        let addRecipientButton = InboxHelper.Composer.addRecipientButton.waitUntil(.visible)
-        XCTAssertTrue(addRecipientButton.isVisible)
-
-        addRecipientButton.hit()
-        let teachers = InboxHelper.Composer.Recipients.teachers.waitUntil(.visible)
-        XCTAssertTrue(teachers.isVisible)
-
-        teachers.hit()
-        let teacherItem = InboxHelper.Composer.Recipients.userItem(user: teacher).waitUntil(.visible)
-        XCTAssertTrue(teacherItem.isVisible)
-
-        teacherItem.hit()
-        let recipientLabel = InboxHelper.Composer.recipientLabel(recipient: teacher).waitUntil(.visible)
-        XCTAssertTrue(recipientLabel.isVisible)
-        XCTAssertTrue(recipientLabel.hasLabel(label: teacher.name))
+        XCTAssertTrue(recipientPill.isVisible)
 
         // MARK: Add a subject and a message, Tap send, Check result
-        subjectInput.pasteText(text: messageSubject)
+        subjectInput.writeText(text: messageSubject)
         messageInput.writeText(text: messageBody)
         XCTAssertTrue(sendButton.waitUntil(.enabled).isEnabled)
 
@@ -285,10 +264,14 @@ class PeopleTests: E2ETestCase {
         XCTAssertTrue(inboxTab.isVisible)
 
         inboxTab.hit()
-        let sentTab = InboxHelper.Filter.sent.waitUntil(.visible)
-        XCTAssertTrue(sentTab.isVisible)
+        let filterByTypeButton = InboxHelper.filterByTypeButton.waitUntil(.visible)
+        XCTAssertTrue(filterByTypeButton.isVisible)
 
-        sentTab.hit()
+        filterByTypeButton.hit()
+        let sentOption = InboxHelper.Filter.sent.waitUntil(.visible)
+        XCTAssertTrue(sentOption.isVisible)
+
+        sentOption.hit()
         let conversationButton = InboxHelper.conversations[0].waitUntil(.visible)
         XCTAssertTrue(conversationButton.isVisible)
         XCTAssertTrue(conversationButton.hasLabel(label: messageSubject, strict: false))

--- a/Student/StudentE2ETests/People/PeopleTests.swift
+++ b/Student/StudentE2ETests/People/PeopleTests.swift
@@ -244,9 +244,9 @@ class PeopleTests: E2ETestCase {
         // MARK: Tap the "Send Email" icon, Check recipient, Check elements
         sendEmailButton.hit()
         let sendButton = InboxHelper.Composer.sendButton.waitUntil(.visible)
-        let courseSelector = InboxHelper.Composer.courseSelectButton.waitUntil(.visible)
+        let courseSelector = InboxHelper.Composer.selectCourseButton.waitUntil(.visible)
         let subjectInput = InboxHelper.Composer.subjectInput.waitUntil(.visible)
-        let messageInput = InboxHelper.Composer.messageInput.waitUntil(.visible)
+        let messageInput = InboxHelper.Composer.bodyInput.waitUntil(.visible)
         XCTAssertTrue(sendButton.isVisible)
         XCTAssertTrue(sendButton.isDisabled)
         XCTAssertTrue(courseSelector.isVisible)
@@ -255,7 +255,7 @@ class PeopleTests: E2ETestCase {
 
         // MARK: Select course
         courseSelector.hit()
-        let courseItem = InboxHelper.Composer.courseSelectionItem(course: course).waitUntil(.visible)
+        let courseItem = InboxHelper.Composer.Recipients.allInCourse(course: course).waitUntil(.visible)
         XCTAssertTrue(courseItem.isVisible)
 
         courseItem.hit()
@@ -263,7 +263,7 @@ class PeopleTests: E2ETestCase {
         XCTAssertTrue(addRecipientButton.isVisible)
 
         addRecipientButton.hit()
-        let teachers = InboxHelper.Composer.Recipients.teachers(course: course).waitUntil(.visible)
+        let teachers = InboxHelper.Composer.Recipients.teachers.waitUntil(.visible)
         XCTAssertTrue(teachers.isVisible)
 
         teachers.hit()

--- a/Student/StudentE2ETests/Settings/SettingsTests.swift
+++ b/Student/StudentE2ETests/Settings/SettingsTests.swift
@@ -115,8 +115,8 @@ class SettingsTests: E2ETestCase {
         doneButton.hit()
         logOut()
         logInDSUser(student)
-        let inboxNavBar = InboxHelper.navBar.waitUntil(.visible)
-        XCTAssertTrue(inboxNavBar.isVisible)
+        let inboxNewMessageButton = InboxHelper.newMessageButton.waitUntil(.visible)
+        XCTAssertTrue(inboxNewMessageButton.isVisible)
     }
 
     func testAppearanceSetting() {

--- a/rn/Teacher/ios/TeacherE2ETests/Inbox/InboxTests.swift
+++ b/rn/Teacher/ios/TeacherE2ETests/Inbox/InboxTests.swift
@@ -35,84 +35,89 @@ class InboxTests: E2ETestCase {
         seeder.enrollTeacher(teacher1, in: course)
         seeder.enrollTeacher(teacher2, in: course)
 
-        // MARK: Get teacher1 logged in
+        // MARK: Get first user logged in
         logInDSUser(teacher1)
         let inboxTab = Helper.TabBar.inboxTab.waitUntil(.visible)
         XCTAssertTrue(inboxTab.isVisible)
 
-        // MARK: Navigate to Inbox
+        // MARK: Navigate to Inbox, Tap on the "New Message" button
         inboxTab.hit()
-        let navBar = Helper.navBar.waitUntil(.visible)
         let newMessageButton = Helper.newMessageButton.waitUntil(.visible)
-        XCTAssertTrue(navBar.isVisible)
         XCTAssertTrue(newMessageButton.isVisible)
 
-        // MARK: Tap "New Message" button, Check visibility of elements
         newMessageButton.hit()
-        let cancelButton = ComposerHelper.cancelButton.waitUntil(.visible)
-        let attachButton = ComposerHelper.attachButton.waitUntil(.visible)
-        var sendButton = ComposerHelper.sendButton.waitUntil(.visible)
-        let courseSelectButton = ComposerHelper.courseSelectButton.waitUntil(.visible)
-        var recipientsLabel = ComposerHelper.recipientsLabel.waitUntil(.vanish)
-        var addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.vanish)
-        let subjectInput = ComposerHelper.subjectInput.waitUntil(.visible)
-        let individualSwitch = ComposerHelper.individualSwitch.waitUntil(.visible)
-        XCTAssertTrue(cancelButton.isVisible)
-        XCTAssertTrue(attachButton.isVisible)
-        XCTAssertTrue(sendButton.isVisible)
-        XCTAssertTrue(sendButton.isDisabled)
-        XCTAssertTrue(courseSelectButton.isVisible)
-        XCTAssertTrue(recipientsLabel.isVanished)
-        XCTAssertTrue(addRecipientButton.isVanished)
-        XCTAssertTrue(subjectInput.isVisible)
-        XCTAssertTrue(individualSwitch.isVisible)
-        XCTAssertTrue(individualSwitch.labelHasSuffix("Off"))
 
-        let messageInput = ComposerHelper.messageInput.waitUntil(.visible)
-        XCTAssertTrue(messageInput.isVisible)
+        // MARK: Check visibility of elements
+        let cancelButton = ComposerHelper.cancelButton.waitUntil(.visible)
+        let subjectLabel = ComposerHelper.subjectLabel.waitUntil(.visible)
+        let subjectInput = ComposerHelper.subjectInput.waitUntil(.visible)
+        let sendButton = ComposerHelper.sendButton.waitUntil(.visible)
+        let selectCourseButton = ComposerHelper.selectCourseButton.waitUntil(.visible)
+        let individualToggle = ComposerHelper.individualToggle.waitUntil(.visible)
+        let addAttachmentButton = ComposerHelper.addAttachmentButton.waitUntil(.visible)
+        let bodyInput = ComposerHelper.bodyInput.waitUntil(.visible)
+        let addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.vanish)
+        XCTAssertTrue(cancelButton.isVisible)
+        XCTAssertTrue(subjectLabel.isVisible)
+        XCTAssertTrue(subjectInput.isVisible)
+        XCTAssertTrue(sendButton.isVisible)
+        XCTAssertTrue(selectCourseButton.isVisible)
+        XCTAssertTrue(individualToggle.isVisible)
+        XCTAssertTrue(addAttachmentButton.isVisible)
+        XCTAssertTrue(addRecipientButton.isVanished)
+        XCTAssertTrue(bodyInput.isVisible)
 
         // MARK: Select course from the list
-        courseSelectButton.hit()
-        let courseSelectionItem = ComposerHelper.courseSelectionItem(course: course).waitUntil(.visible)
-        XCTAssertTrue(courseSelectionItem.isVisible)
+        selectCourseButton.hit()
+        let courseItem = ComposerHelper.courseItem(course: course).waitUntil(.visible)
+        XCTAssertTrue(courseItem.isVisible)
 
-        courseSelectionItem.hit()
+        courseItem.hit()
+        XCTAssertTrue(addRecipientButton.waitUntil(.visible).isVisible)
 
-        // MARK: Check if "Recipients" label and "Add recipients" button appeared
-        addRecipientButton = ComposerHelper.addRecipientButton.waitUntil(.visible)
-        recipientsLabel = ComposerHelper.recipientsLabel.waitUntil(.visible)
-        XCTAssertTrue(recipientsLabel.isVisible)
-        XCTAssertTrue(addRecipientButton.isVisible)
-
-        // MARK: Add recipients
+        // MARK: Add "teacher2" as recipient
         addRecipientButton.hit()
-        let recipientSelectionItem = ComposerHelper.recipientSelectionItem(course: course).waitUntil(.visible)
-        XCTAssertTrue(recipientSelectionItem.isVisible)
+        let allInCourseButton = ComposerHelper.Recipients.allInCourse(course: course).waitUntil(.visible)
+        let teachersButton = ComposerHelper.Recipients.teachers.waitUntil(.visible)
+        let doneButton = ComposerHelper.Recipients.doneButton.waitUntil(.visible)
+        XCTAssertTrue(allInCourseButton.isVisible)
+        XCTAssertTrue(teachersButton.isVisible)
+        XCTAssertTrue(doneButton.isVisible)
 
-        recipientSelectionItem.hit()
+        teachersButton.hit()
+        let recipientButton = ComposerHelper.recipient(user: teacher2).waitUntil(.visible)
+        XCTAssertTrue(recipientButton.isVisible)
+
+        recipientButton.hit()
+        XCTAssertTrue(recipientButton.hasLabel(label: "Selected", strict: false))
+
+        doneButton.hit()
+        let recipientPill = ComposerHelper.recipientPillById(recipient: teacher2).waitUntil(.visible)
+        XCTAssertTrue(recipientPill.isVisible)
 
         // MARK: Fill "Subject" and "Message" inputs
-        subjectInput.hit()
-        subjectInput.pasteText(text: subject)
-        messageInput.hit()
-        messageInput.pasteText(text: message)
+        subjectInput.writeText(text: subject)
+        bodyInput.writeText(text: message)
 
         // MARK: Tap "Send" button
-        sendButton = sendButton.waitUntil(.visible)
-        XCTAssertTrue(sendButton.isVisible)
+        XCTAssertTrue(sendButton.waitUntil(.visible).isVisible)
         XCTAssertTrue(sendButton.isEnabled)
 
         sendButton.hit()
 
         // MARK: Check message in "Sent" filter tab
+        let filterByTypeButton = Helper.filterByTypeButton.waitUntil(.visible)
+        XCTAssertTrue(filterByTypeButton.isVisible)
+
+        filterByTypeButton.hit()
         let filterBySentButton = FilterHelper.sent.waitUntil(.visible)
         XCTAssertTrue(filterBySentButton.isVisible)
 
         filterBySentButton.hit()
-        let sentMessage = Helper.conversationBySubject(subject: subject, unread: false).waitUntil(.visible)
+        let sentMessage = Helper.conversationBySubject(subject: subject).waitUntil(.visible)
         XCTAssertTrue(sentMessage.isVisible)
 
-        // MARK: Check if message is recieved by teacher2
+        // MARK: Check if message is recieved by the other teacher of the course
         Helper.logOut()
         logInDSUser(teacher2)
         Helper.navigateToInbox()
@@ -125,13 +130,7 @@ class InboxTests: E2ETestCase {
         let teacher = seeder.createUser()
         let course = seeder.createCourse()
         seeder.enrollTeacher(teacher, in: course)
-
-        let readConversation = Helper.createConversation(
-            course: course, subject: "Read Message", recipients: [teacher.id])
-        let unreadConversation = Helper.createConversation(
-            course: course, subject: "Unread Message", recipients: [teacher.id])
-        let starredConversation = Helper.createConversation(
-            course: course, subject: "Starred Message", recipients: [teacher.id])
+        Helper.createConversation(course: course, recipients: [teacher.id])
 
         // MARK: Get the user logged in
         logInDSUser(teacher)
@@ -140,168 +139,111 @@ class InboxTests: E2ETestCase {
 
         // MARK: Navigate to Inbox
         inboxTab.hit()
-        let navBar = Helper.navBar.waitUntil(.visible)
-        XCTAssertTrue(navBar.isVisible)
+        let newMessageButton = Helper.newMessageButton.waitUntil(.visible)
+        let filterByCourseButton = Helper.filterByCourseButton.waitUntil(.visible)
+        let filterByTypeButton = Helper.filterByTypeButton.waitUntil(.visible)
+        XCTAssertTrue(newMessageButton.isVisible)
+        XCTAssertTrue(filterByCourseButton.isVisible)
+        XCTAssertTrue(filterByTypeButton.isVisible)
 
-        // MARK: Check filter options
-        let allButton = FilterHelper.all.waitUntil(.visible)
-        XCTAssertTrue(allButton.isVisible)
-        XCTAssertTrue(allButton.isSelected)
+        // MARK: Check filter by course options
+        filterByCourseButton.hit()
+        let allCoursesOption = Helper.Filter.allCourses.waitUntil(.visible)
+        let courseOption = Helper.Filter.course(course: course).waitUntil(.visible)
+        let cancelButton = Helper.Filter.cancelButton.waitUntil(.visible)
+        XCTAssertTrue(allCoursesOption.isVisible)
+        XCTAssertTrue(courseOption.isVisible)
+        XCTAssertTrue(cancelButton.isVisible)
 
-        // MARK: Check if all is unread
-        var readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.visible)
-        var unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.visible)
-        var starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVisible)
-        XCTAssertTrue(readMessageButton.labelHasSuffix("Unread"))
-        XCTAssertTrue(unreadMessageButton.isVisible)
-        XCTAssertTrue(unreadMessageButton.labelHasSuffix("Unread"))
-        XCTAssertTrue(starredMessageButton.isVisible)
-        XCTAssertTrue(starredMessageButton.labelHasSuffix("Unread"))
-
-        // MARK: Tap on message and check if it becomes read
-        readMessageButton.hit()
-        let backButton = Helper.backButton.waitUntil(.visible, timeout: 5)
-        if backButton.isVisible { backButton.hit() }
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVisible)
-        XCTAssertFalse(readMessageButton.labelHasSuffix("Unread"))
-
-        // MARK: Check "Unread" filter button
-        let unreadButton = FilterHelper.unread.waitUntil(.visible)
-        XCTAssertTrue(unreadButton.isVisible)
-        XCTAssertTrue(unreadButton.isUnselected)
-
-        // MARK: Tap "Unread" filter button and check messages again
-        unreadButton.hit()
-        XCTAssertTrue(unreadButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.visible)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVisible)
-        XCTAssertTrue(starredMessageButton.isVisible)
-
-        // MARK: Tap on message and mark it as starred
-        starredMessageButton.hit()
-        let starMessageButton = DetailsHelper.starButton.waitUntil(.visible)
-        XCTAssertTrue(starMessageButton.isVisible)
-
-        starMessageButton.hit()
-        backButton.waitUntil(.visible, timeout: 5)
-        if backButton.isVisible { backButton.hit() }
-
-        // MARK: Check "Starred" filter button
-        let starredButton = FilterHelper.starred.waitUntil(.visible)
-        XCTAssertTrue(starredButton.isVisible)
-        XCTAssertTrue(starredButton.isUnselected)
-
-        // MARK: Tap "Starred" filter button and check messages again
-        starredButton.hit()
-        XCTAssertTrue(starredButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.visible)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVisible)
-
-        // MARK: Check "Sent" filter button
-        let sentButton = FilterHelper.sent.waitUntil(.visible)
-        XCTAssertTrue(sentButton.isVisible)
-        XCTAssertTrue(sentButton.isUnselected)
-
-        // MARK: Tap "Sent" filter button and check messages again
-        sentButton.hit()
-        XCTAssertTrue(sentButton.isSelected)
-
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.vanish)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVanished)
-
-        // MARK: Check "Archived" filter button
-        let archivedButton = FilterHelper.archived.waitUntil(.visible)
-        XCTAssertTrue(archivedButton.isVisible)
-        XCTAssertTrue(archivedButton.isUnselected)
-
-        // MARK: Tap "Archived" filter button and check messages again
-        archivedButton.hit()
-        readMessageButton = Helper.conversation(conversation: readConversation).waitUntil(.vanish)
-        unreadMessageButton = Helper.conversation(conversation: unreadConversation).waitUntil(.vanish)
-        starredMessageButton = Helper.conversation(conversation: starredConversation).waitUntil(.vanish)
-        XCTAssertTrue(archivedButton.isSelected)
-        XCTAssertTrue(readMessageButton.isVanished)
-        XCTAssertTrue(unreadMessageButton.isVanished)
-        XCTAssertTrue(starredMessageButton.isVanished)
+        // MARK: Check filter by type options
+        cancelButton.hit()
+        filterByTypeButton.hit()
+        let inboxOption = Helper.Filter.inbox.waitUntil(.visible)
+        let unreadOption = Helper.Filter.unread.waitUntil(.visible)
+        let starredOption = Helper.Filter.starred.waitUntil(.visible)
+        let sentOption = Helper.Filter.sent.waitUntil(.visible)
+        let archivedOption = Helper.Filter.archived.waitUntil(.visible)
+        XCTAssertTrue(inboxOption.isVisible)
+        XCTAssertTrue(unreadOption.isVisible)
+        XCTAssertTrue(starredOption.isVisible)
+        XCTAssertTrue(sentOption.isVisible)
+        XCTAssertTrue(archivedOption.isVisible)
+        XCTAssertTrue(cancelButton.waitUntil(.visible).isVisible)
     }
 
     func testMessageDetails() {
         // MARK: Seed the usual stuff with a conversation
-        let teacher1 = seeder.createUser()
-        let teacher2 = seeder.createUser()
+        let teacher = seeder.createUser()
         let course = seeder.createCourse()
-        seeder.enrollTeachers([teacher1, teacher2], in: course)
-        let conversation = Helper.createConversation(course: course, recipients: [teacher1.id, teacher2.id])
+        seeder.enrollTeacher(teacher, in: course)
+        let conversation = Helper.createConversation(course: course, recipients: [teacher.id])
 
-        // MARK: Get teacher1 logged in
-        logInDSUser(teacher1)
+        // MARK: Get the user logged in
+        logInDSUser(teacher)
         let inboxTab = Helper.TabBar.inboxTab.waitUntil(.visible)
         XCTAssertTrue(inboxTab.isVisible)
 
-        // MARK: Check message item
         inboxTab.hit()
+
+        // MARK: Check message item
         let messageButton = Helper.conversation(conversation: conversation).waitUntil(.visible)
+        let messageParticipantLabel = Helper.conversationParticipantLabel(conversation: conversation).waitUntil(.visible)
+        let messageDateLabel = Helper.conversationDateLabel(conversation: conversation).waitUntil(.visible)
+        let messageTitleLabel = Helper.conversationTitleLabel(conversation: conversation).waitUntil(.visible)
+        let messageMessageLabel = Helper.conversationMessageLabel(conversation: conversation).waitUntil(.visible)
         XCTAssertTrue(messageButton.isVisible)
-        XCTAssertTrue(messageButton.hasLabel(label: Helper.addDateToSubject(subject: conversation.subject, unread: true)))
+        XCTAssertTrue(messageButton.hasLabel(label: "Unread", strict: false))
+        XCTAssertTrue(messageParticipantLabel.isVisible)
+        XCTAssertTrue(messageDateLabel.isVisible)
+        XCTAssertTrue(messageTitleLabel.isVisible)
+        XCTAssertTrue(messageTitleLabel.hasLabel(label: conversation.subject))
+        XCTAssertTrue(messageMessageLabel.isVisible)
+        XCTAssertTrue(messageMessageLabel.hasLabel(label: conversation.last_authored_message))
+
+        messageButton.hit()
 
         // MARK: Check message details
-        messageButton.hit()
-        let detailsNavBar = DetailsHelper.navBar.waitUntil(.visible)
-        let starButton = DetailsHelper.starButton.waitUntil(.visible)
-        let subjectLabel = DetailsHelper.subjectLabel(conversation: conversation).waitUntil(.visible)
-        let messageLabel = DetailsHelper.message(conversation: conversation).waitUntil(.visible)
-        let messageBody = DetailsHelper.bodyOfMessage(conversation: conversation).waitUntil(.visible)
-        let replyButton = DetailsHelper.replyButton.waitUntil(.visible)
-        XCTAssertTrue(detailsNavBar.isVisible)
-        XCTAssertTrue(starButton.isVisible)
-        XCTAssertTrue(subjectLabel.isVisible)
-        XCTAssertTrue(messageLabel.isVisible)
-        XCTAssertTrue(messageBody.isVisible)
-        XCTAssertTrue(replyButton.isVisible)
-
-        // MARK: Check options
         let optionsButton = DetailsHelper.optionsButton.waitUntil(.visible)
+        let moreButton = DetailsHelper.moreButton.waitUntil(.visible)
+        let replyButton = DetailsHelper.replyButton.waitUntil(.visible)
+        let replyImage = DetailsHelper.replyImage.waitUntil(.visible)
+        let authorLabel = DetailsHelper.authorLabel.waitUntil(.visible)
+        let starButton = DetailsHelper.starButton.waitUntil(.visible)
+        let dateLabel = DetailsHelper.dateLabel.waitUntil(.visible)
+        let bodyLabel = DetailsHelper.bodyLabel.waitUntil(.visible)
+        let subjectLabel = DetailsHelper.subjectLabel.waitUntil(.visible)
         XCTAssertTrue(optionsButton.isVisible)
-        optionsButton.hit()
+        XCTAssertTrue(moreButton.isVisible)
+        XCTAssertTrue(replyButton.isVisible)
+        XCTAssertTrue(replyImage.isVisible)
+        XCTAssertTrue(authorLabel.isVisible)
+        XCTAssertTrue(starButton.isVisible)
+        XCTAssertTrue(dateLabel.isVisible)
+        XCTAssertTrue(bodyLabel.isVisible)
+        XCTAssertTrue(subjectLabel.isVisible)
+        XCTAssertTrue(bodyLabel.hasLabel(label: conversation.last_authored_message))
+        XCTAssertTrue(subjectLabel.hasLabel(label: conversation.subject))
+
+        // MARK: Check "More options"
+        moreButton.hit()
 
         var replyOption = OptionsHelper.replyButton.waitUntil(.visible)
         var replyAllOption = OptionsHelper.replyAllButton.waitUntil(.visible)
         var forwardOption = OptionsHelper.forwardButton.waitUntil(.visible)
+        let markAsUnreadOption = OptionsHelper.markAsUnreadButton.waitUntil(.visible)
+        let archiveOption = OptionsHelper.archiveButton.waitUntil(.visible)
         var deleteOption = OptionsHelper.deleteButton.waitUntil(.visible)
         XCTAssertTrue(replyOption.isVisible)
         XCTAssertTrue(replyAllOption.isVisible)
         XCTAssertTrue(forwardOption.isVisible)
+        XCTAssertTrue(markAsUnreadOption.isVisible)
+        XCTAssertTrue(archiveOption.isVisible)
         XCTAssertTrue(deleteOption.isVisible)
 
-        // On iPhone: There is a cancel button to hit
-        // On iPad: No cancel button, need to tap somewhere outside the box
-        let cancelOption = OptionsHelper.cancelButton.waitUntil(.visible, timeout: 5)
-        if cancelOption.isVisible {
-            cancelOption.hit()
-        } else {
-            optionsButton.forceTap()
-        }
+        moreButton.forceTap()
 
-        // MARK: Check message options
-        let messageOptions = DetailsHelper.messageOptions(conversation: conversation).waitUntil(.visible)
-        XCTAssertTrue(messageOptions.isVisible)
-
-        messageOptions.hit()
+        // MARK: Check "Conversation options"
+        optionsButton.hit()
         replyOption = OptionsHelper.replyButton.waitUntil(.visible)
         replyAllOption = OptionsHelper.replyAllButton.waitUntil(.visible)
         forwardOption = OptionsHelper.forwardButton.waitUntil(.visible)
@@ -310,16 +252,5 @@ class InboxTests: E2ETestCase {
         XCTAssertTrue(replyAllOption.isVisible)
         XCTAssertTrue(forwardOption.isVisible)
         XCTAssertTrue(deleteOption.isVisible)
-
-        // On iPhone: There is a cancel button to hit
-        // On iPad: No cancel button, need to tap somewhere outside the box
-        cancelOption.waitUntil(.visible, timeout: 5)
-        if cancelOption.isVisible {
-            cancelOption.hit()
-        } else {
-            optionsButton.forceTap()
-        }
-
-        XCTAssertTrue(deleteOption.waitUntil(.vanish).isVanished)
     }
 }

--- a/rn/Teacher/ios/TeacherE2ETests/Settings/SettingsTests.swift
+++ b/rn/Teacher/ios/TeacherE2ETests/Settings/SettingsTests.swift
@@ -88,7 +88,7 @@ class SettingsTests: E2ETestCase {
         XCTAssertTrue(inbox.isVisible)
         XCTAssertTrue(backButton.isVisible)
 
-        // MARK: Select "Inbox", logout, login, check landing page
+        // MARK: Select "Inbox", logout, log back in, check landing page
         inbox.hit()
         XCTAssertTrue(inbox.waitUntil(.visible).isVisible)
 
@@ -96,8 +96,8 @@ class SettingsTests: E2ETestCase {
         doneButton.hit()
         logOut()
         logInDSUser(teacher)
-        let inboxNavBar = InboxHelper.navBar.waitUntil(.visible)
-        XCTAssertTrue(inboxNavBar.isVisible)
+        let newMessageButton = InboxHelper.newMessageButton.waitUntil(.visible)
+        XCTAssertTrue(newMessageButton.isVisible)
     }
 
     func testAppearanceSetting() {


### PR DESCRIPTION
Core has been touched, and even if it's just adding accessibilityIds, please review this thoroughly to avoid future issues.
After merging this PR, all E2E tests should pass so we should start seeing green colors in Bitrise.
- added ids to elements of inbox and related screens
- updated helper structs to use the fresh ids for locating the elements (instead of labels)
- updated student and teacher e2e tests regarding the latest changes on inbox screen