### PR TITLE
Enable Creating Events & Todo on Teacher Calendars

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G80" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="22758" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -161,6 +161,7 @@
         <attribute name="name" attributeType="String"/>
         <attribute name="observedUserId" optional="YES" attributeType="String"/>
         <attribute name="rawContextID" attributeType="String"/>
+        <attribute name="rawPurpose" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
     </entity>
     <entity name="CDCourseSyncDownloadProgress" representedClassName="Core.CDCourseSyncDownloadProgress" syncable="YES">
         <attribute name="bytesDownloaded" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -114,7 +114,13 @@ final class EditCalendarEventViewModel: ObservableObject {
     internal lazy var selectCalendarViewModel: SelectCalendarViewModel = {
         return .init(
             calendarListProviderInteractor: calendarListProviderInteractor,
-            calendarTypes: [.user, .group],
+            calendarTypes: {
+                if case .teacher = AppEnvironment.shared.app {
+                    return [.user, .course, .group]
+                } else {
+                    return [.user, .group]
+                }
+            }(),
             selectedCalendar: selectedCalendar
         )
     }()

--- a/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
@@ -19,11 +19,26 @@
 import CoreData
 import SwiftUI
 
+public enum CDCalendarFilterPurpose: Int16 {
+    case viewing = 1
+    case creating = 2
+    case unknown = 0
+
+    var cacheToken: String {
+        switch self {
+        case .viewing: return "viewing"
+        case .creating: return "creating"
+        case .unknown: return "unknown"
+        }
+    }
+}
+
 public class CDCalendarFilterEntry: NSManagedObject {
     @NSManaged public var name: String
     /// For the observer role we have a separate list of filters for each observed student
     @NSManaged public var observedUserId: String?
     @NSManaged public private(set) var rawContextID: String
+    @NSManaged public var rawPurpose: Int16
 
     public var context: Context {
         get {
@@ -31,6 +46,15 @@ public class CDCalendarFilterEntry: NSManagedObject {
         }
         set {
             rawContextID = newValue.canvasContextID
+        }
+    }
+
+    public var purpose: CDCalendarFilterPurpose {
+        get {
+            CDCalendarFilterPurpose(rawValue: rawPurpose) ?? .unknown
+        }
+        set {
+            rawPurpose = newValue.rawValue
         }
     }
 

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/FilterProviders/CalendarFilterEntryProviderTeacher.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/FilterProviders/CalendarFilterEntryProviderTeacher.swift
@@ -21,13 +21,16 @@ import Combine
 struct CalendarFilterEntryProviderTeacher: CalendarFilterEntryProvider {
     private let userName: String?
     private let userId: String?
+    private let purpose: GetTeacherCalendarFilters.Purpose
 
     init(
+        purpose: GetTeacherCalendarFilters.Purpose,
         userName: String? = AppEnvironment.shared.currentSession?.userName,
         userId: String? = AppEnvironment.shared.currentSession?.userID
     ) {
         self.userName = userName
         self.userId = userId
+        self.purpose = purpose
     }
 
     func make(ignoreCache: Bool) -> AnyPublisher<[CDCalendarFilterEntry], Error>? {
@@ -35,10 +38,12 @@ struct CalendarFilterEntryProviderTeacher: CalendarFilterEntryProvider {
             return nil
         }
 
-        let useCase = GetCalendarFilters(currentUserName: userName,
-                                         currentUserId: userId,
-                                         states: [],
-                                         filterUnpublishedCourses: false)
+        let useCase = GetTeacherCalendarFilters(
+            currentUserName: userName,
+            currentUserId: userId,
+            purpose: purpose
+        )
+
         return ReactiveStore(useCase: useCase).getEntities(ignoreCache: ignoreCache)
     }
 }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
@@ -145,7 +145,7 @@ extension Publisher where Output == ([APICourse], (body: [APIGroup], urlResponse
             let validCourseIDs = courses.map { $0.id }
             /// If a course's end date has passed and "Restrict students from viewing course after course end date" is checked
             /// then fetching events for a group in this course will give 403 unauthorized.
-            /// To be on the safe side we drop all courses without a valid course.
+            /// To be on the safe side we drop all groups without a valid course.
             let filteredGroups = groups.body.dropCourseGroupsWithoutValidCourses(validCourseIDs: validCourseIDs)
             return (courses, filteredGroups)
         }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
@@ -146,7 +146,7 @@ private extension GetTeacherCalendarFilters {
     func currentCoursesFetch(env: AppEnvironment) -> AnyPublisher<[APICourse], Error> {
         let coursesRequest = GetCurrentUserCoursesRequest(
             enrollmentState: .active,
-            state: [.available],
+            state: [],
             includes: []
         )
 
@@ -160,10 +160,9 @@ private extension GetTeacherCalendarFilters {
         let coursesRequest = GetCoursesRequest(
             enrollmentState: .active,
             enrollmentType: .teacher,
-            state: [.available],
+            state: [],
             perPage: 100
         )
-
         return env.api
             .exhaust(coursesRequest)
             .map { $0.body }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
+
 import CoreData
 import Combine
 

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
@@ -15,12 +15,10 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
-
 import CoreData
 import Combine
-import SwiftUI
 
-class GetCalendarFilters: UseCase {
+class GetTeacherCalendarFilters: UseCase {
     struct APIResponse: Codable {
         let courses: [APICourse]
         let groups: [APIGroup]
@@ -28,63 +26,64 @@ class GetCalendarFilters: UseCase {
     typealias Model = CDCalendarFilterEntry
     typealias Response = APIResponse
 
-    let cacheKey: String? = "calendar/filters"
-    let scope: Scope = {
-        let unknownPurpose = CDCalendarFilterPurpose.unknown.rawValue
+    enum Purpose {
+        case viewing, creating
+
+        fileprivate var filterPurpose: CDCalendarFilterPurpose {
+            switch self {
+            case .viewing: return .viewing
+            case .creating: return .creating
+            }
+        }
+    }
+
+    var cacheKey: String? { "calendar/filters/teacher/\(purpose.filterPurpose.cacheToken)" }
+    var scope: Scope {
         return .init(
             predicate: NSCompoundPredicate(
                 andPredicateWithSubpredicates: [
-                    .init(key: (\CDCalendarFilterEntry.observedUserId).string, equals: nil),
-                    .init(key: (\CDCalendarFilterEntry.rawPurpose).string, equals: unknownPurpose)
+                    NSPredicate(key: (\CDCalendarFilterEntry.observedUserId).string, equals: nil),
+                    NSPredicate(key: (\CDCalendarFilterEntry.rawPurpose).string,
+                                equals: purpose.filterPurpose.rawValue)
                 ]
             ),
             order: [
                 NSSortDescriptor(key: (\CDCalendarFilterEntry.name).string, ascending: true)
             ]
         )
-    }()
+    }
 
     private var subscriptions = Set<AnyCancellable>()
     private let userName: String
     private let userId: String
-    private let states: [GetCoursesRequest.State]
-    private let filterUnpublishedCourses: Bool
+    private let purpose: Purpose
 
     init(
         currentUserName: String,
         currentUserId: String,
-        states: [GetCoursesRequest.State],
-        filterUnpublishedCourses: Bool
+        purpose: Purpose
     ) {
         userName = currentUserName
         userId = currentUserId
-        self.states = states
-        self.filterUnpublishedCourses = filterUnpublishedCourses
+        self.purpose = purpose
     }
 
     func makeRequest(
         environment: AppEnvironment,
         completionHandler: @escaping RequestCallback
     ) {
-        let coursesRequest = GetCurrentUserCoursesRequest(
-            enrollmentState: .active,
-            state: states,
-            includes: []
-        )
-        let coursesFetch = environment.api
-            .exhaust(coursesRequest)
-            .map { [filterUnpublishedCourses] in
-                let courses = $0.body
-
-                if filterUnpublishedCourses {
-                    return courses.filter { $0.workflow_state != .unpublished }
-                } else {
-                    return courses
-                }
-            }
 
         let groupsRequest = GetGroupsRequest(context: .currentUser)
         let groupsFetch = environment.api.exhaust(groupsRequest)
+
+        let coursesFetch: AnyPublisher<[APICourse], Error>
+
+        switch purpose {
+        case .creating:
+            coursesFetch = coursesAsTeacherFetch(env: environment)
+        case .viewing:
+            coursesFetch = currentCoursesFetch(env: environment)
+        }
 
         Publishers
             .CombineLatest(coursesFetch, groupsFetch)
@@ -117,17 +116,20 @@ class GetCalendarFilters: UseCase {
         let filter: CDCalendarFilterEntry = client.insert()
         filter.context = .user(userId)
         filter.name = userName
+        filter.purpose = purpose.filterPurpose
 
         courses.forEach { course in
             let filter: CDCalendarFilterEntry = client.insert()
             filter.context = .course(course.id.rawValue)
             filter.name = course.name ?? ""
+            filter.purpose = purpose.filterPurpose
         }
 
         groups.forEach { group in
             let filter: CDCalendarFilterEntry = client.insert()
             filter.context = .group(group.id.rawValue)
             filter.name = group.name
+            filter.purpose = purpose.filterPurpose
         }
     }
 
@@ -136,32 +138,34 @@ class GetCalendarFilters: UseCase {
     }
 }
 
-// MARK: - Groups Validation
+// MARK: - Fetch Publishers
 
-extension Publisher where Output == ([APICourse], (body: [APIGroup], urlResponse: HTTPURLResponse?)) {
+private extension GetTeacherCalendarFilters {
 
-    func validateGroups() -> Publishers.Map<Self, ([APICourse], [APIGroup])> {
-        map { (courses, groups) in
-            let validCourseIDs = courses.map { $0.id }
-            /// If a course's end date has passed and "Restrict students from viewing course after course end date" is checked
-            /// then fetching events for a group in this course will give 403 unauthorized.
-            /// To be on the safe side we drop all courses without a valid course.
-            let filteredGroups = groups.body.dropCourseGroupsWithoutValidCourses(validCourseIDs: validCourseIDs)
-            return (courses, filteredGroups)
-        }
+    func currentCoursesFetch(env: AppEnvironment) -> AnyPublisher<[APICourse], Error> {
+        let coursesRequest = GetCurrentUserCoursesRequest(
+            enrollmentState: .active,
+            state: [.available],
+            includes: []
+        )
+
+        return env.api
+            .exhaust(coursesRequest)
+            .map { $0.body }
+            .eraseToAnyPublisher()
     }
-}
 
-private extension Array where Element == APIGroup {
+    func coursesAsTeacherFetch(env: AppEnvironment) -> AnyPublisher<[APICourse], Error> {
+        let coursesRequest = GetCoursesRequest(
+            enrollmentState: .active,
+            enrollmentType: .teacher,
+            state: [.available],
+            perPage: 100
+        )
 
-    func dropCourseGroupsWithoutValidCourses(validCourseIDs: [ID]) -> [Element] {
-        filter { group in
-            switch group.groupType {
-            case .account:
-                return true
-            case .course(let courseId):
-                return validCourseIDs.contains(courseId)
-            }
-        }
+        return env.api
+            .exhaust(coursesRequest)
+            .map { $0.body }
+            .eraseToAnyPublisher()
     }
 }

--- a/Core/Core/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Planner/CalendarMain/PlannerViewController.swift
@@ -51,7 +51,12 @@ public class PlannerViewController: UIViewController {
     public var selectedDate: Date = Clock.now
     var studentID: String?
 
-    lazy var calendarFilterInteractor: CalendarFilterInteractor = PlannerAssembly.makeFilterInteractor(observedUserId: studentID)
+    lazy var calendarFilterInteractor: CalendarFilterInteractor = PlannerAssembly
+        .makeFilterInteractor(observedUserId: studentID)
+
+    lazy var calendarFilterInteractorForCreation: CalendarFilterInteractor = PlannerAssembly
+        .makeFilterInteractor(observedUserId: studentID, forCreating: true)
+
     lazy var offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()
     private var subscriptions = Set<AnyCancellable>()
 
@@ -86,7 +91,7 @@ public class PlannerViewController: UIViewController {
         updateTodayButton()
 
         navigationItem.leftBarButtonItem = profileButton
-        navigationItem.rightBarButtonItems = ExperimentalFeature.teacherCalendar.isEnabled ? [todayButton] : [addButton, todayButton]
+        navigationItem.rightBarButtonItems = [addButton, todayButton]
 
         addChild(calendar)
         view.addSubview(calendar.view)
@@ -184,7 +189,7 @@ public class PlannerViewController: UIViewController {
         let weakVC = WeakViewController()
         let vc = PlannerAssembly.makeCreateEventViewController(
             selectedDate: selectedDate,
-            calendarListProviderInteractor: calendarFilterInteractor,
+            calendarListProviderInteractor: calendarFilterInteractorForCreation,
             completion: { [weak self] in
                 if $0 == .didUpdate {
                     self?.plannerListWillRefresh()

--- a/Core/Core/Planner/PlannerAssembly.swift
+++ b/Core/Core/Planner/PlannerAssembly.swift
@@ -37,7 +37,8 @@ public enum PlannerAssembly {
         let viewModel = EditCalendarEventViewModel(
             selectedDate: selectedDate,
             eventInteractor: CalendarEventInteractorLive(),
-            calendarListProviderInteractor: calendarListProviderInteractor ?? makeFilterInteractor(observedUserId: nil),
+            calendarListProviderInteractor: calendarListProviderInteractor
+                ?? makeFilterInteractor(observedUserId: nil, forCreating: true),
             uploadParameters: makeUploadParameters(env: env),
             router: env.router,
             completion: completion
@@ -56,7 +57,8 @@ public enum PlannerAssembly {
         let viewModel = EditCalendarEventViewModel(
             event: event,
             eventInteractor: CalendarEventInteractorLive(),
-            calendarListProviderInteractor: calendarListProviderInteractor ?? makeFilterInteractor(observedUserId: nil),
+            calendarListProviderInteractor: calendarListProviderInteractor
+                ?? makeFilterInteractor(observedUserId: nil, forCreating: true),
             uploadParameters: makeUploadParameters(env: env),
             router: env.router,
             completion: completion
@@ -202,15 +204,16 @@ public enum PlannerAssembly {
         return host
     }
 
-    public static func makeFilterInteractor(observedUserId: String?) -> CalendarFilterInteractor {
+    public static func makeFilterInteractor(observedUserId: String?, forCreating: Bool = false) -> CalendarFilterInteractor {
         CalendarFilterInteractorLive(
             observedUserId: observedUserId,
-            filterProvider: makeFilterProvider(observedUserId: observedUserId)
+            filterProvider: makeFilterProvider(observedUserId: observedUserId, forCreating: forCreating)
         )
     }
 
     public static func makeFilterProvider(
         observedUserId: String?,
+        forCreating: Bool = false,
         app: AppEnvironment.App? = AppEnvironment.shared.app
     ) -> CalendarFilterEntryProvider {
         switch app {
@@ -219,7 +222,7 @@ public enum PlannerAssembly {
         case .student, .none:
             return CalendarFilterEntryProviderStudent()
         case .teacher:
-            return CalendarFilterEntryProviderTeacher()
+            return CalendarFilterEntryProviderTeacher(purpose: forCreating ? .creating : .viewing)
         }
     }
 

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -537,6 +537,30 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         XCTAssertEqual(hasGroupCalendars, true)
     }
 
+    func testSelectCalendarViewModel_Teachers() {
+        // Given
+        environment.app = .teacher
+
+        // When
+        let testee = makeAddViewModel()
+        let vm = testee.selectCalendarViewModel
+
+        let hasUserCalendars = vm.sections.contains {
+            $0.items.contains { calendar in calendar.context.contextType == .user }
+        }
+        let hasCourseCalendars = vm.sections.contains {
+            $0.items.contains { calendar in calendar.context.contextType == .course }
+        }
+        let hasGroupCalendars = vm.sections.contains {
+            $0.items.contains { calendar in calendar.context.contextType == .group }
+        }
+
+        // Then
+        XCTAssertEqual(hasUserCalendars, true)
+        XCTAssertEqual(hasCourseCalendars, true)
+        XCTAssertEqual(hasGroupCalendars, true)
+    }
+
     func testShowCalendarScreen() {
         let sourceVC = UIViewController()
         let testee = makeAddViewModel()

--- a/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetTeacherCalendarFiltersTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetTeacherCalendarFiltersTests.swift
@@ -1,0 +1,96 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class GetTeacherCalendarFiltersTests: CoreTestCase {
+
+    func test_for_viewing() {
+        let coursesRequest = GetCurrentUserCoursesRequest(
+            enrollmentState: .active,
+            state: [],
+            includes: []
+        )
+        api.mock(coursesRequest, value: [
+            .make(id: "11", name: "Course 11")
+        ])
+
+        let groupsRequest = GetGroupsRequest(context: .currentUser)
+        api.mock(
+            groupsRequest,
+            value: [
+                .make(id: "Some-Group", course_id: "11"),
+                .make(id: "Group-22", course_id: "22"),
+                .make(id: "Another-Group", course_id: nil)
+            ]
+        )
+
+        let testee = GetTeacherCalendarFilters(currentUserName: "", currentUserId: "", purpose: .viewing)
+        let requestCompleted = expectation(description: "requestCompleted")
+
+        testee.makeRequest(environment: environment) { response, _, _ in
+            XCTAssertEqual(response?.groups.count, 2)
+            XCTAssertEqual(response?.groups[0].id, "Some-Group")
+            XCTAssertEqual(response?.groups[1].id, "Another-Group")
+
+            XCTAssertEqual(response?.courses.count, 1)
+            XCTAssertEqual(response?.courses.first?.id, "11")
+            requestCompleted.fulfill()
+        }
+
+        wait(for: [requestCompleted])
+    }
+
+    func test_for_creation() {
+        let coursesRequest = GetCoursesRequest(
+            enrollmentState: .active,
+            enrollmentType: .teacher,
+            state: [],
+            perPage: 100
+        )
+        api.mock(coursesRequest, value: [
+            .make(id: "22", name: "Course 22"),
+            .make(id: "77", name: "Course 77")
+        ])
+
+        let groupsRequest = GetGroupsRequest(context: .currentUser)
+        api.mock(
+            groupsRequest,
+            value: [
+                .make(id: "Some-Group", course_id: "22")
+            ]
+        )
+
+        let testee = GetTeacherCalendarFilters(currentUserName: "", currentUserId: "", purpose: .creating)
+        let requestCompleted = expectation(description: "requestCompleted")
+
+        testee.makeRequest(environment: environment) { response, _, _ in
+            XCTAssertEqual(response?.groups.count, 1)
+            XCTAssertEqual(response?.groups.first?.id, "Some-Group")
+
+            XCTAssertEqual(response?.courses.count, 2)
+            XCTAssertEqual(response?.courses[0].id, "22")
+            XCTAssertEqual(response?.courses[1].id, "77")
+
+            requestCompleted.fulfill()
+        }
+
+        wait(for: [requestCompleted])
+    }
+}


### PR DESCRIPTION
refs: MBL-17889
affects: Teacher
release note: Enabling events & todos creation on Teacher's calendars

## Test Plan
Done smoke tests for both "Add Todo" & "Add Event" actions, the methodology:

- Logged-in to Teacher app with user with `teacher` role assigned to him of at least one course.
- Navigated to "Calendar" tab, tapped on Calendars to view all calendars assigned to the user.
- On the top right corner, tapped on "+" button, selected any of those actions.
- Filled in form and hit submit.
- On both forms, tried to create instances on all available Calendars, and they seem to work as expected.

## Screen Recording

https://github.com/user-attachments/assets/a77aee4b-bef4-4806-9332-1d98b0d9993f

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
