### PR TITLE
Inbox messages truncated

### DIFF
--- a/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageDetailsView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 public struct MessageDetailsView: View {
     @ObservedObject private var model: MessageDetailsViewModel
     @Environment(\.viewController) private var controller
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(model: MessageDetailsViewModel) {
         self.model = model

--- a/Core/Core/Inbox/MessageDetails/View/MessageView.swift
+++ b/Core/Core/Inbox/MessageDetails/View/MessageView.swift
@@ -112,6 +112,7 @@ public struct MessageView: View {
             SelectableText(
                 attributedText: model.body.toAttributedStringWithLinks(),
                 font: .regular16,
+                lineHeight: .fit,
                 textColor: .textDarkest
             )
             .accessibilityIdentifier("MessageDetails.body")

--- a/Core/Core/SwiftUIViews/SelectableText.swift
+++ b/Core/Core/SwiftUIViews/SelectableText.swift
@@ -19,14 +19,17 @@
 import SwiftUI
 
 public struct SelectableText: UIViewRepresentable {
-    // MARK: - Properties
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    // MARK: - Properties
+
     private let text: String?
     private let attributedText: AttributedString?
     private let font: UIFont.Name
     private let textColor: Color
 
-    // MARK: - Inits
+    // MARK: - Init
+
     public init(
         text: String,
         font: UIFont.Name,
@@ -48,6 +51,8 @@ public struct SelectableText: UIViewRepresentable {
         self.textColor = textColor
         self.text = nil
     }
+
+    // MARK: - UIViewRepresentable methods
 
     public func makeUIView(context: Self.Context) -> UITextView {
         let textView = UITextView()
@@ -76,33 +81,23 @@ public struct SelectableText: UIViewRepresentable {
         uiView: UITextView,
         context: Self.Context
     ) -> CGSize? {
-        let dimensions = proposal.replacingUnspecifiedDimensions(
-            by: .init(
-                width: 0,
-                height: CGFloat.greatestFiniteMagnitude
-            )
-        )
+        let proposedWidth = proposal.width ?? 0
+        let calculatedHeight = calculateTextViewHeight(with: proposedWidth, for: uiView.attributedText)
 
-        let calculatedHeight = calculateTextViewHeight(
-            containerSize: dimensions,
-            attributedString: uiView.attributedText
-        )
-
-        return .init(
-            width: dimensions.width,
-            height: calculatedHeight
-        )
+        return CGSize(width: proposedWidth, height: calculatedHeight)
     }
 
     private func calculateTextViewHeight(
-        containerSize: CGSize,
-        attributedString: NSAttributedString
+        with width: CGFloat,
+        for attributedString: NSAttributedString
     ) -> CGFloat {
         let boundingRect = attributedString.boundingRect(
-            with: .init(width: containerSize.width, height: .greatestFiniteMagnitude),
+            with: .init(width: width, height: .greatestFiniteMagnitude),
             options: [.usesLineFragmentOrigin, .usesFontLeading],
             context: nil
         )
-        return boundingRect.height
+
+        // the calculated height must be ceiled, according to the `boundingRect` documentation
+        return ceil(boundingRect.height)
     }
 }


### PR DESCRIPTION
refs: [MBL-18051](https://instructure.atlassian.net/browse/MBL-18051)
affects: Student, Teacher
release note: Fixed the end of a message not being displayed in some cases.

## Problem
On Message Details screen some messages were truncated, but not after a specific size or character count.
It happened only in some cases with some iOS font sizes.

## Solution
- Ceiled the calculated text height, because fractions were not handled properly, causing the last line to not display even though the space for it was almost there.
- Updated the subject to dynamically respond to font size changes

## Test plan
- Verify that a message body which got truncated before this PR now displayed fully
- Play around with iOS font sizes to reproduce the truncation, and check that case in the PR build

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/1bdcc2aa-da75-4bd6-ad22-12245f46fbdb" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ca30101e-36d2-4eed-abfe-5ff4151fd51f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode

[MBL-18051]: https://instructure.atlassian.net/browse/MBL-18051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ