### PR TITLE
Fix LTI content embedded in RCE submissions not displaying in SpeedGrader

### DIFF
--- a/Teacher/Teacher/SpeedGrader/SubmissionViewer.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionViewer.swift
@@ -77,7 +77,12 @@ struct SubmissionViewer: View {
         case .media_recording:
             VideoPlayer(url: submission.mediaComment?.url)
         case .online_text_entry:
-            WebView(html: submission.body, canToggleTheme: true).onLink(handleLink)
+            WebView(
+                html: submission.body,
+                baseURL: env.currentSession?.baseURL,
+                canToggleTheme: true
+            )
+            .onLink(handleLink)
         case .online_upload:
             let file = submission.attachments?.first { fileID == $0.id } ??
                 submission.attachments?.sorted(by: File.idCompare).first


### PR DESCRIPTION
refs: MBL-17939
affects: Teacher
release note: Fixed LTI content embedded in RCE submissions not displaying in SpeedGrader.

test plan: See ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/96db8ef5-0ee9-4227-8530-4b994cf42d69" maxHeight=500>
</td>
<td><img src="https://github.com/user-attachments/assets/2950393a-280a-4c83-bad2-c6552ba3cd20" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [ ] Tested on tablet
