### PR TITLE
Calendar Event Edit confirmation

### DIFF
--- a/Core/Core/API/APIError.swift
+++ b/Core/Core/API/APIError.swift
@@ -22,6 +22,7 @@ public enum HttpError {
     public static let unauthorized = 1000
     public static let forbidden = 1001
     public static let notFound = 1002
+    public static let badRequest = 1003
     public static let unexpected = 2000
 }
 

--- a/Core/Core/Extensions/ErrorExtensions.swift
+++ b/Core/Core/Extensions/ErrorExtensions.swift
@@ -33,6 +33,10 @@ public extension Error {
         nsError.domain == NSError.Constants.domain && nsError.code == HttpError.notFound
     }
 
+    var isBadRequest: Bool {
+        nsError.domain == NSError.Constants.domain && nsError.code == HttpError.badRequest
+    }
+
     /// The media file doesn't contain the necessary audio/video track.
     var isSourceTrackMissing: Bool {
         nsError.domain == AVFoundationErrorDomain && nsError.code == AVError.Code.noSourceTrack.rawValue

--- a/Core/Core/Extensions/NSErrorExtensions.swift
+++ b/Core/Core/Extensions/NSErrorExtensions.swift
@@ -38,6 +38,7 @@ extension NSError {
         }
         let status = response.statusCode
         switch status {
+        case 400: return HttpError.badRequest
         case 401: return HttpError.unauthorized
         case 403: return HttpError.forbidden
         case 404: return HttpError.notFound

--- a/Core/Core/Planner/CalendarEvent/Model/API/APICalendarEventRequestBody.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/API/APICalendarEventRequestBody.swift
@@ -55,6 +55,7 @@ struct APICalendarEventRequestBody: Codable, Equatable {
     }
 
     let calendar_event: CalendarEvent
+    let which: APICalendarEventSeriesModificationType?
 }
 
 #if DEBUG
@@ -68,7 +69,8 @@ extension APICalendarEventRequestBody {
         location_name: String? = nil,
         location_address: String? = nil,
         time_zone_edited: String? = nil,
-        rrule: RecurrenceRule? = nil
+        rrule: RecurrenceRule? = nil,
+        which: APICalendarEventSeriesModificationType? = nil
     ) -> PostCalendarEventRequest.Body {
         .init(
             calendar_event: .init(
@@ -81,7 +83,8 @@ extension APICalendarEventRequestBody {
                 location_address: location_address,
                 time_zone_edited: time_zone_edited,
                 rrule: rrule
-            )
+            ),
+            which: which
         )
     }
 }

--- a/Core/Core/Planner/CalendarEvent/Model/API/PutCalendarEventRequest.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/API/PutCalendarEventRequest.swift
@@ -20,11 +20,21 @@ import Foundation
 
 // https://canvas.instructure.com/doc/api/calendar_events.html#method.calendar_events_api.update
 struct PutCalendarEventRequest: APIRequestable {
-    typealias Response = APICalendarEvent
+    typealias Response = [APICalendarEvent]
 
     let method: APIMethod = .put
     var path: String { "calendar_events/\(id)" }
 
     let id: String
     let body: APICalendarEventRequestBody?
+
+    // API can return either a single object or an array of objects, depending on whether the event repeats or not.
+    public func decode(_ data: Data) throws -> [APICalendarEvent] {
+        do {
+            let event = try APIJSONDecoder().decode(APICalendarEvent.self, from: data)
+            return [event]
+        } catch {
+            return try APIJSONDecoder().decode([APICalendarEvent].self, from: data)
+        }
+    }
 }

--- a/Core/Core/Planner/CalendarEvent/Model/CalendarEventInteractor.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/CalendarEventInteractor.swift
@@ -30,7 +30,11 @@ public protocol CalendarEventInteractor: AnyObject {
 
     func createEvent(model: CalendarEventRequestModel) -> AnyPublisher<Void, Error>
 
-    func updateEvent(id: String, model: CalendarEventRequestModel) -> AnyPublisher<Void, Error>
+    func updateEvent(
+        id: String,
+        model: CalendarEventRequestModel,
+        seriesModificationType: SeriesModificationType?
+    ) -> AnyPublisher<Void, Error>
 
     func deleteEvent(id: String, seriesModificationType: SeriesModificationType?) -> AnyPublisher<Void, Error>
 
@@ -99,7 +103,11 @@ final class CalendarEventInteractorLive: CalendarEventInteractor {
             .eraseToAnyPublisher()
     }
 
-    func updateEvent(id: String, model: CalendarEventRequestModel) -> AnyPublisher<Void, Error> {
+    func updateEvent(
+        id: String,
+        model: CalendarEventRequestModel,
+        seriesModificationType: SeriesModificationType?
+    ) -> AnyPublisher<Void, Error> {
         let useCase = UpdateCalendarEvent(
             id: id,
             context_code: model.contextCode,
@@ -110,7 +118,8 @@ final class CalendarEventInteractorLive: CalendarEventInteractor {
             location_name: model.location,
             location_address: model.address,
             time_zone_edited: model.timeZone,
-            rrule: model.rrule
+            rrule: model.rrule,
+            seriesModificationType: seriesModificationType
         )
         return ReactiveStore(useCase: useCase)
             .getEntities()

--- a/Core/Core/Planner/CalendarEvent/Model/CalendarEventInteractorPreview.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/CalendarEventInteractorPreview.swift
@@ -87,12 +87,16 @@ final class CalendarEventInteractorPreview: CalendarEventInteractor {
     // MARK: - updateEvent
 
     var updateEventCallsCount: Int = 0
-    var updateEventInput: (id: String, model: CalendarEventRequestModel)?
+    var updateEventInput: (id: String, model: CalendarEventRequestModel, seriesModificationType: SeriesModificationType?)?
     var updateEventResult: Result<Void, Error>? = .success
 
-    func updateEvent(id: String, model: CalendarEventRequestModel) -> AnyPublisher<Void, Error> {
+    func updateEvent(
+        id: String,
+        model: CalendarEventRequestModel,
+        seriesModificationType: SeriesModificationType?
+    ) -> AnyPublisher<Void, Error> {
         updateEventCallsCount += 1
-        updateEventInput = (id: id, model: model)
+        updateEventInput = (id: id, model: model, seriesModificationType: seriesModificationType)
 
         if let updateEventResult {
             return updateEventResult.publisher.eraseToAnyPublisher()

--- a/Core/Core/Planner/CalendarEvent/Model/UseCase/CreateCalendarEvent.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/UseCase/CreateCalendarEvent.swift
@@ -49,7 +49,8 @@ final class CreateCalendarEvent: APIUseCase {
                     location_address: location_address,
                     time_zone_edited: time_zone_edited,
                     rrule: rrule
-                )
+                ),
+                which: nil
             )
         )
     }

--- a/Core/Core/Planner/CalendarEvent/Model/UseCase/UpdateCalendarEvent.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/UseCase/UpdateCalendarEvent.swift
@@ -36,7 +36,8 @@ final class UpdateCalendarEvent: APIUseCase {
         location_name: String?,
         location_address: String?,
         time_zone_edited: String?,
-        rrule: RecurrenceRule?
+        rrule: RecurrenceRule?,
+        seriesModificationType: APICalendarEventSeriesModificationType?
     ) {
         self.request = PutCalendarEventRequest(
             id: id,
@@ -51,7 +52,8 @@ final class UpdateCalendarEvent: APIUseCase {
                     location_address: location_address,
                     time_zone_edited: time_zone_edited,
                     rrule: rrule
-                )
+                ),
+                which: seriesModificationType
             )
         )
     }

--- a/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -144,16 +144,20 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
         }
         .navigationTitle(viewModel.pageTitle)
         .navBarItems(
-            leading: .cancel {
+            leading: InstUI.NavigationBarButton.cancel {
                 viewModel.didTapCancel.send()
             },
-            trailing: .init(
+            trailing: InstUI.NavigationBarButton(
                 isEnabled: viewModel.isSaveButtonEnabled,
                 isAvailableOffline: false,
                 title: viewModel.saveButtonTitle,
                 action: {
                     viewModel.didTapSave.send()
                 }
+            )
+            .confirmation(
+                isPresented: $viewModel.shouldShowEditConfirmation,
+                presenting: viewModel.editConfirmation
             )
         )
         .errorAlert(isPresented: $viewModel.shouldShowSaveError, presenting: viewModel.saveErrorAlert)

--- a/Core/Core/Planner/CalendarEvent/ViewModel/CalendarEventDetailsViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/CalendarEventDetailsViewModel.swift
@@ -74,8 +74,8 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
         self.completion = completion
         self.deleteConfirmation = deleteSingleItemConfirmation
 
-        updateDeleteConfirmationModel(onSet: event)
-        updateMenuButtonVisibility(onSet: event, userId: userId)
+        updateDeleteConfirmationModel(onChangeOf: event)
+        updateMenuButtonVisibility(onChangeOf: event, userId: userId)
 
         loadData()
 
@@ -83,7 +83,7 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
         deleteEventAfterConfirmation(on: didTapDelete)
     }
 
-    private func updateDeleteConfirmationModel(onSet subject: CurrentValueSubject<CalendarEvent?, Never>) {
+    private func updateDeleteConfirmationModel(onChangeOf subject: CurrentValueSubject<CalendarEvent?, Never>) {
         subject
             .compactMap { $0 }
             .sink { [weak self] in
@@ -93,7 +93,7 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
-    private func updateMenuButtonVisibility(onSet subject: CurrentValueSubject<CalendarEvent?, Never>, userId: String) {
+    private func updateMenuButtonVisibility(onChangeOf subject: CurrentValueSubject<CalendarEvent?, Never>, userId: String) {
         subject
             .compactMap { $0 }
             .flatMap { [weak self] in

--- a/Core/Core/Planner/CalendarEvent/ViewModel/CalendarEventDetailsViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/CalendarEventDetailsViewModel.swift
@@ -57,7 +57,7 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
     private let completion: ((PlannerAssembly.Completion) -> Void)?
     private var subscriptions = Set<AnyCancellable>()
 
-    private var event = CurrentValueSubject<CalendarEvent?, Never>(nil)
+    private var calendarEvent = CurrentValueSubject<CalendarEvent?, Never>(nil)
 
     // MARK: - Init
 
@@ -74,8 +74,8 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
         self.completion = completion
         self.deleteConfirmation = deleteSingleItemConfirmation
 
-        updateDeleteConfirmationModel(onChangeOf: event)
-        updateMenuButtonVisibility(onChangeOf: event, userId: userId)
+        updateDeleteConfirmationModel(onChangeOf: calendarEvent)
+        updateMenuButtonVisibility(onChangeOf: calendarEvent, userId: userId)
 
         loadData()
 
@@ -151,7 +151,7 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
             } receiveValue: { [weak self] (event, contextColor) in
                 guard let self else { return }
 
-                self.event.value = event
+                self.calendarEvent.value = event
                 self.contextColor = contextColor
                 title = event.title
                 pageSubtitle = event.contextName
@@ -216,7 +216,7 @@ public final class CalendarEventDetailsViewModel: ObservableObject {
     // MARK: - Private methods
 
     private func showEditScreen(from source: WeakViewController) {
-        guard let event = event.value else { return }
+        guard let event = calendarEvent.value else { return }
 
         let weakVC = WeakViewController()
         let vc = PlannerAssembly.makeEditEventViewController(event: event) { [weak self] output in

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -216,7 +216,7 @@ final class EditCalendarEventViewModel: ObservableObject {
             .sink { completion(.didCancel) }
             .store(in: &subscriptions)
 
-        onSaveButtonTapSaveEventAfterConfirmation(completion: completion)
+        saveEventAfterConfirmation(on: didTapSave, completion: completion)
 
         showFrequencySelector
             .sink { [weak self] in self?.showSelectFrequencyScreen(from: $0) }
@@ -376,8 +376,11 @@ final class EditCalendarEventViewModel: ObservableObject {
         )
     }
 
-    private func onSaveButtonTapSaveEventAfterConfirmation(completion: @escaping (PlannerAssembly.Completion) -> Void) {
-        didTapSave
+    private func saveEventAfterConfirmation(
+        on subject: PassthroughSubject<Void, Never>,
+        completion: @escaping (PlannerAssembly.Completion) -> Void
+    ) {
+        subject
             .map { [weak self] in
                 guard self?.wasEventPartOfSeries == true else { return }
                 self?.shouldShowEditConfirmation = true

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -364,7 +364,7 @@ final class EditCalendarEventViewModel: ObservableObject {
         case .add:
             return eventInteractor.createEvent(model: model)
         case .edit(let id):
-            return eventInteractor.updateEvent(id: id, model: model)
+            return eventInteractor.updateEvent(id: id, model: model, seriesModificationType: nil)
         }
     }
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -115,7 +115,7 @@ final class EditCalendarEventViewModel: ObservableObject {
     private var selectedCalendar = CurrentValueSubject<CDCalendarFilterEntry?, Never>(nil)
     /// Returns true if any of the fields had been modified once by the user. It doesn't compare values.
     private var isFieldsTouched: Bool = false
-    private let wasEventPartOfSeries: Bool
+    private let isInitialEventPartOfSeries: Bool
     private var saveErrorMessageFromApi: String?
 
     private var subscriptions = Set<AnyCancellable>()
@@ -147,11 +147,11 @@ final class EditCalendarEventViewModel: ObservableObject {
 
         if let event {
             mode = .edit(id: event.id)
-            wasEventPartOfSeries = event.isPartOfSeries
+            isInitialEventPartOfSeries = event.isPartOfSeries
             editConfirmation = makeEditConfirmation(event: event)
         } else {
             mode = .add
-            wasEventPartOfSeries = false
+            isInitialEventPartOfSeries = false
         }
 
         setupFields(event: event, selectedDate: selectedDate ?? Clock.now)
@@ -382,14 +382,14 @@ final class EditCalendarEventViewModel: ObservableObject {
     ) {
         subject
             .map { [weak self] in
-                guard self?.wasEventPartOfSeries == true else { return }
+                guard self?.isInitialEventPartOfSeries == true else { return }
                 self?.shouldShowEditConfirmation = true
             }
             .flatMap { [weak self] () -> AnyPublisher<SeriesModificationType?, Never> in
                 guard let self else {
                     return Empty().eraseToAnyPublisher()
                 }
-                guard wasEventPartOfSeries else {
+                guard isInitialEventPartOfSeries else {
                     return Just(nil).eraseToAnyPublisher()
                 }
                 return editConfirmation.userConfirmsOption()

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -96,7 +96,7 @@ final class EditCalendarEventViewModel: ObservableObject {
         )
     }
 
-    var editConfirmation: ConfirmationViewModel<SeriesModificationType> = .init()
+    var editConfirmation = ConfirmationViewModel<SeriesModificationType>()
 
     // MARK: - Input
 

--- a/Core/Core/SwiftUIViews/Confirmation.swift
+++ b/Core/Core/SwiftUIViews/Confirmation.swift
@@ -39,7 +39,7 @@ public final class ConfirmationViewModel<Option: Hashable> {
     }
 
     public let title: String
-    public var message: String?
+    public let message: String?
     public let cancelButtonTitle: String
     public let confirmButtons: [ButtonModel]
     public let viewType: ViewType
@@ -100,6 +100,10 @@ public final class ConfirmationViewModel<Option: Hashable> {
             isDestructive: isDestructive,
             confirmValue: true
         )
+    }
+
+    public convenience init() {
+        self.init(title: "", cancelButtonTitle: "", confirmButtons: [])
     }
 
     /**

--- a/Core/Core/SwiftUIViews/Confirmation.swift
+++ b/Core/Core/SwiftUIViews/Confirmation.swift
@@ -102,6 +102,8 @@ public final class ConfirmationViewModel<Option: Hashable> {
         )
     }
 
+    /// To be used as a placeholder where storing the ViewModel as an optional is not feasible.
+    /// - Returns: A ViewModel for an empty dialog.
     public convenience init() {
         self.init(title: "", cancelButtonTitle: "", confirmButtons: [])
     }

--- a/Core/CoreTests/API/APIErrorTests.swift
+++ b/Core/CoreTests/API/APIErrorTests.swift
@@ -88,6 +88,14 @@ class APIErrorTests: XCTestCase {
         XCTAssertEqual(apiError.localizedDescription, "Benutzer ist zu dieser Aktion nicht berechtigt.")
     }
 
+    func testBadRequest() {
+        let response = HTTPURLResponse(url: .make(), statusCode: 400, httpVersion: nil, headerFields: nil)
+        let error = APIError.from(data: nil, response: response, error: NSError.instructureError("default"))
+
+        let nsError = error as NSError
+        XCTAssertEqual(nsError.code, HttpError.badRequest)
+    }
+
     func testUnauthorized() {
         let response = HTTPURLResponse(url: .make(), statusCode: 401, httpVersion: nil, headerFields: nil)
         let error = APIError.from(data: nil, response: response, error: NSError.instructureError("default"))

--- a/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
@@ -18,6 +18,7 @@
 
 import Core
 import XCTest
+import AVFoundation
 
 class ErrorExtensionsTests: XCTestCase {
 
@@ -51,5 +52,13 @@ class ErrorExtensionsTests: XCTestCase {
             code: HttpError.badRequest
         )
         XCTAssertTrue(error.isBadRequest)
+    }
+
+    func testSourceTrackMissingError() {
+        let error: Error = NSError(
+            domain: AVFoundationErrorDomain,
+            code: AVError.Code.noSourceTrack.rawValue
+        )
+        XCTAssertTrue(error.isSourceTrackMissing)
     }
 }

--- a/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ErrorExtensionsTests.swift
@@ -44,4 +44,12 @@ class ErrorExtensionsTests: XCTestCase {
         )
         XCTAssertTrue(error.isNotFound)
     }
+
+    func testBadRequestError() {
+        let error: Error = NSError(
+            domain: NSError.Constants.domain,
+            code: HttpError.badRequest
+        )
+        XCTAssertTrue(error.isBadRequest)
+    }
 }

--- a/Core/CoreTests/Planner/CalendarEvent/Model/API/APICalendarEventRequestBodyTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/API/APICalendarEventRequestBodyTests.swift
@@ -30,6 +30,8 @@ final class APICalendarEventRequestBodyTests: XCTestCase {
         static let locationName = "some locationName"
         static let locationAddress = "some locationAddress"
         static let timeZone = "some timeZone"
+        static let rrule = RecurrenceRule(recurrenceWith: .monthly, interval: 1)
+        static let which: APICalendarEventSeriesModificationType = .following
     }
 
     func testEncoding() throws {
@@ -41,7 +43,9 @@ final class APICalendarEventRequestBodyTests: XCTestCase {
             end_at: TestConstants.endAt,
             location_name: TestConstants.locationName,
             location_address: TestConstants.locationAddress,
-            time_zone_edited: TestConstants.timeZone
+            time_zone_edited: TestConstants.timeZone,
+            rrule: TestConstants.rrule,
+            which: TestConstants.which
         )
 
         let json = try testee.encodeToJson()
@@ -54,6 +58,8 @@ final class APICalendarEventRequestBodyTests: XCTestCase {
         XCTAssertEqual(json.contains(jsonKey: "location_name", value: TestConstants.locationName), true)
         XCTAssertEqual(json.contains(jsonKey: "location_address", value: TestConstants.locationAddress), true)
         XCTAssertEqual(json.contains(jsonKey: "time_zone_edited", value: TestConstants.timeZone), true)
+        XCTAssertEqual(json.contains(jsonKey: "rrule", value: TestConstants.rrule.rruleDescription), true)
+        XCTAssertEqual(json.contains(jsonKey: "which", value: TestConstants.which.rawValue), true)
     }
 
     func testEncodingShouldNotSkipNils() throws {
@@ -61,7 +67,8 @@ final class APICalendarEventRequestBodyTests: XCTestCase {
             description: nil,
             location_name: nil,
             location_address: nil,
-            time_zone_edited: nil
+            time_zone_edited: nil,
+            rrule: nil
         )
 
         let json = try testee.encodeToJson()
@@ -70,5 +77,6 @@ final class APICalendarEventRequestBodyTests: XCTestCase {
         XCTAssertEqual(json.contains(jsonKey: "location_name", value: nil), true)
         XCTAssertEqual(json.contains(jsonKey: "location_address", value: nil), true)
         XCTAssertEqual(json.contains(jsonKey: "time_zone_edited", value: nil), true)
+        XCTAssertEqual(json.contains(jsonKey: "rrule", value: nil), true)
     }
 }

--- a/Core/CoreTests/Planner/CalendarEvent/Model/API/PutCalendarEventRequestTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/API/PutCalendarEventRequestTests.swift
@@ -27,4 +27,32 @@ final class PutCalendarEventRequestTests: XCTestCase {
         XCTAssertEqual(testee.method, .put)
         XCTAssertEqual(testee.path, "calendar_events/42")
     }
+
+    func testDecodingSingleEvent() throws {
+        let testee = PutCalendarEventRequest(id: "", body: .make())
+        let event = APICalendarEvent.make(id: "id 1", created_at: Date(fromISOString: "2018-05-18T06:00:00Z")!, updated_at: Date(fromISOString: "2018-05-18T06:00:00Z")!)
+        let data = try APIJSONEncoder().encode(event)
+
+        let response = try testee.decode(data)
+        XCTAssertEqual(response, [event])
+    }
+
+    func testDecodingSingleEventInArray() throws {
+        let testee = PutCalendarEventRequest(id: "", body: .make())
+        let event = APICalendarEvent.make(id: "id 1")
+        let data = try APIJSONEncoder().encode([event])
+
+        let response = try testee.decode(data)
+        XCTAssertEqual(response, [event])
+    }
+
+    func testDecodingEventArray() throws {
+        let testee = PutCalendarEventRequest(id: "", body: .make())
+        let event1 = APICalendarEvent.make(id: "id 1")
+        let event2 = APICalendarEvent.make(id: "id 2")
+        let data = try APIJSONEncoder().encode([event1, event2])
+
+        let response = try testee.decode(data)
+        XCTAssertEqual(response, [event1, event2])
+    }
 }

--- a/Core/CoreTests/Planner/CalendarEvent/Model/CalendarEventInteractorTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/CalendarEventInteractorTests.swift
@@ -30,6 +30,7 @@ final class CalendarEventInteractorTests: CoreTestCase {
         static let locationName = "some locationName"
         static let locationAddress = "some locationAddress"
         static let timeZone = TimeZone(identifier: "Australia/Sydney")!
+        static let recurrenceRule = RecurrenceRule(recurrenceWith: .monthly, interval: 2)
     }
 
     var testee: CalendarEventInteractorLive!
@@ -131,7 +132,8 @@ final class CalendarEventInteractorTests: CoreTestCase {
                 contextCode: TestConstants.contextCode,
                 location: TestConstants.locationName,
                 address: TestConstants.locationAddress,
-                details: TestConstants.description
+                details: TestConstants.description,
+                rrule: TestConstants.recurrenceRule
             )
         ) { body in
             XCTAssertEqual(body.calendar_event.context_code, TestConstants.contextCode)
@@ -142,6 +144,7 @@ final class CalendarEventInteractorTests: CoreTestCase {
             XCTAssertEqual(body.calendar_event.location_name, TestConstants.locationName)
             XCTAssertEqual(body.calendar_event.location_address, TestConstants.locationAddress)
             XCTAssertEqual(body.calendar_event.time_zone_edited, TestConstants.timeZone.identifier)
+            XCTAssertEqual(body.calendar_event.rrule, TestConstants.recurrenceRule)
         }
     }
 
@@ -175,7 +178,8 @@ final class CalendarEventInteractorTests: CoreTestCase {
                 contextCode: TestConstants.contextCode,
                 location: TestConstants.locationName,
                 address: TestConstants.locationAddress,
-                details: TestConstants.description
+                details: TestConstants.description,
+                rrule: TestConstants.recurrenceRule
             )
         ) { body in
             XCTAssertEqual(body.calendar_event.context_code, TestConstants.contextCode)
@@ -186,6 +190,7 @@ final class CalendarEventInteractorTests: CoreTestCase {
             XCTAssertEqual(body.calendar_event.location_name, TestConstants.locationName)
             XCTAssertEqual(body.calendar_event.location_address, TestConstants.locationAddress)
             XCTAssertEqual(body.calendar_event.time_zone_edited, TestConstants.timeZone.identifier)
+            XCTAssertEqual(body.calendar_event.rrule, TestConstants.recurrenceRule)
         }
     }
 
@@ -200,7 +205,7 @@ final class CalendarEventInteractorTests: CoreTestCase {
             expectation.fulfill()
         }
 
-        let publisher = testee.updateEvent(id: "42", model: model)
+        let publisher = testee.updateEvent(id: "42", model: model, seriesModificationType: nil)
         XCTAssertFinish(publisher)
 
         wait(for: [expectation], timeout: 1)

--- a/Core/CoreTests/Planner/CalendarEvent/Model/UseCase/CreateCalendarEventTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/UseCase/CreateCalendarEventTests.swift
@@ -30,7 +30,7 @@ final class CreateCalendarEventTests: CoreTestCase {
         static let locationName = "some locationName"
         static let locationAddress = "some locationAddress"
         static let timeZone = "some timeZone"
-        static let rrule = RecurrenceRule(recurrenceWith: .daily, interval: 2, end: .occurrenceCount(32))
+        static let recurrenceRule = RecurrenceRule(recurrenceWith: .daily, interval: 1)
 
         static let responseId: ID = "response id"
         static let responseContextCode = "response contextCode"
@@ -40,6 +40,7 @@ final class CreateCalendarEventTests: CoreTestCase {
         static let responseEndAt = Clock.now.addHours(1).addYears(1)
         static let responseLocationName = "response locationName"
         static let responseLocationAddress = "response locationAddress"
+        static let responseRecurrenceRule = RecurrenceRule(recurrenceWith: .yearly, interval: 2)
     }
 
     private var testee: CreateCalendarEvent!
@@ -55,7 +56,7 @@ final class CreateCalendarEventTests: CoreTestCase {
             location_name: TestConstants.locationName,
             location_address: TestConstants.locationAddress,
             time_zone_edited: TestConstants.timeZone,
-            rrule: TestConstants.rrule
+            rrule: TestConstants.recurrenceRule
         )
     }
 
@@ -74,7 +75,7 @@ final class CreateCalendarEventTests: CoreTestCase {
         XCTAssertEqual(nestedObject?.location_name, TestConstants.locationName)
         XCTAssertEqual(nestedObject?.location_address, TestConstants.locationAddress)
         XCTAssertEqual(nestedObject?.time_zone_edited, TestConstants.timeZone)
-        XCTAssertEqual(nestedObject?.rrule, TestConstants.rrule)
+        XCTAssertEqual(nestedObject?.rrule, TestConstants.recurrenceRule)
     }
 
     func testWrite() {
@@ -86,7 +87,7 @@ final class CreateCalendarEventTests: CoreTestCase {
             description: TestConstants.responseDescription,
             location_name: TestConstants.responseLocationName,
             location_address: TestConstants.responseLocationAddress,
-            rrule: TestConstants.rrule.rruleDescription
+            rrule: TestConstants.responseRecurrenceRule.rruleDescription
         )
 
         testee.write(response: response, urlResponse: nil, to: databaseClient)
@@ -98,6 +99,6 @@ final class CreateCalendarEventTests: CoreTestCase {
         XCTAssertEqual(model?.details, TestConstants.responseDescription)
         XCTAssertEqual(model?.locationName, TestConstants.responseLocationName)
         XCTAssertEqual(model?.locationAddress, TestConstants.responseLocationAddress)
-        XCTAssertEqual(model?.repetitionRule, TestConstants.rrule.rruleDescription)
+        XCTAssertEqual(model?.repetitionRule, TestConstants.responseRecurrenceRule.rruleDescription)
     }
 }

--- a/Core/CoreTests/Planner/CalendarEvent/Model/UseCase/UpdateCalendarEventTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/UseCase/UpdateCalendarEventTests.swift
@@ -31,7 +31,8 @@ final class UpdateCalendarEventTests: CoreTestCase {
         static let locationName = "some locationName"
         static let locationAddress = "some locationAddress"
         static let timeZone = "some timeZone"
-        static let rrule = RecurrenceRule(recurrenceWith: .monthly, interval: 1, end: .occurrenceCount(12))
+        static let recurrenceRule = RecurrenceRule(recurrenceWith: .monthly, interval: 1)
+        static let seriesModificationType: APICalendarEventSeriesModificationType = .following
 
         static let responseId: ID = "response id"
         static let responseContextCode = "response contextCode"
@@ -41,6 +42,7 @@ final class UpdateCalendarEventTests: CoreTestCase {
         static let responseEndAt = Clock.now.addHours(1).addYears(1)
         static let responseLocationName = "response locationName"
         static let responseLocationAddress = "response locationAddress"
+        static let responseRecurrenceRule = RecurrenceRule(recurrenceWith: .yearly, interval: 2)
     }
 
     private var testee: UpdateCalendarEvent!
@@ -57,7 +59,8 @@ final class UpdateCalendarEventTests: CoreTestCase {
             location_name: TestConstants.locationName,
             location_address: TestConstants.locationAddress,
             time_zone_edited: TestConstants.timeZone,
-            rrule: TestConstants.rrule
+            rrule: TestConstants.recurrenceRule,
+            seriesModificationType: TestConstants.seriesModificationType
         )
     }
 
@@ -78,7 +81,8 @@ final class UpdateCalendarEventTests: CoreTestCase {
         XCTAssertEqual(nestedObject?.location_name, TestConstants.locationName)
         XCTAssertEqual(nestedObject?.location_address, TestConstants.locationAddress)
         XCTAssertEqual(nestedObject?.time_zone_edited, TestConstants.timeZone)
-        XCTAssertEqual(nestedObject?.rrule, TestConstants.rrule)
+        XCTAssertEqual(nestedObject?.rrule, TestConstants.recurrenceRule)
+        XCTAssertEqual(testee.request.body?.which, TestConstants.seriesModificationType)
     }
 
     func testWrite() {
@@ -90,7 +94,7 @@ final class UpdateCalendarEventTests: CoreTestCase {
             description: TestConstants.responseDescription,
             location_name: TestConstants.responseLocationName,
             location_address: TestConstants.responseLocationAddress,
-            rrule: TestConstants.rrule.rruleDescription
+            rrule: TestConstants.responseRecurrenceRule.rruleDescription
         )
 
         testee.write(response: response, urlResponse: nil, to: databaseClient)
@@ -102,6 +106,6 @@ final class UpdateCalendarEventTests: CoreTestCase {
         XCTAssertEqual(model?.details, TestConstants.responseDescription)
         XCTAssertEqual(model?.locationName, TestConstants.responseLocationName)
         XCTAssertEqual(model?.locationAddress, TestConstants.responseLocationAddress)
-        XCTAssertEqual(model?.repetitionRule, TestConstants.rrule.rruleDescription)
+        XCTAssertEqual(model?.repetitionRule, TestConstants.responseRecurrenceRule.rruleDescription)
     }
 }

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -42,6 +42,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
     private var eventInteractor: CalendarEventInteractorPreview!
     private var calendarListProviderInteractor: CalendarFilterInteractorPreview!
+    private var testee: EditCalendarEventViewModel!
 
     private var completionCallsCount: Int = 0
     private var completionValue: PlannerAssembly.Completion?
@@ -58,6 +59,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         Clock.reset()
         eventInteractor = nil
         calendarListProviderInteractor = nil
+        testee = nil
         super.tearDown()
     }
 
@@ -83,8 +85,6 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testAddModeDefaultDate() {
-        var testee: EditCalendarEventViewModel
-
         testee = makeAddViewModel()
         XCTAssertEqual(testee.date, TestConstants.dateNow.startOfDay())
 
@@ -93,7 +93,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeInitialValues() {
-        let testee = makeEditViewModel(makeEvent(
+        testee = makeEditViewModel(makeEvent(
             title: TestConstants.title,
             locationName: TestConstants.locationName,
             locationAddress: TestConstants.locationAddress,
@@ -112,8 +112,6 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeInitialDates() {
-        var testee: EditCalendarEventViewModel
-
         testee = makeEditViewModel(makeEvent(
             isAllDay: true,
             startAt: TestConstants.dateStart,
@@ -138,8 +136,6 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeInitialCalendar() {
-        var testee: EditCalendarEventViewModel
-
         // existing course context
         testee = makeEditViewModel(makeEvent(context: .course("4")))
         XCTAssertEqual(testee.calendarName, "Course 4")
@@ -156,7 +152,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     // MARK: - Save button enabling
 
     func testAddModeIsSaveButtonEnabled() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
 
         // initial state, valid model (should not happen)
         eventInteractor.isRequestModelValidResult = true
@@ -195,7 +191,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenTitleChanges() {
-        let testee = makeEditViewModel(makeEvent(title: TestConstants.title))
+        testee = makeEditViewModel(makeEvent(title: TestConstants.title))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -215,7 +211,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenDateChanges() {
-        let testee = makeEditViewModel(makeEvent(startAt: TestConstants.dateNow))
+        testee = makeEditViewModel(makeEvent(startAt: TestConstants.dateNow))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -235,7 +231,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenStartTimeChanges() {
-        let testee = makeEditViewModel(makeEvent(isAllDay: false, startAt: TestConstants.dateNow))
+        testee = makeEditViewModel(makeEvent(isAllDay: false, startAt: TestConstants.dateNow))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -255,7 +251,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenEndTimeChanges() {
-        let testee = makeEditViewModel(makeEvent(isAllDay: false, endAt: TestConstants.dateNow))
+        testee = makeEditViewModel(makeEvent(isAllDay: false, endAt: TestConstants.dateNow))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -275,7 +271,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenLocationChanges() {
-        let testee = makeEditViewModel(makeEvent(locationName: TestConstants.locationName))
+        testee = makeEditViewModel(makeEvent(locationName: TestConstants.locationName))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -295,7 +291,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenAddressChanges() {
-        let testee = makeEditViewModel(makeEvent(locationAddress: TestConstants.locationAddress))
+        testee = makeEditViewModel(makeEvent(locationAddress: TestConstants.locationAddress))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -315,7 +311,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenDetailChanges() {
-        let testee = makeEditViewModel(makeEvent(details: TestConstants.details))
+        testee = makeEditViewModel(makeEvent(details: TestConstants.details))
         eventInteractor.isRequestModelValidResult = true
 
         // initial state
@@ -335,31 +331,29 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeIsSaveButtonEnabledWhenCalendarChanges() {
-        let testee = makeEditViewModel(makeEvent(context: TestConstants.calendars[0].context))
+        testee = makeEditViewModel(makeEvent(context: TestConstants.calendars[0].context))
         eventInteractor.isRequestModelValidResult = true
-        // store calendars after viewModel loads the interactor
-        let calendars = calendarListProviderInteractor.filters.value
 
         // initial state
         XCTAssertEqual(testee.isSaveButtonEnabled, false)
 
         // set the same value
-        testee.selectCalendarViewModel.selectedCalendar = calendars[0]
+        triggerCalendarSelection(at: 0)
         XCTAssertEqual(testee.isSaveButtonEnabled, false)
 
         // set another value
-        testee.selectCalendarViewModel.selectedCalendar = calendars[1]
+        triggerCalendarSelection(at: 1)
         XCTAssertEqual(testee.isSaveButtonEnabled, true)
 
         // reset to initial value
-        testee.selectCalendarViewModel.selectedCalendar = calendars[0]
+        triggerCalendarSelection(at: 0)
         XCTAssertEqual(testee.isSaveButtonEnabled, true)
     }
 
     // MARK: - Strings
 
     func testAddModeStrings() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
 
         XCTAssertEqual(testee.pageTitle, String(localized: "New Event", bundle: .core))
         XCTAssertEqual(testee.saveButtonTitle, String(localized: "Add", bundle: .core))
@@ -369,7 +363,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testEditModeStrings() {
-        let testee = makeEditViewModel(makeEvent())
+        testee = makeEditViewModel(makeEvent())
 
         XCTAssertEqual(testee.pageTitle, String(localized: "Edit Event", bundle: .core))
         XCTAssertEqual(testee.saveButtonTitle, String(localized: "Save", bundle: .core))
@@ -378,10 +372,38 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.saveErrorAlert.buttonTitle, String(localized: "OK", bundle: .core))
     }
 
+    func testErrorMessage() {
+        testee = makeAddViewModel()
+        let defaultMessage = String(localized: "We couldn't add your Event at this time. You can try it again.", bundle: .core)
+
+        // initial state
+        XCTAssertEqual(testee.saveErrorAlert.message, defaultMessage)
+
+        // after save fails with bad request
+        eventInteractor.createEventResult = .failure(NSError.instructureError("some error", code: HttpError.badRequest))
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.saveErrorAlert.message, "some error")
+
+        // after save fails with other recognized HttpError
+        eventInteractor.createEventResult = .failure(NSError.instructureError("another error", code: HttpError.notFound))
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.saveErrorAlert.message, defaultMessage)
+
+        // after save fails with other error
+        eventInteractor.createEventResult = .failure(MockError())
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.saveErrorAlert.message, defaultMessage)
+
+        // after save succeeds
+        eventInteractor.createEventResult = .success
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.saveErrorAlert.message, defaultMessage)
+    }
+
     // MARK: - Did Tap Cancel
 
     func testDidTapCancel() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
 
         testee.didTapCancel.send()
 
@@ -392,7 +414,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     // MARK: - Did Tap Save (Add mode)
 
     func testAddModeDidTapAddCallsCreateEvent() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         testee.title = TestConstants.title
         testee.date = TestConstants.dateNow
         testee.isAllDay = true
@@ -401,9 +423,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         testee.location = TestConstants.locationName
         testee.address = TestConstants.locationAddress
         testee.details = TestConstants.details
-
-        let selectedCalendar = calendarListProviderInteractor.filters.value[1]
-        testee.selectCalendarViewModel.selectedCalendar = selectedCalendar
+        let selectedCalendar = triggerCalendarSelection()
 
         testee.didTapSave.send()
 
@@ -423,8 +443,8 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
     // MARK: - Did Tap Save (Edit mode)
 
-    func testEditModeDidTapSaveCallsUpdateToDo() {
-        let testee = makeEditViewModel(makeEvent(
+    func testEditModeDidTapSaveCallsUpdateEvent() {
+        testee = makeEditViewModel(makeEvent(
             id: TestConstants.id,
             title: TestConstants.title,
             isAllDay: false,
@@ -434,15 +454,13 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
             locationAddress: TestConstants.locationAddress,
             details: TestConstants.details
         ))
-
-        let selectedCalendar = calendarListProviderInteractor.filters.value[1]
-        testee.selectCalendarViewModel.selectedCalendar = selectedCalendar
+        let selectedCalendar = triggerCalendarSelection()
 
         testee.didTapSave.send()
 
         XCTAssertEqual(eventInteractor.createEventCallsCount, 0)
         XCTAssertEqual(eventInteractor.updateEventCallsCount, 1)
-        let (id, model) = eventInteractor.updateEventInput ?? ("", .make())
+        let (id, model, _) = eventInteractor.updateEventInput ?? ("", .make(), nil)
         XCTAssertEqual(id, TestConstants.id)
         XCTAssertEqual(model.title, TestConstants.title)
         XCTAssertEqual(model.date, TestConstants.dateStart)
@@ -455,10 +473,21 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(model.details, TestConstants.details)
     }
 
+    func testEditModeDidTapSaveCallsUpdateEventWithSelectedConfirmationOption() {
+        testee = makeEditViewModel(makeEvent(repetitionRule: "some", seriesInNaturalLanguage: "thing"))
+        triggerCalendarSelection()
+
+        testee.didTapSave.send()
+        testee.editConfirmation.notifyCompletion(option: .following)
+
+        let (_, _, seriesModificationType) = eventInteractor.updateEventInput ?? ("", .make(), nil)
+        XCTAssertEqual(seriesModificationType, .following)
+    }
+
     // MARK: - Did Tap Save (common)
 
     func testDidTapSaveShowsLoadingOverlayWhileLoading() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         eventInteractor.createEventResult = nil
 
         testee.didTapSave.send()
@@ -467,7 +496,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testDidTapSaveOnSuccess() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         eventInteractor.createEventResult = .success
 
         testee.didTapSave.send()
@@ -477,7 +506,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testDidTapSaveOnFailure() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         eventInteractor.createEventResult = .failure(MockError())
 
         testee.didTapSave.send()
@@ -488,7 +517,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testRetryAfterFailure() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         eventInteractor.createEventResult = .failure(MockError())
         testee.didTapSave.send()
 
@@ -498,10 +527,104 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(completionCallsCount, 1)
     }
 
+    // MARK: - Edit Confirmation
+
+    func testShouldShowEditConfirmationInAddMode() {
+        testee = makeAddViewModel()
+
+        XCTAssertEqual(testee.shouldShowEditConfirmation, false)
+
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.shouldShowEditConfirmation, false)
+        XCTAssertEqual(testee.state, .data(loadingOverlay: true))
+    }
+
+    func testShouldShowEditConfirmationInEditModeForSingleEvent() {
+        testee = makeEditViewModel(makeEvent())
+
+        XCTAssertEqual(testee.shouldShowEditConfirmation, false)
+
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.shouldShowEditConfirmation, false)
+        XCTAssertEqual(testee.state, .data(loadingOverlay: true))
+    }
+
+    func testShouldShowEditConfirmationInEditModeForRecurringEvent() {
+        testee = makeEditViewModel(makeEvent(repetitionRule: "some", seriesInNaturalLanguage: "thing"))
+
+        XCTAssertEqual(testee.shouldShowEditConfirmation, false)
+
+        testee.didTapSave.send()
+        XCTAssertEqual(testee.shouldShowEditConfirmation, true)
+        XCTAssertEqual(testee.state, .data(loadingOverlay: false))
+
+        testee.editConfirmation.notifyCompletion(option: .one)
+        XCTAssertEqual(testee.state, .data(loadingOverlay: true))
+    }
+
+    func testEditConfirmationOptionsWhenEventIsSeriesHead() {
+        testee = makeEditViewModel(makeEvent(
+            repetitionRule: "some",
+            isSeriesHead: true,
+            seriesInNaturalLanguage: "thing"
+        ))
+
+        guard testee.editConfirmation.confirmButtons.count == 2 else {
+            XCTFail("Invalid count")
+            return
+        }
+
+        XCTAssertEqual(testee.editConfirmation.confirmButtons[0].option, .one)
+        XCTAssertEqual(testee.editConfirmation.confirmButtons[1].option, .all)
+    }
+
+    func testEditConfirmationOptionsWhenEventIsNotSeriesHead() {
+        testee = makeEditViewModel(makeEvent(
+            repetitionRule: "some",
+            isSeriesHead: false,
+            seriesInNaturalLanguage: "thing"
+        ))
+
+        guard testee.editConfirmation.confirmButtons.count == 3 else {
+            XCTFail("Invalid count")
+            return
+        }
+
+        XCTAssertEqual(testee.editConfirmation.confirmButtons[0].option, .one)
+        XCTAssertEqual(testee.editConfirmation.confirmButtons[1].option, .all)
+        XCTAssertEqual(testee.editConfirmation.confirmButtons[2].option, .following)
+    }
+
+    // MARK: - EndTime Error
+
+    func testEndTimeError() {
+        testee = makeAddViewModel()
+
+        testee.startTime = TestConstants.dateStart
+        testee.endTime = nil
+        XCTAssertNil(testee.endTimeErrorMessage)
+
+        testee.startTime = nil
+        testee.endTime = TestConstants.dateStart
+        XCTAssertNil(testee.endTimeErrorMessage)
+
+        testee.startTime = TestConstants.dateStart
+        testee.endTime = TestConstants.dateStart
+        XCTAssertNil(testee.endTimeErrorMessage)
+
+        testee.startTime = TestConstants.dateStart
+        testee.endTime = TestConstants.dateStart.addHours(1)
+        XCTAssertNil(testee.endTimeErrorMessage)
+
+        testee.startTime = TestConstants.dateStart
+        testee.endTime = TestConstants.dateStart.addHours(-1)
+        XCTAssertNotNil(testee.endTimeErrorMessage)
+    }
+
     // MARK: - Select Calendar
 
     func testSelectCalendarViewModelReusesSameInteractor() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         let vm = testee.selectCalendarViewModel
 
         let hasSpecificCalendar = {
@@ -519,7 +642,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testSelectCalendarViewModelHasOnlyUserAndGroupCalendars() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         let vm = testee.selectCalendarViewModel
 
         let hasUserCalendars = vm.sections.contains {
@@ -539,7 +662,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
     func testShowCalendarScreen() {
         let sourceVC = UIViewController()
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
         testee.showCalendarSelector.send(WeakViewController(sourceVC))
 
         guard let lastPresentation = router.viewControllerCalls.last else {
@@ -551,12 +674,11 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     func testSelectCalendarViewModelSelectsCalendar() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
 
         XCTAssertEqual(testee.calendarName, TestConstants.calendars[3].name)
 
-        let selectedCalendar = calendarListProviderInteractor.filters.value[1]
-        testee.selectCalendarViewModel.selectedCalendar = selectedCalendar
+        triggerCalendarSelection(at: 1)
 
         XCTAssertEqual(testee.calendarName, TestConstants.calendars[1].name)
     }
@@ -591,6 +713,9 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         locationName: String? = nil,
         locationAddress: String? = nil,
         details: String? = nil,
+        repetitionRule: String? = nil,
+        isSeriesHead: Bool? = nil,
+        seriesInNaturalLanguage: String? = nil,
         context: Context = .account("")
     ) -> CalendarEvent {
         let event = CalendarEvent.save(
@@ -602,12 +727,22 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
                 all_day: isAllDay,
                 description: details,
                 location_name: locationName,
-                location_address: locationAddress
+                location_address: locationAddress,
+                rrule: repetitionRule,
+                series_head: isSeriesHead,
+                series_natural_language: seriesInNaturalLanguage
             ),
             in: databaseClient
         )
         event.context = context
         return event
+    }
+
+    @discardableResult
+    private func triggerCalendarSelection(at index: Int = 1) -> CDCalendarFilterEntry {
+        let selectedCalendar = calendarListProviderInteractor.filters.value[index]
+        testee.selectCalendarViewModel.selectedCalendar = selectedCalendar
+        return selectedCalendar
     }
 }
 


### PR DESCRIPTION
refs: [MBL-17861](https://instructure.atlassian.net/browse/MBL-17861)
affects: Student
release note: none

## What's changed
Added confirmation for updating recurring calendar events.
Some cases are considered invalid, and backend responds via HTTP status code 400 and a message in such cases.
These localized, user facing error messages are displayed to the user instead of the generic save error message.
Some of the cases (probably not a full list, that's why I didn't replicate this logic on client side):
- Change recurrence rule on just one instance of an event
- Update start date on all instances of an event

## Test plan
- Verify edit confirmation works just like on the web
  - different options for first event and the rest
  - (localized) error messages (see cases above and screenshots below)
- Verify confirmation is only shown for recurring events and only when editing them, not adding
- Verify changed events update in the calendar properly

## Screenshots
<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/02db092f-081d-46d4-a159-01f8b23b24ab" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/3ed23ca8-b2f8-4137-beb7-cda847a736da" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/f5b75d49-e9e6-499d-8a34-fb010653200b" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/046387d8-e6e4-4bb6-97d0-ac97d4fe9a4a" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-17861]: https://instructure.atlassian.net/browse/MBL-17861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ