### PR TITLE
Improve developer support

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -137,11 +137,10 @@ open class CoreWebView: WKWebView {
         backgroundColor = UIColor.clear
         translatesAutoresizingMaskIntoConstraints = false
 
-#if DEBUG
         if #available(iOS 16.4, *) {
             isInspectable = true
         }
-#endif
+
         addScript(js)
         handle("resize") { [weak self] message in
             guard let self = self,

--- a/Core/Core/Login/LoginFindSchoolViewController.swift
+++ b/Core/Core/Login/LoginFindSchoolViewController.swift
@@ -142,9 +142,12 @@ class LoginFindSchoolViewController: UIViewController {
     private func parseInputAndShowLoginScreen() {
         guard var host = searchField.text?.trimmingCharacters(in: .whitespacesAndNewlines), !host.isEmpty else { return }
         host = host.lowercased()
-        if !host.contains(".") {
+
+        // For manual oauth logins we trust the developer and don't modify the host.
+        if method != .manualOAuthLogin, !host.contains(".") {
             host = "\(host).instructure.com"
         }
+
         searchField.resignFirstResponder()
         if let account = accounts.first(where: { $0.domain == host }) {
             env.lastLoginAccount = account

--- a/Core/Core/Login/LoginManualOAuthViewController.storyboard
+++ b/Core/Core/Login/LoginManualOAuthViewController.storyboard
@@ -149,6 +149,7 @@
                     <connections>
                         <outlet property="clientIDField" destination="OIC-Dy-yeC" id="hwO-Yk-Fsd"/>
                         <outlet property="clientSecretField" destination="dyr-GQ-FtL" id="buv-1w-TRk"/>
+                        <outlet property="continueButton" destination="Wu5-SA-4Ne" id="1Fp-0j-XIY"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qQR-JK-n1f" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Core/Core/Login/LoginManualOAuthViewController.storyboard
+++ b/Core/Core/Login/LoginManualOAuthViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OAuth Client ID" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="AJv-l9-h0p" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="60" width="343" height="20.5"/>
+                                <rect key="frame" x="16" y="80" width="343" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -27,7 +27,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SUJ-PA-JyQ" customClass="DividerView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="86.5" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="106.5" width="375" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="RTR-Do-NPP"/>
                                 </constraints>
@@ -36,7 +36,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="ID" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="OIC-Dy-yeC" customClass="DynamicTextField" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="87.5" width="343" height="50"/>
+                                <rect key="frame" x="16" y="107.5" width="343" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="5lX-ro-nfI"/>
                                 </constraints>
@@ -48,7 +48,7 @@
                                 </userDefinedRuntimeAttributes>
                             </textField>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vwE-0N-PiW" customClass="DividerView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="137.5" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="157.5" width="375" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="mif-8k-Ugk"/>
                                 </constraints>
@@ -57,7 +57,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="OAuth Client Secret" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cWU-AM-HMh" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="161.5" width="343" height="20.5"/>
+                                <rect key="frame" x="16" y="181.5" width="343" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -67,7 +67,7 @@
                                 </userDefinedRuntimeAttributes>
                             </label>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="2mE-bm-cba" customClass="DividerView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="187" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="207" width="375" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="JyI-ju-iqM"/>
                                 </constraints>
@@ -76,7 +76,7 @@
                                 </userDefinedRuntimeAttributes>
                             </view>
                             <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Secret" textAlignment="natural" minimumFontSize="17" clearButtonMode="whileEditing" translatesAutoresizingMaskIntoConstraints="NO" id="dyr-GQ-FtL" customClass="DynamicTextField" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="188" width="343" height="50"/>
+                                <rect key="frame" x="16" y="208" width="343" height="50"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="50" id="UJf-SY-KXh"/>
                                 </constraints>
@@ -88,7 +88,7 @@
                                 </userDefinedRuntimeAttributes>
                             </textField>
                             <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="pRQ-ee-my2" customClass="DividerView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="238" width="375" height="1"/>
+                                <rect key="frame" x="0.0" y="258" width="375" height="1"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="1" id="En0-Xk-WtV"/>
                                 </constraints>
@@ -96,12 +96,12 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="tintColorName" value="borderMedium"/>
                                 </userDefinedRuntimeAttributes>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wu5-SA-4Ne" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="102.5" y="262" width="170" height="50"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wu5-SA-4Ne" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
+                                <rect key="frame" x="102.5" y="282" width="170" height="50"/>
                                 <inset key="contentEdgeInsets" minX="54" minY="16" maxX="54" maxY="16"/>
                                 <state key="normal" title="Continue"/>
                                 <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="electric"/>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="backgroundInfo"/>
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                         <integer key="value" value="4"/>
                                     </userDefinedRuntimeAttribute>
@@ -113,6 +113,7 @@
                                 </connections>
                             </button>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="0WO-81-QSU"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="pRQ-ee-my2" secondAttribute="trailing" id="57V-ne-oRG"/>
@@ -142,14 +143,12 @@
                             <constraint firstAttribute="trailing" secondItem="2mE-bm-cba" secondAttribute="trailing" id="mdP-Cx-IBf"/>
                             <constraint firstItem="dyr-GQ-FtL" firstAttribute="top" secondItem="2mE-bm-cba" secondAttribute="bottom" id="pg3-K4-Y0X"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="0WO-81-QSU"/>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="clientIDField" destination="OIC-Dy-yeC" id="hwO-Yk-Fsd"/>
                         <outlet property="clientSecretField" destination="dyr-GQ-FtL" id="buv-1w-TRk"/>
-                        <outlet property="continueButton" destination="Wu5-SA-4Ne" id="hfQ-d3-dDE"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="qQR-JK-n1f" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Core/Core/Login/LoginManualOAuthViewController.swift
+++ b/Core/Core/Login/LoginManualOAuthViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 class LoginManualOAuthViewController: UIViewController {
     @IBOutlet weak var clientIDField: UITextField!
     @IBOutlet weak var clientSecretField: UITextField!
+    @IBOutlet weak var continueButton: UIButton!
 
     var authenticationProvider: String?
     let env = AppEnvironment.shared

--- a/Core/Core/Login/LoginManualOAuthViewController.swift
+++ b/Core/Core/Login/LoginManualOAuthViewController.swift
@@ -21,7 +21,6 @@ import UIKit
 class LoginManualOAuthViewController: UIViewController {
     @IBOutlet weak var clientIDField: UITextField!
     @IBOutlet weak var clientSecretField: UITextField!
-    @IBOutlet weak var continueButton: UIButton!
 
     var authenticationProvider: String?
     let env = AppEnvironment.shared

--- a/Core/Core/Login/LoginWebViewController.swift
+++ b/Core/Core/Login/LoginWebViewController.swift
@@ -96,7 +96,9 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         setupIndeterminateLoadingIndicator()
 
         // Manual OAuth provided mobileVerifyModel
-        if mobileVerifyModel != nil {
+        if let mobileVerifyModel {
+            // Modify the title to include the url scheme to easily catch http/https errors.
+            title = mobileVerifyModel.base_url?.absoluteString
             return loadLoginWebRequest()
         }
 

--- a/Core/CoreTests/Login/LoginFindSchoolViewControllerTests.swift
+++ b/Core/CoreTests/Login/LoginFindSchoolViewControllerTests.swift
@@ -67,10 +67,10 @@ class LoginFindSchoolViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.searchField.delegate?.textFieldShouldReturn?(controller.searchField), false)
         XCTAssert(router.viewControllerCalls.isEmpty)
-        controller.searchField.text = "test"
+        controller.searchField.text = "localhost"
         XCTAssertEqual(controller.searchField.delegate?.textFieldShouldReturn?(controller.searchField), false)
         let shown = router.viewControllerCalls.first?.0 as? LoginManualOAuthViewController
-        XCTAssertEqual(shown?.host, "test.instructure.com")
+        XCTAssertEqual(shown?.host, "localhost")
     }
 
     func testNextButtonHiddenByDefault() {

--- a/Parent/Parent/Info.plist
+++ b/Parent/Parent/Info.plist
@@ -6,12 +6,19 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>localhost</key>
+			<key>canvas-web.inseng.test</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>canvas.docker</key>
+			<key>docker</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>

--- a/Student/Student/Info.plist
+++ b/Student/Student/Info.plist
@@ -78,8 +78,15 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>canvas.docker</key>
+			<key>canvas-web.inseng.test</key>
 			<dict>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>docker</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>

--- a/Teacher/Teacher/Info.plist
+++ b/Teacher/Teacher/Info.plist
@@ -49,12 +49,19 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
-			<key>localhost</key>
+			<key>canvas-web.inseng.test</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 			</dict>
-			<key>canvas.docker</key>
+			<key>docker</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
+			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>


### PR DESCRIPTION
### What's new?
- Fixed continue button not being visible on the manual oauth screen.
- The app no longer appends `.instructure.com` to hosts when doing a manual oauth login.
- Added `canvas-web.inseng.test` and `*.docker` as http enabled domains.
- Enabled the inspection of in-app webviews in release mode.

refs: [MBL-17990](https://instructure.atlassian.net/browse/MBL-17990)
affects: Student, Teacher, Parent
release note: none

test plan:


[MBL-17990]: https://instructure.atlassian.net/browse/MBL-17990?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ