### PR TITLE
Calendar event custom frequency prefill

### DIFF
--- a/Core/Core/Extensions/DateExtensions.swift
+++ b/Core/Core/Extensions/DateExtensions.swift
@@ -20,7 +20,7 @@ import Foundation
 
 public extension Date {
     func isoString() -> String {
-        return ISO8601DateFormatter.string(from: self, timeZone: TimeZone(abbreviation: "UTC")!, formatOptions: .withInternetDateTime)
+        ISO8601DateFormatter.string(from: self, timeZone: TimeZone(abbreviation: "UTC")!, formatOptions: .withInternetDateTime)
     }
 
     init?(fromISOString: String, formatOptions: ISO8601DateFormatter.Options? = nil) {
@@ -34,53 +34,74 @@ public extension Date {
 
     // MARK: - Components
 
+    var months: Int {
+        Cal.currentCalendar.component(.month, from: self)
+    }
+
+    var daysOfMonth: Int {
+        Cal.currentCalendar.component(.day, from: self)
+    }
+
     var hours: Int {
-        return Cal.currentCalendar.component(.hour, from: self)
+        Cal.currentCalendar.component(.hour, from: self)
     }
 
     var minutes: Int {
-        return Cal.currentCalendar.component(.minute, from: self)
+        Cal.currentCalendar.component(.minute, from: self)
     }
 
     // MARK: - add methods
 
     func addYears(_ years: Int) -> Date {
-        return Calendar.current.date(byAdding: .year, value: years, to: self) ?? self
+        Cal.currentCalendar.date(byAdding: .year, value: years, to: self)
+            ?? self
     }
 
     func addMonths(_ numberOfMonths: Int) -> Date {
-        let endDate = Calendar.current.date(byAdding: .month, value: numberOfMonths, to: self)
-        return endDate ?? Date()
+        Cal.currentCalendar.date(byAdding: .month, value: numberOfMonths, to: self)
+            ?? Date()
     }
 
     func addDays(_ days: Int) -> Date {
-        let endDate = Calendar.current.date(byAdding: .day, value: days, to: self)
-        return endDate ?? Date()
+        Cal.currentCalendar.date(byAdding: .day, value: days, to: self)
+            ?? Date()
     }
 
     func addHours(_ hours: Int) -> Date {
-        let endDate = Cal.currentCalendar.date(byAdding: .hour, value: hours, to: self)
-        return endDate ?? Date()
+        Cal.currentCalendar.date(byAdding: .hour, value: hours, to: self)
+            ?? Date()
     }
 
     func addMinutes(_ minutes: Int) -> Date {
-        let endDate = Calendar.current.date(byAdding: .minute, value: minutes, to: self)
-        return endDate ?? Date()
+        Cal.currentCalendar.date(byAdding: .minute, value: minutes, to: self)
+            ?? Date()
     }
 
     func addSeconds(_ seconds: Int) -> Date {
-        Cal.currentCalendar.date(byAdding: .second, value: seconds, to: self) ?? Date()
+        Cal.currentCalendar.date(byAdding: .second, value: seconds, to: self)
+            ?? Date()
     }
 
     // MARK: - start/end methods
 
+    func startOfMonth() -> Date {
+        Cal.currentCalendar.date(from: Cal.currentCalendar.dateComponents([.year, .month], from: startOfDay()))
+            ?? Date()
+    }
+
+    func endOfMonth() -> Date {
+        Cal.currentCalendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth())
+            ?? Date()
+    }
+
     func startOfWeek() -> Date {
-        return Cal.currentCalendar.date(from: Cal.currentCalendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self)) ?? Date()
+        Cal.currentCalendar.date(from: Cal.currentCalendar.dateComponents([.yearForWeekOfYear, .weekOfYear], from: self))
+            ?? Date()
     }
 
     func endOfWeek() -> Date {
-        let start = startOfWeek()
-        return Cal.currentCalendar.date(byAdding: .weekOfYear, value: 1, to: start) ?? Date()
+        Cal.currentCalendar.date(byAdding: .weekOfYear, value: 1, to: startOfWeek())
+            ?? Date()
     }
 
     func startOfDay() -> Date {
@@ -88,19 +109,12 @@ public extension Date {
     }
 
     func endOfDay() -> Date {
-        Cal.currentCalendar.date(bySettingHour: 23, minute: 59, second: 59, of: startOfDay()) ?? Date()
-    }
-
-    func startOfMonth() -> Date {
-        return Cal.currentCalendar.date(from: Cal.currentCalendar.dateComponents([.year, .month], from: startOfDay())) ?? Date()
-    }
-
-    func endOfMonth() -> Date {
-        return Cal.currentCalendar.date(byAdding: DateComponents(month: 1, day: -1), to: startOfMonth()) ?? Date()
+        Cal.currentCalendar.date(bySettingHour: 23, minute: 59, second: 59, of: startOfDay())
+            ?? Date()
     }
 
     func startOfHour() -> Date {
-        return startOfDay().addHours(hours)
+        startOfDay().addHours(hours)
     }
 
     // MARK: - Formatters
@@ -209,7 +223,7 @@ public extension Date {
     }
 
     func formatted(format: String, locale: Locale = .current, calendar: Calendar = Cal.currentCalendar) -> String {
-        return Date
+        Date
             .formatter(withFormat: format, locale: locale, calendar: calendar)
             .string(from: self)
     }
@@ -237,7 +251,7 @@ public extension Date {
     }
 
     func intervalStringTo(_ to: Date) -> String {
-        return Date.intervalDateTimeFormatter.string(from: self, to: to)
+        Date.intervalDateTimeFormatter.string(from: self, to: to)
     }
 
     /**

--- a/Core/Core/Planner/CalendarEvent/Model/API/DeleteCalendarEventRequest.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/API/DeleteCalendarEventRequest.swift
@@ -26,7 +26,7 @@ struct DeleteCalendarEventRequest: APIRequestable {
         let which: APICalendarEventSeriesModificationType?
     }
 
-    let method: APIMethod = .delete
+    var method: APIMethod { .delete }
     var path: String { "calendar_events/\(id)" }
 
     let id: String

--- a/Core/Core/Planner/CalendarEvent/Model/API/PostCalendarEventRequest.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/API/PostCalendarEventRequest.swift
@@ -22,8 +22,8 @@ import Foundation
 struct PostCalendarEventRequest: APIRequestable {
     typealias Response = APICalendarEvent
 
-    let method: APIMethod = .post
-    let path: String = "calendar_events"
+    var method: APIMethod { .post }
+    var path: String { "calendar_events" }
 
     let body: APICalendarEventRequestBody?
 }

--- a/Core/Core/Planner/CalendarEvent/Model/API/PutCalendarEventRequest.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/API/PutCalendarEventRequest.swift
@@ -22,7 +22,7 @@ import Foundation
 struct PutCalendarEventRequest: APIRequestable {
     typealias Response = [APICalendarEvent]
 
-    let method: APIMethod = .put
+    var method: APIMethod { .put }
     var path: String { "calendar_events/\(id)" }
 
     let id: String

--- a/Core/Core/Planner/CalendarEvent/Model/Helpers/FrequencyPreset.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/Helpers/FrequencyPreset.swift
@@ -27,7 +27,7 @@ enum FrequencyPreset: Equatable {
     case yearlyOnThatMonth
     case everyWeekday
 
-    case selected(title: String?, rule: RecurrenceRule)
+    case selected(title: String, rule: RecurrenceRule)
     case custom(RecurrenceRule)
 
     static let calculativePresets: [FrequencyPreset] = [
@@ -112,7 +112,9 @@ extension CalendarEvent {
            let calculativePreset = FrequencyPreset.calculativePreset(matching: recurrenceRule, with: date) {
             return calculativePreset
         } else {
-            return .selected(title: seriesInNaturalLanguage, rule: recurrenceRule)
+            // A `CalendarEvent` with a `recurrenceRule` should always contain a related title. The default value should never be needed.
+            let title = seriesInNaturalLanguage ?? recurrenceRule.text
+            return .selected(title: title, rule: recurrenceRule)
         }
     }
 }

--- a/Core/Core/Planner/CalendarEvent/Model/Helpers/RecurrenceRule.swift
+++ b/Core/Core/Planner/CalendarEvent/Model/Helpers/RecurrenceRule.swift
@@ -452,6 +452,19 @@ extension RecurrenceRule: Codable {
 
 // MARK: - Helpers
 
+extension Date {
+
+    var weekday: Weekday {
+        let comp = Cal.currentCalendar.component(.weekday, from: self)
+        return Weekday(component: comp) ?? .sunday
+    }
+
+    var monthWeekday: RecurrenceRule.DayOfWeek {
+        let weekdayOrdinal = Cal.currentCalendar.component(.weekdayOrdinal, from: self)
+        return RecurrenceRule.DayOfWeek(weekday, weekNumber: weekdayOrdinal)
+    }
+}
+
 private extension String {
 
     var asRRuleSubRules: [String: String] {

--- a/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
@@ -33,21 +33,19 @@ struct SelectEventFrequencyScreen: View, ScreenViewTrackable {
     var body: some View {
         InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { geometry in
             VStack(alignment: .leading, spacing: 0) {
-                ForEach(viewModel.frequencyChoices) { choice in
-                    ChoiceButton(
-                        title: choice.title,
-                        selected: viewModel.selection == choice.preset) {
-                            viewModel.selection = choice.preset
+                ForEach(viewModel.presetViewModels) { presetVM in
+                    FrequencyPresetCell(
+                        title: presetVM.title,
+                        isSelected: viewModel.selectedPreset == presetVM.preset) {
+                            viewModel.selectedPreset = presetVM.preset
                         }
-                    InstUI.Divider()
                 }
 
-                ChoiceButton(
+                FrequencyPresetCell(
                     title: String(localized: "Custom", bundle: .core),
-                    selected: viewModel.selection.isCustom) {
+                    isSelected: viewModel.selectedPreset.isCustom) {
                         viewModel.didSelectCustomFrequency.send(viewController)
                     }
-                InstUI.Divider()
 
                 Spacer()
             }
@@ -60,32 +58,37 @@ struct SelectEventFrequencyScreen: View, ScreenViewTrackable {
     }
 }
 
-struct ChoiceButton: View {
+private struct FrequencyPresetCell: View {
     let title: String
-    let selected: Bool
+    let isSelected: Bool
     let action: () -> Void
 
     var body: some View {
-        Button(
-            action: action,
-            label: {
-                HStack {
-                    Text(title)
-                        .font(.regular14, lineHeight: .fit)
-                        .foregroundStyle(Color.textDarkest)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                    Spacer()
-                    InstUI.Icons.Checkmark()
-                        .foregroundStyle(Color.textDarkest)
-                        .layoutPriority(1)
-                        .opacity(selected ? 1 : 0)
+        VStack(spacing: 0) {
+            Button(
+                action: action,
+                label: {
+                    HStack {
+                        Text(title)
+                            .font(.regular14, lineHeight: .fit)
+                            .foregroundStyle(Color.textDarkest)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Spacer()
+                        InstUI.Icons.Checkmark()
+                            .foregroundStyle(Color.textDarkest)
+                            .layoutPriority(1)
+                            .opacity(isSelected ? 1 : 0)
+                    }
+                    .paddingStyle(set: .standardCell)
+                    .contentShape(Rectangle())
                 }
-                .paddingStyle(set: .standardCell)
-                .contentShape(Rectangle())
-            })
-        .buttonStyle(.plain)
-        .contentShape(Rectangle())
-        .accessibilityAddTraits(selected ? .isSelected : [])
+            )
+            .buttonStyle(.plain)
+            .contentShape(Rectangle())
+            .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+            InstUI.Divider()
+        }
     }
 }
 

--- a/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
@@ -31,12 +31,12 @@ struct SelectEventFrequencyScreen: View, ScreenViewTrackable {
     }
 
     var body: some View {
-        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { geometry in
+        InstUI.BaseScreen(state: .data, config: viewModel.screenConfig) { geometry in
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(viewModel.presetViewModels) { presetVM in
                     FrequencyPresetCell(
                         title: presetVM.title,
-                        isSelected: viewModel.selectedPreset == presetVM.preset,
+                        isSelected: viewModel.isSelected(presetVM.preset),
                         action: {
                             viewModel.didTapPreset.send((presetVM.preset, viewController))
                         }
@@ -93,8 +93,8 @@ private struct FrequencyPresetCell: View {
     SelectEventFrequencyScreen(
         viewModel: SelectEventFrequencyViewModel(
             eventDate: Date(),
-            selectedFrequency: nil,
-            originalPreset: nil,
+            initiallySelectedPreset: nil,
+            eventsOriginalPreset: .noRepeat,
             router: AppEnvironment.shared.router,
             completion: { _ in }
         )

--- a/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
@@ -18,15 +18,15 @@
 
 import SwiftUI
 
-struct EditEventFrequencyScreen: View, ScreenViewTrackable {
+struct SelectEventFrequencyScreen: View, ScreenViewTrackable {
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
     @Environment(\.viewController) private var viewController
 
-    @ObservedObject private var viewModel: EditEventFrequencyViewModel
+    @ObservedObject private var viewModel: SelectEventFrequencyViewModel
 
     var screenViewTrackingParameters: ScreenViewTrackingParameters { viewModel.pageViewEvent }
 
-    init(viewModel: EditEventFrequencyViewModel) {
+    init(viewModel: SelectEventFrequencyViewModel) {
         self.viewModel = viewModel
     }
 
@@ -92,8 +92,8 @@ struct ChoiceButton: View {
 #if DEBUG
 
 #Preview {
-    EditEventFrequencyScreen(
-        viewModel: EditEventFrequencyViewModel(
+    SelectEventFrequencyScreen(
+        viewModel: SelectEventFrequencyViewModel(
             eventDate: Date(),
             selectedFrequency: nil,
             originalPreset: nil,

--- a/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
+++ b/Core/Core/Planner/CalendarEvent/View/SelectEventFrequencyScreen.swift
@@ -36,17 +36,12 @@ struct SelectEventFrequencyScreen: View, ScreenViewTrackable {
                 ForEach(viewModel.presetViewModels) { presetVM in
                     FrequencyPresetCell(
                         title: presetVM.title,
-                        isSelected: viewModel.selectedPreset == presetVM.preset) {
-                            viewModel.selectedPreset = presetVM.preset
+                        isSelected: viewModel.selectedPreset == presetVM.preset,
+                        action: {
+                            viewModel.didTapPreset.send((presetVM.preset, viewController))
                         }
+                    )
                 }
-
-                FrequencyPresetCell(
-                    title: String(localized: "Custom", bundle: .core),
-                    isSelected: viewModel.selectedPreset.isCustom) {
-                        viewModel.didSelectCustomFrequency.send(viewController)
-                    }
-
                 Spacer()
             }
             .frame(minHeight: geometry.size.height)

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -276,15 +276,15 @@ final class EditCalendarEventViewModel: ObservableObject {
             case .monthly:
 
                 if rule.daysOfTheWeek == nil {
-                    rule.daysOfTheMonth = [newDate.monthDay]
+                    rule.daysOfTheMonth = [newDate.daysOfMonth]
                 } else {
                     rule.daysOfTheWeek = [newDate.monthWeekday]
                 }
 
             case .yearly:
 
-                rule.monthsOfTheYear = [newDate.month]
-                rule.daysOfTheMonth = [newDate.monthDay]
+                rule.monthsOfTheYear = [newDate.months]
+                rule.daysOfTheMonth = [newDate.daysOfMonth]
 
             default: return
             }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -315,8 +315,8 @@ final class EditCalendarEventViewModel: ObservableObject {
 
     private func showSelectFrequencyScreen(from source: WeakViewController) {
         let vc = CoreHostingController(
-            EditEventFrequencyScreen(
-                viewModel: EditEventFrequencyViewModel(
+            SelectEventFrequencyScreen(
+                viewModel: SelectEventFrequencyViewModel(
                     eventDate: date ?? Clock.now,
                     selectedFrequency: frequency,
                     originalPreset: eventFrequencyPreset,

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModel.swift
@@ -327,7 +327,6 @@ final class EditCalendarEventViewModel: ObservableObject {
                 )
             )
         )
-        vc.navigationItem.hidesBackButton = true
         router.show(vc, from: source, options: .push)
     }
 

--- a/Core/Core/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModel.swift
@@ -94,7 +94,7 @@ final class EditCustomFrequencyViewModel: ObservableObject {
             self.daysOfTheWeek = rule?.daysOfTheWeek?.map { $0.weekday } ?? []
         }
 
-        self.proposedDayOfMonth = DayOfMonth.day(date.monthDay)
+        self.proposedDayOfMonth = DayOfMonth.day(date.daysOfMonth)
         self.dayOfMonth = proposedDayOfMonth
         if case .monthly = frequency {
             if let weekDay = rule?.daysOfTheWeek?.first {

--- a/Core/Core/Planner/CalendarEvent/ViewModel/FrequencyHelpers/FrequencyPresetViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/FrequencyHelpers/FrequencyPresetViewModel.swift
@@ -30,6 +30,8 @@ struct FrequencyPresetViewModel: Identifiable {
         self.date = date
     }
 
+    /// This `title` is a simplified one, intended only for the SelectFrequency screen.
+    /// It may not match the title coming from backend or the one calculated from the rule.
     var title: String {
         switch preset {
         case .noRepeat:
@@ -48,8 +50,8 @@ struct FrequencyPresetViewModel: Identifiable {
                 .asFormat(for: date.formatted(format: "MMMM d"))
         case .everyWeekday:
             return String(localized: "Every Weekday (Monday to Friday)", bundle: .core)
-        case .selected(let seriesTitle, let rule):
-            return seriesTitle ?? rule.text
+        case .selected(let title, _):
+            return title
         case .custom, .none:
             return String(localized: "Custom", bundle: .core)
         }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/FrequencyHelpers/FrequencySelection.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/FrequencyHelpers/FrequencySelection.swift
@@ -18,17 +18,21 @@
 
 import Foundation
 
+/// Helper type which groups together various representations of a repeating event's frequency.
 struct FrequencySelection: Equatable {
-    let value: RecurrenceRule
-    let title: String
+    /// The frequency's definition, used by APIrequests.
+    let rule: RecurrenceRule
+
+    /// The frequency's user facing name, used on EditEvent screen.
+    /// NOTE: This value is not used on SelectFrequency screen.
+    let title: String?
+
+    /// The frequency's template, either predefined or custom. It allows decoding to selectable options on SelectFrequency screen.
     let preset: FrequencyPreset
 
-    init(_ value: RecurrenceRule, title: String? = nil, preset: FrequencyPreset) {
-        let customTitle: String? = preset.isCustom
-            ? String(localized: "Custom", bundle: .core)
-            : nil
-        self.title = title ?? customTitle ?? value.text
-        self.value = value
+    init(_ rule: RecurrenceRule, title: String? = nil, preset: FrequencyPreset) {
+        self.title = preset.isCustom ? nil : (title ?? rule.text)
+        self.rule = rule
         self.preset = preset
     }
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModel.swift
@@ -97,7 +97,6 @@ final class SelectEventFrequencyViewModel: ObservableObject {
                 )
             )
         )
-        vc.navigationItem.hidesBackButton = true
         router.show(vc, from: source, options: .push)
     }
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModel.swift
@@ -19,7 +19,7 @@
 import SwiftUI
 import Combine
 
-final class EditEventFrequencyViewModel: ObservableObject {
+final class SelectEventFrequencyViewModel: ObservableObject {
 
     // MARK: - Page Setup
 

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyChoice.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyChoice.swift
@@ -62,7 +62,5 @@ struct FrequencyChoice: Identifiable {
 }
 
 extension FrequencyPreset {
-    static var choicesPresets: [FrequencyPreset] {
-        return [.noRepeat] + calculativePresets
-    }
+    static let choicesPresets: [FrequencyPreset] = [.noRepeat] + calculativePresets
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPreset.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPreset.swift
@@ -38,6 +38,18 @@ enum FrequencyPreset: Equatable {
         .everyWeekday
     ]
 
+    static let predefinedPresets: [FrequencyPreset] = [.noRepeat] + calculativePresets
+
+    static func preset(given rule: RecurrenceRule?, date: Date) -> Self {
+        guard let rule else { return .noRepeat }
+
+        return calculativePreset(matching: rule, with: date) ?? .custom(rule)
+    }
+
+    static func calculativePreset(matching rule: RecurrenceRule, with date: Date) -> Self? {
+        calculativePresets.first { $0.rule(given: date) == rule }
+    }
+
     var isCustom: Bool {
         if case .custom = self { return true }
         return false
@@ -86,16 +98,6 @@ enum FrequencyPreset: Equatable {
         case .custom(let rule), .selected(_, let rule):
             return rule
         }
-    }
-
-    static func calculativePreset(matching rule: RecurrenceRule, with date: Date) -> Self? {
-        calculativePresets.first { $0.rule(given: date) == rule }
-    }
-
-    static func preset(given rule: RecurrenceRule?, date: Date) -> Self {
-        guard let rule else { return .noRepeat }
-
-        return calculativePreset(matching: rule, with: date) ?? .custom(rule)
     }
 }
 

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPresetViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPresetViewModel.swift
@@ -18,13 +18,7 @@
 
 import Foundation
 
-struct FrequencyChoice: Identifiable {
-
-    static func allCases(given date: Date) -> [FrequencyChoice] {
-        return FrequencyPreset
-            .choicesPresets
-            .map { FrequencyChoice(date: date, preset: $0) }
-    }
+struct FrequencyPresetViewModel: Identifiable {
 
     let id = Foundation.UUID()
     let date: Date
@@ -59,8 +53,4 @@ struct FrequencyChoice: Identifiable {
             return String(localized: "Custom", bundle: .core) // Should not fall to this case
         }
     }
-}
-
-extension FrequencyPreset {
-    static let choicesPresets: [FrequencyPreset] = [.noRepeat] + calculativePresets
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPresetViewModel.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencyPresetViewModel.swift
@@ -21,12 +21,13 @@ import Foundation
 struct FrequencyPresetViewModel: Identifiable {
 
     let id = Foundation.UUID()
-    let date: Date
-    let preset: FrequencyPreset
+    let preset: FrequencyPreset?
 
-    init(date: Date, preset: FrequencyPreset) {
-        self.date = date
+    private let date: Date
+
+    init(preset: FrequencyPreset?, date: Date) {
         self.preset = preset
+        self.date = date
     }
 
     var title: String {
@@ -49,8 +50,8 @@ struct FrequencyPresetViewModel: Identifiable {
             return String(localized: "Every Weekday (Monday to Friday)", bundle: .core)
         case .selected(let seriesTitle, let rule):
             return seriesTitle ?? rule.text
-        case .custom:
-            return String(localized: "Custom", bundle: .core) // Should not fall to this case
+        case .custom, .none:
+            return String(localized: "Custom", bundle: .core)
         }
     }
 }

--- a/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencySelection.swift
+++ b/Core/Core/Planner/CalendarEvent/ViewModel/SelectionModels/FrequencySelection.swift
@@ -38,13 +38,12 @@ struct FrequencySelection: Equatable {
 extension CalendarEvent {
 
     var frequencySelection: FrequencySelection? {
-        guard let rrule = repetitionRule
-            .flatMap({ RecurrenceRule(rruleDescription: $0) })
-        else { return nil }
+        guard let recurrenceRule else { return nil }
 
         return FrequencySelection(
-            rrule,
+            recurrenceRule,
             title: seriesInNaturalLanguage,
-            preset: frequencyPreset)
+            preset: frequencyPreset
+        )
     }
 }

--- a/Core/Core/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequest.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/API/DeletePlannerNoteRequest.swift
@@ -22,7 +22,7 @@ import Foundation
 struct DeletePlannerNoteRequest: APIRequestable {
     typealias Response = APIPlannerNote
 
-    let method: APIMethod = .delete
+    var method: APIMethod { .delete }
     var path: String { "planner_notes/\(id)" }
 
     let id: String

--- a/Core/Core/Planner/CalendarToDo/Model/API/PostPlannerNoteRequest.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/API/PostPlannerNoteRequest.swift
@@ -31,8 +31,8 @@ struct PostPlannerNoteRequest: APIRequestable {
         let linked_object_id: String?
     }
 
-    let method: APIMethod = .post
-    let path: String = "planner_notes"
+    var method: APIMethod { .post }
+    var path: String { "planner_notes" }
 
     let body: Body?
 }

--- a/Core/Core/Planner/CalendarToDo/Model/API/PutPlannerNoteRequest.swift
+++ b/Core/Core/Planner/CalendarToDo/Model/API/PutPlannerNoteRequest.swift
@@ -37,7 +37,7 @@ struct PutPlannerNoteRequest: APIRequestable {
         }
     }
 
-    let method: APIMethod = .put
+    var method: APIMethod { .put }
     var path: String { "planner_notes/\(id)" }
 
     let id: String

--- a/Core/Core/Planner/Model/CoreData/CalendarEvent.swift
+++ b/Core/Core/Planner/Model/CoreData/CalendarEvent.swift
@@ -98,3 +98,11 @@ final public class CalendarEvent: NSManagedObject, WriteableModel {
         return model
     }
 }
+
+// MARK: - Frequency
+
+extension CalendarEvent {
+    var recurrenceRule: RecurrenceRule? {
+        repetitionRule.flatMap { RecurrenceRule(rruleDescription: $0) }
+    }
+}

--- a/Core/CoreTests/CoreTestCase.swift
+++ b/Core/CoreTests/CoreTestCase.swift
@@ -143,6 +143,7 @@ class CoreTestCase: XCTestCase {
 private let mainViewController = UIStoryboard(name: "Main", bundle: .main).instantiateInitialViewController()
 
 extension CoreTestCase {
+    /// Do not use repeatedly in the same test method, because it could cause flaky `testTree`.
     public func hostSwiftUIController<V: View>(_ view: V) -> CoreHostingController<V> {
         let controller = CoreHostingController(view)
         window.rootViewController = controller

--- a/Core/CoreTests/Dashboard/View/DashboardSettingsViewTests.swift
+++ b/Core/CoreTests/Dashboard/View/DashboardSettingsViewTests.swift
@@ -47,20 +47,24 @@ class DashboardSettingsViewTests: CoreTestCase {
         XCTAssertNotNil(tree.find(id: "DashboardSettings.Switch.ColorOverlay"))
     }
 
-    func testSwitchesInitialStates() {
+    func testSwitchesInitialStatesWhenSwitchesAreVisible() {
         let interactor = DashboardSettingsInteractorPreview(isGradesSwitchVisible: true,
                                                             isColorOverlaySwitchVisible: true)
         interactor.showGrades.send(true)
         interactor.colorOverlay.send(true)
-        var tree = createView(interactor: interactor)
+        let tree = createView(interactor: interactor)
         XCTAssertEqual(tree.find(id: "DashboardSettings.Switch.Grades")?.info("selected"),
                        true)
         XCTAssertEqual(tree.find(id: "DashboardSettings.Switch.ColorOverlay")?.info("selected"),
                        true)
+    }
 
+    func testSwitchesInitialStatesWhenSwitchesAreNotVisible() {
+        let interactor = DashboardSettingsInteractorPreview(isGradesSwitchVisible: true,
+                                                            isColorOverlaySwitchVisible: true)
         interactor.showGrades.send(false)
         interactor.colorOverlay.send(false)
-        tree = createView(interactor: interactor)
+        let tree = createView(interactor: interactor)
         XCTAssertEqual(tree.find(id: "DashboardSettings.Switch.Grades")?.info("selected"),
                        false)
         XCTAssertEqual(tree.find(id: "DashboardSettings.Switch.ColorOverlay")?.info("selected"),

--- a/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/FrequencyPresetTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/FrequencyPresetTests.swift
@@ -69,7 +69,7 @@ final class FrequencyPresetTests: CoreTestCase {
 
             // Then
             XCTAssertEqual(event.frequencyPreset, useCase.preset)
-            XCTAssertEqual(event.frequencySelection?.value, useCase.expected)
+            XCTAssertEqual(event.frequencySelection?.rule, useCase.expected)
         }
 
         // Given - Selected case
@@ -79,23 +79,24 @@ final class FrequencyPresetTests: CoreTestCase {
             daysOfTheWeek: [DayOfWeek(.sunday), DayOfWeek(.wednesday), DayOfWeek(.thursday)],
             end: .occurrenceCount(33)
         )
+        let selectedTitle = "Weekly on Sunday, Wednesday & Thursday, 33 times"
 
         // When
         event.repetitionRule = randomRule.rruleDescription
-        event.seriesInNaturalLanguage = "Weekly on Sunday, Wednesday & Thursday, 33 times"
+        event.seriesInNaturalLanguage = selectedTitle
 
         XCTAssertEqual(
             event.frequencyPreset,
-            .selected(title: event.seriesInNaturalLanguage, rule: randomRule)
+            .selected(title: selectedTitle, rule: randomRule)
         )
 
         XCTAssertEqual(
             event.frequencySelection?.preset,
-            .selected(title: event.seriesInNaturalLanguage, rule: randomRule)
+            .selected(title: selectedTitle, rule: randomRule)
         )
 
-        XCTAssertEqual(event.frequencySelection?.title, event.seriesInNaturalLanguage)
-        XCTAssertEqual(event.frequencySelection?.value, randomRule)
+        XCTAssertEqual(event.frequencySelection?.title, selectedTitle)
+        XCTAssertEqual(event.frequencySelection?.rule, randomRule)
     }
 }
 

--- a/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/FrequencyPresetTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/FrequencyPresetTests.swift
@@ -147,12 +147,12 @@ private enum TestConstants {
         ),
         UseCase(
             preset: .yearlyOnThatMonth,
-            raw: "FREQ=YEARLY;INTERVAL=1;BYMONTH=\(date.month);BYMONTHDAY=\(date.monthDay);COUNT=5",
+            raw: "FREQ=YEARLY;INTERVAL=1;BYMONTH=\(date.months);BYMONTHDAY=\(date.daysOfMonth);COUNT=5",
             expected: RecurrenceRule(
                 recurrenceWith: .yearly,
                 interval: 1,
-                daysOfTheMonth: [date.monthDay],
-                monthsOfTheYear: [date.month],
+                daysOfTheMonth: [date.daysOfMonth],
+                monthsOfTheYear: [date.months],
                 end: .occurrenceCount(5)
             )
         ),

--- a/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/RecurrenceRule+SelectionDescriptionTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/Model/Helpers/RecurrenceRule+SelectionDescriptionTests.swift
@@ -1,0 +1,30 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+final class RecurrenceRuleSelectionDescriptionTests: XCTestCase {
+
+    func test_selectionText() {
+        XCTAssertEqual(RecurrenceFrequency.daily.selectionText, String(localized: "Daily", bundle: .core))
+        XCTAssertEqual(RecurrenceFrequency.weekly.selectionText, String(localized: "Weekly", bundle: .core))
+        XCTAssertEqual(RecurrenceFrequency.monthly.selectionText, String(localized: "Monthly", bundle: .core))
+        XCTAssertEqual(RecurrenceFrequency.yearly.selectionText, String(localized: "Yearly", bundle: .core))
+    }
+}

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModelTests.swift
@@ -440,7 +440,7 @@ private extension EditCustomFrequencyViewModelTests {
 // MARK: - Helpers
 
 private extension EditCustomFrequencyViewModel.DayOfMonth {
-    static func proposed(by date: Date) -> Self { .day(date.monthDay) }
+    static func proposed(by date: Date) -> Self { .day(date.daysOfMonth) }
 }
 
 private extension EditCustomFrequencyViewModel.DayOfYear {

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/FrequencyPresetViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/FrequencyPresetViewModelTests.swift
@@ -1,0 +1,58 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+final class FrequencyPresetViewModelTests: XCTestCase {
+
+    func testTitle() {
+        let rule = RecurrenceRule(recurrenceWith: .daily, interval: 1)
+
+        var testee = makeViewModel(preset: .noRepeat)
+        XCTAssertEqual(testee.title, String(localized: "Does Not Repeat", bundle: .core))
+
+        testee = makeViewModel(preset: .daily)
+        XCTAssertEqual(testee.title, String(localized: "Daily", bundle: .core))
+
+        testee = makeViewModel(preset: .weeklyOnThatDay)
+        XCTAssertEqual(testee.title.hasPrefix(String(localized: "Weekly", bundle: .core)), true)
+
+        testee = makeViewModel(preset: .monthlyOnThatWeekday)
+        XCTAssertEqual(testee.title.hasPrefix(String(localized: "Monthly", bundle: .core)), true)
+
+        testee = makeViewModel(preset: .yearlyOnThatMonth)
+        XCTAssertEqual(testee.title.hasPrefix(String(localized: "Annually", bundle: .core)), true)
+
+        testee = makeViewModel(preset: .everyWeekday)
+        XCTAssertEqual(testee.title, String(localized: "Every Weekday (Monday to Friday)", bundle: .core))
+
+        testee = makeViewModel(preset: .custom(rule))
+        XCTAssertEqual(testee.title, String(localized: "Custom", bundle: .core))
+
+        testee = makeViewModel(preset: .selected(title: "some title", rule: rule))
+        XCTAssertEqual(testee.title, "some title")
+
+        testee = makeViewModel(preset: nil)
+        XCTAssertEqual(testee.title, String(localized: "Custom", bundle: .core))
+    }
+
+    private func makeViewModel(preset: FrequencyPreset?) -> FrequencyPresetViewModel {
+        .init(preset: preset, date: .make(year: 1984, month: 1, day: 1))
+    }
+}

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModelTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 @testable import Core
 
-final class EditEventFrequencyViewModelTests: CoreTestCase {
+final class SelectEventFrequencyViewModelTests: CoreTestCase {
     typealias DayOfWeek = RecurrenceRule.DayOfWeek
 
     private enum TestConstants {
@@ -139,11 +139,12 @@ final class EditEventFrequencyViewModelTests: CoreTestCase {
 
     // MARK: - Helpers
 
-    private func makeViewModel(_ eventDate: Date,
-                               selected: FrequencySelection? = nil,
-                               originalPreset: FrequencyPreset? = nil) -> EditEventFrequencyViewModel {
-
-        return EditEventFrequencyViewModel(
+    private func makeViewModel(
+        _ eventDate: Date,
+        selected: FrequencySelection? = nil,
+        originalPreset: FrequencyPreset? = nil
+    ) -> SelectEventFrequencyViewModel {
+        return SelectEventFrequencyViewModel(
             eventDate: eventDate,
             selectedFrequency: selected,
             originalPreset: originalPreset,

--- a/Core/CoreTests/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModelTests.swift
+++ b/Core/CoreTests/Planner/CalendarEvent/ViewModel/SelectEventFrequencyViewModelTests.swift
@@ -61,13 +61,13 @@ final class SelectEventFrequencyViewModelTests: CoreTestCase {
             originalPreset: .weeklyOnThatDay)
 
         XCTAssertEqual(model.eventDate, TestConstants.eventDate)
-        XCTAssertEqual(model.selection, frequency.preset)
+        XCTAssertEqual(model.selectedPreset, frequency.preset)
     }
 
     func testNoRepeatPresetSelected_NoPreSelection() {
         let model = makeViewModel(TestConstants.eventDate)
 
-        model.selection = .noRepeat
+        model.selectedPreset = .noRepeat
         XCTAssertNil(completionValue)
 
         model.didTapBack.send()
@@ -80,41 +80,40 @@ final class SelectEventFrequencyViewModelTests: CoreTestCase {
             selected: TestConstants.dailyFrequency
         )
 
-        XCTAssertEqual(model.selection, TestConstants.dailyFrequency.preset)
+        XCTAssertEqual(model.selectedPreset, TestConstants.dailyFrequency.preset)
 
-        model.selection = .noRepeat
+        model.selectedPreset = .noRepeat
         model.didTapBack.send()
 
         XCTAssertNil(completionValue)
     }
 
-    func testPresetChoicesGivenNoCustomPreSelection() {
+    func testPresetListGivenNoCustomPreSelection() {
         var model = makeViewModel(TestConstants.eventDate)
-        XCTAssertEqual(model.frequencyChoices.map({ $0.preset }), FrequencyPreset.choicesPresets)
+        XCTAssertEqual(model.presetViewModels.map({ $0.preset }), FrequencyPreset.predefinedPresets)
 
         model = makeViewModel(TestConstants.eventDate, selected: TestConstants.dailyFrequency)
-        XCTAssertEqual(model.frequencyChoices.map({ $0.preset }), FrequencyPreset.choicesPresets)
+        XCTAssertEqual(model.presetViewModels.map({ $0.preset }), FrequencyPreset.predefinedPresets)
     }
 
-    func testPresetChoicesGivenWithCustomPreSelection() {
+    func testPresetListGivenWithCustomPreSelection() {
         let model = makeViewModel(
             TestConstants.eventDate,
             selected: TestConstants.selectedFrequency,
             originalPreset: TestConstants.selectedFrequency.preset
         )
 
-        let modifiedChoicePresets = model.frequencyChoices.map({ $0.preset })
-        let expectedPresetsList = FrequencyPreset.choicesPresets + [
+        let expectedPresetList = FrequencyPreset.predefinedPresets + [
             TestConstants.selectedFrequency.preset
         ]
 
-        XCTAssertEqual(modifiedChoicePresets, expectedPresetsList)
-        XCTAssertEqual(model.frequencyChoices.last?.title, TestConstants.selectedFrequency.preset.selectedTitle)
+        XCTAssertEqual(model.presetViewModels.map({ $0.preset }), expectedPresetList)
+        XCTAssertEqual(model.presetViewModels.last?.title, TestConstants.selectedFrequency.preset.selectedTitle)
     }
 
     func testCalculativePresetSelected() {
         let model = makeViewModel(TestConstants.eventDate)
-        model.selection = TestConstants.dailyFrequency.preset
+        model.selectedPreset = TestConstants.dailyFrequency.preset
 
         XCTAssertNil(completionValue)
 

--- a/Core/CoreTests/Planner/Model/CoreData/CalendarEventTests.swift
+++ b/Core/CoreTests/Planner/Model/CoreData/CalendarEventTests.swift
@@ -50,4 +50,18 @@ class CalendarEventTests: CoreTestCase {
         event.seriesInNaturalLanguage = "anything"
         XCTAssertEqual(event.isPartOfSeries, true)
     }
+
+    func testRecurrenceRule() {
+        let event = CalendarEvent.make()
+
+        event.repetitionRule = nil
+        XCTAssertEqual(event.recurrenceRule, nil)
+
+        event.repetitionRule = "invalid raw value"
+        XCTAssertEqual(event.recurrenceRule, nil)
+
+        let rule = RecurrenceRule(recurrenceWith: .monthly, interval: 2)
+        event.repetitionRule = rule.rruleDescription
+        XCTAssertEqual(event.recurrenceRule, rule)
+    }
 }

--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -51,7 +51,8 @@
   "ignoreContent": [
     "makeUIViewController(context:",
     "makeUIView(context:",
-    "var body: some View"
+    "var body: some View",
+    "func body(content: Content) -> some View"
   ],
   "fileMinCoverage": 0.5,
   "totalMinCoverage": 0.9


### PR DESCRIPTION
refs: [MBL-17971](https://instructure.atlassian.net/browse/MBL-17971)
affects: Student, Teacher
release note: Custom calendar frequency screen now reuses the currently selected frequency.

## What's changed
CustomFrequency screen is now prefilled with values from the current selection in the previous screen.

Tapping "Custom" when current selection is:
- "Does not repeat", it still shows the default state, where nothing is prefilled
- a predefined option (daily/weekly/monthly/annually/weekdays), it prefills values accordingly
- custom frequencies, it prefills values accordingly, both when:
  - coming from backend (and has it's own backend provided title)
  - set by the user but not Saved to backend yet ("Custom" option)

### Chores
- Improved Back button animation
- Renamed `EditEventFrequencyScreen` to `SelectEventFrequencyScreen`
- Renamed `FrequencyChoice` to `FrequencyPresetViewModel`
- Rearranged helpers, methods (like moving general `Date` extensions to its dedicated file, etc.)
- Removed some unused code
- Cleaned up `DateExtensions.swift`
- Added various comments & documentation
- Silenced coverage warnings

## Test plan
- Verify prefill works as described above
- Verify selecting, saving, updating frequencies work as before

## Checklist
- [ ] Follow-up e2e test ticket created
- [x] Tested on phone
- [x] Tested on tablet

[MBL-17971]: https://instructure.atlassian.net/browse/MBL-17971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ