### PR TITLE
Fix issue with assignments without grading period not being shown on Assignment List

### DIFF
--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23G93" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23G80" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -997,6 +997,7 @@
         <attribute name="grade" optional="YES" attributeType="String"/>
         <attribute name="gradedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="gradeMatchesCurrentSubmission" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="gradingPeriodId" optional="YES" attributeType="String"/>
         <attribute name="groupID" optional="YES" attributeType="String"/>
         <attribute name="groupName" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>

--- a/Core/Core/Grades/Model/UseCase/GetAssignmentsByGroup.swift
+++ b/Core/Core/Grades/Model/UseCase/GetAssignmentsByGroup.swift
@@ -108,6 +108,10 @@ public class GetAssignmentsByGroup: UseCase {
                                 .map { AssignmentGroupsByGradingPeriod(gradingPeriod: gradingPeriod, assignmentGroups: $0) }
                         }
                         .collect()
+                        .flatMap { assignmentsByGradingPeriods in
+                            getAssignmentGroups(nil)
+                                .map { [AssignmentGroupsByGradingPeriod(gradingPeriod: nil, assignmentGroups: $0)] + assignmentsByGradingPeriods }
+                        }
                         .eraseToAnyPublisher()
                 }
             }

--- a/Core/Core/Submissions/APISubmission.swift
+++ b/Core/Core/Submissions/APISubmission.swift
@@ -33,6 +33,7 @@ public struct APISubmission: Codable, Equatable {
     var grade: String?
     var graded_at: Date?
     let grade_matches_current_submission: Bool
+    let grading_period_id: ID?
     let group: APISubmissionGroup?
     let id: ID
     let late: Bool?
@@ -152,6 +153,7 @@ extension APISubmission {
         grade: String? = nil,
         graded_at: Date? = nil,
         grade_matches_current_submission: Bool = true,
+        grading_period_id: String? = nil,
         group: APISubmissionGroup? = nil,
         id: String = "1",
         late: Bool = false,
@@ -187,6 +189,7 @@ extension APISubmission {
             grade: grade,
             graded_at: graded_at,
             grade_matches_current_submission: grade_matches_current_submission,
+            grading_period_id: ID(grading_period_id),
             group: group,
             id: ID(id),
             late: late,

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -49,6 +49,7 @@ final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var grade: String?
     @NSManaged public var gradedAt: Date?
     @NSManaged public var gradeMatchesCurrentSubmission: Bool
+    @NSManaged public var gradingPeriodId: String?
     @NSManaged public var groupID: String?
     @NSManaged public var groupName: String?
     @NSManaged public var id: String
@@ -161,6 +162,7 @@ extension Submission: WriteableModel {
         model.grade = item.grade
         model.gradedAt = item.graded_at
         model.gradeMatchesCurrentSubmission = item.grade_matches_current_submission
+        model.gradingPeriodId = item.grading_period_id?.value
         model.groupID = item.group?.id?.value
         model.groupName = item.group?.name
         model.id = item.id.value


### PR DESCRIPTION
refs: MBL-18023
affects: Student, Teacher
release note: Fixed an issue where assignments that don't belong to any of the available grading periods were not shown at Assignments.
test plan: Log in with an account that has multiple grading periods and assignments that don't belong to any of those grading periods, and check Assignment List if they are showing all of the assignments properly.

## Details

- Updated AssignmentListViewModel to have the currently active grading period as the default one.
- Fixed GetAssignmentsByGroup UseCase (all credit goes to Attila on this one).
- Modified AssignmentListViewModel to get all assignment groups (independently from the grading periods) and apply the grading period filtering on them after. To achieve this I needed to append the stored properties of a Submission entity with grading_period_id which we always get from the API (but we didn't use it until now).

## Test
Attila's account is a good one for this. `File Upload 4 Copy` is one of the assignments that weren't shown previously. You can see it in the screenshots.

Account: attilavarga.instructure.com
User: student
Password: password
Course: Primary Student Course

## Screenshots

### Assignment List
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b900901b-e69a-4eee-8a48-a3c5b0eac249" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/89525dca-a482-4d74-860a-7326ce93f65b" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product