### PR TITLE
No file verifiers

### DIFF
--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -290,6 +290,7 @@ extension APIRequestable {
         }()
 
         if shouldAddNoVerifierQuery {
+            /// This will make the API to omit the file verifier parameter when linking course files.
             extraQueryItems.append(URLQueryItem(name: "no_verifiers", value: "1"))
         }
 

--- a/Core/Core/API/APIRequestable.swift
+++ b/Core/Core/API/APIRequestable.swift
@@ -219,13 +219,14 @@ extension APIRequestable {
                 return []
             }
         }()
+        let noFileVerifierQueryItem = [URLQueryItem(name: "no_verifiers", value: "1")]
 
         if useExtendedPercentEncoding, !percentEncodedQueryItems.isEmpty {
-            components.percentEncodedQueryItems = percentEncodedQueryItems + actAsUserQueryItem
+            components.percentEncodedQueryItems = percentEncodedQueryItems + actAsUserQueryItem + noFileVerifierQueryItem
         } else if !queryItems.isEmpty {
-            components.queryItems = (components.queryItems ?? []) + self.queryItems + actAsUserQueryItem
+            components.queryItems = (components.queryItems ?? []) + self.queryItems + actAsUserQueryItem + noFileVerifierQueryItem
         } else if !actAsUserQueryItem.isEmpty {
-            components.queryItems = (components.queryItems ?? []) + actAsUserQueryItem
+            components.queryItems = (components.queryItems ?? []) + actAsUserQueryItem + noFileVerifierQueryItem
         }
 
         // The conditional path prefixing *should* have made this impossible to fail

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -178,22 +178,22 @@ class APIRequestableTests: XCTestCase {
     }
 
     func testUrlRequestQuery() {
-        let expected = expectedUrlRequest(path: "api/v1/?query")
+        let expected = expectedUrlRequest(path: "api/v1/?query&no_verifiers=1")
         XCTAssertEqual(try GetQueryItems().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil), expected)
     }
 
     func testActAsUserIDWithRegularQueryItems() {
-        let expected = expectedUrlRequest(path: "api/v1/?query&as_user_id=78")
+        let expected = expectedUrlRequest(path: "api/v1/?query&as_user_id=78&no_verifiers=1")
         XCTAssertEqual(try GetQueryItems().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: "78"), expected)
     }
 
     func testActAsUserIDWithEmptyQueryItems() {
-        let expected = expectedUrlRequest(path: "api/v1/data?as_user_id=78")
+        let expected = expectedUrlRequest(path: "api/v1/data?as_user_id=78&no_verifiers=1")
         XCTAssertEqual(try GetEmptyQueryItems().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: "78"), expected)
     }
 
     func testActAsUserIDWithPercentEncodedQueryItems() {
-        let expected = expectedUrlRequest(path: "api/v1/calendar?startDate=2024-01-01T10%3A39%3A00.000%2B00%3A00&as_user_id=78")
+        let expected = expectedUrlRequest(path: "api/v1/calendar?startDate=2024-01-01T10%3A39%3A00.000%2B00%3A00&as_user_id=78&no_verifiers=1")
         XCTAssertEqual(try GetPercentEncodedQueryItems().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: "78"), expected)
     }
 

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -214,6 +214,15 @@ class APIRequestableTests: XCTestCase {
         XCTAssertEqual(try PostBody().urlRequest(relativeTo: baseURL, accessToken: nil, actAsUserID: nil), expected)
     }
 
+    func testUrlRequestIgnoresNoVerifierParameterForExcludedRequest() throws {
+        let noVerifierRequest = LoginWebRequest(authMethod: .siteAdminLogin, clientID: "", provider: "")
+
+        let request = try noVerifierRequest.urlRequest(relativeTo: baseURL, accessToken: "token", actAsUserID: "123")
+
+        XCTAssertEqual(request.url?.query(percentEncoded: true)?.contains("as_user_id=123"), true)
+        XCTAssertEqual(request.url?.query(percentEncoded: true)?.contains("no_verifier"), false)
+    }
+
     func testGetNext() {
         let prev = "https://cgnuonline-eniversity.edu/api/v1/date"
         let curr = "https://cgnuonline-eniversity.edu/api/v1/date?page=2"

--- a/Core/CoreTests/API/APIRequestableTests.swift
+++ b/Core/CoreTests/API/APIRequestableTests.swift
@@ -169,7 +169,7 @@ class APIRequestableTests: XCTestCase {
     }
 
     func testUrlRequestPath() {
-        let expected = expectedUrlRequest(path: "api/v1/date")
+        let expected = expectedUrlRequest(path: "api/v1/date?no_verifiers=1")
         XCTAssertEqual(try GetDate().urlRequest(relativeTo: baseURL, accessToken: accessToken, actAsUserID: nil), expected)
     }
 
@@ -198,7 +198,7 @@ class APIRequestableTests: XCTestCase {
     }
 
     func testUrlRequest() {
-        var expected = expectedUrlRequest(path: "api/v1/post")
+        var expected = expectedUrlRequest(path: "api/v1/post?no_verifiers=1")
         expected.httpMethod = "POST"
         expected.setValue("application/json", forHTTPHeaderField: "Content-Type")
         expected.httpBody = "{\"date\":\"1970-01-01T00:00:00Z\"}".data(using: .utf8)
@@ -206,7 +206,7 @@ class APIRequestableTests: XCTestCase {
     }
 
     func testUrlRequestNoToken() {
-        var expected = expectedUrlRequest(path: "api/v1/post")
+        var expected = expectedUrlRequest(path: "api/v1/post?no_verifiers=1")
         expected.httpMethod = "POST"
         expected.setValue("application/json", forHTTPHeaderField: "Content-Type")
         expected.setValue(nil, forHTTPHeaderField: HttpHeader.authorization)


### PR DESCRIPTION
refs: [MBL-17864](https://github.com/instructure/canvas-ios/commit/8bf7f27f92cf2f84961d926dd1feac32310f81d7)
affects: Student, Teacher, Parent
release note: none

test plan:
- Log in to the beta environment.
- Link and embed course files to where rich content is enabled using a web browser. (Assignment, quiz, discussion, announcement, page, syllabus, calendar event)
- Check the linked files if they are still working from the apps.

## Checklist

- [ ] Follow-up e2e test ticket created