### PR TITLE
Fix offline file loading logic

### DIFF
--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -233,8 +233,8 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
             // File is in CoreData and was downloaded as a course file in the Files course tab.
             downloadFile(at: url)
         } else {
-            isPresentingOfflineModeAlert = true
             // This is a file that was not downloaded for offline mode.
+            isPresentingOfflineModeAlert = true
             UIAlertController.showItemNotAvailableInOfflineAlert { [weak self] in
                 guard let self else { return }
                 env.router.dismiss(self)

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -221,8 +221,8 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         }
 
         if isPresentingOfflineModeAlert {
-            /// We failed to load the offline file and the error dialog is alread presented.
-            /// Nothing to do, this is just an unnecessary update() call.
+            // We failed to load the offline file and the error dialog is already presented.
+            // Nothing to do, this is just an unnecessary update() call.
             return
         }
 

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -216,7 +216,7 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
 
     private func handleOfflineFileLoad() {
         if isFileLocalURLAvailable {
-            /// File is already loaded, nothing to do, this is just un unnecessary update() call.
+            // File is already loaded, nothing to do, this is just an unnecessary update() call.
             return
         }
 


### PR DESCRIPTION
### What happened?
It seems that at some point during the offline file support delivery we broke the support for offline files when they are opened via a course's Files or Modules menu. The logic to load such offline files was non-existing so I implemented it.

refs: [MBL-17935](https://instructure.atlassian.net/browse/MBL-17935)
affects: Student
release note: Fixed downloaded files not being available in offline mode.

test plan:
- Have a course with a course file added to modules.
- Sync the course with files for offline mode.
- Go offline.
- Enter the course's Files menu.
- Check if the downloaded file displays in the file viewer.
- Go to Modules, test if the linked file in the module item it will display in offline mode.
- Test if course files (both embedded and linked) in rich content are working in offline mode.
- Smoke test if files are working in online mode.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet


[MBL-17935]: https://instructure.atlassian.net/browse/MBL-17935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ