### PR TITLE
Enable sending messages to an unlimited number of recipients

### DIFF
--- a/Core/Core/Conversations/APIConversation.swift
+++ b/Core/Core/Conversations/APIConversation.swift
@@ -314,6 +314,7 @@ public struct PostConversationRequest: APIRequestable {
         public let attachment_ids: [String]?
         public let group_conversation: Bool?
         public let force_new: Bool? = nil // Setting this seems to cause the api to ignore group_conversation
+        public let bulk_message: Bool
     }
 
     public let body: Body?

--- a/Core/Core/Conversations/CreateConversation.swift
+++ b/Core/Core/Conversations/CreateConversation.swift
@@ -29,6 +29,7 @@ public class CreateConversation: APIUseCase {
     let mediaCommentType: MediaCommentType?
     let attachmentIDs: [String]?
     let groupConversation: Bool
+    let bulkMessage: Bool
     let canvasContextID: String?
 
     public init(
@@ -39,7 +40,8 @@ public class CreateConversation: APIUseCase {
         mediaCommentID: String? = nil,
         mediaCommentType: MediaCommentType? = nil,
         attachmentIDs: [String]? = nil,
-        groupConversation: Bool = true
+        groupConversation: Bool = true,
+        bulkMessage: Bool = false
     ) {
         self.subject = subject
         self.body = body
@@ -49,6 +51,7 @@ public class CreateConversation: APIUseCase {
         self.mediaCommentType = mediaCommentType
         self.attachmentIDs = attachmentIDs
         self.groupConversation = groupConversation
+        self.bulkMessage = bulkMessage
     }
 
     public let cacheKey: String? = nil
@@ -62,7 +65,8 @@ public class CreateConversation: APIUseCase {
             media_comment_id: mediaCommentID,
             media_comment_type: mediaCommentType,
             attachment_ids: attachmentIDs,
-            group_conversation: groupConversation
+            group_conversation: groupConversation,
+            bulk_message: bulkMessage
         ))
     }
 

--- a/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageInteractorLive.swift
+++ b/Core/Core/Inbox/ComposeMessage/Model/ComposeMessageInteractorLive.swift
@@ -128,7 +128,8 @@ public class ComposeMessageInteractorLive: ComposeMessageInteractor {
             recipientIDs: parameters.recipientIDs,
             canvasContextID: parameters.context.canvasContextID,
             attachmentIDs: parameters.attachmentIDs,
-            groupConversation: parameters.groupConversation
+            groupConversation: parameters.groupConversation,
+            bulkMessage: parameters.bulkMessage
         )
         .fetchWithFuture()
     }

--- a/Core/Core/Inbox/ComposeMessage/Model/MessageParameters.swift
+++ b/Core/Core/Inbox/ComposeMessage/Model/MessageParameters.swift
@@ -28,6 +28,7 @@ public struct MessageParameters {
     public let conversationID: String?
     public let groupConversation: Bool
     public let includedMessages: [String]?
+    public let bulkMessage: Bool
 
     public init(
         subject: String,
@@ -37,6 +38,7 @@ public struct MessageParameters {
         context: Context,
         conversationID: String? = nil,
         groupConversation: Bool = true,
+        bulkMessage: Bool,
         includedMessages: [String]? = nil
     ) {
         self.subject = subject
@@ -46,6 +48,7 @@ public struct MessageParameters {
         self.context = context
         self.conversationID = conversationID
         self.groupConversation = groupConversation
+        self.bulkMessage = bulkMessage
         self.includedMessages = includedMessages
     }
 }

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -292,7 +292,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             Spacer()
 
             addRecipientButton
-                .frame(maxHeight: .infinity, alignment: .center)
+                .frame(maxHeight: .infinity, alignment: .top)
                 .accessibilitySortPriority(2)
         }
         .animation(.easeInOut, value: model.recipients.isEmpty)
@@ -307,7 +307,6 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             .font(.regular16, lineHeight: .condensed)
             .foregroundColor(.textDark)
             .padding(.vertical, 12)
-            .frame(maxHeight: .infinity, alignment: .center)
             .accessibilitySortPriority(3)
             .accessibilityIdentifier("ComposeMessage.to")
     }

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -350,9 +350,18 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
     private var individualView: some View {
         Toggle(isOn: $model.sendIndividual) {
-            Text("Send individual message to each recipient", bundle: .core)
-                .font(.regular16, lineHeight: .condensed)
-                .foregroundColor(.textDarkest.opacity(model.isSendIndividualToggleDisabled ? 0.5 : 1))
+            VStack(alignment: .leading, spacing: .zero) {
+                Text("Send individual message to each recipient", bundle: .core)
+                    .font(.regular16, lineHeight: .condensed)
+                    .foregroundColor(model.isSendIndividualToggleDisabled ? .disabledGray : .textDarkest)
+
+               if model.isSendIndividualToggleDisabled {
+                   Text("You can only send individual messages over 100 recipients.", bundle: .core)
+                       .font(.regular14)
+                       .foregroundColor(.textDark)
+               }
+            }
+
         }
         .tint(.accentColor)
         .disabled(model.isSendIndividualToggleDisabled)

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -352,10 +352,10 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         Toggle(isOn: $model.sendIndividual) {
             Text("Send individual message to each recipient", bundle: .core)
                 .font(.regular16, lineHeight: .condensed)
-                .foregroundColor(.textDarkest.opacity(model.isDisableToggle ? 0.5 : 1))
+                .foregroundColor(.textDarkest.opacity(model.isSendIndividualToggleDisabled ? 0.5 : 1))
         }
         .tint(.accentColor)
-        .disabled(model.isDisableToggle)
+        .disabled(model.isSendIndividualToggleDisabled)
         .padding(.horizontal, defaultHorizontalPaddingValue)
         .padding(.vertical, defaultVerticalPaddingValue)
         .contentShape(Rectangle())

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -307,6 +307,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             .font(.regular16, lineHeight: .condensed)
             .foregroundColor(.textDark)
             .padding(.vertical, 12)
+            .frame(maxHeight: .infinity, alignment: .center)
             .accessibilitySortPriority(3)
             .accessibilityIdentifier("ComposeMessage.to")
     }
@@ -351,9 +352,10 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         Toggle(isOn: $model.sendIndividual) {
             Text("Send individual message to each recipient", bundle: .core)
                 .font(.regular16, lineHeight: .condensed)
-                .foregroundColor(.textDarkest)
+                .foregroundColor(.textDarkest.opacity(model.isDisableToggle ? 0.5 : 1))
         }
         .tint(.accentColor)
+        .disabled(model.isDisableToggle)
         .padding(.horizontal, defaultHorizontalPaddingValue)
         .padding(.vertical, defaultVerticalPaddingValue)
         .contentShape(Rectangle())

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -429,8 +429,8 @@ final class ComposeMessageViewModel: ObservableObject {
         if subject.isEmpty {
             subject = title
         }
-        let isExceedLimitRecipients = recipientIDs.count > maxRecipientCount
-        let groupConversation = isExceedLimitRecipients ? true : !sendIndividual
+        let isExceedsRecipientsLimit = recipientIDs.count > maxRecipientCount
+        let groupConversation = isExceedsRecipientsLimit ? true : !sendIndividual
         return MessageParameters(
             subject: subject,
             body: body,
@@ -439,7 +439,7 @@ final class ComposeMessageViewModel: ObservableObject {
             context: context.context,
             conversationID: conversation?.id,
             groupConversation: groupConversation,
-            bulkMessage: isExceedLimitRecipients,
+            bulkMessage: isExceedsRecipientsLimit,
             includedMessages: includedMessages.map { $0.id }
         )
     }

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -34,7 +34,7 @@ final class ComposeMessageViewModel: ObservableObject {
     @Published public private(set) var isSubjectDisabled: Bool = false
     @Published public private(set) var isMessageDisabled: Bool = false
     @Published public private(set) var isIndividualDisabled: Bool = false
-    @Published public private(set) var isDisableToggle: Bool = false
+    @Published public private(set) var isSendIndividualToggleDisabled: Bool = false
     @Published public var isShowingErrorDialog = false
     @Published private(set) var searchedRecipients: [Recipient] = []
     @Published public private(set) var expandedIncludedMessageIds = [String]()
@@ -337,7 +337,7 @@ final class ComposeMessageViewModel: ObservableObject {
                 guard let self else {
                     return
                 }
-                self.isDisableToggle = isExceedRecipientLimit
+                self.isSendIndividualToggleDisabled = isExceedRecipientLimit
                 if isExceedRecipientLimit {
                     self.sendIndividualToggleTemp = self.sendIndividual
                     self.sendIndividual = true

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -104,7 +104,7 @@ final class ComposeMessageViewModel: ObservableObject {
     private var hiddenMessage: String = ""
     private var autoTeacherSelect: Bool = false
     private var teacherOnly: Bool = false
-    private var sendIndividualToggleTemp: Bool = false
+    private var sendIndividualToggleLastValue: Bool = false
     private let maxRecipientCount = 100
 
     // MARK: Public interface
@@ -339,10 +339,10 @@ final class ComposeMessageViewModel: ObservableObject {
                 }
                 self.isSendIndividualToggleDisabled = isExceedRecipientLimit
                 if isExceedRecipientLimit {
-                    self.sendIndividualToggleTemp = self.sendIndividual
+                    self.sendIndividualToggleLastValue = self.sendIndividual
                     self.sendIndividual = true
                 } else {
-                    self.sendIndividual = sendIndividualToggleTemp
+                    self.sendIndividual = sendIndividualToggleLastValue
                 }
             }
             .store(in: &subscriptions)

--- a/Core/CoreTests/Conversations/APIConversationTests.swift
+++ b/Core/CoreTests/Conversations/APIConversationTests.swift
@@ -88,7 +88,8 @@ class APIConversationTests: CoreTestCase {
             media_comment_id: "1",
             media_comment_type: .audio,
             attachment_ids: ["1"],
-            group_conversation: true
+            group_conversation: true,
+            bulk_message: false
         )
         let request = PostConversationRequest(body: body)
         XCTAssertEqual(request.path, "conversations")

--- a/Core/CoreTests/Conversations/ComposeViewControllerTests.swift
+++ b/Core/CoreTests/Conversations/ComposeViewControllerTests.swift
@@ -116,7 +116,7 @@ class ComposeViewControllerTests: CoreTestCase {
             media_comment_id: nil,
             media_comment_type: nil,
             attachment_ids: [],
-            group_conversation: true, 
+            group_conversation: true,
             bulk_message: false
         )), error: NSError.instructureError("Error")
         )

--- a/Core/CoreTests/Conversations/ComposeViewControllerTests.swift
+++ b/Core/CoreTests/Conversations/ComposeViewControllerTests.swift
@@ -93,7 +93,8 @@ class ComposeViewControllerTests: CoreTestCase {
             media_comment_id: nil,
             media_comment_type: nil,
             attachment_ids: [],
-            group_conversation: true
+            group_conversation: true,
+            bulk_message: false
         )
             ), value: [ APIConversation.make() ]
         )
@@ -115,7 +116,8 @@ class ComposeViewControllerTests: CoreTestCase {
             media_comment_id: nil,
             media_comment_type: nil,
             attachment_ids: [],
-            group_conversation: true
+            group_conversation: true, 
+            bulk_message: false
         )), error: NSError.instructureError("Error")
         )
         let sendButton = controller.sendButton

--- a/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageInteractorLiveTests.swift
+++ b/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageInteractorLiveTests.swift
@@ -44,7 +44,7 @@ class ComposeMessageInteractorLiveTests: CoreTestCase {
             attachmentIDs: attachments
         ).request
 
-        let parameters = MessageParameters(subject: subject, body: body, recipientIDs: recipients, context: Context.course(canvasContext))
+        let parameters = MessageParameters(subject: subject, body: body, recipientIDs: recipients, context: Context.course(canvasContext), bulkMessage: false)
         api.mock(createConversationRequest, value: nil, response: nil, error: NSError.instructureError("Failure"))
 
         XCTAssertFailure(testee.createConversation(parameters: parameters))
@@ -64,7 +64,7 @@ class ComposeMessageInteractorLiveTests: CoreTestCase {
             attachmentIDs: attachments
         ).request
         let value = [APIConversation.make(id: "1")]
-        let parameters = MessageParameters(subject: subject, body: body, recipientIDs: recipients, context: Context.course(canvasContext))
+        let parameters = MessageParameters(subject: subject, body: body, recipientIDs: recipients, context: Context.course(canvasContext), bulkMessage: false)
         api.mock(createConversationRequest, value: value)
 
         XCTAssertFinish(testee.createConversation(parameters: parameters))
@@ -93,6 +93,7 @@ class ComposeMessageInteractorLiveTests: CoreTestCase {
             recipientIDs: recipients,
             context: Context.course(canvasContext),
             conversationID: conversation,
+            bulkMessage: false,
             includedMessages: includedMessages
         )
         api.mock(addConversationMessageRequest, value: nil, response: nil, error: NSError.instructureError("Failure"))
@@ -122,6 +123,7 @@ class ComposeMessageInteractorLiveTests: CoreTestCase {
             recipientIDs: recipients,
             context: Context.course(canvasContext),
             conversationID: conversation,
+            bulkMessage: false,
             includedMessages: includedMessages
         )
         api.mock(addConversationMessageRequest, value: value)

--- a/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
@@ -649,6 +649,21 @@ class ComposeMessageViewModelTests: CoreTestCase {
         testee.selectedRecipients.send(recipient)
         // Then
         XCTAssertTrue(testee.isSendIndividualToggleDisabled)
+        XCTAssertTrue(testee.sendIndividual)
+    }
+
+    func test_selectedRecipients_setSendIndividualToPreviousState() {
+        // Given
+        testee.sendIndividual = false
+        let recipientNotExceedMaxLimit = ReceiptStub.recipients
+        let recipientExceedMaxLimit  = ReceiptStub.getRecipientExceedMaxLimit()
+
+        testee.selectedRecipients.send(recipientExceedMaxLimit)
+        XCTAssertTrue(testee.sendIndividual)
+
+        // SendIndividual back to the pervious state
+        testee.selectedRecipients.send(recipientNotExceedMaxLimit)
+        XCTAssertFalse(testee.sendIndividual)
     }
 }
 

--- a/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
@@ -641,6 +641,15 @@ class ComposeMessageViewModelTests: CoreTestCase {
         // Then
         XCTAssertTrue(testee.searchedRecipients.isEmpty)
     }
+
+    func test_selectedRecipients_disableToggle() {
+        // Given
+        let recipient = ReceiptStub.getRecipientExceedMaxLimit()
+        // When
+        testee.selectedRecipients.send(recipient)
+        // Then
+        XCTAssertTrue(testee.isDisableToggle)
+    }
 }
 
 private class ComposeMessageInteractorMock: ComposeMessageInteractor {

--- a/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Inbox/ComposeMessage/ComposeMessageViewModelTests.swift
@@ -648,7 +648,7 @@ class ComposeMessageViewModelTests: CoreTestCase {
         // When
         testee.selectedRecipients.send(recipient)
         // Then
-        XCTAssertTrue(testee.isDisableToggle)
+        XCTAssertTrue(testee.isSendIndividualToggleDisabled)
     }
 }
 

--- a/Core/CoreTests/Inbox/Stubs/ReceiptStub.swift
+++ b/Core/CoreTests/Inbox/Stubs/ReceiptStub.swift
@@ -35,4 +35,13 @@ enum ReceiptStub {
         .init(id: "4", name: "Canvas 4", avatarURL: nil),
         .init(id: "5", name: "ios Test", avatarURL: nil)
     ]
+
+    static func getRecipientExceedMaxLimit() -> [Recipient] {
+        var recipients: [Recipient] = []
+        for id in 0...105 {
+            recipients.append(.init(id: "\(id)", name: "", avatarURL: nil))
+        }
+
+        return  recipients
+    }
 }


### PR DESCRIPTION
refs: [MBL-17936](https://instructure.atlassian.net/browse/MBL-17936)
affects: Student , Teacher
release note: Enabled sending messages to an unlimited number of recipients

## Test Plane
- Open a new message
- Send a message to over 100 recipients.
- Observe that the "Send Individually" toggle becomes disabled.

#### Note 
- If you send a reply message to over 100 recipients, you will receive an error. This is not an issue on our side but a backend issue.

## Screenshots


<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d1c5fc16-cc4c-4a97-9ba3-f5d555888e72" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/bb59a55a-1e8d-4445-86ad-043ec8a2b11c" maxHeight=500></td>
</tr>


https://github.com/user-attachments/assets/8be1c566-abb7-4f2b-98c0-450c1595503b

## Checklist
- [x] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode


[MBL-17936]: https://instructure.atlassian.net/browse/MBL-17936?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ