### PR TITLE
Add support to submission viewer to properly display for non-enhanced assignments

### DIFF
--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -97,6 +97,8 @@
 		CF72EBE82C5930CB0056562A /* ParentSubmissionInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF72EBE72C5930CB0056562A /* ParentSubmissionInteractorTests.swift */; };
 		CF72EBEB2C5A1C590056562A /* ParentSubmissionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF72EBEA2C5A1C590056562A /* ParentSubmissionViewModel.swift */; };
 		CF72EBEE2C5A23540056562A /* ParentSubmissionViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF72EBED2C5A23540056562A /* ParentSubmissionViewModelTests.swift */; };
+		CF9A81E92C8A0261004B2C13 /* ParentSubmissionURLInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9A81E82C8A0261004B2C13 /* ParentSubmissionURLInteractor.swift */; };
+		CF9A81EB2C8A0387004B2C13 /* ParentSubmissionURLInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9A81EA2C8A0387004B2C13 /* ParentSubmissionURLInteractorTests.swift */; };
 		CFAA401D2AE26302002C7AAE /* PSPDFKit in Frameworks */ = {isa = PBXBuildFile; productRef = CFAA401C2AE26302002C7AAE /* PSPDFKit */; };
 		CFEE68D82B1A24ED00A04E43 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */; };
 		CFEE68DB2B1A251C00A04E43 /* LaunchScreen.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */; };
@@ -258,6 +260,8 @@
 		CF72EBE72C5930CB0056562A /* ParentSubmissionInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSubmissionInteractorTests.swift; sourceTree = "<group>"; };
 		CF72EBEA2C5A1C590056562A /* ParentSubmissionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSubmissionViewModel.swift; sourceTree = "<group>"; };
 		CF72EBED2C5A23540056562A /* ParentSubmissionViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSubmissionViewModelTests.swift; sourceTree = "<group>"; };
+		CF9A81E82C8A0261004B2C13 /* ParentSubmissionURLInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSubmissionURLInteractor.swift; sourceTree = "<group>"; };
+		CF9A81EA2C8A0387004B2C13 /* ParentSubmissionURLInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentSubmissionURLInteractorTests.swift; sourceTree = "<group>"; };
 		CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = LaunchScreen.xcstrings; sourceTree = "<group>"; };
 		CFEE68DA2B1A251C00A04E43 /* Localizable.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -777,6 +781,7 @@
 			isa = PBXGroup;
 			children = (
 				CF72EBD42C590A1D0056562A /* ParentSubmissionInteractor.swift */,
+				CF9A81E82C8A0261004B2C13 /* ParentSubmissionURLInteractor.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -793,6 +798,7 @@
 			isa = PBXGroup;
 			children = (
 				CF72EBE72C5930CB0056562A /* ParentSubmissionInteractorTests.swift */,
+				CF9A81EA2C8A0387004B2C13 /* ParentSubmissionURLInteractorTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -1240,6 +1246,7 @@
 				7DFDB43223A3EDFB00B28DED /* ParentConversationListViewControllerTests.swift in Sources */,
 				CF34EC4A2C08C9D80085EA33 /* ObserverAlertsInteractorTests.swift in Sources */,
 				CFFE286A27B3B8A90029A408 /* CourseListCellGradesTests.swift in Sources */,
+				CF9A81EB2C8A0387004B2C13 /* ParentSubmissionURLInteractorTests.swift in Sources */,
 				CF72EBE82C5930CB0056562A /* ParentSubmissionInteractorTests.swift in Sources */,
 				B1AA55D0235785A200DFD184 /* StudentListViewControllerTests.swift in Sources */,
 				CF72EBEE2C5A23540056562A /* ParentSubmissionViewModelTests.swift in Sources */,
@@ -1270,6 +1277,7 @@
 				7DB92CB424C62071004A6C16 /* CourseListViewController.swift in Sources */,
 				7DB92CA524C5FD26004A6C16 /* AccountNotificationDetailsViewController.swift in Sources */,
 				5E4E20511C927EB100E7D709 /* ColorScheme.swift in Sources */,
+				CF9A81E92C8A0261004B2C13 /* ParentSubmissionURLInteractor.swift in Sources */,
 				7D1801B924C207B500A7F023 /* AssignmentDetailsViewController.swift in Sources */,
 				CF72EBD52C590A1D0056562A /* ParentSubmissionInteractor.swift in Sources */,
 				3BA9FF6D2332999900196A06 /* CourseDetailsViewController.swift in Sources */,

--- a/Parent/Parent/Assignments/Model/ParentSubmissionURLInteractor.swift
+++ b/Parent/Parent/Assignments/Model/ParentSubmissionURLInteractor.swift
@@ -1,0 +1,44 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+protocol ParentSubmissionURLInteractor {
+    func submissionURL(
+        assignmentHtmlURL: URL,
+        observedUserID: String,
+        isAssignmentEnhancementsEnabled: Bool
+    ) -> URL
+}
+
+class ParentSubmissionURLInteractorLive: ParentSubmissionURLInteractor {
+
+    func submissionURL(
+        assignmentHtmlURL: URL,
+        observedUserID: String,
+        isAssignmentEnhancementsEnabled: Bool
+    ) -> URL {
+        var assignmentHtmlURL = assignmentHtmlURL
+
+        if isAssignmentEnhancementsEnabled == false {
+            assignmentHtmlURL.appendPathComponent("submissions/\(observedUserID)", conformingTo: .directory)
+        }
+
+        return assignmentHtmlURL
+    }
+}

--- a/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
@@ -51,6 +51,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     private var maxDate = Clock.now
     private var userNotificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current()
     private lazy var localNotifications = LocalNotificationsInteractor(notificationCenter: userNotificationCenter)
+    private var submissionURLInteractor: ParentSubmissionURLInteractor!
 
     lazy var assignment = env.subscribe(GetAssignment(courseID: courseID, assignmentID: assignmentID, include: [.observed_users, .submission])) {  [weak self] in
         self?.update()
@@ -64,18 +65,22 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     lazy var teachers = env.subscribe(GetSearchRecipients(context: .course(courseID), qualifier: .teachers)) { [weak self] in
         self?.update()
     }
+    lazy var featuresStore = env.subscribe(GetEnabledFeatureFlags(context: .course(courseID))) {
+    }
 
     static func create(
         studentID: String,
         courseID: String,
         assignmentID: String,
-        userNotificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current()
+        userNotificationCenter: UserNotificationCenterProtocol = UNUserNotificationCenter.current(),
+        submissionURLInteractor: ParentSubmissionURLInteractor = ParentSubmissionURLInteractorLive()
     ) -> AssignmentDetailsViewController {
         let controller = loadFromStoryboard()
         controller.assignmentID = assignmentID
         controller.courseID = courseID
         controller.studentID = studentID
         controller.userNotificationCenter = userNotificationCenter
+        controller.submissionURLInteractor = submissionURLInteractor
         return controller
     }
 
@@ -141,6 +146,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         course.refresh()
         student.refresh()
         teachers.refresh()
+        featuresStore.refresh()
         localNotifications.getReminder(assignmentID) { [weak self] request in performUIUpdate {
             guard let self = self else { return }
             let date = (request?.trigger as? UNCalendarNotificationTrigger).flatMap {
@@ -169,6 +175,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
         course.refresh(force: true)
         student.refresh(force: true)
         teachers.refresh(force: true)
+        featuresStore.refresh(force: true)
     }
 
     func update() {
@@ -278,8 +285,14 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
             return
         }
 
-        let interactor = ParentSubmissionInteractorLive(
+        let submissionURL = submissionURLInteractor.submissionURL(
             assignmentHtmlURL: assignmentHtmlURL,
+            observedUserID: studentID,
+            isAssignmentEnhancementsEnabled: featuresStore.isFeatureFlagEnabled(.assignmentEnhancements)
+        )
+
+        let interactor = ParentSubmissionInteractorLive(
+            assignmentHtmlURL: submissionURL,
             observedUserID: studentID
         )
         let viewModel = ParentSubmissionViewModel(interactor: interactor, router: router)

--- a/Parent/ParentUnitTests/Assignments/Model/ParentSubmissionURLInteractorTests.swift
+++ b/Parent/ParentUnitTests/Assignments/Model/ParentSubmissionURLInteractorTests.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Parent
+import Foundation
+import XCTest
+
+class ParentSubmissionURLInteractorTests: ParentTestCase {
+
+    func testSubmissionURLWhenAssignmentEnhancementEnabled() {
+        let testee = ParentSubmissionURLInteractorLive()
+
+        // WHEN
+        let result = testee.submissionURL(
+            assignmentHtmlURL: .make("/test_assignment"),
+            observedUserID: "testStudent",
+            isAssignmentEnhancementsEnabled: true)
+
+        // THEN
+        XCTAssertEqual(result, .make("/test_assignment"))
+    }
+
+    func testSubmissionURLWhenAssignmentEnhancementDisabled() {
+        let testee = ParentSubmissionURLInteractorLive()
+
+        // WHEN
+        let result = testee.submissionURL(
+            assignmentHtmlURL: URL(string: "/test_assignment")!,
+            observedUserID: "testStudent",
+            isAssignmentEnhancementsEnabled: false)
+
+        // THEN
+        XCTAssertEqual(result, .make("/test_assignment/submissions/testStudent/"))
+    }
+}

--- a/Parent/ParentUnitTests/Assignments/View/AssignmentDetailsViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Assignments/View/AssignmentDetailsViewControllerTests.swift
@@ -141,4 +141,37 @@ class AssignmentDetailsViewControllerTests: ParentTestCase {
         XCTAssertEqual(presentation?.1, controller)
         XCTAssertEqual(presentation?.2, .modal(.overFullScreen))
     }
+
+    func testUsesSubmissionInteractorForSubmissionPresentation() {
+        let submissionURLInteractorMock = ParentSubmissionURLInteractorMock()
+        let testee = AssignmentDetailsViewController.create(
+            studentID: "1",
+            courseID: "1",
+            assignmentID: "1",
+            userNotificationCenter: notificationCenter,
+            submissionURLInteractor: submissionURLInteractorMock
+        )
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+        XCTAssertEqual(submissionURLInteractorMock.isSubmissionURLCalled, false)
+
+        // WHEN
+        testee.submissionAndRubricButtonPressed(self)
+
+        // THEN
+        XCTAssertEqual(submissionURLInteractorMock.isSubmissionURLCalled, true)
+    }
+}
+
+class ParentSubmissionURLInteractorMock: ParentSubmissionURLInteractor {
+    var isSubmissionURLCalled = false
+
+    func submissionURL(
+        assignmentHtmlURL: URL,
+        observedUserID: String,
+        isAssignmentEnhancementsEnabled: Bool
+    ) -> URL {
+        isSubmissionURLCalled = true
+        return .make("/submissionURL")
+    }
 }


### PR DESCRIPTION
refs: [MBL-17856](https://instructure.atlassian.net/browse/MBL-17856)
affects: Parent
release note: Add support to submission viewer to properly display for non-enhanced assignments.

test plan:
- Turn assignment enhancements off.
- Create an assignment, submit an attempt, add a grade.
- Open the parent app and go to the assignment and view the submission.
- Submission viewer should show the attempt.
- Close the window.
- Turn assignment enhancements on.
- Pull to refresh the parent app's assignment screen.
- Open the submission viewer.
- Submission viewer should still show the attempt.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/00ee8e1b-7543-4ebb-976f-76dc7464cdfd" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/16c9947b-5fb6-4c54-9033-98e6d7950b16" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product


[MBL-17856]: https://instructure.atlassian.net/browse/MBL-17856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ