### PR TITLE
Preserve PDF annotations even when cache is reset

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -72,6 +72,7 @@ open class AppEnvironment {
         OfflineModeAssembly.make()
         api = API(session)
         currentSession = session
+        currentSession?.migrateSavedAnnotatedPDFs()
         userDefaults = SessionDefaults(sessionID: session.uniqueID)
 
         if isSilent {

--- a/Core/Core/AppEnvironment/CacheManager.swift
+++ b/Core/Core/AppEnvironment/CacheManager.swift
@@ -44,7 +44,7 @@ public class CacheManager {
 
         clear()
         LoginSession.clearAll()
-        clearDirectory(URL.Directories.documents) // Also clear documents, which we normally keep around
+        clearDirectory(URL.Directories.documents, keepingAnnotatedPDFs: true) // Also clear documents, which we normally keep around
     }
 
     public static func clearIfNeeded() {
@@ -89,10 +89,11 @@ public class CacheManager {
         try? manifest.write(to: manifestURL, options: .atomic)
     }
 
-    private static func clearDirectory(_ directory: URL) {
+    private static func clearDirectory(_ directory: URL, keepingAnnotatedPDFs: Bool = false) {
         let fs = FileManager.default
         let urls = (try? fs.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
         for url in urls {
+            if keepingAnnotatedPDFs, url.lastPathComponent == URL.Paths.annotatedPDFs { continue }
             try? fs.removeItem(at: url)
         }
     }

--- a/Core/Core/AppEnvironment/CacheManager.swift
+++ b/Core/Core/AppEnvironment/CacheManager.swift
@@ -44,7 +44,12 @@ public class CacheManager {
 
         clear()
         LoginSession.clearAll()
-        clearDirectory(URL.Directories.documents, keepingAnnotatedPDFs: true) // Also clear documents, which we normally keep around
+
+        // Also clear documents, which we normally keep around
+        clearDirectory(
+            URL.Directories.documents,
+            excludingPaths: [URL.Paths.annotatedPDFs] // Keeping annotated PDFs
+        )
     }
 
     public static func clearIfNeeded() {
@@ -89,11 +94,11 @@ public class CacheManager {
         try? manifest.write(to: manifestURL, options: .atomic)
     }
 
-    private static func clearDirectory(_ directory: URL, keepingAnnotatedPDFs: Bool = false) {
+    private static func clearDirectory(_ directory: URL, excludingPaths: [String]? = nil) {
         let fs = FileManager.default
         let urls = (try? fs.contentsOfDirectory(at: directory, includingPropertiesForKeys: nil)) ?? []
         for url in urls {
-            if keepingAnnotatedPDFs, url.lastPathComponent == URL.Paths.annotatedPDFs { continue }
+            if let excludingPaths, excludingPaths.contains(url.lastPathComponent) { continue }
             try? fs.removeItem(at: url)
         }
     }

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -91,6 +91,7 @@ public extension URL {
 
     enum Paths {
         static let annotatedPDFs = "AnnotatedPDFs"
+        static let offline = "Offline"
 
         public enum Offline {
 

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -54,6 +54,11 @@ public extension URL {
             FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         }
 
+        /// The `AnnotatedPDFs` directory in the application documents' private folder.
+        public static var annotatedPDFs: URL {
+            documents.appending(component: URL.Paths.annotatedPDFs, directoryHint: .isDirectory)
+        }
+
         public static var library: URL {
             FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)[0]
         }
@@ -85,6 +90,8 @@ public extension URL {
     }
 
     enum Paths {
+        static let annotatedPDFs = "AnnotatedPDFs"
+
         public enum Offline {
 
             public static func rootURL(

--- a/Core/Core/Files/Model/LocalFileURLCreator.swift
+++ b/Core/Core/Files/Model/LocalFileURLCreator.swift
@@ -35,7 +35,7 @@ extension LocalFileURLCreator {
         if mimeClass == "pdf" {
             // If the user already downloaded and modified the file locally, we don't want to download it again.
             // Instead, return the url pointing to the locally modified version.
-            let docsURL = URL.Directories.documents.appendingPathComponent(fileName)
+            let docsURL = URL.Directories.annotatedPDFs.appendingPathComponent(fileName)
             if FileManager.default.fileExists(atPath: docsURL.path) { return docsURL }
         }
 

--- a/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Files/View/FileDetails/FileDetailsViewController.swift
@@ -685,7 +685,7 @@ extension FileDetailsViewController: PDFViewControllerDelegate, FlexibleToolbarC
 
     public func pdfViewController(_ pdfController: PDFViewController, didSave document: Document, error: Error?) {
         if pdfAnnotationsMutatedMoveToDocsDirectory, let filePathComponent = filePathComponent {
-            let to = URL.Directories.documents.appendingPathComponent(filePathComponent)
+            let to = URL.Directories.annotatedPDFs.appendingPathComponent(filePathComponent)
             if !FileManager.default.fileExists(atPath: to.path), let from = document.fileURL {
                 do {
                     try FileManager.default.createDirectory(at: to.deletingLastPathComponent(), withIntermediateDirectories: true)

--- a/Core/Core/Login/LoginSession.swift
+++ b/Core/Core/Login/LoginSession.swift
@@ -174,7 +174,6 @@ public struct LoginSession: Codable, Hashable {
                 .contentsOfDirectory(at: folderUrl, includingPropertiesForKeys: nil)
                 .filter({ $0.lastPathComponent.isDigitsOnlyFileName })
                 .forEach({ content in
-                    
                     let destFolder = sessionFolder.appending(component: content.lastPathComponent)
                     try fileManager.createDirectory(at: destFolder, withIntermediateDirectories: true)
 

--- a/Core/Core/Login/LoginSession.swift
+++ b/Core/Core/Login/LoginSession.swift
@@ -178,7 +178,12 @@ public struct LoginSession: Codable, Hashable {
                 })
 
         } catch {
-            Logger.shared.error("Failure moving previously saved PDFs to AnnotatedPDFs folder: \(error.localizedDescription)")
+            RemoteLogger
+                .shared
+                .logError(
+                    name: "Failure moving previously saved PDFs to AnnotatedPDFs folder",
+                    reason: error.localizedDescription
+                )
         }
     }
 

--- a/Core/Core/Login/LoginSession.swift
+++ b/Core/Core/Login/LoginSession.swift
@@ -161,8 +161,6 @@ public struct LoginSession: Codable, Hashable {
             guard let folderUrl = urls.first(where: { $0.hasDirectoryPath && $0.lastPathComponent == uniqueID })
             else { return }
 
-            print("Moving previously-saved documents folder for session (\(uniqueID)) ..")
-
             let dest = URL.Directories
                 .annotatedPDFs
                 .appending(component: folderUrl.lastPathComponent, directoryHint: .isDirectory)

--- a/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
+++ b/Core/CoreTests/AppEnvironment/CacheManagerTests.swift
@@ -57,10 +57,12 @@ class CacheManagerTests: CoreTestCase {
     func testResetAppNecessary() {
         UserDefaults.standard.setValue(true, forKey: "reset_cache_on_next_launch")
         let doc = write("doc", in: URL.Directories.documents)
+        let annotated = write("pdf content annotated", in: URL.Directories.annotatedPDFs)
         LoginSession.add(LoginSession.make())
         CacheManager.resetAppIfNecessary()
         XCTAssertNil(UserDefaults.standard.dictionaryRepresentation()["reset_cache_on_next_launch"])
         XCTAssertFalse(FileManager.default.fileExists(atPath: doc.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: annotated.path))
         XCTAssert(LoginSession.sessions.isEmpty)
     }
 

--- a/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
@@ -234,7 +234,6 @@ class FileDetailsViewControllerTests: CoreTestCase {
         mock(APIFile.make(filename: "File.pdf", contentType: "application/pdf", mime_class: "pdf"), isExistingPDFFileWithAnnotations: true)
         controller.view.layoutIfNeeded()
         let result = controller.prepareLocalURL(fileName: fileName, mimeClass: "pdf", location: URL.Directories.temporary)
-        print(result)
         XCTAssertEqual(result, docsUrl)
     }
 

--- a/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Files/View/FileDetails/FileDetailsViewControllerTests.swift
@@ -140,7 +140,7 @@ class FileDetailsViewControllerTests: CoreTestCase {
 
     func mock(_ file: APIFile, isExistingPDFFileWithAnnotations: Bool = false) {
         api.mock(controller.files, value: file)
-        let base = isExistingPDFFileWithAnnotations ? URL.Directories.documents : URL.Directories.temporary
+        let base = isExistingPDFFileWithAnnotations ? URL.Directories.annotatedPDFs : URL.Directories.temporary
         let url = base.appendingPathComponent("\(currentSession.uniqueID)/1/\(file.filename)")
         XCTAssertNoThrow(try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true))
         XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
@@ -230,15 +230,16 @@ class FileDetailsViewControllerTests: CoreTestCase {
 
     func testPrepLocalURLWithExistingPDFFile() {
         let fileName = "\(currentSession.uniqueID)/1/File.pdf"
-        let docsUrl = URL.Directories.documents.appendingPathComponent(fileName)
+        let docsUrl = URL.Directories.annotatedPDFs.appendingPathComponent(fileName)
         mock(APIFile.make(filename: "File.pdf", contentType: "application/pdf", mime_class: "pdf"), isExistingPDFFileWithAnnotations: true)
         controller.view.layoutIfNeeded()
         let result = controller.prepareLocalURL(fileName: fileName, mimeClass: "pdf", location: URL.Directories.temporary)
+        print(result)
         XCTAssertEqual(result, docsUrl)
     }
 
     func testMutatedPdfFileSavesToDocumentsDirectory() {
-        let expectedURL = URL.Directories.documents.appendingPathComponent("\(currentSession.uniqueID)/1/File.pdf")
+        let expectedURL = URL.Directories.annotatedPDFs.appendingPathComponent("\(currentSession.uniqueID)/1/File.pdf")
         try? FileManager.default.removeItem(atPath: expectedURL.path)
         XCTAssertFalse( FileManager.default.fileExists(atPath: expectedURL.path) )
         DocViewerViewController.hasPSPDFKitLicense = true


### PR DESCRIPTION
refs: [MBL-18069](https://instructure.atlassian.net/browse/MBL-18069)
affects: Student
release note: PDF annotations is preserved even when cache is reset

## Test Plan
* Login to Student app
* Open a PDF file and make some annotations to it, then go back.
* Close the app entirely.
* Go to the App's page on Settings app.
* Turn on "Reset cache on next launch" toggle.
* Launch the app, then login back to the same user. 
* Open the PDF file that was annotated in step 2.
* You should see the previously saved annotations on that file.

## Video Record

Recording covering PDF annotation persistence scenarios, which are: 
- On logout
- On cache reset.

https://github.com/user-attachments/assets/6c5e7355-bbff-4950-8fbc-982cb9d5f0fa

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18069]: https://instructure.atlassian.net/browse/MBL-18069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ