### PR TITLE
Fix activity stream not displaying any items

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -11,7 +11,7 @@
     <entity name="Activity" representedClassName=".Activity" syncable="YES">
         <attribute name="canvasContextIDRaw" optional="YES" attributeType="String"/>
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="htmlURL" attributeType="URI"/>
+        <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" optional="YES" attributeType="String"/>
         <attribute name="message" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>

--- a/Core/Core/Notifications/API/APIActivity.swift
+++ b/Core/Core/Notifications/API/APIActivity.swift
@@ -20,6 +20,7 @@ import Foundation
 
 public enum ActivityType: String, Codable {
     case discussion = "DiscussionTopic"
+    case discussionEntry = "DiscussionEntry"
     case announcement = "Announcement"
     case conversation = "Conversation"
     case message = "Message"
@@ -33,7 +34,7 @@ public struct APIActivity: Codable {
     let id: ID
     let title: String?
     let message: String?
-    let html_url: URL
+    let html_url: URL?
     let created_at: Date
     let updated_at: Date
     let type: ActivityType

--- a/Core/Core/Notifications/CoreData/Activity.swift
+++ b/Core/Core/Notifications/CoreData/Activity.swift
@@ -76,7 +76,7 @@ public final class Activity: NSManagedObject, WriteableModel {
 extension Activity {
     public var icon: UIImage? {
         switch type {
-        case .discussion:       return .discussionLine
+        case .discussion, .discussionEntry: return .discussionLine
         case .announcement:     return .announcementLine
         case .conversation:     return .emailLine
         case .message:          return .assignmentLine


### PR DESCRIPTION
Parsing and saving of notification items failed:
- There's a new activity type called `DiscussionEntry`. Since this field is an enum the parsing failed since it lacked this value.
- The Activity entity's `htmlURL` field was optional in the swift file but was no optional in the CoreData model that caused a validation failure upon saving.

refs: [MBL-17805](https://instructure.atlassian.net/browse/MBL-17805)
affects: Student
release note: Fixed an issue that caused the notifications tab not to display any items.

test plan: See ticket for test account.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/89c899e2-4d90-44c3-8fbf-c29db11ee938" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/bed6ed33-3c07-4e44-a43b-d0b2967be349" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created


[MBL-17805]: https://instructure.atlassian.net/browse/MBL-17805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ