### PR TITLE
Don't show inbox leave confirmation for empty message

### DIFF
--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -87,8 +87,8 @@ final class ComposeMessageViewModel: ObservableObject {
     let router: Router
 
     // MARK: - Private
-    private var initialMessageValue = ComposeMessageValue()
-    private var changedMessageValue = ComposeMessageValue()
+    private var initialMessageProperties = ComposeMessageProperties()
+    private var changedMessageProperties = ComposeMessageProperties()
     private var didSentMailSuccessfully: PassthroughSubject<Void, Never>?
     public let didTapRetry = PassthroughRelay<WeakViewController>()
     private var viewController  = WeakViewController()
@@ -348,10 +348,10 @@ final class ComposeMessageViewModel: ObservableObject {
         self.alwaysShowRecipients = extras.alwaysShowRecipients
         self.teacherOnly = extras.teacherOnly
         // Set initial Message Values so can check if there are any changes or not
-        initialMessageValue.courseName = selectedContext?.name
-        initialMessageValue.recipients = fieldContents.selectedRecipients
-        initialMessageValue.message = bodyText
-        initialMessageValue.subject = subject
+        initialMessageProperties.courseName = selectedContext?.name
+        initialMessageProperties.recipients = fieldContents.selectedRecipients
+        initialMessageProperties.message = bodyText
+        initialMessageProperties.subject = subject
 
         if autoTeacherSelect {
             selectedRecipients.send([.init(ids: [], name: String(localized: "Teachers"), avatarURL: nil)])
@@ -517,12 +517,12 @@ final class ComposeMessageViewModel: ObservableObject {
     }
 
     private func didApplyChanges() -> Bool {
-        changedMessageValue.subject = subject
-        changedMessageValue.message = bodyText
-        changedMessageValue.files = attachments
-        changedMessageValue.courseName = selectedContext?.name
-        changedMessageValue.recipients = selectedRecipients.value
-        return changedMessageValue != initialMessageValue
+        changedMessageProperties.subject = subject
+        changedMessageProperties.message = bodyText
+        changedMessageProperties.files = attachments
+        changedMessageProperties.courseName = selectedContext?.name
+        changedMessageProperties.recipients = selectedRecipients.value
+        return changedMessageProperties != initialMessageProperties
     }
 }
 
@@ -530,7 +530,7 @@ final class ComposeMessageViewModel: ObservableObject {
 extension ComposeMessageViewModel {
     /// Using this type to match between the initial values and the changed values to
     /// show confirmation alert or not
-    fileprivate struct ComposeMessageValue: Equatable {
+    fileprivate struct ComposeMessageProperties: Equatable {
         var subject = ""
         var courseName: String?
         var message = ""

--- a/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
@@ -612,6 +612,24 @@ class ComposeMessageViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.searchedRecipients.count, 1)
     }
 
+    func test_didTapCancel_didNotApplyChanges_dimissView() {
+        // Given
+        let viewController = WeakViewController(UIViewController())
+        // When
+        testee.didTapCancel.accept(viewController)
+        // Then
+        wait(for: [router.dismissExpectation], timeout: 0.1)
+    }
+    func test_didTapCancel_didApplyChanges_showConfirmationAlert() {
+        // Given
+        let viewController = WeakViewController(UIViewController())
+        // When
+        testee.bodyText = "New Body is here"
+        testee.didTapCancel.accept(viewController)
+        // Then
+        XCTAssertTrue(testee.isShowingCancelDialog)
+    }
+
     func test_clearSearchedRecipients() {
         // Given
         let viewController = WeakViewController(UIViewController())


### PR DESCRIPTION
refs: [MBL-17836](https://instructure.atlassian.net/browse/MBL-17836)
affects: Student, Teacher
release note: did't show inbox leave confirmation for empty message

# Test plan:
1- Open new or reply to message
2- Tap on cancel button will dismiss the view without showing confirmation alert 
3- If you did any changes and hit cancel button will show alert


https://github.com/user-attachments/assets/a7d00972-1d5b-4b71-84d8-618faf33722c


## Checklist

- [ ] Tested on phone
- [ ] Tested in dark mode
- [ ] Tested in light mode



[MBL-17836]: https://instructure.atlassian.net/browse/MBL-17836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ