### PR TITLE
Fix comment library not showing up when tapping on the comment field

### DIFF
--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -6403,6 +6403,7 @@
       }
     },
     "Comment library is not available" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Teacher/Teacher/SpeedGrader/CommentEditor.swift
+++ b/Teacher/Teacher/SpeedGrader/CommentEditor.swift
@@ -23,6 +23,8 @@ struct CommentEditor: View {
     @Environment(\.viewController) var controller
 
     @Binding var text: String
+    let shouldShowCommentLibrary: Bool
+    @Binding var showCommentLibrary: Bool
     let action: () -> Void
     let containerHeight: CGFloat
 
@@ -33,6 +35,19 @@ struct CommentEditor: View {
                 .lineLimit(10)
                 .accessibility(label: Text("Comment", bundle: .teacher))
                 .identifier("SubmissionComments.commentTextView")
+                .highPriorityGesture( // High priority to take precedence over comment field activation.
+                    TapGesture().onEnded { _ in showCommentLibrary = true },
+                    isEnabled: shouldShowCommentLibrary
+                )
+                .accessibilityActions {
+                    if shouldShowCommentLibrary {
+                        Button {
+                            showCommentLibrary = true
+                        } label: {
+                            Text("Open comment library", bundle: .teacher)
+                        }
+                    }
+                }
             Button(action: {
                 action()
                 controller.view.endEditing(true)
@@ -61,7 +76,10 @@ struct CommentEditor: View {
 
 struct CommentEditor_Previews: PreviewProvider {
     static var previews: some View {
+        @State var showCommentLibrary = false
         CommentEditor(text: .constant("Sample Text"),
+                      shouldShowCommentLibrary: true,
+                      showCommentLibrary: $showCommentLibrary,
                       action: {},
                       containerHeight: 30)
         .frame(width: 200)

--- a/Teacher/Teacher/SpeedGrader/CommentLibrarySheet.swift
+++ b/Teacher/Teacher/SpeedGrader/CommentLibrarySheet.swift
@@ -32,7 +32,12 @@ struct CommentLibrarySheet: View {
                 CommentLibraryList(viewModel: viewModel, comment: $comment) {
                     presentationMode.wrappedValue.dismiss()
                 }
-                CommentEditor(text: $comment, action: editorAction, containerHeight: geometry.size.height)
+                CommentEditor(
+                    text: $comment,
+                    shouldShowCommentLibrary: false,
+                    showCommentLibrary: .constant(false),
+                    action: editorAction, containerHeight: geometry.size.height
+                )
                     .padding(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                     .background(Color.backgroundLight).onChange(of: comment) { text in
                         viewModel.comment = text

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -103,9 +103,10 @@ struct SubmissionCommentList: View {
                 case nil:
                     toolbar(containerHeight: geometry.size.height)
                         .transition(.opacity)
-                        .onTapGesture {
-                            showCommentLibrary = commentLibrary.shouldShow
-                        }
+                        .highPriorityGesture( // High priority to take precedence over comment field activation.
+                            TapGesture().onEnded { _ in showCommentLibrary = true },
+                            isEnabled: commentLibrary.shouldShow
+                        )
                         .accessibilityAction(named: Text("Open comment library", bundle: .teacher)) {
                             if commentLibrary.shouldShow {
                                 showCommentLibrary = true

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -103,17 +103,6 @@ struct SubmissionCommentList: View {
                 case nil:
                     toolbar(containerHeight: geometry.size.height)
                         .transition(.opacity)
-                        .highPriorityGesture( // High priority to take precedence over comment field activation.
-                            TapGesture().onEnded { _ in showCommentLibrary = true },
-                            isEnabled: commentLibrary.shouldShow
-                        )
-                        .accessibilityAction(named: Text("Open comment library", bundle: .teacher)) {
-                            if commentLibrary.shouldShow {
-                                showCommentLibrary = true
-                            } else {
-                                UIAccessibility.post(notification: .screenChanged, argument: String(localized: "Comment library is not available", bundle: .teacher))
-                            }
-                        }
                 }
             }.sheet(isPresented: $showCommentLibrary) {
                 CommentLibrarySheet(viewModel: commentLibrary, comment: $comment) {
@@ -158,7 +147,13 @@ struct SubmissionCommentList: View {
                         .cancel()
                     ])
                 }
-            CommentEditor(text: $comment, action: sendComment, containerHeight: containerHeight)
+            CommentEditor(
+                text: $comment,
+                shouldShowCommentLibrary: commentLibrary.shouldShow,
+                showCommentLibrary: $showCommentLibrary,
+                action: sendComment,
+                containerHeight: containerHeight
+            )
                 .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 16))
         }
             .background(Color.backgroundLight)

--- a/Teacher/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -148,7 +148,10 @@ struct SubmissionGrades: View {
     }
 
     private func commentEditor(id: String) -> some View {
-        CommentEditor(text: $rubricComment, action: {
+        CommentEditor(text: $rubricComment,
+                      shouldShowCommentLibrary: false,
+                      showCommentLibrary: .constant(false),
+                      action: {
             var points: Double?
             var ratingID = ""
             if let assessment = rubricAssessments[id] {


### PR DESCRIPTION
refs: [MBL-18099](https://instructure.atlassian.net/browse/MBL-18099)
affects: Teacher
release note: Fixed comment library not showing up when tapping on the comment field.

test plan:
- Test if comment library properly shows up when tapping on the comment field.
- Turn off comment library on web.
- Log out and log in to the app to force a refresh on this setting.
- Test if text field properly activates and text can be entered.

## Checklist
- [x] Tested on phone
- [ ] Tested on tablet

[MBL-18099]: https://instructure.atlassian.net/browse/MBL-18099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ