### PR TITLE
Fix RCE keyboard hiding much of the screen

### DIFF
--- a/Core/Core/SwiftUIViews/EditorForm.swift
+++ b/Core/Core/SwiftUIViews/EditorForm.swift
@@ -48,7 +48,6 @@ public struct EditorForm<Content: View>: View {
                     .background(Color.backgroundGrouped.opacity(0.5).edgesIgnoringSafeArea(.all))
             }
         }
-            .avoidKeyboardArea()
             .background(Color.backgroundGrouped.edgesIgnoringSafeArea(.all))
             .navigationBarStyle(.modal)
     }


### PR DESCRIPTION
refs: [MBL-17821](https://instructure.atlassian.net/browse/MBL-17821)
affects: Student, Teacher
release note: Fixed keyboard hiding too much of some screens.

## Test plan
Verify keyboard showing up doesn't hide area above it on screens:
- AssignmentEditor (Teacher)
- DiscussionEditor (Teacher / Student)
- PageEditor (Teacher / Student)
- QuizEditor (Teacher)
- SyllabusEditor (Teacher)

Verify keyboard appearance still works as it should on screens:
- CourseSettings
- CustomizeCourse
- FileEditor
- WebSitePreview

Doublecheck that https://instructure.atlassian.net/browse/MBL-17814 is also fixed

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/2d0bb994-a8be-475c-a326-503c8b8f00b9" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/07a57458-f37c-4f1f-b04d-ae712a3a92fc" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode

[MBL-17821]: https://instructure.atlassian.net/browse/MBL-17821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ