### PR TITLE
Add icon for unmarked users in Roll Call Attendance

### DIFF
--- a/Teacher/Teacher/Attendance/StatusCell.swift
+++ b/Teacher/Teacher/Attendance/StatusCell.swift
@@ -69,7 +69,9 @@ class StatusCell: UITableViewCell {
                 accessoryView?.tintColor = attendance.tintColor
                 i18nLabel += " — \(attendance.label)"
             } else {
-                accessoryView = nil
+                accessoryView = UIImageView(image: .noLine)
+                accessoryView?.tintColor = .backgroundDark
+                i18nLabel += " — \(String(localized: "Unmarked", bundle: .teacher))"
             }
             accessibilityLabel = i18nLabel
         }

--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -33635,6 +33635,9 @@
         }
       }
     },
+    "Unmarked" : {
+
+    },
     "URL Preview Image" : {
       "localizations" : {
         "ar" : {

--- a/Teacher/TeacherTests/Attendance/AttendanceViewControllerTests.swift
+++ b/Teacher/TeacherTests/Attendance/AttendanceViewControllerTests.swift
@@ -89,7 +89,7 @@ class AttendanceViewControllerTests: TeacherTestCase {
         let swipes = controller.tableView(controller.tableView, trailingSwipeActionsConfigurationForRowAt: first)?.actions
         XCTAssertEqual(swipes?.count, 3)
         swipes?.last?.handler(swipes!.last!, UIView()) { success in XCTAssertTrue(success) }
-        XCTAssertEqual(cellAt(first).accessibilityLabel, "Bob")
+        XCTAssertEqual(cellAt(first).accessibilityLabel, "Bob — Unmarked")
         XCTAssertEqual(controller.markAllButton.title(for: .normal), "Mark Remaining as Present")
 
         // Use taps to mark row 2
@@ -98,7 +98,7 @@ class AttendanceViewControllerTests: TeacherTestCase {
         controller.tableView(controller.tableView, didSelectRowAt: second)
         XCTAssertEqual(cellAt(second).accessibilityLabel, "Sally — Late")
         controller.tableView(controller.tableView, didSelectRowAt: second)
-        XCTAssertEqual(cellAt(second).accessibilityLabel, "Sally")
+        XCTAssertEqual(cellAt(second).accessibilityLabel, "Sally — Unmarked")
         XCTAssertEqual(controller.markAllButton.title(for: .normal), "Mark All as Present")
         controller.tableView(controller.tableView, didSelectRowAt: second)
         XCTAssertEqual(cellAt(second).accessibilityLabel, "Sally — Present")

--- a/Teacher/TeacherTests/Attendance/StatusCellTests.swift
+++ b/Teacher/TeacherTests/Attendance/StatusCellTests.swift
@@ -26,13 +26,16 @@ class StatusCellTests: TeacherTestCase {
         XCTAssertNil(cell.nameLabel.text)
 
         cell.status = .make(attendance: nil)
-        XCTAssertNil(cell.accessoryView)
         XCTAssertNotNil(cell.nameLabel.text)
+        XCTAssertEqual((cell.accessoryView as? UIImageView)?.image, UIImage.noLine)
 
         cell.status = .make(attendance: .present)
         XCTAssertEqual((cell.accessoryView as? UIImageView)?.image, Attendance.present.icon)
 
         cell.status = .make(student: nil, attendance: .present)
         XCTAssertEqual(cell.accessibilityLabel, " — Present")
+
+        cell.status = .make(student: nil, attendance: nil)
+        XCTAssertEqual(cell.accessibilityLabel, " — Unmarked")
     }
 }


### PR DESCRIPTION
refs: [MBL-17846](https://instructure.atlassian.net/browse/MBL-17846)
affects: Teacher
release note: Added icon for unmarked users in Roll Call Attendance.

## Test plan
- Verify unmarked icon is visible according to ticket.
- Verify "Unmarked" is added in VoiceOver for unmarked users.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/586b3b4e-1b16-4ccd-b5db-4b0bc302096a" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/5068b7f2-3d01-4967-abfd-286ed55086de" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product

[MBL-17846]: https://instructure.atlassian.net/browse/MBL-17846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ