### PR TITLE
Offline content picker fixes

### DIFF
--- a/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
+++ b/Core/Core/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModel.swift
@@ -101,12 +101,14 @@ class CourseSyncSelectorViewModel: ObservableObject {
         updateSelectAllButtonTitle(selectorInteractor)
         updateNavBarSubtitle(selectorInteractor)
 
-        handleCancelButtonTap(cancelConfirmAlert: cancelConfirmAlert)
         handleLeftNavBarTap(selectorInteractor)
         handleSyncButtonTap(
             selectorInteractor: selectorInteractor,
             syncConfirmAlert: syncConfirmAlert
         )
+
+        dismissScreenInLoadingAndErrorState(on: cancelButtonDidTap)
+        showConfirmationAlertInDataState(on: cancelButtonDidTap, cancelConfirmAlert: cancelConfirmAlert)
 
         syncButtonDidTap.logReceiveOutput(
             "offline_sync_button_tapped",
@@ -114,8 +116,25 @@ class CourseSyncSelectorViewModel: ObservableObject {
         )
     }
 
-    private func handleCancelButtonTap(cancelConfirmAlert: ConfirmationAlertViewModel) {
-        cancelButtonDidTap
+    private func dismissScreenInLoadingAndErrorState(on publisher: PassthroughRelay<WeakViewController>) {
+        publisher
+            .filter { [unowned self] _ in
+                state == .loading || state == .error
+            }
+            .sink { [unowned router] viewController in
+                router.dismiss(viewController)
+            }
+            .store(in: &subscriptions)
+    }
+
+    private func showConfirmationAlertInDataState(
+        on publisher: PassthroughRelay<WeakViewController>,
+        cancelConfirmAlert: ConfirmationAlertViewModel
+    ) {
+        publisher
+            .filter { [unowned self] _ in
+                state == .data
+            }
             .handleEvents(receiveOutput: { [unowned self] _ in
                 isShowingCancelConfirmationDialog = true
             })

--- a/Core/Core/Files/Model/API/APIFile.swift
+++ b/Core/Core/Files/Model/API/APIFile.swift
@@ -140,7 +140,6 @@ public struct APIFile: Codable, Equatable {
         uuid = try container.decode(String.self, forKey: .uuid)
         folder_id = try container.decode(ID.self, forKey: .folder_id)
         display_name = try container.decode(String.self, forKey: .display_name)
-        filename = try container.decode(String.self, forKey: .filename)
         contentType = try container.decode(String.self, forKey: .contentType)
         url = try container.decodeURLIfPresent(forKey: .url)
         size = try container.decodeIfPresent(Int.self, forKey: .size)
@@ -161,6 +160,14 @@ public struct APIFile: Codable, Equatable {
         avatar = try container.decodeIfPresent(APIFileToken.self, forKey: .avatar)
         usage_rights = try container.decodeIfPresent(APIUsageRights.self, forKey: .usage_rights)
         visibility_level = try container.decodeIfPresent(String.self, forKey: .visibility_level)
+
+        do {
+            /// We've seen instances where filename is `null` in the JSON.
+            /// We fall back to `display_name` in this case since these two are usually the same.
+            filename = try container.decode(String.self, forKey: .filename)
+        } catch {
+            filename = display_name
+        }
     }
 }
 

--- a/Core/CoreTests/Files/Model/API/APIFileTests.swift
+++ b/Core/CoreTests/Files/Model/API/APIFileTests.swift
@@ -23,6 +23,7 @@ private let decoder = APIJSONDecoder()
 private let encoder = APIJSONEncoder()
 
 class APIFileTests: XCTestCase {
+
     func testAPIFileDecode() throws {
         var fixture = validFixture
         var data = try serialize(json: fixture)
@@ -37,6 +38,18 @@ class APIFileTests: XCTestCase {
         data = try serialize(json: fixture)
         file = try decoder.decode(APIFile.self, from: data)
         XCTAssertNil(file.thumbnail_url)
+    }
+
+    func testAPIFileDecodeWithNullFileName() throws {
+        var fixture = validFixture
+        fixture["filename"] = nil
+        let data = try serialize(json: fixture)
+
+        // WHEN
+        let testee = try decoder.decode(APIFile.self, from: data)
+
+        // THEN
+        XCTAssertEqual(testee.filename, testee.display_name)
     }
 
     func testAPIFolderItem() throws {


### PR DESCRIPTION
- Fixed file parsing failing when filename is null.
- Fixed offline content selector screen not reacting to cancel when in error or loading states.

refs: MBL-17877
affects: Student
release note: Fixed cancel not working on offline sync picker screen while the screen is loading or displaying an error. Fixed offline sync picker failing to load in some cases.

test plan: See ticket.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
