### PR TITLE
Remove Teacher Calendar Experimental Feature Flag

### DIFF
--- a/Core/Core/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/AppEnvironment/ExperimentalFeature.swift
@@ -28,7 +28,6 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case favoriteGroups = "favorite_groups"
     case K5Dashboard = "enable_K5_dashboard"
     case whatIfScore = "what_if_score"
-    case teacherCalendar = "teacher_calendar"
 
     public var isEnabled: Bool {
         get {

--- a/Teacher/Teacher/TeacherTabBarController.swift
+++ b/Teacher/Teacher/TeacherTabBarController.swift
@@ -27,15 +27,8 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
         super.viewDidLoad()
 
         delegate = self
-        let paths: [String]
-
-        if ExperimentalFeature.teacherCalendar.isEnabled {
-            viewControllers = [coursesTab(), calendarTab(), toDoTab(), inboxTab()]
-            paths = [ "/", "/calendar", "/to-do", "/conversations" ]
-        } else {
-            viewControllers = [coursesTab(), toDoTab(), inboxTab()]
-            paths = [ "/", "/to-do", "/conversations" ]
-        }
+        viewControllers = [coursesTab(), calendarTab(), toDoTab(), inboxTab()]
+        let paths = [ "/", "/calendar", "/to-do", "/conversations" ]
         selectedIndex = AppEnvironment.shared.userDefaults?.landingPath.flatMap {
             paths.firstIndex(of: $0)
         } ?? 0
@@ -113,14 +106,7 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
     }
 
     private func reportScreenView(for tabIndex: Int, viewController: UIViewController) {
-        let map: [String]
-
-        if ExperimentalFeature.teacherCalendar.isEnabled {
-            map = ["dashboard", "calendar", "todo", "conversations"]
-        } else {
-            map = ["dashboard", "todo", "conversations"]
-        }
-
+        let map = ["dashboard", "calendar", "todo", "conversations"]
         let event = map[tabIndex]
         Analytics.shared.logScreenView(route: "/tabs/" + event, viewController: viewController)
     }


### PR DESCRIPTION
refs: MBL-17934
affects: Teacher
release note: Remove support for Teacher calendar experimental feature flag.

## Test Plan

- Logged in Teacher app with teacher account on a sandbox school.
- Navigated through Side menu > Developer menu > View Experimental Features.
- Observed results, "teacher_calendar" toggle is expected to be removed. 
- Dismissed Side menu > navigated to "Calendar" tab, observed results.
- Calendar tab is expected to be present and functional.

## Screenshots

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/8c20f6e8-c571-4cba-8c92-1886fbab81e8" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/76b183fe-3b0e-4b6b-8db6-73adcb10735a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
