### PR TITLE
Show media from media comment in the Inbox

### DIFF
--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -473,7 +473,11 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                         }
                     }
                     if isExpanded && (!message.attachments.isEmpty || message.mediaComment != nil) {
-                        AttachmentsView(attachments: message.attachments, mediaComment: message.mediaComment, didSelectAttachment: { model.didSelectFile.accept(($1, $0))})
+                        AttachmentsView(attachments: message.attachments,
+                                        mediaComment: message.mediaComment,
+                                        didSelectAttachment: {
+                            model.didSelectFile.accept(($1, $0))
+                        })
                             .padding(.top, defaultVerticalPaddingValue)
                     }
                 }

--- a/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -472,8 +472,8 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                                 .lineLimit(isExpanded ? nil : 1)
                         }
                     }
-                    if isExpanded && !message.attachments.isEmpty {
-                        AttachmentsView(attachments: message.attachments, didSelectAttachment: { model.didSelectFile.accept(($1, $0))})
+                    if isExpanded && (!message.attachments.isEmpty || message.mediaComment != nil) {
+                        AttachmentsView(attachments: message.attachments, mediaComment: message.mediaComment, didSelectAttachment: { model.didSelectFile.accept(($1, $0))})
                             .padding(.top, defaultVerticalPaddingValue)
                     }
                 }
@@ -485,7 +485,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
     private var attachmentsView: some View {
         ConversationAttachmentsCardView(files: model.attachments) { file in
-            model.didSelectFile.accept((controller, file))
+            model.didSelectFile.accept((controller, file.url))
         } removeHandler: { file in
             model.didRemoveFile.accept(file)
         }

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -481,8 +481,11 @@ final class ComposeMessageViewModel: ObservableObject {
             .store(in: &subscriptions)
         didSelectFile.sink(receiveCompletion: { _ in }, receiveValue: { (controller, url) in
             guard let url else { return }
-            router.route(to: url.appendingQueryItems(.init(name: "canEdit", value: "false")), from: controller, options: .modal(isDismissable: true, embedInNav: true, addDoneButton: true))
-
+            router.route(
+                to: url.appendingQueryItems(.init(name: "canEdit", value: "false")),
+                from: controller,
+                options: .modal(isDismissable: true, embedInNav: true, addDoneButton: true)
+            )
         })
         .store(in: &subscriptions)
 

--- a/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -55,7 +55,7 @@ final class ComposeMessageViewModel: ObservableObject {
     public let didSelectRecipient = PassthroughRelay<Recipient>()
     public let didRemoveRecipient = PassthroughRelay<Recipient>()
     public var selectedRecipients = CurrentValueSubject<[Recipient], Never>([])
-    public var didSelectFile = PassthroughRelay<(WeakViewController, File)>()
+    public var didSelectFile = PassthroughRelay<(WeakViewController, URL?)>()
     public let didRemoveFile = PassthroughRelay<File>()
 
     // MARK: - Inputs / Outputs
@@ -479,11 +479,10 @@ final class ComposeMessageViewModel: ObservableObject {
                 }
             })
             .store(in: &subscriptions)
+        didSelectFile.sink(receiveCompletion: { _ in }, receiveValue: { (controller, url) in
+            guard let url else { return }
+            router.route(to: url.appendingQueryItems(.init(name: "canEdit", value: "false")), from: controller, options: .modal(isDismissable: true, embedInNav: true, addDoneButton: true))
 
-        didSelectFile.sink(receiveCompletion: { _ in }, receiveValue: { (controller, file) in
-            guard let url = file.url, let fileController = router.match(url.appendingQueryItems(.init(name: "canEdit", value: "false"))) else { return }
-
-            router.show(fileController, from: controller, options: .modal(isDismissable: true, embedInNav: true, addDoneButton: true))
         })
         .store(in: &subscriptions)
 

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -117,7 +117,11 @@ public struct MessageView: View {
             .accessibilityIdentifier("MessageDetails.body")
 
             if model.showAttachments {
-                AttachmentsView(attachments: model.attachments, didSelectAttachment: model.handleFileNavigation)
+                AttachmentsView(
+                    attachments: model.attachments,
+                    mediaComment: model.mediaComment,
+                    didSelectAttachment: model.handleFileNavigation
+                )
             }
         }
         .onAppear {

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageViewModel.swift
@@ -68,7 +68,7 @@ public class MessageViewModel: Identifiable {
                 .init(name: "canEdit", value: "false")
             ),
             from: controller,
-            options: .modal(embedInNav: true,addDoneButton: true)
+            options: .modal(embedInNav: true, addDoneButton: true)
         )
     }
 }

--- a/Core/Core/Inbox/MessageDetails/ViewModel/MessageViewModel.swift
+++ b/Core/Core/Inbox/MessageDetails/ViewModel/MessageViewModel.swift
@@ -61,10 +61,15 @@ public class MessageViewModel: Identifiable {
         return .handled
     }
 
-    public func handleFileNavigation(file: File, controller: WeakViewController) {
-        guard let url = file.url else { return }
-
-        router.route(to: url.appendingQueryItems(.init(name: "canEdit", value: "false")), from: controller, options: .modal(embedInNav: true, addDoneButton: true))
+    public func handleFileNavigation(url: URL?, controller: WeakViewController) {
+        guard let url else { return }
+        router.route(
+            to: url.appendingQueryItems(
+                .init(name: "canEdit", value: "false")
+            ),
+            from: controller,
+            options: .modal(embedInNav: true,addDoneButton: true)
+        )
     }
 }
 

--- a/Core/Core/Inbox/Model/Entities/InboxMessageListItem.swift
+++ b/Core/Core/Inbox/Model/Entities/InboxMessageListItem.swift
@@ -104,7 +104,9 @@ public final class InboxMessageListItem: NSManagedObject {
         dbEntity.isSent = isSent
         dbEntity.contextFilter = contextFilter?.canvasContextID
         dbEntity.scopeFilter = scopeFilter.rawValue
-        dbEntity.hasAttachment = apiEntity.properties?.contains(.attachments) ?? false
+        let hasAttachment = apiEntity.properties?.contains(.attachments) ?? false
+        let hasMediaObjects = apiEntity.properties?.contains(.media_objects) ?? false
+        dbEntity.hasAttachment = (hasAttachment || hasMediaObjects)
 
         if case .individual(let name, let profileImageURL) = avatar {
             dbEntity.avatarNameRaw = name

--- a/Core/Core/Inbox/Model/Entities/InboxMessageListItem.swift
+++ b/Core/Core/Inbox/Model/Entities/InboxMessageListItem.swift
@@ -105,8 +105,8 @@ public final class InboxMessageListItem: NSManagedObject {
         dbEntity.contextFilter = contextFilter?.canvasContextID
         dbEntity.scopeFilter = scopeFilter.rawValue
         let hasAttachment = apiEntity.properties?.contains(.attachments) ?? false
-        let hasMediaObjects = apiEntity.properties?.contains(.media_objects) ?? false
-        dbEntity.hasAttachment = (hasAttachment || hasMediaObjects)
+        let hasMediaObject = apiEntity.properties?.contains(.media_objects) ?? false
+        dbEntity.hasAttachment = (hasAttachment || hasMediaObject)
 
         if case .individual(let name, let profileImageURL) = avatar {
             dbEntity.avatarNameRaw = name

--- a/Core/Core/Inbox/View/AttachmentsView.swift
+++ b/Core/Core/Inbox/View/AttachmentsView.swift
@@ -20,12 +20,18 @@ import SwiftUI
 
 public struct AttachmentsView: View {
     private let attachments: [File]
-    private let didSelectAttachment: ((File, WeakViewController) -> Void)?
+    private let mediaComment: MediaComment?
+    private let didSelectAttachment: ((URL?, WeakViewController) -> Void)?
     @State private var isAttachmentDeleted = false
     @Environment(\.viewController) private var controller
 
-    public init(attachments: [File], didSelectAttachment: ((File, WeakViewController) -> Void)? = nil) {
+    public init(
+        attachments: [File],
+        mediaComment: MediaComment?,
+        didSelectAttachment: ((URL?, WeakViewController) -> Void)? = nil
+    ) {
         self.attachments = attachments
+        self.mediaComment = mediaComment
         self.didSelectAttachment = didSelectAttachment
     }
 
@@ -35,13 +41,16 @@ public struct AttachmentsView: View {
                 ForEach(attachments, id: \.self) { file in
                     attachmentView(for: file)
                 }
+                if let mediaComment {
+                    mediaCommentView(media: mediaComment)
+                }
             }
         }
     }
 
     private func attachmentView(for file: File) -> some View {
         Button {
-            didSelectAttachment?(file, controller)
+            didSelectAttachment?(file.url, controller)
         } label: {
             VStack(spacing: 0) {
                 if let thumbnailURL = file.thumbnailURL, !isAttachmentDeleted {
@@ -81,6 +90,28 @@ public struct AttachmentsView: View {
                 .foregroundStyle(Color.textDark)
         }
     }
+
+   private func mediaCommentView(media: MediaComment) -> some View {
+        Button {
+            didSelectAttachment?(media.url, controller)
+        } label: {
+            VStack(spacing: 0) {
+                Image(uiImage: media.mediaType == .video ? .videoLine : .audioLine)
+                    .padding(.bottom, 8)
+                Text(media.displayName ?? "")
+                    .font(.regular14)
+                    .truncationMode(.middle)
+                    .lineLimit(2)
+                    .foregroundStyle(Color.textDark)
+            }
+            .padding(.all, 8)
+            .frame(width: 104, height: 104)
+            .background(Color.backgroundLight)
+            .border(Color.backgroundLight)
+            .accessibilityLabel(Text(media.displayName ?? ""))
+        }
+        .cornerRadius(5)
+    }
 }
 
 private struct ViewHeightKey: PreferenceKey {
@@ -97,7 +128,7 @@ private struct ViewHeightKey: PreferenceKey {
 
 struct AttachmentsView_Previews: PreviewProvider {
     static var previews: some View {
-        AttachmentsView(attachments: [])
+        AttachmentsView(attachments: [], mediaComment: nil)
     }
 }
 

--- a/Core/Core/Inbox/View/AttachmentsView.swift
+++ b/Core/Core/Inbox/View/AttachmentsView.swift
@@ -128,7 +128,10 @@ private struct ViewHeightKey: PreferenceKey {
 
 struct AttachmentsView_Previews: PreviewProvider {
     static var previews: some View {
-        AttachmentsView(attachments: [], mediaComment: nil)
+        AttachmentsView(
+            attachments: [],
+            mediaComment: nil
+        )
     }
 }
 


### PR DESCRIPTION
refs: [MBL-17959](https://instructure.atlassian.net/browse/MBL-17959)
affects: Teacher, Student
release note: Show media from media comment in the Inbox

### Test plan:
 - Open your account as a teacher or student from the web.
 - Go through your inbox.
 - Try to add a media comment, such as a video or audio.
 - Open the iOS app and go through your inbox to access the media.
 
### Please Note
 - I've tried to play the media inside the app, but i've seen the url got from  "mediaComment" is totally different and can't get the file id. 
 - In my opinion, we should create a new ticket to develop a new media player that can handle this URL, instead of applying a workaround to the current player, which is already very large.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/c4d402e2-2a42-46ab-9a9b-bb27a958e9c4"maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f7fdedfa-6a69-46ac-a259-2026c1ef827d" maxHeight=500></td>
</tr>


<tr>
<td><img src="https://github.com/user-attachments/assets/09833b5f-4ac8-4025-9ead-8ae5e9c5c3dc" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ad3f1a79-41ad-4345-aff6-2060f5c8d8f3" maxHeight=500></td>
</tr>


<tr>
<td><img src="https://github.com/user-attachments/assets/9691045c-7678-43f0-8afd-4d7801cfe3f1" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/cb87d21f-1085-4cd0-8e80-bc1b89d4440b" maxHeight=500></td>
</tr>


</table>

https://github.com/user-attachments/assets/a4dc82cc-2f3f-4e53-ad18-7d405490d696


## Checklist
- [ ] Tested on phone
- [ ] Tested in light mode




[MBL-17959]: https://instructure.atlassian.net/browse/MBL-17959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ