### PR TITLE
Fix course color change not being detected by the dashboard screen

### DIFF
--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -274,7 +274,6 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
                     hideColorOverlay: hideColorOverlay,
                     showGrade: showGrade,
                     width: layoutInfo.cardWidth,
-                    contextColor: card.color,
                     isWideLayout: layoutInfo.isWideLayout,
                     isAvailable: availabilityBinding
                 )

--- a/Core/Core/Dashboard/CourseCardList/Model/Entities/DashboardCard.swift
+++ b/Core/Core/Dashboard/CourseCardList/Model/Entities/DashboardCard.swift
@@ -40,7 +40,8 @@ public final class DashboardCard: NSManagedObject {
     @NSManaged public var term: String?
 
     public var context: Context { Context(.course, id: id) }
-    public lazy var color: UIColor = contextColor?.color.ensureContrast(against: .backgroundLightest) ?? .ash
+    /// Ensurecontrast is slow to calculate at each SwiftUI render pass so we have to cache it
+    public lazy var color: UIColor = calculateColor()
 
     public var isTeacherEnrollment: Bool {
         let teacherRoles = ["teacher", "ta"]
@@ -86,5 +87,13 @@ public final class DashboardCard: NSManagedObject {
         }
 
         return model
+    }
+
+    public func refreshCachedColor() {
+        color = calculateColor()
+    }
+
+    private func calculateColor() -> UIColor {
+        contextColor?.color.ensureContrast(against: .backgroundLightest) ?? .ash
     }
 }

--- a/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/CustomizeCourseView.swift
@@ -31,22 +31,22 @@ struct CustomizeCourseView: View {
     @State var isSaving = false
     @State var name: String
 
-    static let colors: KeyValuePairs<String, Text> = [
-        "#BD3C14": Text("Brick", bundle: .core),
-        "#FF2717": Text("Red", bundle: .core),
-        "#E71F63": Text("Magenta", bundle: .core),
-        "#8F3E97": Text("Purple", bundle: .core),
-        "#65499D": Text("Deep Purple", bundle: .core),
-        "#4554A4": Text("Indigo", bundle: .core),
-        "#1770AB": Text("Blue", bundle: .core),
-        "#0B9BE3": Text("Light Blue", bundle: .core),
-        "#06A3B7": Text("Cyan", bundle: .core),
-        "#009688": Text("Teal", bundle: .core),
-        "#009606": Text("Green", bundle: .core),
-        "#8D9900": Text("Olive", bundle: .core),
-        "#D97900": Text("Pumpkin", bundle: .core),
-        "#FD5D10": Text("Orange", bundle: .core),
-        "#F06291": Text("Pink", bundle: .core)
+    static let colors: KeyValuePairs<UIColor, Text> = [
+        UIColor(hexString: "#BD3C14")!.ensureContrast(against: .backgroundLightest): Text("Brick", bundle: .core),
+        UIColor(hexString: "#FF2717")!.ensureContrast(against: .backgroundLightest): Text("Red", bundle: .core),
+        UIColor(hexString: "#E71F63")!.ensureContrast(against: .backgroundLightest): Text("Magenta", bundle: .core),
+        UIColor(hexString: "#8F3E97")!.ensureContrast(against: .backgroundLightest): Text("Purple", bundle: .core),
+        UIColor(hexString: "#65499D")!.ensureContrast(against: .backgroundLightest): Text("Deep Purple", bundle: .core),
+        UIColor(hexString: "#4554A4")!.ensureContrast(against: .backgroundLightest): Text("Indigo", bundle: .core),
+        UIColor(hexString: "#1770AB")!.ensureContrast(against: .backgroundLightest): Text("Blue", bundle: .core),
+        UIColor(hexString: "#0B9BE3")!.ensureContrast(against: .backgroundLightest): Text("Light Blue", bundle: .core),
+        UIColor(hexString: "#06A3B7")!.ensureContrast(against: .backgroundLightest): Text("Cyan", bundle: .core),
+        UIColor(hexString: "#009688")!.ensureContrast(against: .backgroundLightest): Text("Teal", bundle: .core),
+        UIColor(hexString: "#009606")!.ensureContrast(against: .backgroundLightest): Text("Green", bundle: .core),
+        UIColor(hexString: "#8D9900")!.ensureContrast(against: .backgroundLightest): Text("Olive", bundle: .core),
+        UIColor(hexString: "#D97900")!.ensureContrast(against: .backgroundLightest): Text("Pumpkin", bundle: .core),
+        UIColor(hexString: "#FD5D10")!.ensureContrast(against: .backgroundLightest): Text("Orange", bundle: .core),
+        UIColor(hexString: "#F06291")!.ensureContrast(against: .backgroundLightest): Text("Pink", bundle: .core)
     ]
 
     init(course: Course, hideColorOverlay: Bool) {
@@ -92,7 +92,7 @@ struct CustomizeCourseView: View {
                     width: width - 32 // account for padding
                 ) { itemIndex in
                     let item = Self.colors[itemIndex]
-                    let uiColor = UIColor(hexString: item.key) ?? .ash
+                    let uiColor = item.key
                     let isSelected = uiColor.difference(to: color) < 0.02
                     Button(action: { color = uiColor }, label: {
                         Circle().fill(Color(uiColor))

--- a/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -23,7 +23,6 @@ struct DashboardCourseCardView: View {
     let hideColorOverlay: Bool
     let showGrade: Bool
     let width: CGFloat
-    let contextColor: UIColor
     /** Wide layout puts the course image to the left of the cell while the course name and code will be next to it on the right. */
     let isWideLayout: Bool
     @Binding var isAvailable: Bool
@@ -40,7 +39,7 @@ struct DashboardCourseCardView: View {
 
     var body: some View {
         PrimaryButton(isAvailable: $isAvailable) {
-            env.router.route(to: "/courses/\(courseCard.id)?contextColor=\(contextColor.hexString.dropFirst())", from: controller)
+            env.router.route(to: "/courses/\(courseCard.id)?contextColor=\(courseCard.color.hexString.dropFirst())", from: controller)
         } label: {
             ZStack(alignment: .topLeading) {
                 if isWideLayout {
@@ -155,7 +154,7 @@ struct DashboardCourseCardView: View {
 
     private var kebabIcon: some View {
         Image.moreSolid
-            .foregroundColor(Color(contextColor))
+            .foregroundColor(Color(courseCard.color))
             .background(
                 Circle()
                     .fill(Color.backgroundLightest)
@@ -174,7 +173,7 @@ struct DashboardCourseCardView: View {
                     Text(course.displayGrade).font(.semibold14)
                 }
             }
-            .foregroundColor(Color(contextColor))
+            .foregroundColor(Color(courseCard.color))
             .padding(.horizontal, 6).frame(height: 20)
             .background(RoundedRectangle(cornerRadius: 10).fill(Color.backgroundLightest))
             .frame(maxWidth: 120, alignment: .leading)
@@ -222,7 +221,6 @@ struct CourseCard_Previews: PreviewProvider {
                        hideColorOverlay: false,
                        showGrade: true,
                        width: 200,
-                       contextColor: .electric,
                        isWideLayout: false,
                                     isAvailable: .constant(true))
             .frame(width: 200, height: 160)
@@ -233,7 +231,6 @@ struct CourseCard_Previews: PreviewProvider {
                        hideColorOverlay: false,
                        showGrade: true,
                        width: 400,
-                       contextColor: .electric,
                        isWideLayout: false,
                        isAvailable: .constant(true))
             .frame(width: 400, height: 160)
@@ -244,7 +241,6 @@ struct CourseCard_Previews: PreviewProvider {
                        hideColorOverlay: false,
                        showGrade: true,
                        width: 900,
-                       contextColor: .electric,
                        isWideLayout: true,
                        isAvailable: .constant(true))
             .frame(width: 900, height: 100)

--- a/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift
+++ b/Core/Core/Dashboard/CourseCardList/ViewModel/DashboardCourseCardListViewModel.swift
@@ -53,6 +53,8 @@ public class DashboardCourseCardListViewModel: ObservableObject {
         interactor.courseCardList
             .map { !$0.isEmpty }
             .assign(to: &$shouldShowSettingsButton)
+
+        invalidateCourseCardColorCacheOnColorChange()
     }
 
     public func refresh(onComplete: (() -> Void)? = nil) {
@@ -60,6 +62,17 @@ public class DashboardCourseCardListViewModel: ObservableObject {
             .refresh()
             .sink { _ in
                 onComplete?()
+            }
+            .store(in: &subscriptions)
+    }
+
+    private func invalidateCourseCardColorCacheOnColorChange() {
+        let useCase = GetCustomColors()
+        ReactiveStore(useCase: useCase)
+            .getEntitiesFromDatabase(keepObservingDatabaseChanges: true)
+            .replaceError(with: [])
+            .sink { [weak self] _ in
+                self?.courseCardList.forEach { $0.refreshCachedColor() }
             }
             .store(in: &subscriptions)
     }

--- a/Core/Core/Groups/Group.swift
+++ b/Core/Core/Groups/Group.swift
@@ -47,6 +47,7 @@ public final class Group: NSManagedObject, WriteableModel {
     }
 
     public var color: UIColor { contextColor?.color ?? .ash }
+    /// Ensurecontrast is slow to calculate at each SwiftUI render pass so we have to cache it
     public lazy var dashboardCardColor = Color(color.ensureContrast(against: .white))
 
     public var isActive: Bool {


### PR DESCRIPTION
- Fixed cached dashboard card color not being invalidated on course color change.
- Fixed dashboard color overlay and the grade and options bubble using different color sources.
- Fixed selected color not displaying the selection checkmark.
- Fixed colors in the color picker being slightly different than the one that actually got applied after selecting it.
- Known issue: after changing theme (e.g. light to dark) the checkmark won't appear.

refs: MBL-17801
affects: Student, Teacher
release note: Fixed course color change not updating on the dashboard until app restart.

test plan:
- Change the color of a course in the app using the "Customize course" screen.
- After the color picker dialog is dismissed the course's color on the dashboard should have updated.
- Open the customize screen again.
- A checkmark on the previously selected color should be visible.

## Checklist

- [ ] A11y checked
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
