### PR TITLE
Fix Archive swipe action not available after staring a message

### DIFF
--- a/Core/Core/Conversations/StarConversation.swift
+++ b/Core/Core/Conversations/StarConversation.swift
@@ -53,7 +53,7 @@ public class StarConversation: APIUseCase {
                 InboxMessageListItem.save(
                     response,
                     currentUserID: AppEnvironment.shared.currentSession?.userID ?? "",
-                    isSent: true,
+                    isSent: scope == .sent,
                     contextFilter: .none,
                     scopeFilter: scope,
                     in: client

--- a/Core/Core/Conversations/StarConversation.swift
+++ b/Core/Core/Conversations/StarConversation.swift
@@ -44,7 +44,6 @@ public class StarConversation: APIUseCase {
         }
 
         Conversation.save(response, in: client)
-
         let entities: [InboxMessageListItem] = client.fetch(scope: scope)
 
         entities

--- a/Core/CoreTests/Conversations/StarConversationTests.swift
+++ b/Core/CoreTests/Conversations/StarConversationTests.swift
@@ -17,10 +17,11 @@
 //
 
 import XCTest
+import Combine
 @testable import Core
 
 class StarConversationStateTests: CoreTestCase {
-
+    private var subscriptions = Set<AnyCancellable>()
     func testPostRequest() {
         let conversationId = "testId"
         let useCase = StarConversation(id: conversationId, starred: true)
@@ -59,7 +60,7 @@ class StarConversationStateTests: CoreTestCase {
     func testWrite() {
         let conversationId = "testId"
         let useCase = StarConversation(id: conversationId, starred: true)
-        let apiconversation = APIConversation.make(starred: false)
+        let apiconversation = APIConversation.make(id: conversationId, starred: false)
         Conversation.save(apiconversation, in: databaseClient)
         InboxMessageListItem.save(
             apiconversation,
@@ -73,7 +74,7 @@ class StarConversationStateTests: CoreTestCase {
         XCTAssertEqual((databaseClient.fetch() as [Conversation]).count, 1)
         XCTAssertEqual((databaseClient.fetch() as [Conversation]).first?.starred, false)
 
-        let response = APIConversation.make(starred: true)
+        let response = APIConversation.make(id: conversationId, starred: true)
         useCase.write(response: response, urlResponse: nil, to: databaseClient)
 
         XCTAssertEqual((databaseClient.fetch() as [Conversation]).count, 1)

--- a/Core/CoreTests/Conversations/StarConversationTests.swift
+++ b/Core/CoreTests/Conversations/StarConversationTests.swift
@@ -36,11 +36,12 @@ class StarConversationStateTests: CoreTestCase {
     }
 
     func testPostRequestError() {
+        // Given
         let conversationId = "testId"
         let useCase = StarConversation(id: conversationId, starred: true)
         api.mock(useCase.request, error: NSError.instructureError("Error"))
-
         let expectation = XCTestExpectation(description: "make request")
+        // Then
         useCase.makeRequest(environment: environment) { (_, _, error) in
             expectation.fulfill()
             XCTAssertNotNil(error)

--- a/Core/CoreTests/Conversations/StarConversationTests.swift
+++ b/Core/CoreTests/Conversations/StarConversationTests.swift
@@ -17,11 +17,10 @@
 //
 
 import XCTest
-import Combine
 @testable import Core
 
 class StarConversationStateTests: CoreTestCase {
-    private var subscriptions = Set<AnyCancellable>()
+
     func testPostRequest() {
         let conversationId = "testId"
         let useCase = StarConversation(id: conversationId, starred: true)


### PR DESCRIPTION
refs: [MBL-17833](https://instructure.atlassian.net/browse/MBL-17833)
affects: Student , Teacher
release note: Fixed archive message swipe action not always available in Inbox

test plan:
See ticket

## Screenshots
https://github.com/user-attachments/assets/bcded85f-b8c1-45b5-a26a-119dacbf4888

https://github.com/user-attachments/assets/e27d57c6-8c96-499c-84a2-58934ddb39a9

## Checklist

- [ ] Tested on phone
- [ ] Tested in dark mode
- [ ] Tested in light mode


[MBL-17833]: https://instructure.atlassian.net/browse/MBL-17833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ