### PR TITLE
Ignore 404 errors while downloading studio video metadata.

### DIFF
--- a/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
@@ -110,6 +110,7 @@ public enum CourseSyncDownloaderAssembly {
                 studioHtmlParser: StudioHTMLParserInteractorLive()
             ),
             cleanupInteractor: StudioVideoCleanupInteractorLive(offlineStudioDirectory: studioDirectory),
+            metadataDownloadInteractor: StudioMetadataDownloadInteractorLive(),
             downloadInteractor: studioDownloadInteractor,
             scheduler: scheduler
         )

--- a/Core/Core/Extensions/ErrorExtensions.swift
+++ b/Core/Core/Extensions/ErrorExtensions.swift
@@ -28,6 +28,10 @@ public extension Error {
         nsError.domain == NSError.Constants.domain && nsError.code == HttpError.forbidden
     }
 
+    var isNotFound: Bool {
+        nsError.domain == NSError.Constants.domain && nsError.code == HttpError.notFound
+    }
+
     private var nsError: NSError {
         self as NSError
     }

--- a/Core/Core/Extensions/UINavigationControllerExtensions.swift
+++ b/Core/Core/Extensions/UINavigationControllerExtensions.swift
@@ -17,7 +17,6 @@
 //
 
 import Foundation
-import Core
 
 extension UINavigationController {
     // Sets the barTintColor on self as well as a detail in a split view controller situation

--- a/Core/Core/Studio/Model/StudioMetadataDownloadInteractor.swift
+++ b/Core/Core/Studio/Model/StudioMetadataDownloadInteractor.swift
@@ -1,0 +1,62 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+
+public protocol StudioMetadataDownloadInteractor {
+
+    /// - parameters:
+    ///   - api: The API instance pointing to the Studio API.
+    func fetchStudioMediaItems(
+        api: API,
+        courseIDs: [String]
+    ) -> AnyPublisher<[APIStudioMediaItem], Error>
+}
+
+class StudioMetadataDownloadInteractorLive: StudioMetadataDownloadInteractor {
+
+    func fetchStudioMediaItems(
+        api: API,
+        courseIDs: [String]
+    ) -> AnyPublisher<[APIStudioMediaItem], Error> {
+        Publishers.Sequence(sequence: courseIDs)
+            .flatMap { courseID in
+                let request = GetStudioCourseMediaRequest(courseId: courseID)
+                return api.makeRequest(request)
+                    .catch(Self.replaceNotFoundErrorWithEmptyResponse)
+                    .map(\.body)
+            }
+            .collect()
+            .map { (mediaData: [[APIStudioMediaItem]]) in
+                mediaData.flatMap { $0 }
+            }
+            .eraseToAnyPublisher()
+    }
+
+    private static func replaceNotFoundErrorWithEmptyResponse(
+        _ error: Error
+    ) -> AnyPublisher<(body: [APIStudioMediaItem], urlResponse: HTTPURLResponse?), Error> {
+        if error.isNotFound {
+            return Just((body: [], urlResponse: nil))
+                .setFailureType(to: Error.self)
+                .eraseToAnyPublisher()
+        }
+
+        return Fail(error: error).eraseToAnyPublisher()
+    }
+}

--- a/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
@@ -36,4 +36,12 @@ class ErrorExtensionsTests: XCTestCase {
         )
         XCTAssertTrue(error.isForbidden)
     }
+
+    func testNotFoundError() {
+        let error: Error = NSError(
+            domain: NSError.Constants.domain,
+            code: HttpError.notFound
+        )
+        XCTAssertTrue(error.isNotFound)
+    }
 }

--- a/Core/CoreTests/Studio/Model/StudioMetadataDownloadInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioMetadataDownloadInteractorLiveTests.swift
@@ -1,0 +1,105 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class StudioMetadataDownloadInteractorLiveTests: CoreTestCase {
+    enum TestData {
+        static let mediaItem1 = APIStudioMediaItem(
+            id: ID(1),
+            lti_launch_id: "1",
+            title: "1",
+            mime_type: "1",
+            size: 1,
+            url: .make(),
+            captions: []
+        )
+        static let mediaItem2 = APIStudioMediaItem(
+            id: ID(2),
+            lti_launch_id: "2",
+            title: "2",
+            mime_type: "2",
+            size: 2,
+            url: .make(),
+            captions: []
+        )
+    }
+
+    func testDownloadsMediaItems() {
+        let testee: StudioMetadataDownloadInteractor = StudioMetadataDownloadInteractorLive()
+
+        api.mock(
+            GetStudioCourseMediaRequest(courseId: "1"),
+            value: [TestData.mediaItem1]
+        )
+        api.mock(
+            GetStudioCourseMediaRequest(courseId: "2"),
+            value: [TestData.mediaItem2]
+        )
+
+        // WHEN
+        let publisher = testee.fetchStudioMediaItems(api: api, courseIDs: ["1", "2"])
+
+        // THEN
+        XCTAssertSingleOutputEquals(
+            publisher,
+            [TestData.mediaItem1, TestData.mediaItem2]
+        )
+    }
+
+    func testDownloadSucceedsInCaseACourseHasNoStudioVideo() {
+        let testee: StudioMetadataDownloadInteractor = StudioMetadataDownloadInteractorLive()
+
+        api.mock(
+            GetStudioCourseMediaRequest(courseId: "1"),
+            value: [TestData.mediaItem1]
+        )
+        // If a course has no embedded studio videos the API will return 404
+        api.mock(GetStudioCourseMediaRequest(courseId: "2")) { _ in
+            (nil, nil, NSError.instructureError("", code: HttpError.notFound))
+        }
+
+        // WHEN
+        let publisher = testee.fetchStudioMediaItems(api: api, courseIDs: ["1", "2"])
+
+        // THEN
+        XCTAssertSingleOutputEquals(
+            publisher,
+            [TestData.mediaItem1]
+        )
+    }
+
+    func testFailsOnErrorsOtherThanNotFoundError() {
+        let testee: StudioMetadataDownloadInteractor = StudioMetadataDownloadInteractorLive()
+
+        api.mock(
+            GetStudioCourseMediaRequest(courseId: "1"),
+            value: [TestData.mediaItem1]
+        )
+        api.mock(GetStudioCourseMediaRequest(courseId: "2")) { _ in
+            (nil, nil, NSError.instructureError("", code: HttpError.forbidden))
+        }
+
+        // WHEN
+        let publisher = testee.fetchStudioMediaItems(api: api, courseIDs: ["1", "2"])
+
+        // THEN
+        XCTAssertFailure(publisher)
+    }
+}


### PR DESCRIPTION
During offline sync if a course is selected for sync but has no studio videos embedded then the API call for that course fails with a 404 making the whole studio sync stream fail. I extracted the download logic to make it more easily testable and modified it to ignore 404 errors.

refs: [MBL-17806](https://instructure.atlassian.net/browse/MBL-17806)
affects: Student
release note: none

test plan:
- Sync two courses at once for offline availability. One that should have studio videos embedded while the other shouldn't.
- (You can double check this with a proxy, api/public/v1/courses/123/media should return 404 for courses without studio videos.)
- Sync should finish successfully and studio videos should be available in offline mode.
- Check the debug menu's logs if there are any entries for failed studio sync.

[MBL-17806]: https://instructure.atlassian.net/browse/MBL-17806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ