### PR TITLE
Student - Fix incorrect course color on inbox course filter screen in K5

### DIFF
--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -66,11 +66,8 @@ final public class Course: NSManagedObject, WriteableModel {
     }
 
     public var color: UIColor {
-        if AppEnvironment.shared.k5.isK5Enabled {
-            return UIColor(hexString: courseColor)?.ensureContrast(against: .backgroundLightest) ?? .oxford
-        } else {
-            return contextColor?.color.ensureContrast(against: .backgroundLightest) ?? .ash
-        }
+        let defaultColor: UIColor = AppEnvironment.shared.k5.isK5Enabled ? .oxford : .ash
+        return contextColor?.color.ensureContrast(against: .backgroundLightest) ?? defaultColor
     }
 
     @discardableResult


### PR DESCRIPTION
refs: MBL-17837
affects: Student
release note: Fix incorrect course color on inbox course filter screen in K5
test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/09e92635-5b35-4805-94c3-55e83c511d7e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/819d4b96-38b4-46d0-aba5-68746d46545f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
