### PR TITLE
Fix the issue of missing Indicator of unread messages on Inbox icon

### DIFF
--- a/Core/Core/Inbox/Model/InboxMessageInteractorLive.swift
+++ b/Core/Core/Inbox/Model/InboxMessageInteractorLive.swift
@@ -54,11 +54,10 @@ public class InboxMessageInteractorLive: InboxMessageInteractor {
 
         messageListStore
             .allObjects
-            .map({ messages in
-                return UInt(messages.count(where: { $0.state == .unread }))
-            })
-            .sink(receiveValue: { count in
-                TabBarBadgeCounts.unreadMessageCount = count
+            .receive(on: DispatchQueue.main)
+            .sink(receiveValue: { messages in
+                let unreadMessages = messages.filter { $0.state == .unread }
+                TabBarBadgeCounts.unreadMessageCount = UInt(unreadMessages.count)
             })
             .store(in: &subscriptions)
 

--- a/Core/Core/Inbox/Model/InboxMessageInteractorLive.swift
+++ b/Core/Core/Inbox/Model/InboxMessageInteractorLive.swift
@@ -53,6 +53,16 @@ public class InboxMessageInteractorLive: InboxMessageInteractor {
             .store(in: &subscriptions)
 
         messageListStore
+            .allObjects
+            .map({ messages in
+                return UInt(messages.count(where: { $0.state == .unread }))
+            })
+            .sink(receiveValue: { count in
+                TabBarBadgeCounts.unreadMessageCount = count
+            })
+            .store(in: &subscriptions)
+
+        messageListStore
             .statePublisher
             .subscribe(state)
             .store(in: &subscriptions)

--- a/Core/CoreTests/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarterTests.swift
+++ b/Core/CoreTests/Files/FileSubmission/Model/BinaryUpload/FileSubmissionItemsUploadStarterTests.swift
@@ -77,7 +77,7 @@ class FileSubmissionItemsUploadStarterTests: CoreTestCase {
         item.uploadTarget = FileUploadTarget(upload_url: URL(string: "/uploadURL")!, upload_params: [:])
         item.fileSubmission = submission
 
-        let apiMock = api.mock(url: URL(string: "///uploadURL")!, method: .post)
+        let apiMock = api.mock(url: URL(string: "///uploadURL?no_verifiers=1")!, method: .post)
         apiMock.suspend()
 
         let completionEvent = expectation(description: "completion event fire")

--- a/Core/CoreTests/Inbox/Model/InboxMessageInteractorLiveTests.swift
+++ b/Core/CoreTests/Inbox/Model/InboxMessageInteractorLiveTests.swift
@@ -79,7 +79,7 @@ class InboxMessageInteractorLiveTests: CoreTestCase {
                 .make(id: "m6", workflow_state: .read),
                 .make(id: "m7", workflow_state: .unread),
                 .make(id: "m8", workflow_state: .read),
-                .make(id: "m9", workflow_state: .unread),
+                .make(id: "m9", workflow_state: .unread)
             ],
             scope: .inbox,
             context: context


### PR DESCRIPTION
refs: [MBL-18045](https://instructure.atlassian.net/browse/MBL-18045)
affects: Student,Teacher
release note: Fix the issue of missing Indicator of unread messages on Inbox icon

## Test Plan

See [ticket](https://instructure.atlassian.net/browse/MBL-18045) description.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">Student App</th ></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/550804d2-b9b4-4dfc-b720-4867eee11dd8" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/4d264140-aa83-405d-926e-a55a9295344d" maxHeight=500></td>
</tr>

<tr><th colspan="2">Teacher App</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/1f6f7ccf-98c7-4861-9356-d6b56c077e11" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/2d06bcb5-9ae3-4e99-813d-253785b667a3" maxHeight=500></td>
</tr>

</table>

## Checklist

- [x] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18045]: https://instructure.atlassian.net/browse/MBL-18045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ