### PR TITLE
Startup crash on iPads running iOS 18

### DIFF
--- a/Core/Core/Offline/View/OfflineBannerView.swift
+++ b/Core/Core/Offline/View/OfflineBannerView.swift
@@ -62,8 +62,12 @@ class OfflineBannerView: UIView {
 
         viewModel
             .$isVisible
-            .map { !$0 }
-            .assign(to: \.accessibilityElementsHidden, on: self, ownership: .weak)
+            .sink { [weak self] isVisible in
+                UIView.animate(withDuration: isVisible ? 0 : 0.3) {
+                    self?.alpha = isVisible ? 1 : 0
+                }
+                self?.accessibilityElementsHidden = !isVisible
+            }
             .store(in: &subscriptions)
     }
 }

--- a/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
+++ b/Core/Core/SnackBar/View/UIKit/SnackBarProvider.swift
@@ -44,9 +44,17 @@ public extension SnackBarProvider where Self: UITabBarController {
         let snackView = snackBarController.view!
         view.addSubview(snackView)
         snackView.pin(inside: view, bottom: nil)
-        snackView.bottomAnchor.constraint(
-            equalTo: tabBar.topAnchor,
-            constant: 0
-        ).isActive = true
+
+        if isRegularBottomTabBarEnsured {
+            // constrain to `tabBar` only if it is ensured that it is part of the view hierarchy
+            snackView.bottomAnchor.constraint(equalTo: tabBar.topAnchor, constant: 0).isActive = true
+        } else {
+            // as a fallback, constrain to `view` which will result in the snackbar overlapping some of the tabbar
+            snackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: 0).isActive = true
+        }
+    }
+
+    private var isRegularBottomTabBarEnsured: Bool {
+        view.subviews.contains(tabBar)
     }
 }


### PR DESCRIPTION
refs: MBL-18078
affects: Student, Teacher
release note: Fixed a startup crash which occurred on some devices.

- Fix startup crash
- Fix always visible Back Online banner

## Test Plan
Test on iPad @ iOS 18 (and also on other devices)
- Verify the app doesn't crash when user is already logged in or after login
- Verify there is no green "Back Online" banner at the bottom in Student app
- Verify Offline/Onlin transitions show/hide the banners properly

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
