### PR TITLE
Replace Calendar Event Details TextEditor with RCE

### DIFF
--- a/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
+++ b/Core/Core/Assignments/AssignmentEditor/AssignmentEditorView.swift
@@ -119,8 +119,7 @@ public struct AssignmentEditorView: View, ScreenViewTrackable {
                 placeholder: String(localized: "Add description", bundle: .core),
                 a11yLabel: String(localized: "Description", bundle: .core),
                 html: $description,
-                context: .course(courseID),
-                uploadTo: .context(.course(courseID)),
+                uploadParameters: .init(context: .course(courseID)),
                 height: $rceHeight,
                 canSubmit: $rceCanSubmit,
                 error: Binding(get: {

--- a/Core/Core/Discussions/DiscussionEditorView.swift
+++ b/Core/Core/Discussions/DiscussionEditorView.swift
@@ -147,8 +147,7 @@ public struct DiscussionEditorView: View {
                     placeholder: String(localized: "Add description", bundle: .core),
                     a11yLabel: String(localized: "Description", bundle: .core),
                     html: $message,
-                    context: context,
-                    uploadTo: .context(context),
+                    uploadParameters: .init(context: context),
                     height: $rceHeight,
                     canSubmit: $rceCanSubmit,
                     error: Binding(get: {

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -30,6 +30,8 @@ extension InstUI {
         private let placeholder: String
 
         @Binding private var text: String
+        @Binding private var isUploading: Bool
+        @Binding private var error: Error?
         @State private var rceHeight: CGFloat = 0
 
         @FocusState private var isFocused: Bool
@@ -53,6 +55,8 @@ extension InstUI {
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             text: Binding<String>,
+            isUploading: Binding<Bool> = .constant(false),
+            error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
         ) {
             self.label = label
@@ -60,6 +64,8 @@ extension InstUI {
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder ?? ""
             self._text = text
+            self._isUploading = isUploading
+            self._error = error
             self.onFocus = onFocus
         }
 
@@ -67,6 +73,8 @@ extension InstUI {
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             text: Binding<String>,
+            isUploading: Binding<Bool> = .constant(false),
+            error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
         ) where Label == Text? {
             self.init(
@@ -75,6 +83,8 @@ extension InstUI {
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
                 text: text,
+                isUploading: isUploading,
+                error: error,
                 onFocus: onFocus
             )
         }
@@ -114,8 +124,8 @@ extension InstUI {
                 context: .currentUser, // TODO: inject
                 uploadTo: .context(.currentUser), // TODO: file context, inject or calculate
                 height: $rceHeight,
-                canSubmit: .constant(true), // TODO: inject
-                error: .constant(nil), // TODO: inject (or only some alert string?)
+                isUploading: $isUploading,
+                error: $error,
                 onFocus: onFocus,
                 focusTrigger: focusedPublisher.eraseToAnyPublisher()
             )

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -30,6 +30,7 @@ extension InstUI {
 
         @Binding private var text: String
         @FocusState private var isFocused: Bool
+        @State private var rceHeight: CGFloat = 0
 
         private var accessibilityLabel: Text {
             customAccessibilityLabel ?? label ?? Text("")
@@ -94,14 +95,21 @@ extension InstUI {
         }
 
         private var rcEditor: some View {
-            TextField("", text: $text, prompt: Text(placeholder).foregroundColor(Color.placeholderGray))
-                .focused($isFocused)
-                .multilineTextAlignment(.leading)
-                .font(label == nil ? .semibold16 : .regular16, lineHeight: .fit)
-                .foregroundStyle(Color.textDarkest)
-                .submitLabel(.done)
-                .accessibilityLabel(accessibilityLabel)
-                .accessibilityValue(accessibilityValue)
+            return RichContentEditor(
+                placeholder: placeholder,
+                a11yLabel: "Some custom acc label",
+                html: $text,
+                context: .currentUser, // TODO: inject
+                uploadTo: .context(.currentUser), // TODO: file context, inject or calculate
+                height: $rceHeight,
+                canSubmit: .constant(true), // TODO: inject
+                error: .constant(nil) // TODO: inject (or only some alert string?)
+            )
+            .scrollDisabled(true)
+            .focused($isFocused)
+            .frame(height: rceHeight)
+//            .accessibilityLabel(accessibilityLabel)
+//            .accessibilityValue(accessibilityValue)
         }
     }
 }

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -43,13 +43,6 @@ extension InstUI {
             customAccessibilityLabel ?? label ?? Text("")
         }
 
-        private var accessibilityValue: String {
-            // adding pause before `value`, not after `label`, otherwise it will be read out
-            let pause = accessibilityLabel != Text("") ? "," : ""
-            let value = html.nilIfEmpty ?? placeholder
-            return pause + value
-        }
-
         public init(
             label: Text?,
             labelTransform: @escaping (Text) -> Label = { $0 },
@@ -124,7 +117,7 @@ extension InstUI {
         private var rcEditor: some View {
             return RichContentEditor(
                 placeholder: placeholder,
-                a11yLabel: "Some custom acc label",
+                a11yLabel: "",
                 html: $html,
                 uploadParameters: uploadParameters,
                 height: $rceHeight,
@@ -136,8 +129,8 @@ extension InstUI {
             .scrollDisabled(true)
             .focused($isFocused)
             .frame(height: rceHeight)
-//            .accessibilityLabel(accessibilityLabel)
-//            .accessibilityValue(accessibilityValue)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(accessibilityLabel)
         }
     }
 }

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -130,4 +130,22 @@ extension InstUI {
 
 #if DEBUG
 
+#Preview {
+    VStack {
+        InstUI.RichContentEditorCell(placeholder: "Add text here", text: .constant(""))
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", text: .constant(""))
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", text: .constant(InstUI.PreviewData.loremIpsumMedium))
+        InstUI.RichContentEditorCell(
+            label: Text(verbatim: "Styled Label"),
+            labelTransform: {
+                $0
+                    .foregroundStyle(Color.red)
+                    .textStyle(.heading)
+            },
+            placeholder: "Add text here",
+            text: .constant("Some text entered")
+        )
+    }
+}
+
 #endif

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -1,0 +1,111 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension InstUI {
+
+    public struct RichContentEditorCell<Label: View>: View {
+        @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+        private let label: Text?
+        private let labelTransform: (Text) -> Label
+        private let customAccessibilityLabel: Text?
+        private let placeholder: String
+
+        @Binding private var text: String
+        @FocusState private var isFocused: Bool
+
+        private var accessibilityLabel: Text {
+            customAccessibilityLabel ?? label ?? Text("")
+        }
+
+        private var accessibilityValue: String {
+            // adding pause before `value`, not after `label`, otherwise it will be read out
+            let pause = accessibilityLabel != Text("") ? "," : ""
+            let value = text.nilIfEmpty ?? placeholder
+            return pause + value
+        }
+
+        public init(
+            label: Text?,
+            labelTransform: @escaping (Text) -> Label = { $0 },
+            customAccessibilityLabel: Text? = nil,
+            placeholder: String? = nil,
+            text: Binding<String>
+        ) {
+            self.label = label
+            self.labelTransform = labelTransform
+            self.customAccessibilityLabel = customAccessibilityLabel
+            self.placeholder = placeholder ?? ""
+            self._text = text
+        }
+
+        public init(
+            customAccessibilityLabel: Text? = nil,
+            placeholder: String? = nil,
+            text: Binding<String>
+        ) where Label == Text? {
+            self.init(
+                label: nil,
+                labelTransform: { $0 },
+                customAccessibilityLabel: customAccessibilityLabel,
+                placeholder: placeholder,
+                text: text
+            )
+        }
+
+        public var body: some View {
+            SwiftUI.Group {
+                if let label {
+                    VStack(spacing: 0) {
+                        labelTransform(label)
+                            .textStyle(.cellLabel)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .paddingStyle(.top, .cellTop)
+                            .paddingStyle(.horizontal, .standard)
+                            .accessibility(hidden: true)
+
+                        rcEditor
+                    }
+                } else {
+                    rcEditor
+                }
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+                isFocused = true
+            }
+        }
+
+        private var rcEditor: some View {
+            TextField("", text: $text, prompt: Text(placeholder).foregroundColor(Color.placeholderGray))
+                .focused($isFocused)
+                .multilineTextAlignment(.leading)
+                .font(label == nil ? .semibold16 : .regular16, lineHeight: .fit)
+                .foregroundStyle(Color.textDarkest)
+                .submitLabel(.done)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityValue(accessibilityValue)
+        }
+    }
+}
+
+#if DEBUG
+
+#endif

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -28,6 +28,7 @@ extension InstUI {
         private let labelTransform: (Text) -> Label
         private let customAccessibilityLabel: Text?
         private let placeholder: String
+        private let uploadParameters: RichContentEditorUploadParameters
 
         @Binding private var html: String
         @Binding private var isUploading: Bool
@@ -55,6 +56,7 @@ extension InstUI {
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             html: Binding<String>,
+            uploadParameters: RichContentEditorUploadParameters,
             isUploading: Binding<Bool> = .constant(false),
             error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
@@ -64,6 +66,7 @@ extension InstUI {
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder ?? ""
             self._html = html
+            self.uploadParameters = uploadParameters
             self._isUploading = isUploading
             self._error = error
             self.onFocus = onFocus
@@ -73,6 +76,7 @@ extension InstUI {
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             html: Binding<String>,
+            uploadParameters: RichContentEditorUploadParameters,
             isUploading: Binding<Bool> = .constant(false),
             error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
@@ -83,6 +87,7 @@ extension InstUI {
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
                 html: html,
+                uploadParameters: uploadParameters,
                 isUploading: isUploading,
                 error: error,
                 onFocus: onFocus
@@ -121,8 +126,7 @@ extension InstUI {
                 placeholder: placeholder,
                 a11yLabel: "Some custom acc label",
                 html: $html,
-                context: .currentUser, // TODO: inject
-                uploadTo: .context(.currentUser), // TODO: file context, inject or calculate
+                uploadParameters: uploadParameters,
                 height: $rceHeight,
                 isUploading: $isUploading,
                 error: $error,
@@ -141,10 +145,12 @@ extension InstUI {
 #if DEBUG
 
 #Preview {
-    VStack {
-        InstUI.RichContentEditorCell(placeholder: "Add text here", html: .constant(""))
-        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(""))
-        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(InstUI.PreviewData.loremIpsumMedium))
+    let uploadParameters = RichContentEditorUploadParameters(context: .course("1"))
+
+    return VStack {
+        InstUI.RichContentEditorCell(placeholder: "Add text here", html: .constant(""), uploadParameters: uploadParameters)
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(""), uploadParameters: uploadParameters)
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(InstUI.PreviewData.loremIpsumMedium), uploadParameters: uploadParameters)
         InstUI.RichContentEditorCell(
             label: Text(verbatim: "Styled Label"),
             labelTransform: {
@@ -153,7 +159,8 @@ extension InstUI {
                     .textStyle(.heading)
             },
             placeholder: "Add text here",
-            html: .constant("Some text entered")
+            html: .constant("Some text entered"),
+            uploadParameters: uploadParameters
         )
     }
 }

--- a/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -29,7 +29,7 @@ extension InstUI {
         private let customAccessibilityLabel: Text?
         private let placeholder: String
 
-        @Binding private var text: String
+        @Binding private var html: String
         @Binding private var isUploading: Bool
         @Binding private var error: Error?
         @State private var rceHeight: CGFloat = 0
@@ -45,7 +45,7 @@ extension InstUI {
         private var accessibilityValue: String {
             // adding pause before `value`, not after `label`, otherwise it will be read out
             let pause = accessibilityLabel != Text("") ? "," : ""
-            let value = text.nilIfEmpty ?? placeholder
+            let value = html.nilIfEmpty ?? placeholder
             return pause + value
         }
 
@@ -54,7 +54,7 @@ extension InstUI {
             labelTransform: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
-            text: Binding<String>,
+            html: Binding<String>,
             isUploading: Binding<Bool> = .constant(false),
             error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
@@ -63,7 +63,7 @@ extension InstUI {
             self.labelTransform = labelTransform
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder ?? ""
-            self._text = text
+            self._html = html
             self._isUploading = isUploading
             self._error = error
             self.onFocus = onFocus
@@ -72,7 +72,7 @@ extension InstUI {
         public init(
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
-            text: Binding<String>,
+            html: Binding<String>,
             isUploading: Binding<Bool> = .constant(false),
             error: Binding<Error?> = .constant(nil),
             onFocus: (() -> Void)? = nil
@@ -82,7 +82,7 @@ extension InstUI {
                 labelTransform: { $0 },
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
-                text: text,
+                html: html,
                 isUploading: isUploading,
                 error: error,
                 onFocus: onFocus
@@ -120,7 +120,7 @@ extension InstUI {
             return RichContentEditor(
                 placeholder: placeholder,
                 a11yLabel: "Some custom acc label",
-                html: $text,
+                html: $html,
                 context: .currentUser, // TODO: inject
                 uploadTo: .context(.currentUser), // TODO: file context, inject or calculate
                 height: $rceHeight,
@@ -142,9 +142,9 @@ extension InstUI {
 
 #Preview {
     VStack {
-        InstUI.RichContentEditorCell(placeholder: "Add text here", text: .constant(""))
-        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", text: .constant(""))
-        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", text: .constant(InstUI.PreviewData.loremIpsumMedium))
+        InstUI.RichContentEditorCell(placeholder: "Add text here", html: .constant(""))
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(""))
+        InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(InstUI.PreviewData.loremIpsumMedium))
         InstUI.RichContentEditorCell(
             label: Text(verbatim: "Styled Label"),
             labelTransform: {
@@ -153,7 +153,7 @@ extension InstUI {
                     .textStyle(.heading)
             },
             placeholder: "Add text here",
-            text: .constant("Some text entered")
+            html: .constant("Some text entered")
         )
     }
 }

--- a/Core/Core/InstUI/Views/Cells/ToggleCell.swift
+++ b/Core/Core/InstUI/Views/Cells/ToggleCell.swift
@@ -33,7 +33,7 @@ extension InstUI {
 
         public var body: some View {
             VStack(spacing: 0) {
-                Toggle(isOn: $value) { label }
+                Toggle(isOn: $value) { label.allowsHitTesting(false) }
                     .textStyle(.cellLabel)
                     .paddingStyle(.leading, .standard)
                     .paddingStyle(.trailing, .standard)

--- a/Core/Core/Pages/PageEditor/PageEditorView.swift
+++ b/Core/Core/Pages/PageEditor/PageEditorView.swift
@@ -91,8 +91,7 @@ public struct PageEditorView: View {
                     placeholder: String(localized: "Add content", bundle: .core),
                     a11yLabel: String(localized: "Page content", bundle: .core),
                     html: $html,
-                    context: context,
-                    uploadTo: .context(context),
+                    uploadParameters: .init(context: context),
                     height: $rceHeight,
                     canSubmit: $rceCanSubmit,
                     error: $error

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -109,6 +109,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         InstUI.RichContentEditorCell(
                             label: Text("Details", bundle: .core),
                             text: $viewModel.details,
+                            isUploading: $viewModel.isUploading,
                             onFocus: {
                                 // wait a bit for keyboard to start appearing, so it's considered during scroll
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -110,14 +110,8 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                             label: Text("Details", bundle: .core),
                             text: $viewModel.details,
                             onFocus: {
+                                // wait a bit for keyboard to start appearing, so it's considered during scroll
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                                    // wait a bit for keyboard to start appearing, so it's considered during scroll
-                                    withAnimation {
-                                        scrollProxy.scrollTo("details", anchor: .bottom)
-                                    }
-                                }
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
-                                    // wait some more just in case we started scrolling too fast
                                     withAnimation {
                                         scrollProxy.scrollTo("details", anchor: .bottom)
                                     }

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -108,7 +108,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
 
                         InstUI.RichContentEditorCell(
                             label: Text("Details", bundle: .core),
-                            text: $viewModel.details,
+                            html: $viewModel.details,
                             isUploading: $viewModel.isUploading,
                             onFocus: {
                                 // wait a bit for keyboard to start appearing, so it's considered during scroll

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -105,7 +105,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                     .focused($focusedInput, equals: .address)
                     InstUI.Divider()
 
-                    InstUI.TextEditorCell(
+                    InstUI.RichContentEditorCell(
                         label: Text("Details", bundle: .core),
                         text: $viewModel.details
                     )

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -109,6 +109,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         InstUI.RichContentEditorCell(
                             label: Text("Details", bundle: .core),
                             html: $viewModel.details,
+                            uploadParameters: viewModel.uploadParameters,
                             isUploading: $viewModel.isUploading,
                             onFocus: {
                                 // wait a bit for keyboard to start appearing, so it's considered during scroll

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -38,6 +38,7 @@ final class EditCalendarEventViewModel: ObservableObject {
 
     let pageViewEvent = ScreenViewTrackingParameters(eventName: "/calendar/new")
     let screenConfig = InstUI.BaseScreenConfig(refreshable: false)
+    let uploadParameters: RichContentEditorUploadParameters
 
     @Published private(set) var state: InstUI.ScreenState = .data
     @Published var title: String = ""
@@ -128,11 +129,13 @@ final class EditCalendarEventViewModel: ObservableObject {
         event: CalendarEvent? = nil,
         eventInteractor: CalendarEventInteractor,
         calendarListProviderInteractor: CalendarFilterInteractor,
+        uploadParameters: RichContentEditorUploadParameters,
         router: Router,
         completion: @escaping (PlannerAssembly.Completion) -> Void
     ) {
         self.eventInteractor = eventInteractor
         self.calendarListProviderInteractor = calendarListProviderInteractor
+        self.uploadParameters = uploadParameters
         self.router = router
 
         if let event {

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -50,12 +50,14 @@ final class EditCalendarEventViewModel: ObservableObject {
     @Published var location: String = ""
     @Published var address: String = ""
     @Published var details: String = ""
+    @Published var isUploading: Bool = false
 
     @Published private(set) var endTimeErrorMessage: String?
     @Published var shouldShowSaveError: Bool = false
 
     var isSaveButtonEnabled: Bool {
         state == .data
+        && !isUploading
         && eventInteractor.isRequestModelValid(model)
         && isFieldsTouched
     }

--- a/Core/Core/Planner/PlannerAssembly.swift
+++ b/Core/Core/Planner/PlannerAssembly.swift
@@ -36,6 +36,7 @@ public enum PlannerAssembly {
         let viewModel = EditCalendarEventViewModel(
             eventInteractor: CalendarEventInteractorLive(),
             calendarListProviderInteractor: calendarListProviderInteractor ?? makeFilterInteractor(observedUserId: nil),
+            uploadParameters: makeUploadParameters(env: env),
             router: env.router,
             completion: completion
         )
@@ -54,6 +55,7 @@ public enum PlannerAssembly {
             event: event,
             eventInteractor: CalendarEventInteractorLive(),
             calendarListProviderInteractor: calendarListProviderInteractor ?? makeFilterInteractor(observedUserId: nil),
+            uploadParameters: makeUploadParameters(env: env),
             router: env.router,
             completion: completion
         )
@@ -75,12 +77,20 @@ public enum PlannerAssembly {
         return host
     }
 
+    private static func makeUploadParameters(env: AppEnvironment) -> RichContentEditorUploadParameters {
+        .init(
+            context: .currentUser,
+            uploadTo: .makeForRCEUploads(app: env.app, context: .currentUser, session: env.currentSession)
+        )
+    }
+
 #if DEBUG
 
     public static func makeEditEventScreenPreview(env: AppEnvironment = .shared) -> some View {
         let viewModel = EditCalendarEventViewModel(
             eventInteractor: CalendarEventInteractorPreview(),
             calendarListProviderInteractor: CalendarFilterInteractorPreview(),
+            uploadParameters: .init(context: .course("1")),
             router: env.router,
             completion: { _ in }
         )

--- a/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
+++ b/Core/Core/Quizzes/QuizDetails/View/QuizEditorView.swift
@@ -114,8 +114,7 @@ public struct QuizEditorView<ViewModel: QuizEditorViewModelProtocol>: View {
                 placeholder: String(localized: "Add description", bundle: .core),
                 a11yLabel: String(localized: "Description", bundle: .core),
                 html: $viewModel.description,
-                context: .course(viewModel.courseID),
-                uploadTo: .context(.course(viewModel.courseID)),
+                uploadParameters: .init(context: .course(viewModel.courseID)),
                 height: $rceHeight,
                 canSubmit: $rceCanSubmit,
                 error: Binding(get: {

--- a/Core/Core/RichContentEditor/Model/RichContentEditorUploadParameters.swift
+++ b/Core/Core/RichContentEditor/Model/RichContentEditorUploadParameters.swift
@@ -1,0 +1,31 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public struct RichContentEditorUploadParameters {
+    public let context: Context
+    public let uploadTo: FileUploadContext
+    public let baseUrl: URL?
+
+    public init(context: Context, uploadTo: FileUploadContext? = nil, baseUrl: URL? = nil) {
+        self.context = context
+        self.uploadTo = uploadTo ?? .context(context)
+        self.baseUrl = baseUrl
+    }
+}

--- a/Core/Core/RichContentEditor/RichContentEditor.js
+++ b/Core/Core/RichContentEditor/RichContentEditor.js
@@ -244,6 +244,7 @@ const editor = window.editor = {
         selection.removeAllRanges()
         selection.addRange(range)
         content.focus()
+        webkit.messageHandlers.focused.postMessage('')
     },
 
     getSelectionBoundingRect () {

--- a/Core/Core/RichContentEditor/RichContentEditor.swift
+++ b/Core/Core/RichContentEditor/RichContentEditor.swift
@@ -27,6 +27,7 @@ struct RichContentEditor: UIViewControllerRepresentable {
     private let uploadTo: FileUploadContext
     @Binding private var height: CGFloat
     @Binding private var canSubmit: Bool
+    @Binding private var isUploading: Bool
     @Binding private var error: Error?
     private let onFocus: (() -> Void)?
     private let focusTrigger: AnyPublisher<Void, Never>?
@@ -45,6 +46,10 @@ struct RichContentEditor: UIViewControllerRepresentable {
                 self.lastHTML = $0
                 self.view.html = $0
             }
+        }
+
+        func rce(_ editor: RichContentEditorViewController, isUploading: Bool) {
+            view.isUploading = isUploading
         }
 
         func rce(_ editor: RichContentEditorViewController, didError error: Error) {
@@ -67,7 +72,8 @@ struct RichContentEditor: UIViewControllerRepresentable {
         context: Context,
         uploadTo: FileUploadContext,
         height: Binding<CGFloat>,
-        canSubmit: Binding<Bool>,
+        canSubmit: Binding<Bool> = .constant(true),
+        isUploading: Binding<Bool> = .constant(false),
         error: Binding<Error?>,
         onFocus: (() -> Void)? = nil,
         focusTrigger: AnyPublisher<Void, Never>? = nil
@@ -79,6 +85,7 @@ struct RichContentEditor: UIViewControllerRepresentable {
         self.uploadTo = uploadTo
         self._height = height
         self._canSubmit = canSubmit
+        self._isUploading = isUploading
         self._error = error
         self.onFocus = onFocus
         self.focusTrigger = focusTrigger
@@ -122,6 +129,7 @@ struct RichContentEditorView_Previews: PreviewProvider {
         @State var html: String = "Edit Me!"
         @State var height: CGFloat = 200
         @State var canSubmit: Bool = false
+        @State var isUploading: Bool = false
         @State var error: Error?
         var body: some View {
             RichContentEditor(
@@ -132,6 +140,7 @@ struct RichContentEditorView_Previews: PreviewProvider {
                 uploadTo: .myFiles,
                 height: $height,
                 canSubmit: $canSubmit,
+                isUploading: $isUploading,
                 error: $error
             ).frame(minHeight: 60, idealHeight: max(60, height))
         }

--- a/Core/Core/RichContentEditor/RichContentEditor.swift
+++ b/Core/Core/RichContentEditor/RichContentEditor.swift
@@ -23,8 +23,7 @@ struct RichContentEditor: UIViewControllerRepresentable {
     private let placeholder: String
     private let a11yLabel: String
     @Binding private var html: String
-    private let context: Context
-    private let uploadTo: FileUploadContext
+    private let uploadParameters: RichContentEditorUploadParameters
     @Binding private var height: CGFloat
     @Binding private var canSubmit: Bool
     @Binding private var isUploading: Bool
@@ -69,8 +68,7 @@ struct RichContentEditor: UIViewControllerRepresentable {
         placeholder: String,
         a11yLabel: String,
         html: Binding<String>,
-        context: Context,
-        uploadTo: FileUploadContext,
+        uploadParameters: RichContentEditorUploadParameters,
         height: Binding<CGFloat>,
         canSubmit: Binding<Bool> = .constant(true),
         isUploading: Binding<Bool> = .constant(false),
@@ -81,8 +79,7 @@ struct RichContentEditor: UIViewControllerRepresentable {
         self.placeholder = placeholder
         self.a11yLabel = a11yLabel
         self._html = html
-        self.context = context
-        self.uploadTo = uploadTo
+        self.uploadParameters = uploadParameters
         self._height = height
         self._canSubmit = canSubmit
         self._isUploading = isUploading
@@ -96,7 +93,11 @@ struct RichContentEditor: UIViewControllerRepresentable {
     }
 
     func makeUIViewController(context: Self.Context) -> RichContentEditorViewController {
-        let uiViewController = RichContentEditorViewController.create(context: self.context, uploadTo: uploadTo)
+        let uiViewController = RichContentEditorViewController.create(
+            context: uploadParameters.context,
+            uploadTo: uploadParameters.uploadTo
+        )
+        uiViewController.fileUploadBaseURL = uploadParameters.baseUrl
         uiViewController.webView.autoresizesHeight = true
         uiViewController.delegate = context.coordinator
         uiViewController.webView.sizeDelegate = context.coordinator
@@ -136,8 +137,7 @@ struct RichContentEditorView_Previews: PreviewProvider {
                 placeholder: "Placeholder",
                 a11yLabel: "Editor",
                 html: $html,
-                context: .course("1"),
-                uploadTo: .myFiles,
+                uploadParameters: .init(context: .course("1")),
                 height: $height,
                 canSubmit: $canSubmit,
                 isUploading: $isUploading,

--- a/Core/Core/RichContentEditor/RichContentEditor.swift
+++ b/Core/Core/RichContentEditor/RichContentEditor.swift
@@ -17,19 +17,22 @@
 //
 
 import SwiftUI
+import Combine
 
 struct RichContentEditor: UIViewControllerRepresentable {
-    let placeholder: String
-    let a11yLabel: String
-    @Binding var html: String
-    let context: Context
-    let uploadTo: FileUploadContext
-    @Binding var height: CGFloat
-    @Binding var canSubmit: Bool
-    @Binding var error: Error?
+    private let placeholder: String
+    private let a11yLabel: String
+    @Binding private var html: String
+    private let context: Context
+    private let uploadTo: FileUploadContext
+    @Binding private var height: CGFloat
+    @Binding private var canSubmit: Bool
+    @Binding private var error: Error?
+    private let onFocus: (() -> Void)?
+    private let focusTrigger: AnyPublisher<Void, Never>?
 
-    class Coordinator: RichContentEditorDelegate, CoreWebViewSizeDelegate {
-        let view: RichContentEditor
+    final class Coordinator: RichContentEditorDelegate, CoreWebViewSizeDelegate {
+        private let view: RichContentEditor
         var lastHTML: String = ""
 
         init(_ view: RichContentEditor) {
@@ -48,9 +51,37 @@ struct RichContentEditor: UIViewControllerRepresentable {
             view.error = error
         }
 
+        func rceDidFocus(_ editor: RichContentEditorViewController) {
+            view.onFocus?()
+        }
+
         func coreWebView(_ webView: CoreWebView, didChangeContentHeight height: CGFloat) {
             view.height = height
         }
+    }
+
+    init(
+        placeholder: String,
+        a11yLabel: String,
+        html: Binding<String>,
+        context: Context,
+        uploadTo: FileUploadContext,
+        height: Binding<CGFloat>,
+        canSubmit: Binding<Bool>,
+        error: Binding<Error?>,
+        onFocus: (() -> Void)? = nil,
+        focusTrigger: AnyPublisher<Void, Never>? = nil
+    ) {
+        self.placeholder = placeholder
+        self.a11yLabel = a11yLabel
+        self._html = html
+        self.context = context
+        self.uploadTo = uploadTo
+        self._height = height
+        self._canSubmit = canSubmit
+        self._error = error
+        self.onFocus = onFocus
+        self.focusTrigger = focusTrigger
     }
 
     func makeCoordinator() -> Coordinator {
@@ -60,20 +91,27 @@ struct RichContentEditor: UIViewControllerRepresentable {
     func makeUIViewController(context: Self.Context) -> RichContentEditorViewController {
         let uiViewController = RichContentEditorViewController.create(context: self.context, uploadTo: uploadTo)
         uiViewController.webView.autoresizesHeight = true
+        uiViewController.delegate = context.coordinator
+        uiViewController.webView.sizeDelegate = context.coordinator
+
         // Prevent bad adjustedContentInset from adding unnecessary scrollbars
         NotificationCenter.default.removeObserver(uiViewController.webView, name: UIResponder.keyboardWillShowNotification, object: nil)
         NotificationCenter.default.removeObserver(uiViewController.webView, name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
         NotificationCenter.default.removeObserver(uiViewController.webView, name: UIResponder.keyboardWillHideNotification, object: nil)
+
         return uiViewController
     }
 
     func updateUIViewController(_ uiViewController: RichContentEditorViewController, context: Self.Context) {
-        uiViewController.delegate = context.coordinator
-        uiViewController.webView.sizeDelegate = context.coordinator
         uiViewController.placeholder = placeholder
         uiViewController.a11yLabel = a11yLabel
+
         if context.coordinator.lastHTML != html {
             uiViewController.setHTML(html)
+        }
+
+        if let focusTrigger {
+            uiViewController.subscribeToFocusTrigger(focusTrigger)
         }
     }
 }

--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -24,11 +24,14 @@ import Combine
 
 public protocol RichContentEditorDelegate: AnyObject {
     func rce(_ editor: RichContentEditorViewController, canSubmit: Bool)
+    func rce(_ editor: RichContentEditorViewController, isUploading: Bool)
     func rce(_ editor: RichContentEditorViewController, didError error: Error)
     func rceDidFocus(_ editor: RichContentEditorViewController)
 }
 
 public extension RichContentEditorDelegate {
+    func rce(_ editor: RichContentEditorViewController, canSubmit: Bool) {}
+    func rce(_ editor: RichContentEditorViewController, isUploading: Bool) {}
     func rceDidFocus(_ editor: RichContentEditorViewController) {}
 }
 
@@ -175,6 +178,7 @@ public class RichContentEditorViewController: UIViewController {
         let isEmpty = state?["isEmpty"] as? Bool ?? true
         let isUploading = state?["isUploading"] as? Bool ?? false
         delegate?.rce(self, canSubmit: !isEmpty && !isUploading)
+        delegate?.rce(self, isUploading: isUploading)
     }
 
     func subscribeToFocusTrigger(_ trigger: AnyPublisher<Void, Never>) {

--- a/Core/Core/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/RichContentEditor/RichContentEditorViewController.swift
@@ -30,7 +30,7 @@ public class RichContentEditorViewController: UIViewController {
     let toolbar = RichContentToolbarView()
     public var webView = CoreWebView(frame: .zero)
 
-    let batchID = UUID.string
+    private let batchID = UUID.string
     public weak var delegate: RichContentEditorDelegate?
     var env = AppEnvironment.shared
     public var placeholder: String = "" {
@@ -49,11 +49,11 @@ public class RichContentEditorViewController: UIViewController {
     public var uploadContext = FileUploadContext.myFiles
     let uploadManager = UploadManager.shared
 
-    lazy var files = uploadManager.subscribe(batchID: batchID) { [weak self] in
+    private lazy var files = uploadManager.subscribe(batchID: batchID) { [weak self] in
         self?.updateUploadProgress()
     }
 
-    lazy var featureFlags = env.subscribe(GetEnabledFeatureFlags(context: context)) {}
+    private lazy var featureFlags = env.subscribe(GetEnabledFeatureFlags(context: context)) {}
     /// The base url to be used for API access during file upload.
     public var fileUploadBaseURL: URL?
 
@@ -90,11 +90,11 @@ public class RichContentEditorViewController: UIViewController {
         }
     }
 
-    public func showError(_ error: Error) {
+    private func showError(_ error: Error) {
         delegate?.rce(self, didError: error)
     }
 
-    func loadHTML() {
+    private func loadHTML() {
         webView.loadHTMLString("""
             <style>
             :root {
@@ -146,7 +146,7 @@ public class RichContentEditorViewController: UIViewController {
         webView.evaluateJavaScript("editor.backupRange()")
     }
 
-    public func focus() {
+    func focus() {
         webView.evaluateJavaScript("editor.focus()")
     }
 
@@ -170,7 +170,7 @@ public class RichContentEditorViewController: UIViewController {
         delegate?.rce(self, canSubmit: !isEmpty && !isUploading)
     }
 
-    func setFeatureFlags() {
+    private func setFeatureFlags() {
         let flags = featureFlags.map { $0.name }
         if let data = try? JSONSerialization.data(withJSONObject: flags),
             let flags = String(data: data, encoding: .utf8) {
@@ -178,7 +178,7 @@ public class RichContentEditorViewController: UIViewController {
         }
     }
 
-    func updateScroll(_ state: [String: Any?]?) {
+    private func updateScroll(_ state: [String: Any?]?) {
         guard
             let r = state?["selection"] as? [String: CGFloat],
             let x = r["x"], let y = r["y"], let width = r["width"], let height = r["height"]
@@ -231,11 +231,11 @@ public class RichContentEditorViewController: UIViewController {
 }
 
 extension RichContentEditorViewController {
-    enum Message: String, CaseIterable {
+    private enum Message: String, CaseIterable {
         case link, ready, state, retryUpload
     }
 
-    func setupScriptMessaging() {
+    private func setupScriptMessaging() {
         for message in Message.allCases {
             webView.handle(message.rawValue) { [weak self] message in
                 self?.handleScriptMessage(message)
@@ -254,7 +254,7 @@ extension RichContentEditorViewController {
         }
     }
 
-    func handleScriptMessage(_ message: WKScriptMessage) {
+    private func handleScriptMessage(_ message: WKScriptMessage) {
         guard let name = Message(rawValue: message.name) else { return }
         switch name {
         case .link:
@@ -300,7 +300,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func retry(_ url: URL) {
+    private func retry(_ url: URL) {
         if ["png", "jpeg", "jpg"].contains(url.pathExtension) {
             createFile(url, isRetry: true, then: uploadImage)
         } else {
@@ -308,7 +308,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func createFile(_ url: URL, isRetry: Bool, then: @escaping (URL, File, Bool) -> Void) {
+    private func createFile(_ url: URL, isRetry: Bool, then: @escaping (URL, File, Bool) -> Void) {
         let context = uploadManager.viewContext
         context.performAndWait {
             do {
@@ -329,7 +329,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func uploadImage(_ url: URL, file: File, isRetry: Bool) {
+    private func uploadImage(_ url: URL, file: File, isRetry: Bool) {
         do {
             if !isRetry {
                 let string = CoreWebView.jsString(url.absoluteString)
@@ -343,7 +343,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func uploadMedia(_ url: URL, file: File, isRetry: Bool) {
+    private func uploadMedia(_ url: URL, file: File, isRetry: Bool) {
         if !isRetry {
             let string = CoreWebView.jsString(url.absoluteString)
             webView.evaluateJavaScript("editor.insertVideoPlaceholder(\(string))")
@@ -353,7 +353,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func updateFile(_ file: File, error: Error?, mediaID: String? = nil) {
+    private func updateFile(_ file: File, error: Error?, mediaID: String? = nil) {
         let context = uploadManager.viewContext
         context.performAndWait { [weak self] in
             do {
@@ -367,7 +367,7 @@ extension RichContentEditorViewController: UIImagePickerControllerDelegate, UINa
         }
     }
 
-    func updateUploadProgress() {
+    private func updateUploadProgress() {
         let data = try? JSONSerialization.data(withJSONObject: files.map { file -> [String: Any?] in [
             "localFileURL": file.localFileURL?.absoluteString,
             "url": file.url?.absoluteString,

--- a/Core/Core/Syllabus/SyllabusEditorView.swift
+++ b/Core/Core/Syllabus/SyllabusEditorView.swift
@@ -75,8 +75,7 @@ public struct SyllabusEditorView: View {
                     placeholder: String(localized: "Add content", bundle: .core),
                     a11yLabel: String(localized: "Syllabus content", bundle: .core),
                     html: $html,
-                    context: context,
-                    uploadTo: .context(context),
+                    uploadParameters: .init(context: context),
                     height: $rceHeight,
                     canSubmit: $rceCanSubmit,
                     error: $error

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -37,6 +37,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
             ("User 3", .user("3")),
             ("Group 6", .group("6"))
         ]
+        static let uploadContext: Context = .course("some upload target")
     }
 
     private var eventInteractor: CalendarEventInteractorPreview!
@@ -68,6 +69,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.state, .data)
         XCTAssertEqual(testee.endTimeErrorMessage, nil)
         XCTAssertEqual(testee.shouldShowSaveError, false)
+        XCTAssertEqual(testee.uploadParameters.context, TestConstants.uploadContext)
 
         XCTAssertEqual(testee.title, "")
         XCTAssertEqual(testee.date, Date.make(year: 2024, month: 1, day: 1))
@@ -91,6 +93,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.state, .data)
         XCTAssertEqual(testee.endTimeErrorMessage, nil)
         XCTAssertEqual(testee.shouldShowSaveError, false)
+        XCTAssertEqual(testee.uploadParameters.context, TestConstants.uploadContext)
 
         XCTAssertEqual(testee.title, TestConstants.title)
         XCTAssertEqual(testee.location, TestConstants.locationName)
@@ -165,6 +168,15 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
         // reset to enabled
         eventInteractor.isRequestModelValidResult = true
+        XCTAssertEqual(testee.isSaveButtonEnabled, true)
+
+        // start uploading details media
+        testee.isUploading = true
+        XCTAssertEqual(testee.isSaveButtonEnabled, false)
+
+        // reset to enabled (stop uploading)
+        testee.isUploading = false
+        XCTAssertEqual(testee.isSaveButtonEnabled, true)
 
         // trigger saving state
         eventInteractor.createEventResult = nil
@@ -550,7 +562,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
             event: event,
             eventInteractor: eventInteractor,
             calendarListProviderInteractor: calendarListProviderInteractor,
-            uploadParameters: .init(context: .course("128")),
+            uploadParameters: .init(context: TestConstants.uploadContext),
             router: router,
             completion: { [weak self] in
                 self?.completionValue = $0

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -550,6 +550,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
             event: event,
             eventInteractor: eventInteractor,
             calendarListProviderInteractor: calendarListProviderInteractor,
+            uploadParameters: .init(context: .course("128")),
             router: router,
             completion: { [weak self] in
                 self?.completionValue = $0


### PR DESCRIPTION
refs: [MBL-17818](https://instructure.atlassian.net/browse/MBL-17818)
affects: Student, Teacher
release note: none

## What's new
- Replaced TextEditor with RCE for Add/Edit Calendar Event details
  - RCE should scroll to the end of it's content when focused
- Fix `ToggleCell` label swallowing taps

## What's not changed
Already existing issues with RCE:
- VoiceOver sometimes reads RCE content twice
- Links sometimes duplicate when edited
- RCE doesn't scroll to cursor position when focused

## Test plan
- Verify Add/Edit CalendarEvent Details RCE works in Student app
- Smoke test RCE in other places, eg.:
  - Submit text entry for assignment
  - Add announcement
  - Edit page

## Screenshots
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/b4627929-e6d1-42de-b11a-257d6ea771f6" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/3ad143a1-c730-4a37-ab6f-87d6adf0e917" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode

[MBL-17818]: https://instructure.atlassian.net/browse/MBL-17818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ