### PR TITLE
Remove reply button for messages where reply is disabled

### DIFF
--- a/Core/Core/Conversations/APIConversation.swift
+++ b/Core/Core/Conversations/APIConversation.swift
@@ -46,6 +46,7 @@ public struct APIConversation: Codable, Equatable {
     let visible: Bool
     let context_name: String?
     let context_code: String?
+    let cannot_reply: Bool?
     let messages: [APIConversationMessage]?
 }
 
@@ -95,7 +96,8 @@ extension APIConversation {
         visible: Bool = true,
         context_name: String? = "Canvas 101",
         context_code: String? = "course_1",
-        messages: [APIConversationMessage]? = nil
+        messages: [APIConversationMessage]? = nil,
+        cannot_reply: Bool = false
     ) -> APIConversation {
         return APIConversation(
             id: ID(id),
@@ -116,6 +118,7 @@ extension APIConversation {
             visible: visible,
             context_name: context_name,
             context_code: context_code,
+            cannot_reply: cannot_reply,
             messages: messages
         )
     }

--- a/Core/Core/Conversations/Conversation.swift
+++ b/Core/Core/Conversations/Conversation.swift
@@ -33,6 +33,7 @@ final public class Conversation: NSManagedObject, WriteableModel {
     @NSManaged public var starred: Bool
     @NSManaged public var subject: String
     @NSManaged var workflowStateRaw: String
+    @NSManaged public var cannotReply: Bool
 
     public var audience: [ConversationParticipant] {
         return audienceIDs.compactMap { id in participants.first(where: { $0.id == id }) }
@@ -76,6 +77,7 @@ final public class Conversation: NSManagedObject, WriteableModel {
         }
 
         model.starred = item.starred
+        model.cannotReply = item.cannot_reply ?? false
         model.subject = item.subject ?? ""
         model.workflowState = item.workflow_state
         return model

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -249,7 +249,7 @@
     <entity name="Conversation" representedClassName="Core.Conversation" syncable="YES">
         <attribute name="audienceIDsRaw" attributeType="String"/>
         <attribute name="avatarURL" attributeType="URI"/>
-        <attribute name="cannotReply" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="cannotReply" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="contextCode" optional="YES" attributeType="String"/>
         <attribute name="contextName" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -249,6 +249,7 @@
     <entity name="Conversation" representedClassName="Core.Conversation" syncable="YES">
         <attribute name="audienceIDsRaw" attributeType="String"/>
         <attribute name="avatarURL" attributeType="URI"/>
+        <attribute name="cannotReply" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="contextCode" optional="YES" attributeType="String"/>
         <attribute name="contextName" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -132,7 +132,7 @@ public struct MessageDetailsView: View {
                     .frame(height: 0.5)
 
                 MessageView(model: message,
-                            hideReplyButton: model.isHideReplyButton,
+                            isReplyButtonVisible: model.isReplyButtonVisible,
                             replyDidTap: { model.replyTapped(message: message.conversationMessage, viewController: controller) },
                             moreDidTap: { model.messageMoreTapped(message: message.conversationMessage, viewController: controller) })
                 .padding(16)

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -132,7 +132,7 @@ public struct MessageDetailsView: View {
                     .frame(height: 0.5)
 
                 MessageView(model: message,
-                            hideReplyButton: model.hideReplyButton,
+                            hideReplyButton: model.isHideReplyButton,
                             replyDidTap: { model.replyTapped(message: message.conversationMessage, viewController: controller) },
                             moreDidTap: { model.messageMoreTapped(message: message.conversationMessage, viewController: controller) })
                 .padding(16)

--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -132,6 +132,7 @@ public struct MessageDetailsView: View {
                     .frame(height: 0.5)
 
                 MessageView(model: message,
+                            hideReplyButton: model.hideReplyButton,
                             replyDidTap: { model.replyTapped(message: message.conversationMessage, viewController: controller) },
                             moreDidTap: { model.messageMoreTapped(message: message.conversationMessage, viewController: controller) })
                 .padding(16)

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -23,29 +23,38 @@ public struct MessageView: View {
     @ScaledMetric private var uiScale: CGFloat = 1
 
     private var model: MessageViewModel
+    private let hideReplyButton: Bool
     private var replyDidTap: () -> Void
     private var moreDidTap: () -> Void
 
     public init(model: MessageViewModel,
+                hideReplyButton: Bool,
                 replyDidTap: @escaping () -> Void,
                 moreDidTap: @escaping () -> Void ) {
         self.model = model
         self.replyDidTap = replyDidTap
         self.moreDidTap = moreDidTap
+        self.hideReplyButton = hideReplyButton
     }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             headerView
             bodyView
-            Button {
-                replyDidTap()
-            } label: {
-                Text("Reply", bundle: .core)
-                    .font(.regular16)
-                    .foregroundColor(Color(Brand.shared.linkColor))
-                    .accessibilityIdentifier("MessageDetails.replyButton")
+            if !hideReplyButton {
+                replyButton
             }
+        }
+    }
+
+    private var replyButton: some View {
+        Button {
+            replyDidTap()
+        } label: {
+            Text("Reply", bundle: .core)
+                .font(.regular16)
+                .foregroundColor(Color(Brand.shared.linkColor))
+                .accessibilityIdentifier("MessageDetails.replyButton")
         }
     }
 
@@ -65,16 +74,8 @@ public struct MessageView: View {
                     .accessibilityIdentifier("MessageDetails.date")
             }
             Spacer()
-            Button {
-                replyDidTap()
-            } label: {
-                Image
-                    .replyLine
-                    .size(uiScale.iconScale * 20)
-                    .foregroundColor(.textDark)
-                    .padding(.leading, 6)
-                    .accessibilityLabel(Text("Reply", bundle: .core))
-                    .accessibilityIdentifier("MessageDetails.replyImage")
+            if !hideReplyButton {
+                replyIconButton
             }
             Button {
                 moreDidTap()
@@ -87,6 +88,20 @@ public struct MessageView: View {
                     .accessibilityLabel(Text("Conversation options", bundle: .core))
                     .accessibilityIdentifier("MessageDetails.options")
             }
+        }
+    }
+
+    private var replyIconButton: some View {
+        Button {
+            replyDidTap()
+        } label: {
+            Image
+                .replyLine
+                .size(uiScale.iconScale * 20)
+                .foregroundColor(.textDark)
+                .padding(.leading, 6)
+                .accessibilityLabel(Text("Reply", bundle: .core))
+                .accessibilityIdentifier("MessageDetails.replyImage")
         }
     }
 

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -23,27 +23,27 @@ public struct MessageView: View {
     @ScaledMetric private var uiScale: CGFloat = 1
 
     private var model: MessageViewModel
-    private let hideReplyButton: Bool
+    private let isReplyButtonVisible: Bool
     private var replyDidTap: () -> Void
     private var moreDidTap: () -> Void
 
     public init(
         model: MessageViewModel,
-        hideReplyButton: Bool,
+        isReplyButtonVisible: Bool,
         replyDidTap: @escaping () -> Void,
         moreDidTap: @escaping () -> Void
     ) {
         self.model = model
         self.replyDidTap = replyDidTap
         self.moreDidTap = moreDidTap
-        self.hideReplyButton = hideReplyButton
+        self.isReplyButtonVisible = isReplyButtonVisible
     }
 
     public var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             headerView
             bodyView
-            if !hideReplyButton {
+            if isReplyButtonVisible {
                 replyButton
             }
         }
@@ -76,7 +76,7 @@ public struct MessageView: View {
                     .accessibilityIdentifier("MessageDetails.date")
             }
             Spacer()
-            if !hideReplyButton {
+            if isReplyButtonVisible {
                 replyIconButton
             }
             Button {

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -27,10 +27,12 @@ public struct MessageView: View {
     private var replyDidTap: () -> Void
     private var moreDidTap: () -> Void
 
-    public init(model: MessageViewModel,
-                hideReplyButton: Bool,
-                replyDidTap: @escaping () -> Void,
-                moreDidTap: @escaping () -> Void ) {
+    public init(
+        model: MessageViewModel,
+        hideReplyButton: Bool,
+        replyDidTap: @escaping () -> Void,
+        moreDidTap: @escaping () -> Void
+    ) {
         self.model = model
         self.replyDidTap = replyDidTap
         self.moreDidTap = moreDidTap

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -25,7 +25,7 @@ class MessageDetailsViewModel: ObservableObject {
     @Published public private(set) var messages: [MessageViewModel] = []
     @Published public private(set) var conversations: [Conversation] = []
     @Published public private(set) var starred: Bool = false
-    @Published public private(set) var isHideReplyButton: Bool = false
+    @Published public private(set) var isReplyButtonVisible: Bool = false
 
     public let title = String(localized: "Message Details", bundle: .core)
 
@@ -64,7 +64,7 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func conversationMoreTapped(viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-       if !isHideReplyButton {
+       if isReplyButtonVisible {
            addReplyAction(sheet) { [weak self] in
                self?.replyTapped(message: nil, viewController: viewController)
            }
@@ -135,7 +135,7 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func messageMoreTapped(message: ConversationMessage?, viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-        if !isHideReplyButton {
+        if isReplyButtonVisible {
             addReplyAction(sheet) { [weak self] in
                 if let message {
                     self?.replyTapped(message: message, viewController: viewController)
@@ -221,7 +221,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         interactor.conversation
             .map { [weak self] in
-                self?.isHideReplyButton = $0.first?.cannotReply ?? false
+                self?.isReplyButtonVisible = !($0.first?.cannotReply ?? false)
                 return $0
             }
             .assign(to: &$conversations)

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -25,6 +25,7 @@ class MessageDetailsViewModel: ObservableObject {
     @Published public private(set) var messages: [MessageViewModel] = []
     @Published public private(set) var conversations: [Conversation] = []
     @Published public private(set) var starred: Bool = false
+    @Published public private(set) var hideReplyButton: Bool = false
 
     public let title = String(localized: "Message Details", bundle: .core)
 
@@ -63,27 +64,23 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func conversationMoreTapped(viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-        sheet.addAction(
-            image: .replyLine,
-            title: String(localized: "Reply"),
-            accessibilityIdentifier: "MessageDetails.reply"
-        ) {
-            self.replyTapped(message: nil, viewController: viewController)
-        }
-        sheet.addAction(
-            image: .replyAllLine,
-            title: String(localized: "Reply All", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.replyAll"
-        ) {
-            self.replyAllTapped(message: nil, viewController: viewController)
+       if !hideReplyButton {
+           addReplyAction(sheet) { [weak self] in
+               self?.replyTapped(message: nil, viewController: viewController)
+           }
+
+           addReplyAllAction(sheet) { [weak self] in
+               self?.replyAllTapped(message: nil, viewController: viewController)
+
+           }
         }
 
         sheet.addAction(
             image: .forwardLine,
             title: String(localized: "Forward", bundle: .core),
             accessibilityIdentifier: "MessageDetails.forward"
-        ) {
-            self.forwardTapped(message: nil, viewController: viewController)
+        ) { [weak self] in
+            self?.forwardTapped(message: nil, viewController: viewController)
         }
 
         if (conversations.first?.workflowState == .read) {
@@ -91,16 +88,16 @@ class MessageDetailsViewModel: ObservableObject {
                 image: .nextUnreadLine,
                 title: String(localized: "Mark as Unread", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.markAsUnread"
-            ) {
-                self.updateState.send(.unread)
+            ) { [weak self] in
+                self?.updateState.send(.unread)
             }
         } else {
             sheet.addAction(
                 image: .emailLine,
                 title: String(localized: "Mark as Read", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.markAsRead"
-            ) {
-                self.updateState.send(.read)
+            ) { [weak self] in
+                self?.updateState.send(.read)
             }
         }
 
@@ -109,8 +106,8 @@ class MessageDetailsViewModel: ObservableObject {
                 image: .archiveLine,
                 title: String(localized: "Archive", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.archive"
-            ) {
-                self.updateState.send(.archived)
+            ) { [weak self] in
+                self?.updateState.send(.archived)
             }
         }
 
@@ -119,8 +116,8 @@ class MessageDetailsViewModel: ObservableObject {
                 image: .unarchiveLine,
                 title: String(localized: "Unarchive", bundle: .core),
                 accessibilityIdentifier: "MessageDetails.unarchive"
-            ) {
-                self.updateState.send(.read)
+            ) { [weak self] in
+                self?.updateState.send(.read)
             }
         }
 
@@ -128,9 +125,9 @@ class MessageDetailsViewModel: ObservableObject {
             image: .trashLine,
             title: String(localized: "Delete Conversation", bundle: .core),
             accessibilityIdentifier: "MessageDetails.delete"
-        ) {
-            if let conversationId = self.conversations.first?.id {
-                self.deleteConversationDidTap.send((conversationId, viewController))
+        ) { [weak self] in
+            if let conversationId = self?.conversations.first?.id {
+                self?.deleteConversationDidTap.send((conversationId, viewController))
             }
         }
         router.show(sheet, from: viewController, options: .modal())
@@ -138,22 +135,17 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func messageMoreTapped(message: ConversationMessage?, viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-        sheet.addAction(
-            image: .replyLine,
-            title: String(localized: "Reply", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.reply"
-        ) {
-            if let message {
-                self.replyTapped(message: message, viewController: viewController)
+        if !hideReplyButton {
+            addReplyAction(sheet) { [weak self] in
+                if let message {
+                    self?.replyTapped(message: message, viewController: viewController)
+                }
             }
-        }
-        sheet.addAction(
-            image: .replyAllLine,
-            title: String(localized: "Reply All", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.replyAll"
-        ) {
-            if let message {
-                self.replyAllTapped(message: message, viewController: viewController)
+
+            addReplyAllAction(sheet) { [weak self] in
+                if let message {
+                    self?.replyAllTapped(message: message, viewController: viewController)
+                }
             }
         }
 
@@ -161,20 +153,34 @@ class MessageDetailsViewModel: ObservableObject {
             image: .forwardLine,
             title: String(localized: "Forward", bundle: .core),
             accessibilityIdentifier: "MessageDetails.forward"
-        ) {
-            self.forwardTapped(message: message, viewController: viewController)
+        ) { [weak self] in
+            self?.forwardTapped(message: message, viewController: viewController)
         }
 
         sheet.addAction(
             image: .trashLine,
             title: String(localized: "Delete Message", bundle: .core),
             accessibilityIdentifier: "MessageDetails.delete"
-        ) {
-            if let conversationId = self.conversations.first?.id, let messageId = message?.id {
-                self.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
+        ) { [weak self] in
+            if let conversationId = self?.conversations.first?.id, let messageId = message?.id {
+                self?.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
             }
         }
         router.show(sheet, from: viewController, options: .modal())
+    }
+
+    private func addReplyAction(_ sheet: BottomSheetPickerViewController, action: @escaping () -> Void ) {
+        sheet.addAction(
+            image: .replyLine,
+            title: String(localized: "Reply", bundle: .core),
+            accessibilityIdentifier: "MessageDetails.reply", action: action)
+    }
+
+    private func addReplyAllAction(_ sheet: BottomSheetPickerViewController, action: @escaping () -> Void ) {
+        sheet.addAction(
+            image: .replyAllLine,
+            title: String(localized: "Reply All", bundle: .core),
+            accessibilityIdentifier: "MessageDetails.replyAll", action: action)
     }
 
     public func forwardTapped(message: ConversationMessage? = nil, viewController: WeakViewController) {
@@ -214,6 +220,10 @@ class MessageDetailsViewModel: ObservableObject {
             .assign(to: &$subject)
 
         interactor.conversation
+            .map { [weak self] in
+                self?.hideReplyButton = $0.first?.cannotReply ?? false
+                return $0
+            }
             .assign(to: &$conversations)
         interactor.messages
             .map { messages in

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -25,7 +25,7 @@ class MessageDetailsViewModel: ObservableObject {
     @Published public private(set) var messages: [MessageViewModel] = []
     @Published public private(set) var conversations: [Conversation] = []
     @Published public private(set) var starred: Bool = false
-    @Published public private(set) var hideReplyButton: Bool = false
+    @Published public private(set) var isHideReplyButton: Bool = false
 
     public let title = String(localized: "Message Details", bundle: .core)
 
@@ -64,7 +64,7 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func conversationMoreTapped(viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-       if !hideReplyButton {
+       if !isHideReplyButton {
            addReplyAction(sheet) { [weak self] in
                self?.replyTapped(message: nil, viewController: viewController)
            }
@@ -135,7 +135,7 @@ class MessageDetailsViewModel: ObservableObject {
 
     public func messageMoreTapped(message: ConversationMessage?, viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
-        if !hideReplyButton {
+        if !isHideReplyButton {
             addReplyAction(sheet) { [weak self] in
                 if let message {
                     self?.replyTapped(message: message, viewController: viewController)
@@ -221,7 +221,7 @@ class MessageDetailsViewModel: ObservableObject {
 
         interactor.conversation
             .map { [weak self] in
-                self?.hideReplyButton = $0.first?.cannotReply ?? false
+                self?.isHideReplyButton = $0.first?.cannotReply ?? false
                 return $0
             }
             .assign(to: &$conversations)

--- a/Core/CoreTests/Inbox/MessageDetails/MessageDetailsViewModelTests.swift
+++ b/Core/CoreTests/Inbox/MessageDetails/MessageDetailsViewModelTests.swift
@@ -157,6 +157,184 @@ class MessageDetailsViewModelTests: CoreTestCase {
         XCTAssertEqual(links[0].absoluteString, "https://instructure.com")
         XCTAssertEqual(links[1].absoluteString, "https://instructure.design")
     }
+
+    func test_messageMoreTapped_reply_presentComposeMessageView() {
+        // Given
+        let sourceView = UIViewController()
+        // When
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(
+                sourceView
+            )
+        )
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[0]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 1)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
+    func test_messageMoreTapped_replyAll_presentComposeMessageView() {
+        // Given
+        let sourceView = UIViewController()
+        // When
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(
+                sourceView
+            )
+        )
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[1]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 1)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
+    func test_messageMoreTapped_forward_presentComposeMessageView() {
+        // Given
+        let sourceView = UIViewController()
+        // When
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(
+                sourceView
+            )
+        )
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[2]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 1)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
+    func test_messageMoreTapped_withCannotReplyIsTrue_numberOfActionsOnSheetMustBeTwo() {
+        // Given
+        let sourceView = UIViewController()
+        // When
+        mockInteractor.passConversationEvent(with: true)
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(
+                sourceView
+            )
+        )
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        XCTAssertEqual(sheet?.actions.count, 2)
+    }
+
+    func test_messageMoreTapped_delete_showAlert() {
+        // Given
+        let sourceView = UIViewController()
+        // When
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(
+                sourceView
+            )
+        )
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[3]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 1)
+        XCTAssertTrue(testee.isShowingCancelDialog)
+    }
+
+    func test_conversationMoreTapped_withCannotReplyIsTrue_numberOfActionsOnSheetMustBeFour() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        mockInteractor.passConversationEvent(with: true)
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        XCTAssertEqual(sheet?.actions.count, 4)
+    }
+
+    func test_conversationMoreTapped_replyAll_presentComposeMessageView() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[1]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
+    func test_conversationMoreTapped_reply_presentComposeMessageView() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[0]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
+    func test_conversationMoreTapped_delete_showAlert() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[5]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(testee.isShowingCancelDialog)
+    }
+
+    func test_conversationMoreTapped_markAsRead_updateStateCalled() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[3]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(mockInteractor.updateStateCalled)
+    }
+
+    func test_conversationMoreTapped_archive_updateStateCalled() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[4]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(mockInteractor.updateStateCalled)
+    }
+
+    func test_conversationMoreTapped_forward_presentComposeMessageView() {
+        // Given
+        let sourceView = WeakViewController()
+        // When
+        testee.conversationMoreTapped(viewController: sourceView)
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let replyAction = sheet?.actions[2]
+        replyAction?.action()
+        wait(for: [router.showExpectation], timeout: 0.3)
+        XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
+    }
+
 }
 
 private class MessageDetailsInteractorMock: MessageDetailsInteractor {
@@ -213,5 +391,10 @@ private class MessageDetailsInteractorMock: MessageDetailsInteractor {
         Future<URLResponse?, Error> { promise in
             promise(.success(nil))
         }
+    }
+
+    func passConversationEvent(with cannotReply: Bool) {
+        conversation.send(([
+            Conversation.make(from: .make( message_count: 1, messages: [ .make() ], cannot_reply: cannotReply))]))
     }
 }


### PR DESCRIPTION
refs: [MBL-17826](https://instructure.atlassian.net/browse/MBL-17826)
affects: Student, Teacher
release note: Removed the reply button for messages where replying was disabled

test plan:
- Open inbox messages
- Open message details
- When the replay messages is disable must hide the button


## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d95e732a-4006-4241-83aa-8b9a7d1763c9" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/9ff325c3-c0ce-49b1-960f-753344317bc0" maxHeight=500></td>
</tr>


<tr>
<td><img src="https://github.com/user-attachments/assets/c4224c99-2cd1-4c4b-a77b-6646dba3779b"  maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/3c2ff17b-10d7-4bcd-b465-2d8104d2b0f2" maxHeight=500></td>
</tr>



<tr>
<td><img src="https://github.com/user-attachments/assets/429d8bd7-06bf-4419-a3d1-4a9bb3ee6b25"  maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/856016a3-38f5-4063-8b71-99ab09db3c9d" maxHeight=500></td>
</tr>


</table>

## Checklist

- [ ] Tested on phone
- [x] Tested in dark mode
- [ ] Tested in light mode




[MBL-17826]: https://instructure.atlassian.net/browse/MBL-17826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ