### PR TITLE
Fix the issue of shown status for "No Submission" & "On Paper"  assignments

### DIFF
--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -62,10 +62,10 @@ public struct GradeRowView: View {
                 .multilineTextAlignment(.leading)
 
             let submission = assignment.submissions?.first { $0.userID == userID }
-            let status = submission?.status ?? .notSubmitted
+            let statusDescription = submission?.statusDescription ?? .byStatus(.notSubmitted)
 
-            Text(submission?.statusText ?? "")
-                .foregroundStyle(Color(status.color))
+            Text(statusDescription.text)
+                .foregroundStyle(Color(statusDescription.color))
                 .font(.regular14)
         }
     }

--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -62,10 +62,10 @@ public struct GradeRowView: View {
                 .multilineTextAlignment(.leading)
 
             let submission = assignment.submissions?.first { $0.userID == userID }
-            let statusDescription = submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
+            let displayProperties = submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
 
-            Text(statusDescription.text)
-                .foregroundStyle(Color(statusDescription.color))
+            Text(displayProperties.text)
+                .foregroundStyle(Color(displayProperties.color))
                 .font(.regular14)
         }
     }

--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -62,7 +62,7 @@ public struct GradeRowView: View {
                 .multilineTextAlignment(.leading)
 
             let submission = assignment.submissions?.first { $0.userID == userID }
-            let statusDescription = submission?.statusDescription ?? .byStatus(.notSubmitted)
+            let statusDescription = submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
 
             Text(statusDescription.text)
                 .foregroundStyle(Color(statusDescription.color))

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
@@ -33,7 +33,7 @@ struct ContextCardSubmissionsView: View {
                 submitted += 1
             case .missing:
                 missing += 1
-            case .notSubmitted, .onPaper, .noSubmission, .graded:
+            case .notSubmitted:
                 break
             }
         }

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
@@ -33,7 +33,7 @@ struct ContextCardSubmissionsView: View {
                 submitted += 1
             case .missing:
                 missing += 1
-            case .notSubmitted:
+            case .notSubmitted, .onPaper, .noSubmission:
                 break
             }
         }

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionsView.swift
@@ -33,7 +33,7 @@ struct ContextCardSubmissionsView: View {
                 submitted += 1
             case .missing:
                 missing += 1
-            case .notSubmitted, .onPaper, .noSubmission:
+            case .notSubmitted, .onPaper, .noSubmission, .graded:
                 break
             }
         }

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -358,7 +358,6 @@ extension Submission {
         }()
 
         // Graded check
-        
         switch desc {
         case .byStatus(.submitted):
             return needsGrading == false ? .graded : desc // Maintaining the old logic

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -347,6 +347,7 @@ extension Submission {
         if late { return .late }
         if missing { return .missing }
         if submittedAt != nil { return .submitted }
+        if isGraded { return .graded }
 
         if let submissionTypes = assignment?.submissionTypes {
             if submissionTypes.contains(.on_paper) { return .onPaper }
@@ -362,6 +363,7 @@ public enum SubmissionStatus {
     case missing
     case submitted
     case onPaper
+    case graded
     case noSubmission
     case notSubmitted
 
@@ -377,6 +379,8 @@ public enum SubmissionStatus {
             return String(localized: "Not Submitted", bundle: .core)
         case .onPaper:
             return String(localized: "On Paper", bundle: .core)
+        case .graded:
+            return String(localized: "Graded", bundle: .core)
         case .noSubmission:
             return String(localized: "No Submission", bundle: .core)
         }
@@ -388,7 +392,7 @@ public enum SubmissionStatus {
             return .textWarning
         case .missing:
             return .textDanger
-        case .submitted:
+        case .submitted, .graded:
             return .textSuccess
         case .notSubmitted, .onPaper, .noSubmission:
             return .textDark
@@ -397,7 +401,7 @@ public enum SubmissionStatus {
 
     public var icon: UIImage {
         switch self {
-        case .submitted:
+        case .submitted, .graded:
             return .completeSolid
         case .late:
             return .clockSolid

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -346,7 +346,13 @@ extension Submission {
     public var status: SubmissionStatus {
         if late { return .late }
         if missing { return .missing }
-        if submittedAt != nil { return .submitted}
+        if submittedAt != nil { return .submitted }
+
+        if let submissionTypes = assignment?.submissionTypes {
+            if submissionTypes.contains(.on_paper) { return .onPaper }
+            if submissionTypes.contains(.none) { return .noSubmission }
+        }
+
         return .notSubmitted
     }
 }
@@ -355,6 +361,8 @@ public enum SubmissionStatus {
     case late
     case missing
     case submitted
+    case onPaper
+    case noSubmission
     case notSubmitted
 
     public var text: String {
@@ -367,6 +375,10 @@ public enum SubmissionStatus {
             return String(localized: "Submitted", bundle: .core)
         case .notSubmitted:
             return String(localized: "Not Submitted", bundle: .core)
+        case .onPaper:
+            return String(localized: "On Paper", bundle: .core)
+        case .noSubmission:
+            return String(localized: "No Submission", bundle: .core)
         }
     }
 
@@ -378,7 +390,7 @@ public enum SubmissionStatus {
             return .textDanger
         case .submitted:
             return .textSuccess
-        case .notSubmitted:
+        case .notSubmitted, .onPaper, .noSubmission:
             return .textDark
         }
     }
@@ -389,7 +401,7 @@ public enum SubmissionStatus {
             return .completeSolid
         case .late:
             return .clockSolid
-        case .missing, .notSubmitted:
+        case .missing, .notSubmitted, .onPaper, .noSubmission:
             return .noSolid
         }
     }

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -268,19 +268,19 @@ class SubmissionTests: CoreTestCase {
         XCTAssertEqual(notSubmitted.status, .notSubmitted)
     }
 
-    func testSubmissionStatusDescription() {
+    func testSubmissionStateDisplayProperties() {
         let late = Submission.make(from: .make(late: true))
-        XCTAssertEqual(late.statusDescription, .byStatus(.late))
+        XCTAssertEqual(late.stateDisplayProperties, .usingStatus(.late))
 
         let missing = Submission.make(from: .make(missing: true))
-        XCTAssertEqual(missing.statusDescription, .byStatus(.missing))
+        XCTAssertEqual(missing.stateDisplayProperties, .usingStatus(.missing))
 
         let submitted = Submission.make(from: .make(submitted_at: Date()))
         submitted.typeRaw = SubmissionType.online_text_entry.rawValue
-        XCTAssertEqual(submitted.statusDescription, .byStatus(.submitted))
+        XCTAssertEqual(submitted.stateDisplayProperties, .usingStatus(.submitted))
 
         let notSubmitted = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
-        XCTAssertEqual(notSubmitted.statusDescription, .byStatus(.notSubmitted))
+        XCTAssertEqual(notSubmitted.stateDisplayProperties, .usingStatus(.notSubmitted))
 
         // No Submission
         let assignment = Assignment.make()
@@ -289,7 +289,7 @@ class SubmissionTests: CoreTestCase {
         let noSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         noSubmission.assignment = assignment
 
-        XCTAssertEqual(noSubmission.statusDescription, .noSubmission)
+        XCTAssertEqual(noSubmission.stateDisplayProperties, .noSubmission)
 
         // On Paper Submission
         assignment.submissionTypes = [.on_paper]
@@ -297,7 +297,7 @@ class SubmissionTests: CoreTestCase {
         let onPaperSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         onPaperSubmission.assignment = assignment
 
-        XCTAssertEqual(onPaperSubmission.statusDescription, .onPaper)
+        XCTAssertEqual(onPaperSubmission.stateDisplayProperties, .onPaper)
 
         // On Paper/Graded Submission
         assignment.submissionTypes = [.on_paper]
@@ -307,7 +307,7 @@ class SubmissionTests: CoreTestCase {
         onPaperGradedSubmission.workflowState = .graded
         onPaperGradedSubmission.assignment = assignment
 
-        XCTAssertEqual(onPaperGradedSubmission.statusDescription, .graded)
+        XCTAssertEqual(onPaperGradedSubmission.stateDisplayProperties, .graded)
     }
 }
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -274,7 +274,7 @@ class SubmissionTests: CoreTestCase {
         let noSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         noSubmission.assignment = assignment
 
-        XCTAssertEqual(notSubmitted.status, .noSubmission)
+        XCTAssertEqual(noSubmission.status, .noSubmission)
 
         // On Paper Submission
         assignment.submissionTypes = [.on_paper]
@@ -282,7 +282,17 @@ class SubmissionTests: CoreTestCase {
         let onPaperSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         onPaperSubmission.assignment = assignment
 
-        XCTAssertEqual(notSubmitted.status, .onPaper)
+        XCTAssertEqual(onPaperSubmission.status, .onPaper)
+
+        // On Paper/Graded Submission
+        assignment.submissionTypes = [.on_paper]
+
+        let onPaperGradedSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
+        onPaperGradedSubmission.score = 7
+        onPaperGradedSubmission.workflowState = .graded
+        onPaperGradedSubmission.assignment = assignment
+
+        XCTAssertEqual(onPaperGradedSubmission.status, .graded)
     }
 }
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -266,6 +266,21 @@ class SubmissionTests: CoreTestCase {
 
         let notSubmitted = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         XCTAssertEqual(notSubmitted.status, .notSubmitted)
+    }
+
+    func testSubmissionStatusDescription() {
+        let late = Submission.make(from: .make(late: true))
+        XCTAssertEqual(late.statusDescription, .byStatus(.late))
+
+        let missing = Submission.make(from: .make(missing: true))
+        XCTAssertEqual(missing.statusDescription, .byStatus(.missing))
+
+        let submitted = Submission.make(from: .make(submitted_at: Date()))
+        submitted.typeRaw = SubmissionType.online_text_entry.rawValue
+        XCTAssertEqual(submitted.statusDescription, .byStatus(.submitted))
+
+        let notSubmitted = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
+        XCTAssertEqual(notSubmitted.statusDescription, .byStatus(.notSubmitted))
 
         // No Submission
         let assignment = Assignment.make()
@@ -274,7 +289,7 @@ class SubmissionTests: CoreTestCase {
         let noSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         noSubmission.assignment = assignment
 
-        XCTAssertEqual(noSubmission.status, .noSubmission)
+        XCTAssertEqual(noSubmission.statusDescription, .noSubmission)
 
         // On Paper Submission
         assignment.submissionTypes = [.on_paper]
@@ -282,7 +297,7 @@ class SubmissionTests: CoreTestCase {
         let onPaperSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         onPaperSubmission.assignment = assignment
 
-        XCTAssertEqual(onPaperSubmission.status, .onPaper)
+        XCTAssertEqual(onPaperSubmission.statusDescription, .onPaper)
 
         // On Paper/Graded Submission
         assignment.submissionTypes = [.on_paper]
@@ -292,7 +307,7 @@ class SubmissionTests: CoreTestCase {
         onPaperGradedSubmission.workflowState = .graded
         onPaperGradedSubmission.assignment = assignment
 
-        XCTAssertEqual(onPaperGradedSubmission.status, .graded)
+        XCTAssertEqual(onPaperGradedSubmission.statusDescription, .graded)
     }
 }
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -266,6 +266,23 @@ class SubmissionTests: CoreTestCase {
 
         let notSubmitted = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
         XCTAssertEqual(notSubmitted.status, .notSubmitted)
+
+        // No Submission
+        let assignment = Assignment.make()
+        assignment.submissionTypes = [.none]
+
+        let noSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
+        noSubmission.assignment = assignment
+
+        XCTAssertEqual(notSubmitted.status, .noSubmission)
+
+        // On Paper Submission
+        assignment.submissionTypes = [.on_paper]
+
+        let onPaperSubmission = Submission.make(from: .make(late: false, missing: false, submitted_at: nil))
+        onPaperSubmission.assignment = assignment
+
+        XCTAssertEqual(notSubmitted.status, .onPaper)
     }
 }
 

--- a/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
@@ -181,7 +181,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     func update() {
         guard let assignment = assignment.first else { return }
         let submission = assignment.submissions?.first(where: { $0.userID == studentID })
-        let statusDescription = submission?.statusDescription ?? .usingStatus(.notSubmitted)
+        let displayProperties = submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
         title = course.first?.name ?? String(localized: "Assignment Details", bundle: .parent)
 
         titleLabel.text = assignment.name
@@ -192,11 +192,11 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
             return assignment.pointsPossibleText
         }()
         statusIconView.isHidden = assignment.submissionStatusIsHidden
-        statusIconView.image = statusDescription.icon
-        statusIconView.tintColor = statusDescription.color
+        statusIconView.image = displayProperties.icon
+        statusIconView.tintColor = displayProperties.color
         statusLabel.isHidden = assignment.submissionStatusIsHidden
-        statusLabel.textColor = statusDescription.color
-        statusLabel?.text = statusDescription.text
+        statusLabel.textColor = displayProperties.color
+        statusLabel?.text = displayProperties.text
         dateLabel.text = assignment.dueAt?.dateTimeString ?? String(localized: "No Due Date", bundle: .parent)
         reminderSwitch.isEnabled = true
         reminderDateButton.isEnabled = true

--- a/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
@@ -180,7 +180,8 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
 
     func update() {
         guard let assignment = assignment.first else { return }
-        let status = assignment.submissions?.first(where: { $0.userID == studentID })?.status ?? .notSubmitted
+        let submission = assignment.submissions?.first(where: { $0.userID == studentID })
+        let statusDescription = submission?.statusDescription ?? .byStatus(.notSubmitted)
         title = course.first?.name ?? String(localized: "Assignment Details", bundle: .parent)
 
         titleLabel.text = assignment.name
@@ -191,11 +192,11 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
             return assignment.pointsPossibleText
         }()
         statusIconView.isHidden = assignment.submissionStatusIsHidden
-        statusIconView.image = status.icon
-        statusIconView.tintColor = status.color
+        statusIconView.image = statusDescription.icon
+        statusIconView.tintColor = statusDescription.color
         statusLabel.isHidden = assignment.submissionStatusIsHidden
-        statusLabel.textColor = status.color
-        statusLabel?.text = assignment.submissions?.first(where: { $0.userID == studentID })?.statusText
+        statusLabel.textColor = statusDescription.color
+        statusLabel?.text = statusDescription.text
         dateLabel.text = assignment.dueAt?.dateTimeString ?? String(localized: "No Due Date", bundle: .parent)
         reminderSwitch.isEnabled = true
         reminderDateButton.isEnabled = true

--- a/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
+++ b/Parent/Parent/Assignments/View/AssignmentDetailsViewController.swift
@@ -181,7 +181,7 @@ class AssignmentDetailsViewController: UIViewController, CoreWebViewLinkDelegate
     func update() {
         guard let assignment = assignment.first else { return }
         let submission = assignment.submissions?.first(where: { $0.userID == studentID })
-        let statusDescription = submission?.statusDescription ?? .byStatus(.notSubmitted)
+        let statusDescription = submission?.statusDescription ?? .usingStatus(.notSubmitted)
         title = course.first?.name ?? String(localized: "Assignment Details", bundle: .parent)
 
         titleLabel.text = assignment.name

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -385,13 +385,13 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         nameLabel?.text = assignment.name
         pointsLabel?.text = hideScores ? nil : assignment.pointsPossibleText
         pointsLabel?.isHidden = pointsLabel?.text == nil
-        let status = assignment.submission?.status ?? .notSubmitted
+        let statusDescription = assignment.submission?.statusDescription ?? .byStatus(.notSubmitted)
         statusIconView?.isHidden = assignment.submissionStatusIsHidden
-        statusIconView?.image = status.icon
-        statusIconView?.tintColor = status.color
+        statusIconView?.image = statusDescription.icon
+        statusIconView?.tintColor = statusDescription.color
         statusLabel?.isHidden = assignment.submissionStatusIsHidden
-        statusLabel?.textColor = status.color
-        statusLabel?.text = submission?.statusText
+        statusLabel?.textColor = statusDescription.color
+        statusLabel?.text = statusDescription.text
         dueSection?.subHeader.text = assignment.dueAt.flatMap {
             $0.dateTimeString
         } ?? String(localized: "No Due Date", bundle: .student)

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -385,13 +385,13 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         nameLabel?.text = assignment.name
         pointsLabel?.text = hideScores ? nil : assignment.pointsPossibleText
         pointsLabel?.isHidden = pointsLabel?.text == nil
-        let statusDescription = assignment.submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
+        let displayProperties = assignment.submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
         statusIconView?.isHidden = assignment.submissionStatusIsHidden
-        statusIconView?.image = statusDescription.icon
-        statusIconView?.tintColor = statusDescription.color
+        statusIconView?.image = displayProperties.icon
+        statusIconView?.tintColor = displayProperties.color
         statusLabel?.isHidden = assignment.submissionStatusIsHidden
-        statusLabel?.textColor = statusDescription.color
-        statusLabel?.text = statusDescription.text
+        statusLabel?.textColor = displayProperties.color
+        statusLabel?.text = displayProperties.text
         dueSection?.subHeader.text = assignment.dueAt.flatMap {
             $0.dateTimeString
         } ?? String(localized: "No Due Date", bundle: .student)

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -385,7 +385,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
         nameLabel?.text = assignment.name
         pointsLabel?.text = hideScores ? nil : assignment.pointsPossibleText
         pointsLabel?.isHidden = pointsLabel?.text == nil
-        let statusDescription = assignment.submission?.statusDescription ?? .byStatus(.notSubmitted)
+        let statusDescription = assignment.submission?.stateDisplayProperties ?? .usingStatus(.notSubmitted)
         statusIconView?.isHidden = assignment.submissionStatusIsHidden
         statusIconView?.image = statusDescription.icon
         statusIconView?.tintColor = statusDescription.color


### PR DESCRIPTION
refs: [MBL-18029](https://instructure.atlassian.net/browse/MBL-18029)
affects: Student,Parent
release note: "No Submission" & "On Paper"  assignments displayed status fixed.

## Test Plan

See [ticket](https://instructure.atlassian.net/browse/MBL-18029) description.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>


<tr><th colspan="2">Student App</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/55d17ca3-f28a-4913-83e0-2dbb4431fb94" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/655fe6d6-aae7-4dcf-b4c8-729d71030215" maxHeight=500></td>
</tr>

<tr><th colspan="2">Parent App</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/63d0e607-b3ea-4f4f-ba21-d06786969644" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/1bf51f07-b45a-4f52-87d2-6e2594407ef4" maxHeight=500></td>
</tr>

<tr><th colspan="2">Student App</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/57218682-f11d-4110-8a8e-d5ee5ec7df5c" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/3207e0d9-48a7-4024-9806-7523c5ecf02f" maxHeight=500></td>
</tr>

<tr><th colspan="2">Parent App</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/4acdb939-9ef0-44d1-9e42-db089eb85ff6" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/7a46a7a4-e0fd-44e6-b7fe-94372debb0e1" maxHeight=500></td>
</tr>

</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18029]: https://instructure.atlassian.net/browse/MBL-18029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ