### PR TITLE
Reset cookies and force a cookie refresh when a new user logs in.

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -80,6 +80,13 @@ open class AppEnvironment {
 
         refreshWidgets()
         saveAccount(for: session)
+
+        CoreWebView
+            .deleteAllCookies()
+            .sink {
+                CoreWebView.refreshKeepAliveCookies()
+            }
+            .store(in: &subscriptions)
     }
 
     public func userDidLogout(session: LoginSession) {

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -17,6 +17,7 @@
 //
 
 import WebKit
+import Combine
 
 @IBDesignable
 open class CoreWebView: WKWebView {
@@ -506,7 +507,7 @@ extension CoreWebView {
                     cookieKeepAliveWebView.load(keepAliveRequest)
                 } }
             }
-            cookieKeepAliveTimer?.fire()
+            refreshKeepAliveCookies()
         }
     }
 
@@ -515,6 +516,21 @@ extension CoreWebView {
             cookieKeepAliveTimer?.invalidate()
             cookieKeepAliveTimer = nil
         }
+    }
+
+    /// Refreshes webview session cookies immediately outside of the scheduled renewal.
+    public static func refreshKeepAliveCookies() {
+        performUIUpdate {
+            cookieKeepAliveTimer?.fire()
+        }
+    }
+
+    public static func deleteAllCookies() -> AnyPublisher<Void, Never> {
+        cookieKeepAliveWebView
+            .configuration
+            .websiteDataStore
+            .httpCookieStore
+            .deleteAllCookies()
     }
 }
 

--- a/Core/Core/Extensions/HTTPCookieExtensions.swift
+++ b/Core/Core/Extensions/HTTPCookieExtensions.swift
@@ -1,0 +1,44 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public extension HTTPCookie {
+
+#if DEBUG
+
+    static func make(
+        name: String = "testName",
+        value: String = "testValue",
+        path: String = "/login",
+        domain: String = "instructure.com",
+        version: Int = 1
+    ) -> HTTPCookie {
+        HTTPCookie(
+            properties: [
+                .name: name,
+                .value: value,
+                .path: path,
+                .domain: domain,
+                .version: 1
+            ]
+        )!
+    }
+
+#endif
+}

--- a/Core/Core/Extensions/WKHTTPCookieStoreExtensions.swift
+++ b/Core/Core/Extensions/WKHTTPCookieStoreExtensions.swift
@@ -29,9 +29,31 @@ public extension WKHTTPCookieStore {
         }.eraseToAnyPublisher()
     }
 
+    func deleteAllCookies() -> AnyPublisher<Void, Never> {
+        getAllCookies()
+            .flatMap { cookies in
+                Publishers.Sequence(sequence: cookies)
+                    .flatMap { cookie in
+                        self.deleteCookie(cookie)
+                    }
+                    .collect()
+            }
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
     func setCookie(_ cookie: HTTPCookie) -> AnyPublisher<Void, Never> {
         Future { promise in
             self.setCookie(cookie) {
+                promise(.success)
+            }
+        }
+        .eraseToAnyPublisher()
+    }
+
+    func deleteCookie(_ cookie: HTTPCookie) -> AnyPublisher<Void, Never> {
+        Future { promise in
+            self.delete(cookie) {
                 promise(.success)
             }
         }

--- a/Core/CoreTests/Extensions/WKHTTPCookieStoreExtensionTests.swift
+++ b/Core/CoreTests/Extensions/WKHTTPCookieStoreExtensionTests.swift
@@ -22,15 +22,7 @@ import XCTest
 
 class WKHTTPCookieStoreExtensionTests: XCTestCase {
     private var webViewConfiguration: WKWebViewConfiguration!
-    private let cookie = HTTPCookie(
-        properties: [
-            .name: "testName",
-            .value: "testValue",
-            .path: "/login",
-            .domain: "instructure.com",
-            .version: 1
-        ]
-    )!
+    private let cookie = HTTPCookie.make()
 
     override func setUp() {
         super.setUp()
@@ -74,6 +66,25 @@ class WKHTTPCookieStoreExtensionTests: XCTestCase {
         XCTAssertSingleOutputEquals(
             cookieStore.getAllCookies(),
             [cookie],
+            timeout: 10
+        )
+    }
+
+    func testDeleteAllCookies() {
+        let webView = WKWebView(
+            frame: .zero,
+            configuration: webViewConfiguration
+        )
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+        XCTAssertFinish(cookieStore.setCookie(cookie), timeout: 10)
+
+        // WHEN
+        XCTAssertFinish(cookieStore.deleteAllCookies())
+
+        // THEN
+        XCTAssertSingleOutputEquals(
+            cookieStore.getAllCookies(),
+            [],
             timeout: 10
         )
     }


### PR DESCRIPTION
What happened?
- When you logged in with a user the cookie keep alive kicked in and saved cookies to the shared cookie store.
- After switching users the same cookies were in the store since user switch didn't reset them and the automatic cookie refresh only happens at every 10 minutes so this also didn't overwrite the cookies.
- The result was a forbidden error page for the second elementary user since it still had the cookies for the previous user.

refs: [MBL-17832](https://instructure.atlassian.net/browse/MBL-17832)
affects: Student
release note: Fixed elementary view not loading content after switching users.

test plan:
- Log out will all users to clean keychain entries and prevent automatic login after install.
- Re-install the app.
- Log in with a non-elementary user.
- Change user and log in with an elementary user.
- Go to an elementary course and check if its home page displays.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/4018410c-7d95-4ff3-9e41-5c43b725d4ea" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/b60b773c-9608-40e8-9567-9cd959bb22d3" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet


[MBL-17832]: https://instructure.atlassian.net/browse/MBL-17832?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ