### PR TITLE
Fix some UI issues

### DIFF
--- a/Core/Core/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
+++ b/Core/Core/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
@@ -102,7 +102,8 @@ private class DarkModeForWebDiscussions: CoreWebViewFeature {
 
             /* Info boxes */
             span[data-testid="anon-conversation"],
-            span[data-testid="locked-for-user"] {
+            span[data-testid="locked-for-user"],
+            span[data-testid="post-required"] {
                 color: \(textLightest) !important;
             }
             .css-1oqo41g-view-alert {

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -112,7 +112,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             submissionRubricButton?.makeUnavailableInOfflineMode()
         }
     }
-    /** The view containing a separator and the rubruc button. */
+    /** The view containing a separator and the rubric button. */
     @IBOutlet weak var submissionRubricButtonSection: UIView?
 
     @IBOutlet weak var lockedIconContainerView: UIView!

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -17,7 +17,7 @@
         <!--Submission Details View Controller-->
         <scene sceneID="RqT-cb-7Go">
             <objects>
-                <viewController storyboardIdentifier="SubmissionDetailsViewController" hidesBottomBarWhenPushed="YES" useStoryboardIdentifierAsRestorationIdentifier="YES" id="l3A-rq-KxF" customClass="SubmissionDetailsViewController" customModule="Student" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SubmissionDetailsViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="l3A-rq-KxF" customClass="SubmissionDetailsViewController" customModule="Student" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="bcu-XY-Y5h">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>


### PR DESCRIPTION
While checking RC issues I was able to fix a few of them on the spot.
- Missing CSS override for discussions in dark mode.
- Hidden tab bar that revealed the "Back online" banner. The `hidesBottomBarWhenPushed` for the view controller was turned on but it hid only for elementary users.

refs: MBL-17807
affects: Student, Teacher
release note: none

test plan:
- Create a discussion that requires a post before you can see other replies.
- Load the discussion in dark mode.
- The banner for the post requirement should have the appropriate contrast ratio.
--
- Log in to an elementary account and go to an assignment's submission and rubric page.
- Tab bar should be visible on the page. Back online banner shouldn't be visible.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/eb39cca6-872d-441e-b104-18bc6e614f0b" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/4aae5091-fc67-43f8-9fbd-c47a81ff00f5" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b8371171-6af8-4501-abff-01dcf66cee4b" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f940a7ae-fc22-469f-a2b3-2bd54371fce6" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
