### PR TITLE
Update video poster generation logic

### DIFF
--- a/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
+++ b/Core/Core/CourseSync/CourseSyncDownloader/CourseSyncDownloaderAssembly.swift
@@ -100,7 +100,8 @@ public enum CourseSyncDownloaderAssembly {
         let studioDownloadInteractor = StudioVideoDownloadInteractorLive(
             rootDirectory: studioDirectory,
             captionsInteractor: StudioCaptionsInteractorLive(),
-            videoCacheInteractor: StudioVideoCacheInteractorLive()
+            videoCacheInteractor: StudioVideoCacheInteractorLive(),
+            posterInteractor: StudioVideoPosterInteractorLive()
         )
         return CourseSyncStudioMediaInteractorLive(
             offlineDirectory: offlineFolder,

--- a/Core/Core/Extensions/ErrorExtensions.swift
+++ b/Core/Core/Extensions/ErrorExtensions.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import AVFoundation
 import Foundation
 
 public extension Error {
@@ -30,6 +31,11 @@ public extension Error {
 
     var isNotFound: Bool {
         nsError.domain == NSError.Constants.domain && nsError.code == HttpError.notFound
+    }
+
+    /// The media file doesn't contain the necessary audio/video track.
+    var isSourceTrackMissing: Bool {
+        nsError.domain == AVFoundationErrorDomain && nsError.code == AVError.Code.noSourceTrack.rawValue
     }
 
     private var nsError: NSError {

--- a/Core/Core/Extensions/InstIconExtensions.swift
+++ b/Core/Core/Extensions/InstIconExtensions.swift
@@ -459,7 +459,7 @@ public extension Image {
     static var warningBorderlessSolid: Image { Image("warningBorderlessSolid", bundle: .core) }
     static var xLine: Image { Image("xLine", bundle: .core) }
     static var xSolid: Image { Image("xSolid", bundle: .core) }
-    
+
     static var addAudioLine: Image { Image("addAudioLine", bundle: .core) }
     static var addCameraLine: Image { Image("addCameraLine", bundle: .core) }
     static var addDocumentLine: Image { Image("addDocumentLine", bundle: .core) }

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -260,6 +260,10 @@ public extension URL {
         guard let imageData = previewImage.pngData() else {
             throw "Failed to convert preview data to png."
         }
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
         try imageData.write(to: url)
     }
 }

--- a/Core/Core/Studio/Model/StudioAPIAuthInteractor.swift
+++ b/Core/Core/Studio/Model/StudioAPIAuthInteractor.swift
@@ -20,12 +20,16 @@ import Combine
 import CombineExt
 import WebKit
 
-public enum StudioAPIAuthError: Error {
+public enum StudioAPIAuthError: String, Error {
     case failedToGetLTIs
     case failedToGetTokenFromWebView
     case failedToGetAPIBaseURL
     case studioLTINotFound
     case failedToGetLaunchURL
+
+    var localizedDescription: String {
+        "\(Self.self).\(self)"
+    }
 }
 
 public protocol StudioAPIAuthInteractor {

--- a/Core/Core/Studio/Model/StudioIFrameReplaceInteractor.swift
+++ b/Core/Core/Studio/Model/StudioIFrameReplaceInteractor.swift
@@ -26,7 +26,7 @@ public enum StudioIFrameReplaceError: LocalizedError {
     case failedToSaveUpdatedHtml
 
     public var errorDescription: String? {
-        // ReplaceError.failedToConvertDataToString
+        // StudioIFrameReplaceError.failedToConvertDataToString
         "\(Self.self).\(self)"
     }
 }
@@ -97,8 +97,15 @@ public class StudioIFrameReplaceInteractorLive: StudioIFrameReplaceInteractor {
             captionTags.append("  <track kind=\"captions\" src=\"\(caption.path)\" srclang=\"\(languageCode)\" />\n")
         }
 
+        let posterProperty: String = {
+            guard let posterLocation = studioVideo.videoPosterLocation else {
+                return ""
+            }
+            return " poster=\"\(posterLocation.path)\""
+        }()
+
         let videoTag = """
-        <video controls playsinline preload="auto" poster="\(studioVideo.videoPosterLocation.path)">
+        <video controls playsinline preload="auto"\(posterProperty)>
           <source src="\(studioVideo.videoLocation.path)" type="\(studioVideo.videoMimeType)\" />
         \(captionTags)</video>
         """

--- a/Core/Core/Studio/Model/StudioVideoPosterInteractor.swift
+++ b/Core/Core/Studio/Model/StudioVideoPosterInteractor.swift
@@ -1,0 +1,81 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public protocol StudioVideoPosterInteractor {
+
+    /// - returns: The URL of the poster file. Nil if it wasn't created due to an error.
+    func createVideoPosterIfNeeded(
+        isVideoCached: Bool,
+        mediaFolder: URL,
+        videoFile: URL
+    ) -> URL?
+}
+
+public class StudioVideoPosterInteractorLive: StudioVideoPosterInteractor {
+    public typealias PosterFactory = (_ videoFile: URL, _ posterLocation: URL) throws -> Void
+
+    private let analytics: Analytics
+    private let posterFactory: PosterFactory
+
+    /// - parameters:
+    ///   - analytics: Since poster creation is not a blocker step we don't throw any errors from here only report them to analytics.
+    ///   - posterFactory: For testing purposes. Live implementation should have a default value for this parameter.
+    public init(
+        analytics: Analytics = .shared,
+        posterFactory: @escaping PosterFactory = posterFactory
+    ) {
+        self.analytics = analytics
+        self.posterFactory = posterFactory
+    }
+
+    public func createVideoPosterIfNeeded(
+        isVideoCached: Bool,
+        mediaFolder: URL,
+        videoFile: URL
+    ) -> URL? {
+        let posterLocation = mediaFolder.appendingPathComponent(
+            "poster.png",
+            isDirectory: false
+        )
+
+        if isVideoCached {
+            return posterLocation
+        }
+
+        do {
+            try posterFactory(videoFile, posterLocation)
+        } catch let error {
+            if error.isSourceTrackMissing == false {
+                // report
+                analytics.logError(name: "asd")
+            }
+            return nil
+        }
+
+        return posterLocation
+    }
+
+    public static func posterFactory(
+        _ videoFile: URL,
+        _ posterLocation: URL
+    ) throws {
+        try videoFile.writeVideoPreview(to: posterLocation)
+    }
+}

--- a/Core/CoreTests/Studio/Model/StudioAPIAuthInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioAPIAuthInteractorLiveTests.swift
@@ -54,6 +54,10 @@ class StudioAPIAuthInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(mockWebView.receivedQueryForToken, true)
     }
 
+    func testErrorDescription() {
+        XCTAssertEqual(StudioAPIAuthError.failedToGetLTIs.localizedDescription, "StudioAPIAuthError.failedToGetLTIs")
+    }
+
     private func mockStudioLTIData() {
         api.mock(
             GetGlobalNavExternalToolsPlacements(

--- a/Core/CoreTests/Studio/Model/StudioIFrameReplaceInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioIFrameReplaceInteractorLiveTests.swift
@@ -20,46 +20,57 @@
 import XCTest
 
 class StudioIFrameReplaceInteractorLiveTests: CoreTestCase {
+    private enum TestData {
+        static let videoURL = URL(string: "/video.mp4")!
+        static let videoPosterURL = URL(string: "/video.png")!
+        static let mimeType = "video/mp4"
+        static let subtitle1URL = URL(string: "/en.srt")!
+        static let subtitle2URL = URL(string: "/hu.srt")!
+        static let iframe = StudioIFrame(
+            mediaLTILaunchID: StudioTestData.ltiLaunchID,
+            sourceHtml: StudioTestData.iframe
+        )
 
-    func testReplacesStudioIFrames() throws {
-        let videoURL = URL(string: "/video.mp4")!
-        let videoPosterURL = URL(string: "/video.png")!
-        let mimeType = "video/mp4"
-        let subtitle1URL = URL(string: "/en.srt")!
-        let subtitle2URL = URL(string: "/hu.srt")!
+    }
+    lazy var htmlFileURL = workingDirectory.appending(path: "body.html")
 
-        let htmlFileURL = workingDirectory.appending(path: "body.html")
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
         try StudioTestData.html.write(
             to: htmlFileURL,
             atomically: false,
             encoding: .utf8
         )
+    }
 
-        let iframe = StudioIFrame(
-            mediaLTILaunchID: StudioTestData.ltiLaunchID,
-            sourceHtml: StudioTestData.iframe
-        )
+    override func tearDownWithError() throws {
+        try FileManager.default.removeItem(atPath: htmlFileURL.path)
+        try super.tearDownWithError()
+    }
+
+    func testReplacesStudioIFrames() throws {
         let offlineVideo = StudioOfflineVideo(
             ltiLaunchID: StudioTestData.ltiLaunchID,
-            videoLocation: videoURL,
-            videoPosterLocation: videoPosterURL,
-            videoMimeType: mimeType,
-            captionLocations: [subtitle1URL, subtitle2URL]
+            videoLocation: TestData.videoURL,
+            videoPosterLocation: TestData.videoPosterURL,
+            videoMimeType: TestData.mimeType,
+            captionLocations: [TestData.subtitle1URL, TestData.subtitle2URL]
         )
 
         // WHEN
         try StudioIFrameReplaceInteractorLive().replaceStudioIFrames(
             inHtmlAtURL: htmlFileURL,
-            iframes: [iframe],
+            iframes: [TestData.iframe],
             offlineVideos: [offlineVideo]
         )
 
         let expectedResult = """
         <p>
         <video controls playsinline preload="auto" poster="/video.png">
-          <source src="\(videoURL)" type="\(mimeType)" />
-          <track kind="captions" src="\(subtitle1URL)" srclang="en" />
-          <track kind="captions" src="\(subtitle2URL)" srclang="hu" />
+          <source src="\(TestData.videoURL)" type="\(TestData.mimeType)" />
+          <track kind="captions" src="\(TestData.subtitle1URL)" srclang="en" />
+          <track kind="captions" src="\(TestData.subtitle2URL)" srclang="hu" />
         </video>
         </p>
         """
@@ -68,6 +79,46 @@ class StudioIFrameReplaceInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(
             String(data: modifiedHtmlData, encoding: .utf8),
             expectedResult
+        )
+    }
+
+    func testReplacesStudioIFramesWithoutPosterFile() throws {
+        let offlineVideo = StudioOfflineVideo(
+            ltiLaunchID: StudioTestData.ltiLaunchID,
+            videoLocation: TestData.videoURL,
+            videoPosterLocation: nil,
+            videoMimeType: TestData.mimeType,
+            captionLocations: [TestData.subtitle1URL, TestData.subtitle2URL]
+        )
+
+        // WHEN
+        try StudioIFrameReplaceInteractorLive().replaceStudioIFrames(
+            inHtmlAtURL: htmlFileURL,
+            iframes: [TestData.iframe],
+            offlineVideos: [offlineVideo]
+        )
+
+        let expectedResult = """
+        <p>
+        <video controls playsinline preload="auto">
+          <source src="\(TestData.videoURL)" type="\(TestData.mimeType)" />
+          <track kind="captions" src="\(TestData.subtitle1URL)" srclang="en" />
+          <track kind="captions" src="\(TestData.subtitle2URL)" srclang="hu" />
+        </video>
+        </p>
+        """
+        let modifiedHtmlData = try Data(contentsOf: htmlFileURL)
+
+        XCTAssertEqual(
+            String(data: modifiedHtmlData, encoding: .utf8),
+            expectedResult
+        )
+    }
+
+    func testErrorDescription() {
+        XCTAssertEqual(
+            StudioIFrameReplaceError.failedToConvertDataToString.localizedDescription,
+            "StudioIFrameReplaceError.failedToConvertDataToString"
         )
     }
 }

--- a/Core/CoreTests/Studio/Model/StudioVideoDownloadInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioVideoDownloadInteractorLiveTests.swift
@@ -48,19 +48,21 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         API.resetMocks(useMocks: false)
     }
 
-    func testDownloadsVideoAndGeneratesPoster() {
+    func testDownloadsVideoAndInvokesPosterGeneration() {
         let mockCacheInteractor = MockStudioVideoCacheInteractor(isVideoDownloadedResult: false)
         let mockCaptionsInteractor = MockStudioCaptionsInteractor()
+        let mockPosterInteractor = MockStudioVidePosterInteractor()
         let testee = StudioVideoDownloadInteractorLive(
             rootDirectory: workingDirectory,
             captionsInteractor: mockCaptionsInteractor,
-            videoCacheInteractor: mockCacheInteractor
+            videoCacheInteractor: mockCacheInteractor,
+            posterInteractor: mockPosterInteractor
         )
 
         let expectedVideoURL = workingDirectory.appending(path: "\(TestData.mediaID.value)/\(TestData.mediaID.value).mp4")
         XCTAssertEqual(FileManager.default.fileExists(atPath: expectedVideoURL.path()), false)
         let expectedPosterURL = workingDirectory.appending(path: "\(TestData.mediaID.value)/poster.png")
-        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), false)
+        mockPosterInteractor.posterLocationResult = expectedPosterURL
         let expectedCaptionURL = workingDirectory.appending(path: "\(TestData.mediaID.value)/\(TestData.caption.srclang).vtt")
         mockCaptionsInteractor.mockedCaptionURL = expectedCaptionURL
 
@@ -78,7 +80,9 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         // THEN
         XCTAssertEqual(mockCaptionsInteractor.receivedCaptionsToWrite, [TestData.caption])
         XCTAssertEqual(FileManager.default.fileExists(atPath: expectedVideoURL.path()), true)
-        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), true)
+        XCTAssertEqual(mockPosterInteractor.receivedCachedFlag, false)
+        XCTAssertEqual(mockPosterInteractor.receivedVideoFile, expectedVideoURL)
+        XCTAssertEqual(mockPosterInteractor.receivedMediaFolder, workingDirectory.appending(path: "\(TestData.mediaID.value)/"))
     }
 
     func testSkipsDownloadWhenVideoIsAlreadyCached() {
@@ -87,7 +91,8 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         let testee = StudioVideoDownloadInteractorLive(
             rootDirectory: workingDirectory,
             captionsInteractor: mockCaptionsInteractor,
-            videoCacheInteractor: mockCacheInteractor
+            videoCacheInteractor: mockCacheInteractor,
+            posterInteractor: MockStudioVidePosterInteractor()
         )
         let expectedVideoURL = workingDirectory.appending(path: "\(TestData.mediaID.value)/\(TestData.mediaID.value).mp4")
 
@@ -133,5 +138,24 @@ class MockStudioVideoCacheInteractor: StudioVideoCacheInteractor {
         receivedVideoLocation = videoLocation
         receivedExpectedSize = expectedSize
         return isVideoDownloadedResult
+    }
+}
+
+class MockStudioVidePosterInteractor: StudioVideoPosterInteractor {
+    public var posterLocationResult: URL?
+
+    private(set) var receivedCachedFlag: Bool?
+    private(set) var receivedMediaFolder: URL?
+    private(set) var receivedVideoFile: URL?
+
+    func createVideoPosterIfNeeded(
+        isVideoCached: Bool,
+        mediaFolder: URL,
+        videoFile: URL
+    ) -> URL? {
+        receivedCachedFlag = isVideoCached
+        receivedMediaFolder = mediaFolder
+        receivedVideoFile = videoFile
+        return posterLocationResult
     }
 }

--- a/Core/CoreTests/Studio/Model/StudioVideoPosterInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioVideoPosterInteractorLiveTests.swift
@@ -1,0 +1,98 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import AVFoundation
+@testable import Core
+import Combine
+import XCTest
+
+class StudioVideoPosterInteractorLiveTests: CoreTestCase {
+    lazy var mediaFolder = workingDirectory.appending(path: "123/")
+    let videoURL = Bundle(for: StudioVideoPosterInteractorLiveTests.self).url(
+        forResource: "preview_test",
+        withExtension: "mp4"
+    )!
+
+    func testGeneratesPoster() {
+        let testee = StudioVideoPosterInteractorLive()
+        let expectedPosterURL = workingDirectory.appending(path: "123/poster.png")
+        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), false)
+
+        // WHEN
+        let posterURL = testee.createVideoPosterIfNeeded(
+            isVideoCached: false,
+            mediaFolder: mediaFolder,
+            videoFile: videoURL
+        )
+
+        // THEN
+        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), true)
+        XCTAssertEqual(posterURL, expectedPosterURL)
+    }
+
+    func testSkipsPosterGenerationIfVideoIsCached() {
+        let testee = StudioVideoPosterInteractorLive()
+        let expectedPosterURL = workingDirectory.appending(path: "123/poster.png")
+        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), false)
+
+        // WHEN
+        let posterURL = testee.createVideoPosterIfNeeded(
+            isVideoCached: true,
+            mediaFolder: mediaFolder,
+            videoFile: videoURL
+        )
+
+        // THEN
+        XCTAssertEqual(FileManager.default.fileExists(atPath: expectedPosterURL.path()), false)
+        XCTAssertEqual(posterURL, nil)
+    }
+
+    func testSwallowsNoVideoTrackError() {
+        let testee = StudioVideoPosterInteractorLive { _, _ in
+            throw NSError(domain: AVFoundationErrorDomain, code: AVError.Code.noSourceTrack.rawValue)
+        }
+
+        // WHEN
+        let posterURL = testee.createVideoPosterIfNeeded(
+            isVideoCached: false,
+            mediaFolder: mediaFolder,
+            videoFile: videoURL
+        )
+
+        // THEN
+        XCTAssertEqual(posterURL, nil)
+        XCTAssertEqual(analytics.totalErrorCount, 0)
+    }
+
+    func testReportsUnknownErrors() {
+        let testee = StudioVideoPosterInteractorLive { _, _ in
+            throw NSError.instructureError("random error")
+        }
+
+        // WHEN
+        let posterURL = testee.createVideoPosterIfNeeded(
+            isVideoCached: false,
+            mediaFolder: mediaFolder,
+            videoFile: videoURL
+        )
+
+        // THEN
+        XCTAssertEqual(posterURL, nil)
+        XCTAssertEqual(analytics.totalErrorCount, 1)
+    }
+}


### PR DESCRIPTION
### What happened?
- Studio videos failed to sync in case a video had only audio track.
- The reason was that the thumbnail generation failed for such videos that interrupted the studio sync as a whole.

### What changed?
- I updated the thumbnail generation logic so it can't make the outer reactive stream fail.
- Errors instead are reported to Crashlytics for this step.
- The thumbnail generation error for audio only videos is swallowed now, it's safe to ignore it.
- I unified the error descriptions so they will be properly grouped in Crashlytics.
- The thumbnail generation code was extracted to a standalone entity.

refs: MBL-17853
affects: Student
release note: Fixed Studio videos not loading in offline mode in case a video only has audio track.

test plan:
- See ticket for account details.
- Sync the course containing audio only studio video.
- Go offline mode.
- Studio videos should load.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
