### PR TITLE
Fix media in offline rich content

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -626,12 +626,26 @@ extension CoreWebView {
 }
 
 // MARK: Offline parsing
+
 extension CoreWebView {
-    public func loadContent(isOffline: Bool?, filePath: URL?, content: String?, originalBaseURL: URL?, offlineBaseURL: URL?) {
-        if let filePath, isOffline == true && FileManager.default.fileExists(atPath: filePath.path) {
-            loadFileURL(URL.Directories.documents, allowingReadAccessTo: URL.Directories.documents)
+
+    public func loadContent(
+        isOffline: Bool?,
+        filePath: URL?,
+        content: String?,
+        originalBaseURL: URL?,
+        offlineBaseURL: URL? //TODO: Needed?
+    ) {
+        if let filePath,
+           isOffline == true,
+           FileManager.default.fileExists(atPath: filePath.path)
+        {
+            loadFileURL(
+                URL.Directories.documents,
+                allowingReadAccessTo: URL.Directories.documents
+            )
             let rawHtmlValue = try? String(contentsOf: filePath, encoding: .utf8)
-            loadHTMLString(rawHtmlValue ?? "", baseURL: offlineBaseURL)
+            loadHTMLString(rawHtmlValue ?? "", baseURL: URL.Directories.documents)
         } else {
             loadHTMLString(content ?? "", baseURL: originalBaseURL)
         }

--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -633,8 +633,7 @@ extension CoreWebView {
         isOffline: Bool?,
         filePath: URL?,
         content: String?,
-        originalBaseURL: URL?,
-        offlineBaseURL: URL? //TODO: Needed?
+        originalBaseURL: URL?
     ) {
         if let filePath,
            isOffline == true,
@@ -645,6 +644,7 @@ extension CoreWebView {
                 allowingReadAccessTo: URL.Directories.documents
             )
             let rawHtmlValue = try? String(contentsOf: filePath, encoding: .utf8)
+            // All offline content should have relative links to the documents directory
             loadHTMLString(rawHtmlValue ?? "", baseURL: URL.Directories.documents)
         } else {
             loadHTMLString(content ?? "", baseURL: originalBaseURL)

--- a/Core/Core/Extensions/URLExtensions.swift
+++ b/Core/Core/Extensions/URLExtensions.swift
@@ -223,6 +223,23 @@ public extension URL {
         return components.url
     }
 
+    func makeRelativePath(toBaseUrl: URL) throws -> String {
+        guard self.absoluteString.hasPrefix(toBaseUrl.absoluteString) else {
+            throw NSError.instructureError("No common ancestor", code: 0)
+        }
+
+        let relativePath = self
+            .pathComponents
+            .dropFirst(toBaseUrl.pathComponents.count)
+            .joined(separator: "/")
+
+        guard let relativeURL = URL(string: relativePath, relativeTo: baseURL) else {
+            throw NSError.instructureError("Failed to create URL", code: 0)
+        }
+
+        return relativeURL.path()
+    }
+
     #if DEBUG
 
     static func make(_ string: String = "/") -> URL {

--- a/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
+++ b/Core/Core/Pages/PageDetails/PageDetailsViewController.swift
@@ -139,8 +139,7 @@ public final class PageDetailsViewController: UIViewController, ColoredNavViewPr
             isOffline: offlineModeInteractor?.isNetworkOffline(),
             filePath: offlinePath,
             content: page.body,
-            originalBaseURL: page.htmlURL,
-            offlineBaseURL: URL.Paths.Offline.rootURL(sessionID: env.currentSession?.uniqueID ?? "")
+            originalBaseURL: page.htmlURL
         )
     }
 

--- a/Core/Core/Quizzes/QuizDetails/Student/StudentQuizDetailsViewController.swift
+++ b/Core/Core/Quizzes/QuizDetails/Student/StudentQuizDetailsViewController.swift
@@ -172,8 +172,7 @@ public class StudentQuizDetailsViewController: ScreenViewTrackableViewController
             isOffline: offlineModeInteractor?.isNetworkOffline(),
             filePath: offlinePath,
             content: html,
-            originalBaseURL: quiz?.htmlURL,
-            offlineBaseURL: URL.Paths.Offline.rootURL(sessionID: env.currentSession?.uniqueID ?? "")
+            originalBaseURL: quiz?.htmlURL
         )
 
         scrollView.isHidden = quiz == nil

--- a/Core/Core/Studio/Model/Entities/StudioOfflineVideo.swift
+++ b/Core/Core/Studio/Model/Entities/StudioOfflineVideo.swift
@@ -1,0 +1,67 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public struct StudioOfflineVideo: Equatable {
+    public let ltiLaunchID: String
+    public let videoRelativePath: String
+    /// The png file of the first frame of the video.
+    public let videoPosterRelativePath: String?
+    public let videoMimeType: String
+    public let captions: [Caption]
+
+    /// - parameters:
+    ///   - baseURL: This URL will be used to create relative paths to the video files. This url should also be used as a`baseURL` in `WKWebView` when presenting a html string with such relative paths .
+    public init(
+        ltiLaunchID: String,
+        videoLocation: URL,
+        videoPosterLocation: URL?,
+        videoMimeType: String,
+        captionLocations: [URL],
+        baseURL: URL = URL.Directories.documents
+    ) throws {
+        self.ltiLaunchID = ltiLaunchID
+        self.videoMimeType = videoMimeType
+        captions = try captionLocations.map {
+            try Caption(captionUrl: $0, baseUrl: baseURL)
+        }
+
+        videoRelativePath = try videoLocation.makeRelativePath(toBaseUrl: baseURL)
+        videoPosterRelativePath = try videoPosterLocation?.makeRelativePath(toBaseUrl: baseURL)
+    }
+}
+
+extension StudioOfflineVideo {
+    public struct Caption: Equatable {
+        public let relativePath: String
+        public let languageCode: String
+
+        public init(
+            captionUrl: URL,
+            baseUrl: URL
+        ) throws {
+            let languageCode = captionUrl.lastPathComponent.split(separator: ".").first
+
+            guard let languageCode else {
+                throw NSError.instructureError("No language code detected in file name.")
+            }
+
+            relativePath = try captionUrl.makeRelativePath(toBaseUrl: baseUrl)
+            self.languageCode = String(languageCode)
+        }
+    }
+}

--- a/Core/Core/Studio/Model/StudioIFrameReplaceInteractor.swift
+++ b/Core/Core/Studio/Model/StudioIFrameReplaceInteractor.swift
@@ -87,26 +87,20 @@ public class StudioIFrameReplaceInteractorLive: StudioIFrameReplaceInteractor {
     ) -> String {
         var captionTags = ""
 
-        for caption in studioVideo.captionLocations {
-            let languageCode = caption.lastPathComponent.split(separator: ".").first
-
-            guard let languageCode else {
-                continue
-            }
-
-            captionTags.append("  <track kind=\"captions\" src=\"\(caption.path)\" srclang=\"\(languageCode)\" />\n")
+        for caption in studioVideo.captions {
+            captionTags.append("  <track kind=\"captions\" src=\"\(caption.relativePath)\" srclang=\"\(caption.languageCode)\" />\n")
         }
 
         let posterProperty: String = {
-            guard let posterLocation = studioVideo.videoPosterLocation else {
+            guard let posterLocation = studioVideo.videoPosterRelativePath else {
                 return ""
             }
-            return " poster=\"\(posterLocation.path)\""
+            return " poster=\"\(posterLocation)\""
         }()
 
         let videoTag = """
         <video controls playsinline preload="auto"\(posterProperty)>
-          <source src="\(studioVideo.videoLocation.path)" type="\(studioVideo.videoMimeType)\" />
+          <source src="\(studioVideo.videoRelativePath)" type="\(studioVideo.videoMimeType)\" />
         \(captionTags)</video>
         """
 

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
@@ -60,7 +60,7 @@ class CourseSyncStudioMediaInteractorLiveTests: CoreTestCase {
 
         // Step 5 - Download actual video files
         let mockDownloadInteractor = MockStudioVideoDownloadInteractor()
-        let mockOfflineVideo = StudioOfflineVideo(
+        let mockOfflineVideo = try! StudioOfflineVideo(
             ltiLaunchID: StudioTestData.ltiLaunchID,
             videoLocation: .make(),
             videoPosterLocation: .make(),

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
@@ -22,7 +22,7 @@ import XCTest
 
 class CourseSyncStudioMediaInteractorLiveTests: CoreTestCase {
 
-    func testDownload() {
+    func testDownload() throws {
         let mockOfflineDirectory = URL.make()
 
         // Step 1 - Discover iframes
@@ -60,12 +60,13 @@ class CourseSyncStudioMediaInteractorLiveTests: CoreTestCase {
 
         // Step 5 - Download actual video files
         let mockDownloadInteractor = MockStudioVideoDownloadInteractor()
-        let mockOfflineVideo = try! StudioOfflineVideo(
+        let mockOfflineVideo = try StudioOfflineVideo(
             ltiLaunchID: StudioTestData.ltiLaunchID,
-            videoLocation: .make(),
-            videoPosterLocation: .make(),
+            videoLocation: .make("/test.mp4"),
+            videoPosterLocation: .make("/poster.png"),
             videoMimeType: "",
-            captionLocations: []
+            captionLocations: [],
+            baseURL: .make()
         )
         mockDownloadInteractor.mockedOfflineVideoReponse = mockOfflineVideo
 

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/HTMLParser/HTMLDownloadInteractorMock.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/HTMLParser/HTMLDownloadInteractorMock.swift
@@ -30,17 +30,13 @@ class HTMLDownloadInteractorMock: HTMLDownloadInteractor {
         _ url: URL,
         courseId: String,
         resourceId: String,
-        publisherProvider: Core.URLSessionDataTaskPublisherProvider = URLSessionDataTaskPublisherProviderLive()
+        documentsDirectory: URL
     ) -> AnyPublisher<String, Error> {
         fileNames.append(url.lastPathComponent)
 
         return Just(url.path)
             .setFailureType(to: Error.self)
             .eraseToAnyPublisher()
-    }
-
-    func download(_ url: URL, courseId: String, resourceId: String) -> AnyPublisher<String, Error> {
-        download(url, courseId: courseId, resourceId: resourceId, publisherProvider: URLSessionDataTaskPublisherProviderLive())
     }
 
     private func copy(_ localURL: URL, fileName: String, courseId: String, resourceId: String) -> AnyPublisher<URL, Error> {
@@ -52,10 +48,6 @@ class HTMLDownloadInteractorMock: HTMLDownloadInteractor {
     }
 
     func downloadFile(_ url: URL, courseId: String, resourceId: String) -> AnyPublisher<String, Never> {
-        return downloadFile(url, courseId: courseId, resourceId: resourceId, publisherProvider: URLSessionDataTaskPublisherProviderLive())
-    }
-
-    func downloadFile(_ url: URL, courseId: String, resourceId: String, publisherProvider: Core.URLSessionDataTaskPublisherProvider) -> AnyPublisher<String, Never> {
         fileNames.append(url.lastPathComponent)
 
         return Just(url.path)

--- a/Core/CoreTests/Extensions/URLExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLExtensionsTests.swift
@@ -147,6 +147,16 @@ class URLExtensionsTests: XCTestCase {
         let testee = url.apiBaseURL
         XCTAssertEqual(testee, URL(string: "https://test.instructure.com")!)
     }
+
+    func testMakesRelativePath() throws {
+        var testee = URL(string: "folder/file")!
+        var result = try testee.makeRelativePath(toBaseUrl: URL(string: "folder")!)
+        XCTAssertEqual(result, "file")
+
+        XCTAssertThrowsError(try testee.makeRelativePath(toBaseUrl: URL(string: "anotherFolder")!)) { error in
+            XCTAssertEqual(error as NSError, NSError.instructureError("No common ancestor", code: 0))
+        }
+    }
 }
 
 class DatabaseURLTests: XCTestCase {

--- a/Core/CoreTests/Studio/Model/Entities/StudioOfflineVideoTests.swift
+++ b/Core/CoreTests/Studio/Model/Entities/StudioOfflineVideoTests.swift
@@ -1,0 +1,49 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class StudioOfflineVideoTests: XCTestCase {
+    enum TestData {
+        static let ltiLaunchID = "testLaunchID"
+        static let videoMimeType = "video/mp4"
+        static let folder = "/folder"
+        static let videoFileName = "video.mp4"
+        static let posterFileName = "video.mp4"
+        static let captionFileName = "en.srt"
+    }
+
+    func testMakesRelativeURLs() throws {
+        let testee = try StudioOfflineVideo(
+            ltiLaunchID: TestData.ltiLaunchID,
+            videoLocation: URL(string: "\(TestData.folder)/\(TestData.videoFileName)")!,
+            videoPosterLocation: URL(string: "\(TestData.folder)/\(TestData.posterFileName)")!,
+            videoMimeType: TestData.videoMimeType,
+            captionLocations: [URL(string: "\(TestData.folder)/\(TestData.captionFileName)")!],
+            baseURL: URL(string: TestData.folder)!
+        )
+
+        XCTAssertEqual(testee.ltiLaunchID, TestData.ltiLaunchID)
+        XCTAssertEqual(testee.videoMimeType, TestData.videoMimeType)
+        XCTAssertEqual(testee.videoRelativePath, TestData.videoFileName)
+        XCTAssertEqual(testee.videoPosterRelativePath, TestData.posterFileName)
+        XCTAssertEqual(testee.captions[0].relativePath, TestData.captionFileName)
+        XCTAssertEqual(testee.captions[0].languageCode, "en")
+    }
+}

--- a/Core/CoreTests/Studio/Model/StudioVideoDownloadInteractorLiveTests.swift
+++ b/Core/CoreTests/Studio/Model/StudioVideoDownloadInteractorLiveTests.swift
@@ -54,6 +54,7 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         let mockPosterInteractor = MockStudioVideoPosterInteractor()
         let testee = StudioVideoDownloadInteractorLive(
             rootDirectory: workingDirectory,
+            documentsDirectory: workingDirectory,
             captionsInteractor: mockCaptionsInteractor,
             videoCacheInteractor: mockCacheInteractor,
             posterInteractor: mockPosterInteractor
@@ -66,12 +67,13 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         let expectedCaptionURL = workingDirectory.appending(path: "\(TestData.mediaID.value)/\(TestData.caption.srclang).vtt")
         mockCaptionsInteractor.mockedCaptionURL = expectedCaptionURL
 
-        let expectedResult = StudioOfflineVideo(
+        let expectedResult = try! StudioOfflineVideo(
             ltiLaunchID: StudioTestData.ltiLaunchID,
             videoLocation: expectedVideoURL,
             videoPosterLocation: expectedPosterURL,
             videoMimeType: TestData.mimeType,
-            captionLocations: [expectedCaptionURL]
+            captionLocations: [expectedCaptionURL],
+            baseURL: workingDirectory
         )
 
         // WHEN
@@ -90,6 +92,7 @@ class StudioVideoDownloadInteractorLiveTests: CoreTestCase {
         let mockCaptionsInteractor = MockStudioCaptionsInteractor()
         let testee = StudioVideoDownloadInteractorLive(
             rootDirectory: workingDirectory,
+            documentsDirectory: workingDirectory,
             captionsInteractor: mockCaptionsInteractor,
             videoCacheInteractor: mockCacheInteractor,
             posterInteractor: MockStudioVideoPosterInteractor()


### PR DESCRIPTION
### What's new?
- URLs in rich content pointing to local offline content were modified to be referenced via relative urls instead of absolute ones.
- I simplified the `HTMLDownloadInteractor` entity to be easier to understand what it does.

refs: [MBL-18070](https://instructure.atlassian.net/browse/MBL-18070)
affects: Student
release note: Fixed images and Studio videos not being available for offline mode after an app update.

test plan:
- Check the ticket for a detailed description on the issue.
- Sync rich content with images and studio videos.
- Go offline and go to the rich content.
- They should appear just as expected.
- Check the offline html content with safari or with a breakpoint in CoreWebView.loadContent (look for the rawHtmlValue variable).
- Urls should be all relative without the application's UUID container ID in it.
- Check out the branch and install the app into the same phone to simulate an app update.
- Start the app in offline mode, rich content should appear just as before.
- Note: we can't test this with other builds because the base url for the offline webview have changed and other builds point to a different one.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
