### PR TITLE
Remove unnecessary color contrast calculation

### DIFF
--- a/Core/Core/SwiftUIViews/ButtonStyles/ContextButton.swift
+++ b/Core/Core/SwiftUIViews/ButtonStyles/ContextButton.swift
@@ -31,7 +31,7 @@ public struct ContextButton: ButtonStyle {
         - isHighlighted: If this parameter is true, then the button will show its highlighted state even if it isn't pressed down. Useful to indicate selected state.
      */
     public init(contextColor: UIColor?, isHighlighted: Bool = false) {
-        self.contextColor = contextColor?.ensureContrast(against: .backgroundLightest) ?? selectionBackgroundColor
+        self.contextColor = contextColor ?? selectionBackgroundColor
         self.forceHighlight = isHighlighted
     }
 


### PR DESCRIPTION
I noticed that there are significant lags and fps drops on screens using the ContextButton button style. This was because this style re-calculated the color to get it to the minimum contrast ratio but in fact colors reaching the UI should already have enough contrast ratio after the color palette update that we delivered recently.

affects: Student, Teacher, Parent

[ignore-commit-lint]

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

https://github.com/user-attachments/assets/3df4621c-ce83-43b0-8e66-9453c455691d

</td>
<td>

https://github.com/user-attachments/assets/dbe9e510-a701-4990-a7b7-ba7e24cda95f

</td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
