### PR TITLE
Fix calendar not loading when calendar context limit is increased

### DIFF
--- a/Core/Core/AppEnvironment/EnvironmentSettings/CDEnvironmentSettings.swift
+++ b/Core/Core/AppEnvironment/EnvironmentSettings/CDEnvironmentSettings.swift
@@ -19,32 +19,21 @@
 import Foundation
 import CoreData
 
-public final class CDEnvironmentSetting: NSManagedObject, WriteableModel {
-    public enum EnvironmentSettingName: String {
-        case calendar_contexts_limit
+public final class CDEnvironmentSettings: NSManagedObject, WriteableModel {
+    @NSManaged public var calendarContextsLimitRaw: NSNumber?
+
+    public var calendarContextsLimit: Int? {
+        get { return calendarContextsLimitRaw?.intValue }
+        set { calendarContextsLimitRaw = NSNumber(value: newValue) }
     }
-
-    public typealias JSON = (name: String, isEnabled: Bool)
-
-    @NSManaged public var name: String
-    @NSManaged public var isEnabled: Bool
 
     @discardableResult
     public static func save(
-        _ item: (name: String, isEnabled: Bool),
+        _ apiEntity: GetEnvironmentSettingsRequest.Response,
         in context: NSManagedObjectContext
-    ) -> CDEnvironmentSetting {
-        let predicate = NSPredicate(format: "%K == %@", #keyPath(CDEnvironmentSetting.name), item.name)
-        let flag: CDEnvironmentSetting = context.fetch(predicate).first ?? context.insert()
-        flag.name = item.name
-        flag.isEnabled = item.isEnabled
+    ) -> CDEnvironmentSettings {
+        let flag: CDEnvironmentSettings = context.fetch(.all).first ?? context.insert()
+        flag.calendarContextsLimit = apiEntity.calendar_contexts_limit
         return flag
-    }
-}
-
-public extension Array where Element == CDEnvironmentSetting {
-
-    func isEnabled(_ name: CDEnvironmentSetting.EnvironmentSettingName) -> Bool {
-        contains { $0.name == name.rawValue && $0.isEnabled }
     }
 }

--- a/Core/Core/AppEnvironment/EnvironmentSettings/GetEnvironmentSettings.swift
+++ b/Core/Core/AppEnvironment/EnvironmentSettings/GetEnvironmentSettings.swift
@@ -20,24 +20,9 @@ import CoreData
 import Foundation
 
 public class GetEnvironmentSettings: CollectionUseCase {
-    public typealias Model = CDEnvironmentSetting
+    public typealias Model = CDEnvironmentSettings
 
     public let scope: Scope = .all
     public let cacheKey: String? = "environment-settings"
-
-    public var request: GetEnvironmentSettingsRequest {
-        GetEnvironmentSettingsRequest()
-    }
-
-    public func write(
-        response: [String: Bool]?,
-        urlResponse: URLResponse?,
-        to client: NSManagedObjectContext
-    ) {
-        guard let response else { return }
-
-        for (key, isEnabled) in response {
-            CDEnvironmentSetting.save((key, isEnabled), in: client)
-        }
-    }
+    public let request = GetEnvironmentSettingsRequest()
 }

--- a/Core/Core/AppEnvironment/EnvironmentSettings/GetEnvironmentSettingsRequest.swift
+++ b/Core/Core/AppEnvironment/EnvironmentSettings/GetEnvironmentSettingsRequest.swift
@@ -17,7 +17,9 @@
 //
 
 public struct GetEnvironmentSettingsRequest: APIRequestable {
-    public typealias Response = [String: Bool]
+    public struct Response: Codable {
+        public let calendar_contexts_limit: Int?
+    }
 
     public let path = "settings/environment.json"
 

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23G80" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -180,9 +180,8 @@
         <attribute name="stateRaw" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="tabID" optional="YES" attributeType="String"/>
     </entity>
-    <entity name="CDEnvironmentSetting" representedClassName="Core.CDEnvironmentSetting" syncable="YES">
-        <attribute name="isEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="name" attributeType="String"/>
+    <entity name="CDEnvironmentSettings" representedClassName="Core.CDEnvironmentSettings" syncable="YES">
+        <attribute name="calendarContextsLimitRaw" optional="YES" attributeType="Integer 64" defaultValueString="0.0" usesScalarValueType="YES"/>
     </entity>
     <entity name="CDWidgetAnnouncement" representedClassName="Core.CDWidgetAnnouncement" syncable="YES">
         <attribute name="authorName" attributeType="String"/>

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
@@ -16,10 +16,18 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-public enum CalendarFilterCountLimit: Int {
-    case base = 10
-    case extended = 20
-    case unlimited = 9999
+public enum CalendarFilterCountLimit: Equatable {
+    case base
+    case extended(Int)
+    case unlimited
+
+    public var rawValue: Int {
+        switch self {
+        case .base: return 10
+        case .extended(let value): return value
+        case .unlimited: return 9999
+        }
+    }
 }
 
 public extension Optional where Wrapped == AppEnvironment.App {
@@ -32,7 +40,7 @@ public extension Optional where Wrapped == AppEnvironment.App {
     }
 }
 
-public extension Array where Element == CDEnvironmentSetting {
+public extension Optional where Wrapped == CDEnvironmentSettings {
 
     func calendarFilterCountLimit(
         isCalendarFilterLimitEnabled: Bool
@@ -41,6 +49,10 @@ public extension Array where Element == CDEnvironmentSetting {
             return .unlimited
         }
 
-        return isEnabled(.calendar_contexts_limit) ? .extended : .base
+        if let limit = self?.calendarContextsLimit {
+            return .extended(limit)
+        }
+
+        return .base
     }
 }

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractor.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractor.swift
@@ -139,6 +139,7 @@ public class CalendarFilterInteractorLive: CalendarFilterInteractor {
         let useCase = GetEnvironmentSettings()
         return ReactiveStore(useCase: useCase)
             .getEntities(ignoreCache: ignoreCache)
+            .map { $0.first }
             .map { $0.calendarFilterCountLimit(isCalendarFilterLimitEnabled: isCalendarFilterLimitEnabled) }
             .eraseToAnyPublisher()
     }

--- a/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractorPreview.swift
+++ b/Core/Core/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractorPreview.swift
@@ -23,7 +23,7 @@ import Combine
 public class CalendarFilterInteractorPreview: CalendarFilterInteractor {
     public var filters = CurrentValueSubject<[CDCalendarFilterEntry], Never>([])
     public var selectedContexts = CurrentValueSubject<Set<Context>, Never>(Set())
-    public var filterCountLimit = CurrentValueSubject<CalendarFilterCountLimit, Never>(.extended)
+    public var filterCountLimit = CurrentValueSubject<CalendarFilterCountLimit, Never>(.extended(20))
     public var mockedFilters: [(String, Context)] = [
         ("Test User", .user("1")),
 

--- a/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
@@ -1,0 +1,72 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import XCTest
+
+class CalendarFilterCountLimitTests: CoreTestCase {
+
+    func test_isCalendarFilterLimitEnabled() {
+        var testee: AppEnvironment.App?
+        XCTAssertEqual(testee.isCalendarFilterLimitEnabled, false)
+
+        testee = .parent
+        XCTAssertEqual(testee.isCalendarFilterLimitEnabled, false)
+
+        testee = .student
+        XCTAssertEqual(testee.isCalendarFilterLimitEnabled, false)
+
+        testee = .teacher
+        XCTAssertEqual(testee.isCalendarFilterLimitEnabled, true)
+    }
+
+    func test_calendarFilterCountLimit_emptyDatabase() {
+        var testee: CDEnvironmentSettings?
+        XCTAssertEqual(
+            testee.calendarFilterCountLimit(isCalendarFilterLimitEnabled: false),
+            .unlimited
+        )
+
+        XCTAssertEqual(
+            testee.calendarFilterCountLimit(isCalendarFilterLimitEnabled: true),
+            .base
+        )
+
+        testee = databaseClient.insert() as CDEnvironmentSettings
+        testee?.calendarContextsLimit = nil
+        XCTAssertEqual(
+            testee.calendarFilterCountLimit(isCalendarFilterLimitEnabled: false),
+            .unlimited
+        )
+
+        XCTAssertEqual(
+            testee.calendarFilterCountLimit(isCalendarFilterLimitEnabled: true),
+            .base
+        )
+    }
+
+    func test_calendarFilterCountLimit_validDatabase() {
+        let testee: CDEnvironmentSettings? = databaseClient.insert() as CDEnvironmentSettings
+        testee?.calendarContextsLimit = 6
+
+        XCTAssertEqual(
+            testee.calendarFilterCountLimit(isCalendarFilterLimitEnabled: true),
+            .extended(6)
+        )
+    }
+}

--- a/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractorTests.swift
+++ b/Core/CoreTests/Planner/CalendarFilter/Model/Interactor/CalendarFilterInteractorTests.swift
@@ -132,8 +132,10 @@ class CalendarFilterInteractorTests: CoreTestCase {
 
         // Mock max 10 context filter limit
         let settingsRequest = GetEnvironmentSettingsRequest()
-        api.mock(settingsRequest,
-                 value: [CDEnvironmentSetting.EnvironmentSettingName.calendar_contexts_limit.rawValue: false])
+        api.mock(
+            settingsRequest,
+            value: .init(calendar_contexts_limit: 10)
+        )
 
         let testee = CalendarFilterInteractorLive(
             observedUserId: nil,


### PR DESCRIPTION
### What changed?
- There was a breaking API change in `/api/v1/settings/environment.json`: the `calendar_contexts_limit` field no longer returns a bool whether it's enabled or not but returns the actual limit as an integer in case the `Increase calendar context limit` toggle is enabled. If this setting is not enabled the API won't return this field at all.
- I changed how we store this setting and from now on we use the limit returned by the API instead of the hardcoded 20 value.

refs: [MBL-18102](https://instructure.atlassian.net/browse/MBL-18102)
affects: Student, Teacher, Parent
release note: Fixed calendar not displaying the filter list and events properly.

test plan:
- Enable "Increase calendar context limit" in course settings on web.
- Go to all apps, check if calendar loads.
- Check if calendar filter loads, pull to refresh doesn't show an error page.
- Test if teacher app still has a functioning calendar filter (max 10/20 events).

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet


[MBL-18102]: https://instructure.atlassian.net/browse/MBL-18102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ