### PR TITLE
Escape quotation mark when uploading a file

### DIFF
--- a/Core/Core/API/APIFormData.swift
+++ b/Core/Core/API/APIFormData.swift
@@ -71,10 +71,10 @@ extension APIFormData {
             case .string(let string):
                 outputStream += "\r\n\r\n\(string)"
             case .data(let filename, let type, let contents):
-                outputStream += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n"
+                outputStream += "; filename=\"\(filename.escaped)\"\r\nContent-Type: \(type)\r\n\r\n"
                 outputStream += contents
             case .file(let filename, let type, let url):
-                outputStream += "; filename=\"\(filename)\"\r\nContent-Type: \(type)\r\n\r\n"
+                outputStream += "; filename=\"\(filename.escaped)\"\r\nContent-Type: \(type)\r\n\r\n"
 
                 if url.isFileURL {
                     guard let inputStream = InputStream(fileAtPath: url.path) else {
@@ -91,5 +91,13 @@ extension APIFormData {
         }
 
         outputStream += "--\(boundary)--\r\n"
+    }
+}
+
+private extension String {
+
+    /// Replaces " with \"
+    var escaped: String {
+        replacingOccurrences(of: "\"", with: "\\\"")
     }
 }


### PR DESCRIPTION
refs: [MBL-18046](https://instructure.atlassian.net/browse/MBL-18046)
affects: Student, Teacher, Parent
release note: Fixed file uploads failing when the file's name contained a quotation mark.

test plan: 
- See ticket.
- You can share the file from anywhere, no need to create a file in the drive, just use the Files app.
- All apps affected, the parent is due to file uploads from inbox.


## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18046]: https://instructure.atlassian.net/browse/MBL-18046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ