### PR TITLE
Calendar Filter crash

### DIFF
--- a/Core/Core/API/ID.swift
+++ b/Core/Core/API/ID.swift
@@ -40,6 +40,11 @@ public struct ID: Codable, Equatable, Hashable, CustomStringConvertible, RawRepr
             return
         }
 
+        Analytics.shared.logError(
+            name: "Empty ID decoded from unhandled data",
+            reason: "baseUrl: \(Analytics.analyticsBaseUrl)"
+        )
+
         value = ""
     }
 

--- a/Core/Core/Analytics/Analytics.swift
+++ b/Core/Core/Analytics/Analytics.swift
@@ -113,4 +113,11 @@ public class Analytics: NSObject {
 
         return name
     }
+
+    public static var analyticsBaseUrl: String {
+        guard let session = AppEnvironment.shared.currentSession else {
+            return ""
+        }
+        return session.baseURL.absoluteString
+    }
 }

--- a/Core/Core/Contexts/Context.swift
+++ b/Core/Core/Contexts/Context.swift
@@ -77,4 +77,8 @@ public extension Context {
     var courseId: String? { contextType == .course ? id : nil }
     var groupId: String? { contextType == .group ? id : nil }
     var userId: String? { contextType == .user ? id : nil }
+
+    var isValid: Bool {
+        id.isNotEmpty
+    }
 }

--- a/Core/Core/Contexts/Context.swift
+++ b/Core/Core/Contexts/Context.swift
@@ -37,6 +37,13 @@ public struct Context: Codable, Equatable, Hashable {
     public var pathComponent: String { "\(contextType.pathComponent)/\(id)" }
 
     public init(_ contextType: ContextType, id: String) {
+        if id.isEmpty {
+            Analytics.shared.logError(
+                name: "Context created with invalid contextId",
+                reason: "contextType: \(contextType.rawValue), contextId: \"\(id)\", baseUrl: \(Analytics.analyticsBaseUrl)"
+            )
+        }
+
         self.contextType = contextType
         self.id = ID.expandTildeID(id)
     }

--- a/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
@@ -93,7 +93,13 @@ public class CDCalendarFilterEntry: NSManagedObject {
         purpose: CDCalendarFilterPurpose = .unknown,
         in moContext: NSManagedObjectContext
     ) -> CDCalendarFilterEntry? {
-        guard context.isValid else { return nil }
+        guard context.isValid else {
+            Analytics.shared.logError(
+                name: "CDCalendarFilterEntry save failed with invalid contextId",
+                reason: "contextType: \(context.contextType.rawValue), contextId: \"\(context.id)\", baseUrl: \(Analytics.analyticsBaseUrl)"
+            )
+            return nil
+        }
 
         let canvasContextID = context.canvasContextID
 

--- a/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
@@ -37,7 +37,7 @@ public class CDCalendarFilterEntry: NSManagedObject {
     @NSManaged public var name: String
     /// For the observer role we have a separate list of filters for each observed student
     @NSManaged public var observedUserId: String?
-    @NSManaged public private(set) var rawContextID: String
+    @NSManaged public private(set) var rawContextID: String // example: "course_42"
     @NSManaged public var rawPurpose: Int16
 
     public var context: Context {
@@ -83,6 +83,29 @@ public class CDCalendarFilterEntry: NSManagedObject {
 
     public var courseName: String? {
         context.contextType == .course ? name : nil
+    }
+
+    @discardableResult
+    public static func save(
+        context: Context,
+        observedUserId: String? = nil,
+        name: String,
+        purpose: CDCalendarFilterPurpose = .unknown,
+        in moContext: NSManagedObjectContext
+    ) -> CDCalendarFilterEntry? {
+        guard context.isValid else { return nil }
+
+        let canvasContextID = context.canvasContextID
+
+        let predicate = NSPredicate(key: (\CDCalendarFilterEntry.rawContextID).string, equals: canvasContextID)
+            .and(NSPredicate(key: (\CDCalendarFilterEntry.observedUserId).string, equals: observedUserId))
+
+        let model: CDCalendarFilterEntry = moContext.fetch(predicate).first ?? moContext.insert()
+        model.rawContextID = canvasContextID
+        model.observedUserId = observedUserId
+        model.name = name
+        model.purpose = purpose
+        return model
     }
 }
 

--- a/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
@@ -107,6 +107,52 @@ public class CDCalendarFilterEntry: NSManagedObject {
         model.purpose = purpose
         return model
     }
+
+    @discardableResult
+    public static func save(
+        userId: String,
+        userName: String,
+        courses: [APICourse],
+        groups: [APIGroup],
+        observedUserId: String? = nil,
+        purpose: CDCalendarFilterPurpose = .unknown,
+        in moContext: NSManagedObjectContext
+    ) -> [CDCalendarFilterEntry] {
+        // save user filter
+        let userFilters = [
+            CDCalendarFilterEntry.save(
+                context: .user(userId),
+                observedUserId: observedUserId,
+                name: userName,
+                purpose: purpose,
+                in: moContext
+            )
+        ].compactMap { $0 }
+
+        // save course filters
+        let courseFilters = courses.compactMap { course in
+            CDCalendarFilterEntry.save(
+                context: .course(course.id.value),
+                observedUserId: observedUserId,
+                name: course.name ?? "",
+                purpose: purpose,
+                in: moContext
+            )
+        }
+
+        // save group filters
+        let groupFilters = groups.compactMap { group in
+            CDCalendarFilterEntry.save(
+                context: .group(group.id.value),
+                observedUserId: observedUserId,
+                name: group.name,
+                purpose: purpose,
+                in: moContext
+            )
+        }
+
+        return userFilters + courseFilters + groupFilters
+    }
 }
 
 extension CDCalendarFilterEntry: Comparable {

--- a/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntry.swift
@@ -49,6 +49,10 @@ public class CDCalendarFilterEntry: NSManagedObject {
         }
     }
 
+    public var wrappedContext: Context? {
+        Context(canvasContextID: rawContextID)
+    }
+
     public var purpose: CDCalendarFilterPurpose {
         get {
             CDCalendarFilterPurpose(rawValue: rawPurpose) ?? .unknown

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractor.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractor.swift
@@ -163,7 +163,8 @@ public class CalendarFilterInteractorLive: CalendarFilterInteractor {
 private extension Set where Element == Context {
 
     func removeUnavailableFilters(filters: [CDCalendarFilterEntry]) -> Set<Element> {
-        let availableContexts = filters.map { $0.context }
+        // using compactMap here to handle invalid contextIDs, which may have been cached before
+        let availableContexts = filters.compactMap { $0.wrappedContext }
         return intersection(availableContexts)
     }
 }
@@ -171,7 +172,8 @@ private extension Set where Element == Context {
 private extension Array where Element == CDCalendarFilterEntry {
 
     func defaultFilters(limit: CalendarFilterCountLimit) -> Set<Context> {
-        let contexts = sorted().map { $0.context }
+        // using compactMap here to handle invalid contextIDs, which may have been cached before
+        let contexts = sorted().compactMap { $0.wrappedContext }
         return Set(contexts.prefix(limit.rawValue))
     }
 }

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/FilterProviders/CalendarFilterEntryProviderStudent.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/FilterProviders/CalendarFilterEntryProviderStudent.swift
@@ -35,10 +35,12 @@ struct CalendarFilterEntryProviderStudent: CalendarFilterEntryProvider {
             return nil
         }
 
-        let useCase = GetCalendarFilters(currentUserName: userName,
-                                         currentUserId: userId,
-                                         states: [.current_and_concluded],
-                                         filterUnpublishedCourses: true)
+        let useCase = GetStudentCalendarFilters(
+            currentUserName: userName,
+            currentUserId: userId,
+            states: [.current_and_concluded],
+            filterUnpublishedCourses: true
+        )
         return ReactiveStore(useCase: useCase).getEntities(ignoreCache: ignoreCache)
     }
 }

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetCalendarFilters.swift
@@ -108,26 +108,31 @@ class GetCalendarFilters: UseCase {
         urlResponse: URLResponse?,
         to client: NSManagedObjectContext
     ) {
-        guard let courses = response?.courses,
-              let groups = response?.groups
-        else {
-            return
+        guard let response else { return }
+
+        // save user filter
+        CDCalendarFilterEntry.save(
+            context: .user(userId),
+            name: userName,
+            in: client
+        )
+
+        // save course filters
+        response.courses.forEach { course in
+            CDCalendarFilterEntry.save(
+                context: .course(course.id.value),
+                name: course.name ?? "",
+                in: client
+            )
         }
 
-        let filter: CDCalendarFilterEntry = client.insert()
-        filter.context = .user(userId)
-        filter.name = userName
-
-        courses.forEach { course in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .course(course.id.rawValue)
-            filter.name = course.name ?? ""
-        }
-
-        groups.forEach { group in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .group(group.id.rawValue)
-            filter.name = group.name
+        // save group filters
+        response.groups.forEach { group in
+            CDCalendarFilterEntry.save(
+                context: .group(group.id.value),
+                name: group.name,
+                in: client
+            )
         }
     }
 

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
@@ -91,29 +91,34 @@ class GetParentCalendarFilters: UseCase {
         urlResponse: URLResponse?,
         to client: NSManagedObjectContext
     ) {
-        guard let courses = response?.courses,
-              let groups = response?.groups
-        else {
-            return
+        guard let response else { return }
+
+        // save user filter
+        CDCalendarFilterEntry.save(
+            context: .user(userId),
+            observedUserId: observedUserId,
+            name: userName,
+            in: client
+        )
+
+        // save course filters
+        response.courses.forEach { course in
+            CDCalendarFilterEntry.save(
+                context: .course(course.id.value),
+                observedUserId: observedUserId,
+                name: course.name ?? "",
+                in: client
+            )
         }
 
-        let filter: CDCalendarFilterEntry = client.insert()
-        filter.context = .user(userId)
-        filter.name = userName
-        filter.observedUserId = observedUserId
-
-        courses.forEach { course in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .course(course.id.rawValue)
-            filter.name = course.name ?? ""
-            filter.observedUserId = observedUserId
-        }
-
-        groups.forEach { group in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .group(group.id.rawValue)
-            filter.name = group.name
-            filter.observedUserId = observedUserId
+        // save group filters
+        response.groups.forEach { group in
+            CDCalendarFilterEntry.save(
+                context: .group(group.id.value),
+                observedUserId: observedUserId,
+                name: group.name,
+                in: client
+            )
         }
     }
 

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetParentCalendarFilters.swift
@@ -86,40 +86,17 @@ class GetParentCalendarFilters: UseCase {
             .store(in: &subscriptions)
     }
 
-    func write(
-        response: APIResponse?,
-        urlResponse: URLResponse?,
-        to client: NSManagedObjectContext
-    ) {
+    func write(response: APIResponse?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         guard let response else { return }
 
-        // save user filter
         CDCalendarFilterEntry.save(
-            context: .user(userId),
+            userId: userId,
+            userName: userName,
+            courses: response.courses,
+            groups: response.groups,
             observedUserId: observedUserId,
-            name: userName,
             in: client
         )
-
-        // save course filters
-        response.courses.forEach { course in
-            CDCalendarFilterEntry.save(
-                context: .course(course.id.value),
-                observedUserId: observedUserId,
-                name: course.name ?? "",
-                in: client
-            )
-        }
-
-        // save group filters
-        response.groups.forEach { group in
-            CDCalendarFilterEntry.save(
-                context: .group(group.id.value),
-                observedUserId: observedUserId,
-                name: group.name,
-                in: client
-            )
-        }
     }
 
     func reset(context: NSManagedObjectContext) {

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetStudentCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetStudentCalendarFilters.swift
@@ -103,37 +103,16 @@ class GetStudentCalendarFilters: UseCase {
             .store(in: &subscriptions)
     }
 
-    func write(
-        response: APIResponse?,
-        urlResponse: URLResponse?,
-        to client: NSManagedObjectContext
-    ) {
+    func write(response: APIResponse?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         guard let response else { return }
 
-        // save user filter
         CDCalendarFilterEntry.save(
-            context: .user(userId),
-            name: userName,
+            userId: userId,
+            userName: userName,
+            courses: response.courses,
+            groups: response.groups,
             in: client
         )
-
-        // save course filters
-        response.courses.forEach { course in
-            CDCalendarFilterEntry.save(
-                context: .course(course.id.value),
-                name: course.name ?? "",
-                in: client
-            )
-        }
-
-        // save group filters
-        response.groups.forEach { group in
-            CDCalendarFilterEntry.save(
-                context: .group(group.id.value),
-                name: group.name,
-                in: client
-            )
-        }
     }
 
     func reset(context: NSManagedObjectContext) {

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetStudentCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetStudentCalendarFilters.swift
@@ -20,7 +20,7 @@ import CoreData
 import Combine
 import SwiftUI
 
-class GetCalendarFilters: UseCase {
+class GetStudentCalendarFilters: UseCase {
     struct APIResponse: Codable {
         let courses: [APICourse]
         let groups: [APIGroup]

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
@@ -103,42 +103,17 @@ class GetTeacherCalendarFilters: UseCase {
             .store(in: &subscriptions)
     }
 
-    func write(
-        response: APIResponse?,
-        urlResponse: URLResponse?,
-        to client: NSManagedObjectContext
-    ) {
+    func write(response: APIResponse?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         guard let response else { return }
 
-        let filterPurpose = purpose.filterPurpose
-
-        // save user filter
         CDCalendarFilterEntry.save(
-            context: .user(userId),
-            name: userName,
-            purpose: filterPurpose,
+            userId: userId,
+            userName: userName,
+            courses: response.courses,
+            groups: response.groups,
+            purpose: purpose.filterPurpose,
             in: client
         )
-
-        // save course filters
-        response.courses.forEach { course in
-            CDCalendarFilterEntry.save(
-                context: .course(course.id.value),
-                name: course.name ?? "",
-                purpose: filterPurpose,
-                in: client
-            )
-        }
-
-        // save group filters
-        response.groups.forEach { group in
-            CDCalendarFilterEntry.save(
-                context: .group(group.id.value),
-                name: group.name,
-                purpose: filterPurpose,
-                in: client
-            )
-        }
     }
 
     func reset(context: NSManagedObjectContext) {

--- a/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/UseCase/GetTeacherCalendarFilters.swift
@@ -108,29 +108,36 @@ class GetTeacherCalendarFilters: UseCase {
         urlResponse: URLResponse?,
         to client: NSManagedObjectContext
     ) {
-        guard let courses = response?.courses,
-              let groups = response?.groups
-        else {
-            return
+        guard let response else { return }
+
+        let filterPurpose = purpose.filterPurpose
+
+        // save user filter
+        CDCalendarFilterEntry.save(
+            context: .user(userId),
+            name: userName,
+            purpose: filterPurpose,
+            in: client
+        )
+
+        // save course filters
+        response.courses.forEach { course in
+            CDCalendarFilterEntry.save(
+                context: .course(course.id.value),
+                name: course.name ?? "",
+                purpose: filterPurpose,
+                in: client
+            )
         }
 
-        let filter: CDCalendarFilterEntry = client.insert()
-        filter.context = .user(userId)
-        filter.name = userName
-        filter.purpose = purpose.filterPurpose
-
-        courses.forEach { course in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .course(course.id.rawValue)
-            filter.name = course.name ?? ""
-            filter.purpose = purpose.filterPurpose
-        }
-
-        groups.forEach { group in
-            let filter: CDCalendarFilterEntry = client.insert()
-            filter.context = .group(group.id.rawValue)
-            filter.name = group.name
-            filter.purpose = purpose.filterPurpose
+        // save group filters
+        response.groups.forEach { group in
+            CDCalendarFilterEntry.save(
+                context: .group(group.id.value),
+                name: group.name,
+                purpose: filterPurpose,
+                in: client
+            )
         }
     }
 

--- a/Core/CoreTests/Analytics/AnalyticsTests.swift
+++ b/Core/CoreTests/Analytics/AnalyticsTests.swift
@@ -99,6 +99,7 @@ class AnalyticsTests: XCTestCase {
     }
 
     func testAnalyticsBaseUrl() {
+        AppEnvironment.shared.currentSession = nil
         XCTAssertEqual(Analytics.analyticsBaseUrl, "")
 
         AppEnvironment.shared.currentSession = .make(baseURL: URL(string: "https://canvas.instructure.com")!)

--- a/Core/CoreTests/Analytics/AnalyticsTests.swift
+++ b/Core/CoreTests/Analytics/AnalyticsTests.swift
@@ -97,4 +97,11 @@ class AnalyticsTests: XCTestCase {
         AppEnvironment.shared.app = .teacher
         XCTAssertEqual(Analytics.analyticsAppName, "teacher")
     }
+
+    func testAnalyticsBaseUrl() {
+        XCTAssertEqual(Analytics.analyticsBaseUrl, "")
+
+        AppEnvironment.shared.currentSession = .make(baseURL: URL(string: "https://canvas.instructure.com")!)
+        XCTAssertEqual(Analytics.analyticsBaseUrl, "https://canvas.instructure.com")
+    }
 }

--- a/Core/CoreTests/Contexts/ContextTests.swift
+++ b/Core/CoreTests/Contexts/ContextTests.swift
@@ -101,4 +101,21 @@ class ContextTests: XCTestCase {
         XCTAssertEqual(context.groupId, nil)
         XCTAssertEqual(context.userId, id)
     }
+
+    func testIsValid() {
+        var context = Context.course("42")
+        XCTAssertEqual(context.isValid, true)
+
+        context = Context.course("some text")
+        XCTAssertEqual(context.isValid, true)
+
+        context = Context.course("")
+        XCTAssertEqual(context.isValid, false)
+
+        context = Context.course("_")
+        XCTAssertEqual(context.isValid, true)
+
+        context = Context.course(" ")
+        XCTAssertEqual(context.isValid, true)
+    }
 }

--- a/Core/CoreTests/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntryTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntryTests.swift
@@ -84,4 +84,41 @@ class CDCalendarFilterEntryTests: CoreTestCase {
         testee.context = .group("1")
         XCTAssertEqual(testee.courseName, nil)
     }
+
+    func testSaveWhenContextIsValid() {
+        let result = CDCalendarFilterEntry.save(
+            context: .group("42"),
+            observedUserId: "7",
+            name: "some name",
+            purpose: .viewing,
+            in: databaseClient
+        )
+        XCTAssertNoThrow(try databaseClient.save())
+
+        let fetched: CDCalendarFilterEntry? = databaseClient.fetch().first
+
+        XCTAssertEqual(result?.rawContextID, "group_42")
+        XCTAssertEqual(result?.observedUserId, "7")
+        XCTAssertEqual(result?.name, "some name")
+        XCTAssertEqual(result?.rawPurpose, CDCalendarFilterPurpose.viewing.rawValue)
+
+        XCTAssertEqual(fetched?.context, result?.context)
+        XCTAssertEqual(fetched?.observedUserId, result?.observedUserId)
+        XCTAssertEqual(fetched?.name, result?.name)
+        XCTAssertEqual(fetched?.purpose, result?.purpose)
+    }
+
+    func testSaveWhenContextIsNotValid() {
+        let result = CDCalendarFilterEntry.save(
+            context: .group(""),
+            name: "name",
+            in: databaseClient
+        )
+        XCTAssertNoThrow(try databaseClient.save())
+
+        let fetched: CDCalendarFilterEntry? = databaseClient.fetch().first
+
+        XCTAssertEqual(result, nil)
+        XCTAssertEqual(fetched, nil)
+    }
 }

--- a/Core/CoreTests/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntryTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/CoreData/CDCalendarFilterEntryTests.swift
@@ -26,10 +26,13 @@ class CDCalendarFilterEntryTests: CoreTestCase {
         let testee: CDCalendarFilterEntry = databaseClient.insert()
         let testContext = Context(.group, id: "g1")
 
+        XCTAssertEqual(testee.wrappedContext, nil)
+
         testee.context = testContext
 
         XCTAssertEqual(testee.rawContextID, testContext.canvasContextID)
         XCTAssertEqual(testee.context, testContext)
+        XCTAssertEqual(testee.wrappedContext, testContext)
     }
 
     func testSort() {

--- a/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetStudentCalendarFiltersTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/UseCase/GetStudentCalendarFiltersTests.swift
@@ -19,7 +19,7 @@
 @testable import Core
 import XCTest
 
-class GetCalendarFiltersTests: CoreTestCase {
+class GetStudentCalendarFiltersTests: CoreTestCase {
 
     /// If a course's end date has passed and "Restrict students from viewing course after course end date"
     /// is checked then fetching events for a group in this course will give 403 unauthorized.
@@ -40,10 +40,12 @@ class GetCalendarFiltersTests: CoreTestCase {
             ]
         )
 
-        let testee = GetCalendarFilters(currentUserName: "",
-                                        currentUserId: "",
-                                        states: [],
-                                        filterUnpublishedCourses: true)
+        let testee = GetStudentCalendarFilters(
+            currentUserName: "",
+            currentUserId: "",
+            states: [],
+            filterUnpublishedCourses: true
+        )
         let requestCompleted = expectation(description: "requestCompleted")
 
         testee.makeRequest(environment: environment) { response, _, _ in


### PR DESCRIPTION
refs: [MBL-17976](https://instructure.atlassian.net/browse/MBL-17976)
affects: Student, Teacher, Parent
release note: none

Because it was not reproducible, this is a best effort attempt to fix the crash during CalendarFilter load.

## Problem
`CDCalendarFilterEntry` is sometimes stored without a valid contextID, which results in a crash while force unwrapping `CDCalendarFilterEntry.context`. We assume that this may be a result of some old ID format which we are not aware of, but still used in some accounts.
- Removing the force unwrap would have required extensive changes and complications.
- Providing a default value is also difficult, because there is no meaningful fallback context here.
- Silently ignoring the filters with invalid (which means empty) contextIDs seemed to be the lesser evil here, especially that a PTR should fix any missing calendars.

## What's changed
- CalendarFilters with invalid contextIDs already stored in CoreData are not displayed
- CalendarFilters with invalid contextIDs coming from backend are not saved to CoreData
- invalid contextIDs during `save` are logged as errors: `"CDCalendarFilterEntry save failed with invalid contextId"`
- invalid contextIDs during `Context` init are logged as errors: `"Context created with invalid contextId"`
- failed `ID` inits (failing to decode as `Int` or `String`) are logged as errors: `"Empty ID decoded from unhandled data"`

## Test Plan
Smoke test Calendar Filters in all 3 apps.

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-17976]: https://instructure.atlassian.net/browse/MBL-17976?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ