### PR TITLE
Fix crash of audio player showing infinite time

### DIFF
--- a/Core/Core/AudioVideo/AudioPlayerViewController.swift
+++ b/Core/Core/AudioVideo/AudioPlayerViewController.swift
@@ -179,7 +179,8 @@ public class AudioPlayerViewController: UIViewController {
     }
 
     private func formatTime(_ value: TimeInterval) -> String? {
-        return formatter.string(from: value.formatterValid)
+        let correctValue = value.isFinite ? value : 0
+        return formatter.string(from: correctValue)
     }
 }
 
@@ -193,12 +194,5 @@ extension AudioPlayerViewController: AVAudioPlayerDelegate {
     public func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
         pause()
         if let error = error { showError(error) }
-    }
-}
-
-private extension TimeInterval {
-    var formatterValid: TimeInterval {
-        guard isFinite && isNaN == false else { return 0 }
-        return self
     }
 }

--- a/Core/Core/AudioVideo/AudioPlayerViewController.swift
+++ b/Core/Core/AudioVideo/AudioPlayerViewController.swift
@@ -146,8 +146,8 @@ public class AudioPlayerViewController: UIViewController {
 
     @objc func tick(_ timer: CADisplayLink? = nil) {
         guard let player = player else { return }
-        currentTimeLabel?.text = formatter.string(from: player.currentTime)
-        remainingTimeLabel?.text = formatter.string(from: player.duration)
+        currentTimeLabel?.text = formatTime(player.currentTime)
+        remainingTimeLabel?.text = formatTime(player.duration)
         timeSlider?.accessibilityValue = currentTimeLabel?.text
         timeSlider?.maximumValue = Float(player.duration)
         timeSlider?.setValue(Float(player.currentTime), animated: false)
@@ -177,6 +177,10 @@ public class AudioPlayerViewController: UIViewController {
             play()
         }
     }
+
+    private func formatTime(_ value: TimeInterval) -> String? {
+        return formatter.string(from: value.formatterValid)
+    }
 }
 
 extension AudioPlayerViewController: AVAudioPlayerDelegate {
@@ -189,5 +193,12 @@ extension AudioPlayerViewController: AVAudioPlayerDelegate {
     public func audioPlayerDecodeErrorDidOccur(_ player: AVAudioPlayer, error: Error?) {
         pause()
         if let error = error { showError(error) }
+    }
+}
+
+private extension TimeInterval {
+    var formatterValid: TimeInterval {
+        guard isFinite && isNaN == false else { return 0 }
+        return self
     }
 }


### PR DESCRIPTION
refs: MBL-17941
affects: Student, Teacher
release note: Fixes crash of audio player showing infinite time 

## Test Plan

Couldn't reproduce the issue on Teacher app.  Though those changes can definitely fix such anticipated issue. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
