### PR TITLE
Restrict disabled tabs

### DIFF
--- a/Core/Core/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/AppEnvironment/AppEnvironment.swift
@@ -73,6 +73,8 @@ open class AppEnvironment {
         api = API(session)
         currentSession = session
         userDefaults = SessionDefaults(sessionID: session.uniqueID)
+        router.courseTabUrlInteractor?.clearEnabledTabs()
+        router.courseTabUrlInteractor?.setupTabSubscription()
 
         if isSilent {
             return

--- a/Core/Core/Contexts/GetContextTabs.swift
+++ b/Core/Core/Contexts/GetContextTabs.swift
@@ -57,8 +57,5 @@ public class GetContextTabs: CollectionUseCase {
             let model: Tab = client.fetch(predicate).first ?? client.insert()
             model.save(item, in: client, context: context)
         }
-
-        // update enabled course tabs directly
-        AppEnvironment.shared.router.courseTabUrlInteractor?.setEnabledCourseTabs(response, context: context)
     }
 }

--- a/Core/Core/Contexts/GetContextTabs.swift
+++ b/Core/Core/Contexts/GetContextTabs.swift
@@ -57,5 +57,8 @@ public class GetContextTabs: CollectionUseCase {
             let model: Tab = client.fetch(predicate).first ?? client.insert()
             model.save(item, in: client, context: context)
         }
+
+        // update enabled course tabs directly
+        AppEnvironment.shared.router.courseTabUrlInteractor?.setEnabledCourseTabs(response, context: context)
     }
 }

--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -161,6 +161,23 @@ final public class Course: NSManagedObject, WriteableModel {
 
         model.roles = item.enrollments.roles
 
+        if let apiTabs = item.tabs {
+            let courseContext = Context.course(item.id.value)
+
+            let contextPredicate = NSPredicate(
+                format: "%K == %@", #keyPath(Tab.contextRaw),
+                courseContext.canvasContextID
+            )
+
+            context.delete(context.fetch(contextPredicate) as [Tab])
+
+            // not adding tabs to Course, just saving them
+            apiTabs.forEach { apiTab in
+                let tab: Tab = context.insert()
+                tab.save(apiTab, in: context, context: courseContext)
+            }
+        }
+
         return model
     }
 }

--- a/Core/Core/Dashboard/CourseCardList/Model/UseCase/GetDashboardCourses.swift
+++ b/Core/Core/Dashboard/CourseCardList/Model/UseCase/GetDashboardCourses.swift
@@ -39,7 +39,7 @@ public class GetDashboardCourses: CollectionUseCase {
         request = GetCurrentUserCoursesRequest(
             enrollmentState: enrollmentState,
             state: [.current_and_concluded],
-            includes: GetCourseRequest.defaultIncludes
+            includes: GetCourseRequest.defaultIncludes + [.tabs]
         )
     }
 

--- a/Core/Core/Router/CourseTabUrlInteractor.swift
+++ b/Core/Core/Router/CourseTabUrlInteractor.swift
@@ -1,0 +1,120 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public final class CourseTabUrlInteractor {
+
+    private var enabledTabsPerCourse: [Context: [String]] = [:]
+
+    public init() { }
+
+    public func setEnabledCourseTabs(_ tabs: [APITab], context: Context) {
+        guard context.contextType == .course else { return }
+
+        var tabPaths = tabs.map { $0.html_url.absoluteString }
+
+        // Adding extra paths for some tabs besides the ones from `html_url`.
+        // Some have counterparts defined in `routes`, used only for in-app navigation or they are just legacy.
+        // Some have related paths and they should be enabled/disabled together.
+        tabs.forEach { tab in
+            switch tab.id.value {
+            case "syllabus":
+                // proper path from `html_url`: "course/:courseID/assignments/syllabus"
+                // internal path from `routes`: "course/:courseID/syllabus"
+                tabPaths.append("/\(context.pathComponent)/syllabus")
+            case "discussions":
+                // proper path from `html_url`: "course/:courseID/discussion_topics"
+                // internal path from `routes`: "course/:courseID/discussion"
+                tabPaths.append("/\(context.pathComponent)/discussions")
+            case "pages":
+                // proper path from `html_url`: "course/:courseID/wiki"
+                // related path also disabled on web: "course/:courseID/pages"
+                tabPaths.append("/\(context.pathComponent)/pages")
+                // related path also disabled on web: "course/:courseID/pages/front_page"
+                tabPaths.append("/\(context.pathComponent)/pages/front_page")
+                // internal path from `routes`: "course/:courseID/front_page"
+                tabPaths.append("/\(context.pathComponent)/front_page")
+            default:
+                break
+            }
+        }
+
+        enabledTabsPerCourse[context] = tabPaths
+    }
+
+    public func clearEnabledCourseTabs() {
+        enabledTabsPerCourse = [:]
+    }
+
+    /// Returns `true` if `url` is not a course tab URL OR it is but it's not in the list of enabled course tab URLs.
+    public func isAllowedUrl(_ url: URL) -> Bool {
+        // if url doesn't match ""/courses/:courseID/*" for the known courses -> it's not a tab, allow it
+        guard let context = Context(url: url), let enabledTabs = enabledTabsPerCourse[context] else {
+            return true
+        }
+
+        let relativePath = String(url.relativePath.trimmingPrefix("/api/v1"))
+        let parts = relativePath.split(separator: "/").map { String($0) }
+
+        // if url doesn't even match known tab path formats -> it's not a tab, allow it
+        guard CourseTabFormat.allCases.contains(where: { $0.isMatch(for: parts) }) else {
+            return true
+        }
+
+        // it's a tab, if it matches any of the enabled tabs allow it, otherwise block it
+        return enabledTabs.contains(relativePath)
+    }
+}
+
+/// Known course tab formats
+private enum CourseTabFormat: CaseIterable {
+    case regularTab
+    case syllabusTab
+    case frontPage
+    case externalToolTab
+
+    func isMatch(for parts: [String]) -> Bool {
+        switch self {
+
+        case .regularTab:
+            // example: "/courses/42/grades"
+            guard parts.count == 3 else { return false }
+
+            let lastPart = parts[2]
+            let internalOnlyRouteComponents = [
+                "tabs",
+                "activity_stream"
+            ]
+            // if the last part matches an internal only suffix -> it's not a tab
+            return !internalOnlyRouteComponents.contains(lastPart)
+
+        case .syllabusTab:
+            // example: "/courses/42/assignments/syllabus"
+            return parts.count == 4 && parts[3] == "syllabus"
+
+        case .frontPage:
+            // example: "/courses/42/pages/front_page"
+            return parts.count == 4 && parts[2] == "pages" && parts[3] == "front_page"
+
+        case .externalToolTab:
+            // example: "/courses/42/external_tools/1234"
+            return parts.count == 4 && parts[2] == "external_tools"
+        }
+    }
+}

--- a/Core/Core/Router/Router.swift
+++ b/Core/Core/Router/Router.swift
@@ -100,14 +100,21 @@ open class Router {
     public typealias FallbackHandler = (URLComponents, [String: Any]?, UIViewController, RouteOptions) -> Void
     public static let DefaultRouteOptions: RouteOptions = .push
 
+    public let courseTabUrlInteractor: CourseTabUrlInteractor?
+
     public var count: Int { handlers.count }
 
     private let handlers: [RouteHandler]
     private let fallback: FallbackHandler
 
-    public init(routes: [RouteHandler], fallback: @escaping FallbackHandler = { url, _, _, _ in open(url: url) }) {
+    public init(
+        routes: [RouteHandler],
+        fallback: @escaping FallbackHandler = { url, _, _, _ in open(url: url) },
+        courseTabUrlInteractor: CourseTabUrlInteractor? = nil
+    ) {
         self.handlers = routes
         self.fallback = fallback
+        self.courseTabUrlInteractor = courseTabUrlInteractor
     }
 
     // MARK: - Route Matching
@@ -168,6 +175,11 @@ open class Router {
         #if DEBUG
         DeveloperMenuViewController.recordRouteInHistory(url.url?.absoluteString)
         #endif
+
+        // block disabled course tab urls
+        if let courseTabUrlInteractor, let url = url.url, !courseTabUrlInteractor.isAllowedUrl(url) {
+            return
+        }
 
         for route in handlers {
             if let params = route.match(url) {

--- a/Core/CoreTests/Courses/CourseTests.swift
+++ b/Core/CoreTests/Courses/CourseTests.swift
@@ -260,4 +260,53 @@ class CourseTests: CoreTestCase {
                                 ],
                                 settings: .make(restrict_quantitative_data: restrict_quantitative_data)))
     }
+
+    func testSavingTabs() {
+        func tabsForCourseId(_ id: String) -> [Tab] {
+            databaseClient.fetch(scope: .where(#keyPath(Tab.contextRaw), equals: "course_\(id)"))
+        }
+
+        var tabs42: [Tab] = []
+        var tabs7: [Tab] = []
+
+        // save course with tabs
+        Course.make(from: .make(
+            id: "42",
+            tabs: [
+                .make(id: "modules", html_url: URL(string: "/courses/42/modules")!),
+                .make(id: "people", html_url: URL(string: "/courses/42/users")!)
+            ]
+        ))
+        tabs42 = tabsForCourseId("42")
+        XCTAssertEqual(tabs42.count, 2)
+        XCTAssertEqual(tabs42.contains { $0.id == "modules" }, true)
+        XCTAssertEqual(tabs42.contains { $0.id == "people" }, true)
+
+        // save another course with tabs
+        Course.make(from: .make(
+            id: "7",
+            tabs: [
+                .make(id: "grades", html_url: URL(string: "/courses/7/grades")!)
+            ]
+        ))
+        tabs42 = tabsForCourseId("42")
+        XCTAssertEqual(tabs42.count, 2)
+        XCTAssertEqual(tabs42.contains { $0.id == "modules" }, true)
+        XCTAssertEqual(tabs42.contains { $0.id == "people" }, true)
+        tabs7 = tabsForCourseId("7")
+        XCTAssertEqual(tabs7.contains { $0.id == "grades" }, true)
+
+        // save original course with different tab
+        Course.make(from: .make(
+            id: "42",
+            tabs: [
+                .make(id: "pages", html_url: URL(string: "/courses/42/wiki")!),
+            ]
+        ))
+        tabs42 = tabsForCourseId("42")
+        XCTAssertEqual(tabs42.count, 1)
+        XCTAssertEqual(tabs42.contains { $0.id == "pages" }, true)
+        tabs7 = tabsForCourseId("7")
+        XCTAssertEqual(tabs7.contains { $0.id == "grades" }, true)
+    }
 }

--- a/Core/CoreTests/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Router/CourseTabUrlInteractorTests.swift
@@ -1,0 +1,272 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import TestsFoundation
+@testable import Core
+
+final class CourseTabUrlInteractorTests: CoreTestCase {
+
+    private var testee: CourseTabUrlInteractor!
+
+    override func setUp() {
+        super.setUp()
+        testee = .init()
+        testee.setupTabSubscription()
+    }
+
+    override func tearDown() {
+        testee = nil
+        super.tearDown()
+    }
+
+    // MARK: - No tab subscription
+
+    func test_isAllowedUrl_whenNotSetup_shouldAllowAll() {
+        testee = .init()
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/discussion_topics?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/discussion_topics")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/discussion_topics")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unkown_thing")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/1234")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/1234/")), true)
+
+        verifyUnrelatedURLsAreAllowed()
+    }
+
+    // MARK: - Enabled / Disabled tabs
+
+    func test_isAllowedUrl_whenSetupWithTabs_shouldAllowOnlyEnabledTabs() {
+        saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/users", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), true)
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/modules")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unkown_thing")), false)
+
+        verifyUnrelatedURLsAreAllowed()
+    }
+
+    func test_isAllowedUrl_whenUrlIsNotCourseTab_shouldAllow() {
+        saveTab(htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/groups/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/users/42/settings")), true)
+    }
+
+    func test_isAllowedUrl_whenTabIsDisabledInAnotherCourse_shouldBlockOnlyForThatCourse() {
+        saveTab(htmlUrl: "/courses/7/not_grades", context: .course("7"))
+        saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
+
+        // tab disabled in course -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/7/grades")), false)
+
+        // tab enabled in course -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+
+        // tab in unknown course -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/0/grades")), true)
+    }
+
+    // MARK: - Tab Format rules
+
+    func test_isAllowedUrl_whenTabIsDisabled_shouldBlockAllVariants() {
+        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), false)
+    }
+
+    func test_isAllowedUrl_whenTabIsDisabled_shouldAllowSubpages() {
+        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+
+        // subpage -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/123")), true)
+
+        // tab -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
+    }
+
+    func test_isAllowedUrl_whenTabIsDisabled_shouldAllowInternalNavigationPaths() {
+        saveTab(htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/tabs")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/activity_stream")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/users/42/activity_stream")), true)
+    }
+
+    func test_isAllowedUrl_whenSyllabusIsDisabled_shouldBlockSyllabusUrlFormat() {
+        saveTab(htmlUrl: "/courses/42/not_syllabus", context: .course("42"))
+
+        // matching special format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/assignments/syllabus")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/any_component_here/syllabus")), false)
+
+        // matching basic format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/syllabus")), false)
+
+        // not matching format -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/assignments/syllabus/something")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/syllabus/something")), true)
+    }
+
+    func test_isAllowedUrl_whenPagesIsDisabled_shouldBlockFrontPageUrlFormat() {
+        saveTab(htmlUrl: "/courses/42/not_pages", context: .course("42"))
+
+        // matching special format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages/front_page")), false)
+
+        // matching basic format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/front_page")), false)
+
+        // not matching format -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/any_component_here/front_page")), true)
+    }
+
+    func test_isAllowedUrl_whenExternalToolsIsDisabled_shouldBlockExternalToolsUrlFormat() {
+        saveTab(htmlUrl: "/courses/42/not_external_tools", context: .course("42"))
+
+        // matching special format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/external_tools/1234")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/external_tools/something")), false)
+
+        // matching basic (but still disabled) format -> block
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/external_tools")), false)
+
+        // not matching format -> allow
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/external_tools/1234/something")), true)
+    }
+
+    // MARK: - Setup enabled tabs
+
+    func test_setupEnabledTabs_shouldUseHtmlUrl() {
+        let apiTab = APITab.make(
+            id: "people",
+            html_url: URL(string: "/courses/42/modules")!,
+            full_url: URL(string: "/courses/42/pages")!,
+            url: URL(string: "/courses/42/grades")!
+        )
+        let tab: Tab = databaseClient.insert()
+        tab.save(apiTab, in: databaseClient, context: .course("42"))
+        drainMainQueue()
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/modules")), true)
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
+    }
+
+    func test_setupEnabledTabs_whenSyllabusIsEnabled_shouldEnableAlternativePaths() {
+        saveTab(id: "syllabus", htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/syllabus")), true)
+    }
+
+    func test_setupEnabledTabs_whenDiscussionsIsEnabled_shouldEnableAlternativePaths() {
+        saveTab(id: "discussions", htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/discussions")), true)
+    }
+
+    func test_setupEnabledTabs_whenPagesIsEnabled_shouldEnableAlternativePaths() {
+        saveTab(id: "pages", htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages/front_page")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/front_page")), true)
+    }
+
+    func test_setupEnabledTabs_whenPathFormatIsUnknown_shouldLogIt() {
+        // known path formats are not logged
+        saveTab(id: "grades", htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(id: "syllabus", htmlUrl: "/courses/42/assignments/syllabus", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
+
+        // unknown path format is logged
+        saveTab(id: "pages", htmlUrl: "/courses/42/tabs/grades", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, "Unexpected Course Tab path format")
+    }
+
+    func test_setupEnabledTabs_whenTabIsHome_shouldNotLogIt() {
+        // `id: home` is not logged
+        saveTab(id: "home", htmlUrl: "/courses/42/ignoring/this/url", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
+
+        // home-like format with different id is logged
+        saveTab(id: "pages", htmlUrl: "/courses/42", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, "Unexpected Course Tab path format")
+    }
+
+    // MARK: - Clear tabs
+
+    func test_clearEnabledTabs_shouldAllowAll() {
+        saveTab(htmlUrl: "/courses/42/users", context: .course("42"))
+
+        testee.clearEnabledTabs()
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages")), true)
+        verifyUnrelatedURLsAreAllowed()
+    }
+
+    func test_clearEnabledTabs_shouldNotRemoveTabsFromDatabase() {
+        saveTab(id:"people", htmlUrl: "/courses/42/users", context: .course("42"))
+
+        testee.clearEnabledTabs()
+
+        let tabs: [Tab] = databaseClient.fetch(scope: .all)
+        XCTAssertEqual(tabs.first?.id, "people")
+
+        saveTab(htmlUrl: "/courses/42/pages", context: .course("42"))
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/modules")), false)
+        verifyUnrelatedURLsAreAllowed()
+    }
+
+    // MARK: - Private helpers
+
+    @discardableResult
+    private func saveTab(id: String = "", htmlUrl: String, context: Context) -> Tab {
+        let apiTab = APITab.make(id: ID(id), html_url: URL(string: htmlUrl)!)
+        let tab: Tab = databaseClient.insert()
+        tab.save(apiTab, in: databaseClient, context: context)
+        drainMainQueue()
+        return tab
+    }
+
+    private func verifyUnrelatedURLsAreAllowed() {
+        XCTAssertEqual(testee.isAllowedUrl(.make("/users/self/activity_stream")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/login/session_token")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://instructure.com")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("stuff")), true)
+    }
+}
+
+private extension URL {
+    static func make(_ string: String) -> URL {
+        URL(string: string)!
+    }
+}

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -445,7 +445,7 @@ let router = Router(routes: [
     RouteHandler("/about") { _, _, _ in
         AboutAssembly.makeAboutViewController()
     }
-])
+], courseTabUrlInteractor: .init())
 
 private func nativeFactory(url _: URLComponents, params: [String: String], userInfo: [String: Any]?) -> UIViewController? {
     guard let route = params["route"] else { return nil }


### PR DESCRIPTION
refs: MBL-18057
affects: Student
release note: Fixed disabled tabs being available in some cases.

## What's changed
Routes which lead to disabled tabs are not opening anymore.
Behavior follows the website, including the enabling/disabling of some related pages.
The special cases are the following:
- when "Pages" tab is disabled we disable
  - `course/:courseID/wiki`
  - `course/:courseID/pages`
  - `course/:courseID/pages/front_page`
- there are some other cases but they involve internal URLs only

## Problems
- Our `router` doesn't know whether a route is for internal navigation only or not. This means we need to consider app-only URLs too when checking for disabled tabs. The known exceptions had been handled.
- Backend doesn't provide a list of disabled tabs. It just returns the currently enabled tabs. We also have no list of all the tabs and new ones could be added any time. Remote logging is in place for unexpected tab formats.
- We assume the following tab url format: `course/:courseId/tabname`, plus there are some known exceptions. When a non-tab URL is introduced in Canvas which matches this format, the app won't know about it and disable it. We can handle this once we are made aware.

## Test plan
- Verify disabled tabs are not available via
  - direct links on pages, messages, etc
  - push notifications
  - outside apps when app is open
  - outside apps when app is closed
- Verify all other kind of links are opening properly
- Verify links to another course's disabled tabs are disabled properly

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet