### PR TITLE
Update GetWebSessionRequest to support masquerading

### DIFF
--- a/Core/Core/Courses/K5/ViewModel/K5SubjectViewMasqueradedSession.swift
+++ b/Core/Core/Courses/K5/ViewModel/K5SubjectViewMasqueradedSession.swift
@@ -52,7 +52,7 @@ public class K5SubjectViewMasqueradedSession {
 
     private func startMasqueradedSession(for url: URL, itemIndex: Int) {
         masqueradedSessionRequest?.cancel()
-        masqueradedSessionRequest = env.api.makeRequest(GetWebSessionRequest(to: url, path: "login/session_token")) { [weak self] response, _, _ in
+        masqueradedSessionRequest = env.api.makeRequest(GetWebSessionRequest(to: url)) { [weak self] response, _, _ in
             performUIUpdate {
                 let safeURL = response?.session_url ?? url
                 self?.masqueradedSessionURLSubject.send(safeURL)

--- a/Core/CoreTests/Courses/K5/ViewModel/K5SubjectViewMasqueradedSessionTests.swift
+++ b/Core/CoreTests/Courses/K5/ViewModel/K5SubjectViewMasqueradedSessionTests.swift
@@ -41,7 +41,7 @@ class K5SubjectViewMasqueradedSessionTests: CoreTestCase {
 
     func testFetchesSessionURL() {
         let sessionExpectation = expectation(description: "Session fetched from API")
-        let request = GetWebSessionRequest(to: URL(string: "/first_tab_url")!, path: "login/session_token")
+        let request = GetWebSessionRequest(to: URL(string: "/first_tab_url")!)
         api.mock(request, value: .init(session_url: URL(string: "/session_url")!, requires_terms_acceptance: false))
 
         let testee = K5SubjectViewMasqueradedSession(env: environment)

--- a/Core/CoreTests/Login/APIOAuthTests.swift
+++ b/Core/CoreTests/Login/APIOAuthTests.swift
@@ -17,9 +17,10 @@
 //
 
 import XCTest
+import TestsFoundation
 @testable import Core
 
-class APIOAuthTests: XCTestCase {
+class APIOAuthTests: CoreTestCase {
     func testGetMobileVerifyRequest() {
         XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").path, "https://canvas.instructure.com/api/v1/mobile_verify.json")
         XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").queryItems, [
@@ -61,11 +62,24 @@ class APIOAuthTests: XCTestCase {
         XCTAssertEqual(DeleteLoginOAuthRequest().path, "/login/oauth2/token")
     }
 
-    func testGetWebSessionRequest() {
+    func testGetWebSessionRequestWhenNotMasquerading() {
         XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/login/session_token")
         XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
         XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
             URLQueryItem(name: "return_to", value: "/?display=borderless")
+        ])
+    }
+
+    func testGetWebSessionRequestWhenMasquerading() {
+        environment.currentSession = .make(
+            masquerader: URL(string: "something"),
+            userID: "42"
+        )
+
+        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/api/v1/login/session_token")
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
         ])
     }
 }


### PR DESCRIPTION
refs: [MBL-17910](https://instructure.atlassian.net/browse/MBL-17910)
affects: Student, Teacher, Parent
release note: none

## Problem
When an admin acted as a student, closed discussions were still repliable, although students should not be able to reply to closed discussions. This was because the hybrid discussion page was reached with the admin's permissions instead of the masqueraded user's.

## Solution
When masquerading getting `session_token` needs to use `"/api/v1/login/session_token"` path instead of `"/login/session_token"`, and the URL in the `return_to` query parameter also needs to have the `as_user_id` parameter.

## Test plan:
- Verify closed discussions are not repliable when an admin acts as a student. See ticket for details and credentials.
- Verify it works properly when logging in as the student, directly.
- Smoke test a K5 user's Homeroom, Classes, etc.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d83f35e9-8818-4ed9-bed3-3534b68d060e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/dab3cdaa-f11d-4b67-9b21-f6336e6af3a2" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-17910]: https://instructure.atlassian.net/browse/MBL-17910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ