### PR TITLE
Fix iOS 18 iPad issues

### DIFF
--- a/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardContainerView.swift
@@ -76,7 +76,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
             }
         }
         .background(Color.backgroundLightest.edgesIgnoringSafeArea(.all))
-        .navigationBarGlobal()
+        .navigationBarDashboard()
         .navigationBarItems(leading: profileMenuButton, trailing: rightNavBarButtons)
         .onAppear {
             refresh(force: false) {

--- a/Core/Core/Dashboard/Container/View/DashboardNavigationBar.swift
+++ b/Core/Core/Dashboard/Container/View/DashboardNavigationBar.swift
@@ -1,0 +1,72 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+/// The purpose of this modifier is to dynamically turn the nav bar logo on and off
+/// when the tab bar changes between its regular and elevated designs.
+/// When the elevated tab bar is displayed we hide the logo so the tab bar can take the logo's place and there won't be
+/// an extra line in the nav bar below the elevated tab bar just to display the logo.
+struct DashboardNavigationBar: ViewModifier {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @State private var isElevatedTabBar = false
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *) {
+            content
+                .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+                .toolbarBackground(Color(uiColor: Brand.shared.navBackground), for: .navigationBar)
+                .toolbar {
+                    ToolbarItem(placement: .principal) {
+                        navBarLogo
+                    }
+                }
+                .onChange(of: horizontalSizeClass, initial: true) { oldValue, newValue in
+                    updateNavBarLogoVisibility(horizontalSizeClass: newValue)
+                }
+        } else {
+            content
+                .navigationBarGlobal()
+        }
+    }
+
+    private func updateNavBarLogoVisibility(horizontalSizeClass: UserInterfaceSizeClass?) {
+        // We can't use `self.horizontalSizeClass` here because it's still holding the old value
+        isElevatedTabBar = horizontalSizeClass == .regular
+    }
+
+    @ViewBuilder
+    private var navBarLogo: some View {
+        if !isElevatedTabBar, let headerImage = Brand.shared.headerImage {
+            ZStack {
+                Color(Brand.shared.headerImageBackground)
+                Image(uiImage: headerImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+            }
+            .frame(width: 44, height: 44)
+        }
+    }
+}
+
+extension View {
+
+    func navigationBarDashboard() -> some View {
+        modifier(DashboardNavigationBar())
+    }
+}

--- a/Core/Core/InstUI/Utils/TabChangeTransition.swift
+++ b/Core/Core/InstUI/Utils/TabChangeTransition.swift
@@ -1,0 +1,48 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+extension InstUI {
+
+    /// The animation when TabBar changes tabs.
+    public class TabChangeTransition: NSObject, UIViewControllerAnimatedTransitioning {
+        private let animationDuration: TimeInterval = 0.1
+
+        public func transitionDuration(
+            using transitionContext: (any UIViewControllerContextTransitioning)?
+        ) -> TimeInterval {
+            animationDuration
+        }
+
+        public func animateTransition(
+            using transitionContext: any UIViewControllerContextTransitioning
+        ) {
+            guard let newTab = transitionContext.view(forKey: .to) else {
+                return
+            }
+
+            newTab.alpha = 0
+            transitionContext.containerView.addSubview(newTab)
+
+            UIView.animate(withDuration: animationDuration) {
+                newTab.alpha = 1
+            } completion: { _ in
+                transitionContext.completeTransition(true)
+            }
+        }
+    }
+}

--- a/Core/Core/Profile/SideMenu/SideMenuTransitioning.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuTransitioning.swift
@@ -26,8 +26,8 @@ public class SideMenuOpenTransitioning: NSObject, UIViewControllerAnimatedTransi
         guard
             let from = transitionContext.viewController(forKey: .from)?.view,
             let to = transitionContext.viewController(forKey: .to)?.view
-            else {
-                return transitionContext.completeTransition(false)
+        else {
+            return transitionContext.completeTransition(false)
         }
 
         transitionContext.containerView.insertSubview(to, belowSubview: from)
@@ -89,7 +89,7 @@ public class SideMenuPresentationController: UIPresentationController {
 
     public override func presentationTransitionWillBegin() {
         super.presentationTransitionWillBegin()
-        guard let containerView = containerView else { return }
+        guard let containerView else { return }
 
         let backGroundColor: UIColor = traitCollection.isDarkInterface ? .backgroundLightest : .backgroundDarkest
         dimmer.backgroundColor = backGroundColor.withAlphaComponent(0.9)
@@ -106,9 +106,9 @@ public class SideMenuPresentationController: UIPresentationController {
         dimmer.accessibilityLabel = String(localized: "Close", bundle: .core)
         dimmer.accessibilityFrame = CGRect(x: drawerWidth, y: 0, width: containerView.bounds.width - drawerWidth, height: containerView.bounds.height)
 
-        presentingViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+        UIView.animate(withDuration: animationDuration) {
             self.dimmer.alpha = 1
-        })
+        }
     }
 
     public override func presentationTransitionDidEnd(_ completed: Bool) {
@@ -120,9 +120,10 @@ public class SideMenuPresentationController: UIPresentationController {
 
     public override func dismissalTransitionWillBegin() {
         super.dismissalTransitionWillBegin()
-        presentingViewController.transitionCoordinator?.animate(alongsideTransition: { _ in
+
+        UIView.animate(withDuration: animationDuration) {
             self.dimmer.alpha = 0
-        })
+        }
     }
 
     public override func dismissalTransitionDidEnd(_ completed: Bool) {

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -47,6 +47,9 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])
         addSnackBar()
+
+        // This changes the elevated tab bar's text color
+        view.tintColor = Brand.shared.primary
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -82,7 +85,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
             tabBarImageSelected = .homeroomTabActive
         } else {
             let dashboard = CoreHostingController(DashboardContainerView(shouldShowGroupList: true,
-                                                                    showOnlyTeacherEnrollment: false))
+                                                                         showOnlyTeacherEnrollment: false))
             result = DashboardContainerViewController(rootViewController: dashboard) { CoreSplitViewController() }
 
             tabBarTitle = String(localized: "Dashboard", bundle: .student, comment: "dashboard page title")
@@ -190,6 +193,7 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
 }
 
 extension StudentTabBarController: UITabBarControllerDelegate {
+
     func tabBarController(_ tabBarController: UITabBarController, shouldSelect viewController: UIViewController) -> Bool {
         tabBarController.resetViewControllerIfSelected(viewController)
 
@@ -198,5 +202,13 @@ extension StudentTabBarController: UITabBarControllerDelegate {
         }
 
         return true
+    }
+
+    func tabBarController(
+        _ tabBarController: UITabBarController,
+        animationControllerForTransitionFrom fromVC: UIViewController,
+        to toVC: UIViewController
+    ) -> (any UIViewControllerAnimatedTransitioning)? {
+        InstUI.TabChangeTransition()
     }
 }

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -47,9 +47,6 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])
         addSnackBar()
-
-        // This changes the elevated tab bar's text color
-        view.tintColor = Brand.shared.primary
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -66,6 +63,9 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         tabBar.useGlobalNavStyle()
+
+        // This changes the elevated tab bar's text color (but for some reason only in light mode)
+        view.tintColor = Brand.shared.tabBarHighlightColor
     }
 
     func dashboardTab() -> UIViewController {

--- a/Teacher/Teacher/TeacherTabBarController.swift
+++ b/Teacher/Teacher/TeacherTabBarController.swift
@@ -36,6 +36,9 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
         NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])
         addSnackBar()
+
+        // This changes the elevated tab bar's text color
+        view.tintColor = Brand.shared.primary
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -132,5 +135,13 @@ extension TeacherTabBarController: UITabBarControllerDelegate {
         }
 
         return true
+    }
+
+    func tabBarController(
+        _ tabBarController: UITabBarController,
+        animationControllerForTransitionFrom fromVC: UIViewController,
+        to toVC: UIViewController
+    ) -> (any UIViewControllerAnimatedTransitioning)? {
+        InstUI.TabChangeTransition()
     }
 }

--- a/Teacher/Teacher/TeacherTabBarController.swift
+++ b/Teacher/Teacher/TeacherTabBarController.swift
@@ -36,9 +36,6 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
         NotificationCenter.default.addObserver(self, selector: #selector(checkForPolicyChanges), name: UIApplication.didBecomeActiveNotification, object: nil)
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])
         addSnackBar()
-
-        // This changes the elevated tab bar's text color
-        view.tintColor = Brand.shared.primary
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -55,6 +52,9 @@ class TeacherTabBarController: UITabBarController, SnackBarProvider {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         tabBar.useGlobalNavStyle()
+
+        // This changes the elevated tab bar's text color (but for some reason only in light mode)
+        view.tintColor = Brand.shared.tabBarHighlightColor
     }
 
     func coursesTab() -> UIViewController {


### PR DESCRIPTION
refs: MBL-18079
affects: Student, Teacher, Parent
release note: none

test plan:
- Test all three apps on iPads/iPhones both iOS 17/18 (use the checklist at the bottom of the PR).

### What was fixed?
- Opening the profile menu sometimes didn't dim the screen and closing the menu by tapping outside of it was impossible. This was caused by an animation not being run in `SideMenuTransitioning`. I changed the animation from the `alongsideTransition` since that should only be used to animations outside of the transition's `transitionView`.
- The tab change has a new transition animation that shrinks and enlarges the tab's content. This looks nice on views with white navigation bars or without any navigation bars but look weird when the white background flashes around a dark navigation bar for a split second upon tab change. I changed the transition to a simple quick fade animation.
- On iOS 18 iPads when there was enough space for the app being in split mode the tab bar got elevated and placed inside the navigation bar. This looked strange on the dashboard because the navigation bar was vertically very large with its bottom area only holding the logo image at its center. I made the rendering of this logo image dynamic and getting removed in case of an elevated tab bar.
- The elevated tab bar's text color was black, I modified it to respect the brand's color as it does with a regular tab bar.

### Known issues
- The elevated tab bar's text color is always white in dark mode despite we set the brand's color that works in light mode.
- When the a tab's content is displayed for the first time its detail view resizes on screen due to the elevated tab bar. This causes a flicker.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/6d681341-64a1-4c32-ab88-236faabe5538" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/411e248e-4e89-4882-88b8-59c8800194b9" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/119f6d8e-6f9c-461d-b43b-be9b00fdba17" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/5c954a8d-05b9-4b3f-a193-06bb66b8c70d" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on iPhone (iOS 17)
- [ ] Tested on iPhone (iOS 18)
- [ ] Tested on iPad (iOS 17)
- [ ] Tested on iPad (iOS 18)