### PR TITLE
New Quiz LTI labeling

### DIFF
--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -331,21 +331,18 @@ extension Assignment {
         return submission?.status ?? .notSubmitted
     }
 
-    public var icon: UIImage? {
-        var image: UIImage? = .assignmentLine
-        if quizID != nil {
-            image = .quizLine
-        } else if submissionTypes.contains(.discussion_topic) {
-            image = .discussionLine
-        } else if submissionTypes.contains(.external_tool) || submissionTypes.contains(.basic_lti_launch) {
-            image = .ltiLine
-        }
-
+    public var icon: UIImage {
         if lockedForUser {
-            image = .lockLine
+            .lockLine
+        } else if quizID != nil || isQuizLTI {
+            .quizLine
+        } else if submissionTypes.contains(.discussion_topic) {
+            .discussionLine
+        } else if submissionTypes.contains(.external_tool) || submissionTypes.contains(.basic_lti_launch) {
+            .ltiLine
+        } else {
+            .assignmentLine
         }
-
-        return image
     }
 
     public func requiresLTILaunch(toViewSubmission submission: Submission) -> Bool {

--- a/Core/Core/Assignments/Assignment.swift
+++ b/Core/Core/Assignments/Assignment.swift
@@ -146,6 +146,15 @@ public class Assignment: NSManagedObject {
         set { submissionTypesRaw = newValue.map { $0.rawValue } .joined(separator: ",") }
     }
 
+    public var submissionTypesWithQuizLTIMapping: [SubmissionType] {
+        guard isQuizLTI else { return submissionTypes }
+
+        var types = submissionTypes
+        types.removeAll { $0 == .online_quiz }
+        types.replace([.external_tool], with: [.online_quiz])
+        return types
+    }
+
     public var hasMultipleDueDates: Bool {
         allDates.count > 1
     }

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -176,7 +176,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
             Button(action: launchLTITool, label: {
                 HStack {
                     Spacer()
-                    Text(launchLtiTitle(for: assignment))
+                    Text(assignment.openLtiButtonTitle)
                         .font(.semibold16).foregroundColor(Color(Brand.shared.buttonPrimaryText))
                     Spacer()
                 }
@@ -211,14 +211,6 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
                 content
             }
                 .padding(16)
-        }
-    }
-
-    private func launchLtiTitle(for assignment: Assignment) -> String {
-        if assignment.isQuizLTI {
-            String(localized: "Open the Quiz", bundle: .core)
-        } else {
-            String(localized: "Launch External Tool", bundle: .core)
         }
     }
 
@@ -266,5 +258,15 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
             assignmentID: assignmentID,
             from: controller.value
         )
+    }
+}
+
+private extension Assignment {
+    var openLtiButtonTitle: String {
+        if isQuizLTI {
+            String(localized: "Open the Quiz", bundle: .core)
+        } else {
+            String(localized: "Launch External Tool", bundle: .core)
+        }
     }
 }

--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -126,7 +126,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
 
         let types = Section(label: Text("Submission Types", bundle: .core)) {
             Text(ListFormatter.localizedString(
-                from: assignment.submissionTypes.map { $0.localizedString },
+                from: assignment.submissionTypesWithQuizLTIMapping.map { $0.localizedString },
                 conjunction: .or
             ))
                 .font(.regular16).foregroundColor(.textDarkest)
@@ -176,7 +176,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
             Button(action: launchLTITool, label: {
                 HStack {
                     Spacer()
-                    Text("Launch External Tool", bundle: .core)
+                    Text(launchLtiTitle(for: assignment))
                         .font(.semibold16).foregroundColor(Color(Brand.shared.buttonPrimaryText))
                     Spacer()
                 }
@@ -211,6 +211,14 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
                 content
             }
                 .padding(16)
+        }
+    }
+
+    private func launchLtiTitle(for assignment: Assignment) -> String {
+        if assignment.isQuizLTI {
+            String(localized: "Open the Quiz", bundle: .core)
+        } else {
+            String(localized: "Launch External Tool", bundle: .core)
         }
     }
 

--- a/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
+++ b/Core/Core/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
@@ -31,7 +31,7 @@ public class AssignmentCellViewModel: ObservableObject {
     }
 
     public var route: URL? { assignment.htmlURL }
-    public var icon: UIImage { assignment.icon ?? .assignmentLine }
+    public var icon: UIImage { assignment.icon }
     public var name: String { assignment.name }
     public var submissionStatus: String { stateDisplayProperties.text }
     public var submissionIcon: UIImage { stateDisplayProperties.icon }

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -904,7 +904,7 @@
         <attribute name="order" optional="YES" attributeType="String"/>
         <attribute name="pointsPossibleRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="published" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
-        <attribute name="questionCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="questionCountRaw" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="questionTypesRaw" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
         <attribute name="quizTypeOrder" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="quizTypeRaw" attributeType="String"/>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="24B91" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -55,7 +55,7 @@
         <attribute name="htmlURL" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="inClosedGradingPeriod" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="isQuizLTI" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isQuizLTI" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lastUpdatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lockAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -713,7 +713,7 @@
         <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="indent" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="isQuizLTI" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isQuizLTI" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lockExplanation" optional="YES" attributeType="String"/>
         <attribute name="minScoreRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -55,7 +55,7 @@
         <attribute name="htmlURL" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="inClosedGradingPeriod" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="isQuizLTI" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isQuizLTI" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lastUpdatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lockAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
@@ -713,7 +713,7 @@
         <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="indent" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="isQuizLTI" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="isQuizLTI" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lockExplanation" optional="YES" attributeType="String"/>
         <attribute name="minScoreRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>

--- a/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23507" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23231" systemVersion="23H222" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -713,6 +713,7 @@
         <attribute name="htmlURL" optional="YES" attributeType="URI"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="indent" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="isQuizLTI" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="lockedForUser" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
         <attribute name="lockExplanation" optional="YES" attributeType="String"/>
         <attribute name="minScoreRaw" optional="YES" attributeType="Double" usesScalarValueType="YES"/>

--- a/Core/Core/Grades/View/GradeRowView.swift
+++ b/Core/Core/Grades/View/GradeRowView.swift
@@ -44,7 +44,7 @@ public struct GradeRowView: View {
     }
 
     private var assignmentIcon: some View {
-        Image(uiImage: assignment.icon ?? .assignmentLine)
+        Image(uiImage: assignment.icon)
             .padding(.top, 12)
             .padding(.leading, 22)
             .padding(.trailing, 18)

--- a/Core/Core/LTI/View/LTIViewController.storyboard
+++ b/Core/Core/LTI/View/LTIViewController.storyboard
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -18,7 +19,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LTI Tool" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dW-v6-GRg" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="60" width="382" height="20.5"/>
+                                <rect key="frame" x="16" y="64" width="382" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -27,8 +28,8 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="bold20"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This page can only be viewed from a web browser." textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gdo-sp-Qqp" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="113" width="382" height="41"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gdo-sp-Qqp" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                <rect key="frame" x="16" y="117" width="382" height="20.5"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -37,10 +38,9 @@
                                     <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
                                 </userDefinedRuntimeAttributes>
                             </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FEg-ym-aNw" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FEg-ym-aNw" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
                                 <rect key="frame" x="0.0" y="808" width="414" height="54"/>
                                 <inset key="contentEdgeInsets" minX="0.0" minY="18" maxX="0.0" maxY="18"/>
-                                <state key="normal" title="Open in Safari"/>
                                 <userDefinedRuntimeAttributes>
                                     <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="buttonPrimaryBackground"/>
                                     <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
@@ -51,22 +51,23 @@
                                 </connections>
                             </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="37k-c3-ELz" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="187" y="433" width="40" height="40"/>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                                <rect key="frame" x="187" y="435" width="40" height="40"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="40" id="1es-lB-psk"/>
                                     <constraint firstAttribute="width" constant="40" id="hgV-AZ-Cqe"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZiZ-T9-6yO">
-                                <rect key="frame" x="16" y="96.5" width="382" height="0.5"/>
+                                <rect key="frame" x="16" y="100.5" width="382" height="0.5"/>
                                 <color key="backgroundColor" name="borderMedium"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="0.5" id="5YL-eH-HJ0"/>
                                 </constraints>
                             </view>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6vh-22-FCW"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="FEg-ym-aNw" firstAttribute="leading" secondItem="6vh-22-FCW" secondAttribute="leading" id="15s-cG-55S"/>
                             <constraint firstItem="ZiZ-T9-6yO" firstAttribute="top" secondItem="2dW-v6-GRg" secondAttribute="bottom" constant="16" id="6qS-YN-mLp"/>
@@ -83,9 +84,9 @@
                             <constraint firstItem="6vh-22-FCW" firstAttribute="trailing" secondItem="ZiZ-T9-6yO" secondAttribute="trailing" constant="16" id="pjA-kN-asM"/>
                             <constraint firstItem="37k-c3-ELz" firstAttribute="centerY" secondItem="6vh-22-FCW" secondAttribute="centerY" id="zUN-5q-efF"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="6vh-22-FCW"/>
                     </view>
                     <connections>
+                        <outlet property="descriptionLabel" destination="gdo-sp-Qqp" id="SJx-RO-PTP"/>
                         <outlet property="nameLabel" destination="2dW-v6-GRg" id="dFI-r3-Uuv"/>
                         <outlet property="openButton" destination="FEg-ym-aNw" id="Aok-f3-jIU"/>
                         <outlet property="spinnerView" destination="37k-c3-ELz" id="Y0P-OK-dVi"/>
@@ -98,7 +99,10 @@
     </scenes>
     <resources>
         <namedColor name="borderMedium">
-            <color red="0.7803921568627451" green="0.80392156862745101" blue="0.81960784313725488" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.61960784313725492" green="0.65098039215686276" blue="0.67843137254901964" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Core/Core/LTI/View/LTIViewController.swift
+++ b/Core/Core/LTI/View/LTIViewController.swift
@@ -21,10 +21,12 @@ import Foundation
 public class LTIViewController: UIViewController, ErrorViewController, ColoredNavViewProtocol {
     @IBOutlet weak var spinnerView: CircleProgressView!
     @IBOutlet weak var nameLabel: UILabel!
+    @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var openButton: UIButton!
 
     private var env: AppEnvironment = .defaultValue
     public var tools: LTITools!
+    public var isQuizLTI: Bool!
     public var name: String?
     public var color: UIColor?
     public var titleSubtitleView: TitleSubtitleView = TitleSubtitleView.create()
@@ -42,9 +44,10 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
         return tools.context.id
     }
 
-    public static func create(env: AppEnvironment, tools: LTITools, name: String? = nil) -> Self {
+    public static func create(env: AppEnvironment, tools: LTITools, isQuizLTI: Bool, name: String? = nil) -> Self {
         let controller = loadFromStoryboard()
         controller.tools = tools
+        controller.isQuizLTI = isQuizLTI
         controller.name = name
         controller.env = env
         return controller
@@ -64,6 +67,13 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
                 }
             }
         }
+        descriptionLabel.text = isQuizLTI
+            ? String(localized: "This quiz opens in a web browser. Select \"Open the Quiz\" to proceed.", bundle: .core)
+            : String(localized: "This page can only be viewed from a web browser.", bundle: .core)
+        let openButtonTitle = isQuizLTI
+            ? String(localized: "Open the Quiz", bundle: .core)
+            : String(localized: "Open in Safari", bundle: .core)
+        openButton.setTitle(openButtonTitle, for: .normal)
         colors.refresh()
         courses?.refresh()
     }

--- a/Core/Core/Models/Viewable/SubmissionViewable.swift
+++ b/Core/Core/Models/Viewable/SubmissionViewable.swift
@@ -21,6 +21,7 @@ import UIKit
 public protocol SubmissionViewable {
     var submission: Submission? { get }
     var submissionTypes: [SubmissionType] { get }
+    var submissionTypesWithQuizLTIMapping: [SubmissionType] { get }
     var allowedExtensions: [String] { get }
 }
 
@@ -35,7 +36,7 @@ extension SubmissionViewable {
     }
 
     public var submissionTypeText: String {
-        let list = submissionTypes.map { (type: SubmissionType) in return type.localizedString }
+        let list = submissionTypesWithQuizLTIMapping.map { $0.localizedString }
         return ListFormatter.localizedString(from: list, conjunction: .or)
     }
 

--- a/Core/Core/Modules/APIModule.swift
+++ b/Core/Core/Modules/APIModule.swift
@@ -68,6 +68,7 @@ public struct APIModuleItem: Codable, Equatable {
     public let content_details: ContentDetails? // include[]=content_details not available in sequence call
     public var completion_requirement: CompletionRequirement? // not available in sequence call
     public let mastery_paths: APIMasteryPath? // include[]=mastery_paths
+    public let quiz_lti: Bool?
 
     public init(
         id: ID,
@@ -83,7 +84,8 @@ public struct APIModuleItem: Codable, Equatable {
         unpublishable: Bool?,
         content_details: ContentDetails?,
         completion_requirement: CompletionRequirement?,
-        mastery_paths: APIMasteryPath?
+        mastery_paths: APIMasteryPath?,
+        quiz_lti: Bool?
     ) {
         self.id = id
         self.module_id = module_id
@@ -99,6 +101,7 @@ public struct APIModuleItem: Codable, Equatable {
         self.content_details = content_details
         self.completion_requirement = completion_requirement
         self.mastery_paths = mastery_paths
+        self.quiz_lti = quiz_lti
     }
 
     public enum CodingKeys: String, CodingKey {
@@ -116,6 +119,7 @@ public struct APIModuleItem: Codable, Equatable {
         case content_details
         case completion_requirement
         case mastery_paths
+        case quiz_lti
     }
 
     public init(from decoder: Decoder) throws {
@@ -134,6 +138,7 @@ public struct APIModuleItem: Codable, Equatable {
         content_details = try container.decodeIfPresent(ContentDetails.self, forKey: .content_details)
         completion_requirement = try container.decodeIfPresent(CompletionRequirement.self, forKey: .completion_requirement)
         mastery_paths = try container.decodeIfPresent(APIMasteryPath.self, forKey: .mastery_paths)
+        quiz_lti = try container.decodeIfPresent(Bool.self, forKey: .quiz_lti)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -150,6 +155,7 @@ public struct APIModuleItem: Codable, Equatable {
         try container.encodeIfPresent(content_details, forKey: .content_details)
         try container.encode(completion_requirement, forKey: .completion_requirement)
         try container.encodeIfPresent(mastery_paths, forKey: .mastery_paths)
+        try container.encodeIfPresent(quiz_lti, forKey: .quiz_lti)
         try content?.encode(to: encoder)
     }
 }
@@ -236,7 +242,8 @@ extension APIModuleItem {
         unpublishable: Bool? = nil,
         content_details: ContentDetails? = nil,
         completion_requirement: CompletionRequirement? = nil,
-        mastery_paths: APIMasteryPath? = nil
+        mastery_paths: APIMasteryPath? = nil,
+        quiz_lti: Bool? = nil
     ) -> APIModuleItem {
         return APIModuleItem(
             id: id,
@@ -252,7 +259,8 @@ extension APIModuleItem {
             unpublishable: unpublishable,
             content_details: content_details,
             completion_requirement: completion_requirement,
-            mastery_paths: mastery_paths
+            mastery_paths: mastery_paths,
+            quiz_lti: quiz_lti
         )
     }
 }

--- a/Core/Core/Modules/ModuleItem.swift
+++ b/Core/Core/Modules/ModuleItem.swift
@@ -47,6 +47,7 @@ public class ModuleItem: NSManagedObject {
     @NSManaged public var masteryPath: MasteryPath?
     @NSManaged public var moduleItem: ModuleItem? // inverse of masteryPathItem
     @NSManaged public var fileAvailabilityRaw: NSNumber?
+    @NSManaged public var isQuizLTI: Bool
 
     /// In case the module item is a file it can have 4 states of availability. Only used for the teacher modules list.
     public var fileAvailability: FileAvailability? {
@@ -176,6 +177,7 @@ public class ModuleItem: NSManagedObject {
         model.completionRequirement = item.completion_requirement
         model.courseID = courseID
         model.fileAvailability = .init(moduleItem: item)
+        model.isQuizLTI = item.quiz_lti ?? false
 
         if updateMasteryPath {
             if let masteryPath = item.mastery_paths, masteryPath.selected_set_id == nil {

--- a/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -150,7 +150,7 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
                 moduleID: moduleID,
                 moduleItemID: itemID
             )
-            return LTIViewController.create(env: env, tools: tools, name: item.title)
+            return LTIViewController.create(env: env, tools: tools, isQuizLTI: item.isQuizLTI, name: item.title)
         default:
             guard let url = item.url else { return nil }
             let preparedURL = url.appendingOrigin("module_item_details")

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -78,7 +78,13 @@ class ModuleItemCell: UITableViewCell {
         nameLabel.isEnabled = isUserInteractionEnabled
         nameLabel.textColor = nameLabel.isEnabled ? .textDarkest : .textLight
 
-        iconView.image = item.masteryPath?.locked == true ? UIImage.lockLine : item.type?.icon
+        if item.masteryPath?.locked == true {
+            iconView.image = .lockLine
+        } else if item.isQuizLTI {
+            iconView.image = ModuleItemType.quiz("").icon
+        } else {
+            iconView.image = item.type?.icon
+        }
         contentStackView.setCustomSpacing(16, after: iconView)
         iconView.isHidden = (iconView.image == nil)
 
@@ -132,7 +138,7 @@ class ModuleItemCell: UITableViewCell {
 
     private func updateA11yLabel(_ item: ModuleItem, isPublishing: Bool) {
         var a11yLabels: [String?] = [
-            item.type?.label,
+            item.isQuizLTI ? ModuleItemType.quiz("").label : item.type?.label,
             item.title
         ]
 

--- a/Core/Core/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Modules/ModuleList/ModuleItemCell.swift
@@ -80,10 +80,8 @@ class ModuleItemCell: UITableViewCell {
 
         if item.masteryPath?.locked == true {
             iconView.image = .lockLine
-        } else if item.isQuizLTI {
-            iconView.image = ModuleItemType.quiz("").icon
         } else {
-            iconView.image = item.type?.icon
+            iconView.image = item.displayedType?.icon
         }
         contentStackView.setCustomSpacing(16, after: iconView)
         iconView.isHidden = (iconView.image == nil)
@@ -138,7 +136,7 @@ class ModuleItemCell: UITableViewCell {
 
     private func updateA11yLabel(_ item: ModuleItem, isPublishing: Bool) {
         var a11yLabels: [String?] = [
-            item.isQuizLTI ? ModuleItemType.quiz("").label : item.type?.label,
+            item.displayedType?.label,
             item.title
         ]
 
@@ -295,6 +293,10 @@ class ModuleItemCell: UITableViewCell {
 private extension ModuleItem {
     var shouldEnablePublishControl: Bool {
         type.isFile || published == false || canBeUnpublished
+    }
+
+    var displayedType: ModuleItemType? {
+        isQuizLTI ? .quiz("") : type
     }
 }
 

--- a/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardSubmissionRow.swift
@@ -67,7 +67,7 @@ struct ContextCardSubmissionRow: View {
             GradeFormatter.string(from: assignment, submission: submission) ?? ""
         }()
         self.icon = {
-            if assignment.submissionTypes.contains(.online_quiz) {
+            if assignment.submissionTypesWithQuizLTIMapping.contains(.online_quiz) {
                 return .quizLine
             } else if assignment.submissionTypes.contains(.discussion_topic) {
                 return .discussionLine

--- a/Core/Core/Quizzes/APIQuiz.swift
+++ b/Core/Core/Quizzes/APIQuiz.swift
@@ -190,7 +190,7 @@ extension APIQuiz {
         one_question_at_a_time: Bool = false,
         points_possible: Double? = 11.1,
         published: Bool? = true,
-        question_count: Int = 5,
+        question_count: Int? = 5,
         question_types: [QuizQuestionType]? = nil,
         quiz_type: QuizType = .survey,
         require_lockdown_browser_for_results: Bool = false,

--- a/Core/Core/Quizzes/Quiz.swift
+++ b/Core/Core/Quizzes/Quiz.swift
@@ -42,7 +42,7 @@ public class Quiz: NSManagedObject {
     @NSManaged public var order: String?
     @NSManaged var pointsPossibleRaw: NSNumber?
     @NSManaged public var published: Bool
-    @NSManaged public var questionCount: Int
+    @NSManaged public var questionCountRaw: NSNumber?
     @NSManaged var questionTypesRaw: [String]
     @NSManaged var quizTypeOrder: Int
     @NSManaged var quizTypeRaw: String
@@ -72,6 +72,11 @@ public class Quiz: NSManagedObject {
     public var pointsPossible: Double? {
         get { return pointsPossibleRaw?.doubleValue }
         set { pointsPossibleRaw = NSNumber(value: newValue) }
+    }
+
+    public var questionCount: Int? {
+        get { return questionCountRaw?.intValue }
+        set { questionCountRaw = NSNumber(value: newValue) }
     }
 
     public var questionTypes: [QuizQuestionType] {
@@ -138,11 +143,15 @@ extension Quiz: DueViewable, GradeViewable, LockStatusViewable {
         return NumberFormatter.localizedString(from: NSNumber(value: allowedAttempts), number: .none)
     }
 
-    public var questionCountText: String {
+    public var questionCountText: String? {
+        guard let questionCount else { return nil }
+
         return NumberFormatter.localizedString(from: NSNumber(value: questionCount), number: .none)
     }
 
-    public var nQuestionsText: String {
+    public var nQuestionsText: String? {
+        guard let questionCount else { return nil }
+
         let format = String(localized: "d_questions", bundle: .core)
         return String.localizedStringWithFormat(format, questionCount)
     }
@@ -189,7 +198,7 @@ extension Quiz {
         model.oneQuestionAtATime = item.one_question_at_a_time ?? false
         model.pointsPossible = item.points_possible
         model.published = item.published == true
-        model.questionCount = item.question_count ?? 0
+        model.questionCount = item.question_count
         model.questionTypes = item.question_types ?? []
         model.quizType = item.quiz_type
         model.quizTypeOrder = QuizType.allCases.firstIndex(of: item.quiz_type) ?? QuizType.allCases.count

--- a/Core/Core/Quizzes/QuizListViewController.swift
+++ b/Core/Core/Quizzes/QuizListViewController.swift
@@ -163,14 +163,12 @@ class QuizListCell: UITableViewCell {
         } else {
             iconImageView.state = nil
         }
-        dateLabel.setText(quiz?.dueText, style: .textCellSupportingText)
-        dateLabel.accessibilityIdentifier = "dateLabel"
+
+        // title
         titleLabel.setText(quiz?.title, style: .textCellTitle)
         titleLabel.accessibilityIdentifier = "titleLabel"
-        pointsLabel.setText(quiz?.pointsPossibleText, style: .textCellBottomLabel)
-        pointsLabel.accessibilityIdentifier = "pointsLabel"
-        questionsLabel.setText(quiz?.nQuestionsText, style: .textCellBottomLabel)
-        questionsLabel.accessibilityIdentifier = "questionsLabel"
+
+        // status + date
         if let statusText = quiz?.lockStatusText {
             statusLabel.setText(statusText, style: .textCellSupportingText)
             statusLabel.accessibilityIdentifier = "statusLabel"
@@ -180,10 +178,17 @@ class QuizListCell: UITableViewCell {
             statusLabel.isHidden = true
             statusDot.isHidden = true
         }
+        dateLabel.setText(quiz?.dueText, style: .textCellSupportingText)
+        dateLabel.accessibilityIdentifier = "dateLabel"
 
-        if quiz?.hideQuantitativeData == true {
-            pointsLabel.isHidden = true
-            pointsDot.isHidden = true
-        }
+        // points + question count
+        pointsLabel.setText(quiz?.pointsPossibleText, style: .textCellBottomLabel)
+        pointsLabel.accessibilityIdentifier = "pointsLabel"
+        pointsLabel.isHidden = quiz?.hideQuantitativeData == true
+        let nQuestionsText = quiz?.nQuestionsText
+        questionsLabel.setText(nQuestionsText, style: .textCellBottomLabel)
+        questionsLabel.accessibilityIdentifier = "questionsLabel"
+        questionsLabel.isHidden = nQuestionsText == nil
+        pointsDot.isHidden = pointsLabel.isHidden || questionsLabel.isHidden
     }
 }

--- a/Core/Core/Submissions/Submission.swift
+++ b/Core/Core/Submissions/Submission.swift
@@ -271,35 +271,50 @@ extension Submission: WriteableModel {
 }
 
 extension Submission {
-    public var icon: UIImage? {
-        guard let type = type else { return nil }
-        switch type {
+
+    private var typeWithQuizLTIMapping: SubmissionType? {
+        if let assignment, assignment.isQuizLTI {
+            .online_quiz
+        } else {
+            type
+        }
+    }
+
+    public var attemptIcon: UIImage? {
+        guard let typeWithQuizLTIMapping else { return nil }
+
+        switch typeWithQuizLTIMapping {
         case .basic_lti_launch, .external_tool:
-            return UIImage.ltiLine
+            return .ltiLine
         case .discussion_topic:
-            return UIImage.discussionLine
+            return .discussionLine
         case .media_recording:
-            return mediaComment?.mediaType == .audio ? UIImage.audioLine : UIImage.videoLine
+            return mediaComment?.mediaType == .audio ? .audioLine : .videoLine
         case .online_quiz:
-            return UIImage.quizLine
+            return .quizLine
         case .online_text_entry:
-            return UIImage.textLine
+            return .textLine
         case .online_upload:
             return attachments?.first?.icon
         case .online_url:
-            return UIImage.linkLine
+            return .linkLine
         case .student_annotation:
-            return UIImage.annotateLine
+            return .annotateLine
         case .wiki_page:
-            return UIImage.documentLine
+            return .documentLine
         case .none, .not_graded, .on_paper:
             return nil
         }
     }
 
-    public var subtitle: String? {
-        guard let type = type else { return nil }
-        switch type {
+    public var attemptTitle: String? {
+        typeWithQuizLTIMapping?.localizedString
+    }
+
+    public var attemptSubtitle: String? {
+        guard let typeWithQuizLTIMapping else { return nil }
+
+        switch typeWithQuizLTIMapping {
         case .basic_lti_launch, .external_tool, .online_quiz:
             return String.localizedStringWithFormat(
                 String(localized: "Attempt %d", bundle: .core),
@@ -321,6 +336,9 @@ extension Submission {
             return nil
         }
     }
+}
+
+extension Submission {
 
     /// See canvas-lms submission.rb `def needs_grading?`
     public var needsGrading: Bool {

--- a/Core/CoreTests/Assignments/AssignmentTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentTests.swift
@@ -392,4 +392,29 @@ class AssignmentTests: CoreTestCase {
         ]))
         XCTAssertTrue(a.hasMultipleDueDates)
     }
+
+    func testSubmissionTypesWithQuizLTIMapping_whenIsQuizLTIIsFalse() {
+        let a = Assignment.make()
+        a.isQuizLTI = false
+
+        a.submissionTypes = [.external_tool, .media_recording]
+        XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.external_tool, .media_recording])
+    }
+
+    func testSubmissionTypesWithQuizLTIMapping_whenIsQuizLTIIsTrue() {
+        let a = Assignment.make()
+        a.isQuizLTI = true
+
+        a.submissionTypes = [.external_tool]
+        XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.online_quiz])
+
+        a.submissionTypes = [.external_tool, .media_recording]
+        XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.online_quiz, .media_recording])
+
+        a.submissionTypes = [.online_quiz, .external_tool, .media_recording]
+        XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.online_quiz, .media_recording])
+        
+        a.submissionTypes = [.basic_lti_launch]
+        XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.basic_lti_launch])
+    }
 }

--- a/Core/CoreTests/Assignments/AssignmentTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentTests.swift
@@ -260,6 +260,13 @@ class AssignmentTests: CoreTestCase {
         XCTAssertEqual(icon, expected)
     }
 
+    func testIconForQuizLTI() {
+        let a = Assignment.make(from: .make(id: "1", is_quiz_lti_assignment: true, quiz_id: nil))
+        let icon = a.icon
+        let expected = UIImage.quizLine
+        XCTAssertEqual(icon, expected)
+    }
+
     func testIconForExternalTool() {
         let a = Assignment.make(from: .make(id: "1", submission_types: [ .external_tool ]))
         let icon = a.icon

--- a/Core/CoreTests/Assignments/AssignmentTests.swift
+++ b/Core/CoreTests/Assignments/AssignmentTests.swift
@@ -413,7 +413,7 @@ class AssignmentTests: CoreTestCase {
 
         a.submissionTypes = [.online_quiz, .external_tool, .media_recording]
         XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.online_quiz, .media_recording])
-        
+
         a.submissionTypes = [.basic_lti_launch]
         XCTAssertEqual(a.submissionTypesWithQuizLTIMapping, [.basic_lti_launch])
     }

--- a/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
+++ b/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
@@ -63,4 +63,18 @@ class LTIViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.titleSubtitleView.subtitle, "Fancy Course")
     }
+
+    func testTextsWhenIsQuizLTI() {
+        let controller = LTIViewController.create(env: environment, tools: .init(), isQuizLTI: true)
+        controller.view.layoutIfNeeded()
+        XCTAssertEqual(controller.descriptionLabel.text?.lowercased().contains("quiz"), true)
+        XCTAssertEqual(controller.openButton.titleLabel?.text?.lowercased().contains("quiz"), true)
+    }
+
+    func testTextsWhenIsNotQuizLTI() {
+        let controller = LTIViewController.create(env: environment, tools: .init(), isQuizLTI: false)
+        controller.view.layoutIfNeeded()
+        XCTAssertEqual(controller.descriptionLabel.text?.lowercased().contains("quiz"), false)
+        XCTAssertEqual(controller.openButton.titleLabel?.text?.lowercased().contains("quiz"), false)
+    }
 }

--- a/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
+++ b/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
@@ -25,7 +25,7 @@ import SafariServices
 class LTIViewControllerTests: CoreTestCase {
     func testLayout() {
         let tools = LTITools(id: "1")
-        let controller = LTIViewController.create(env: environment, tools: tools)
+        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false)
         var task = api.mock(tools.request, value: .make(name: "So Descriptive", url: .make()))
         task.suspend()
 
@@ -50,7 +50,7 @@ class LTIViewControllerTests: CoreTestCase {
 
     func testName() {
         let tools = LTITools(env: environment, id: "1")
-        let controller = LTIViewController.create(env: environment, tools: tools, name: "Fancy Tool")
+        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false, name: "Fancy Tool")
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.nameLabel.text, "Fancy Tool")
     }
@@ -58,7 +58,7 @@ class LTIViewControllerTests: CoreTestCase {
     func testCourseSubtitle() {
         let course = APICourse.make(id: "1", name: "Fancy Course")
         let tools = LTITools(env: environment, context: .course(course.id.value))
-        let controller = LTIViewController.create(env: environment, tools: tools)
+        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false)
         api.mock(controller.courses!, value: course)
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.titleSubtitleView.subtitle, "Fancy Course")

--- a/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
+++ b/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
@@ -23,15 +23,18 @@ class SubmissionViewableTests: XCTestCase {
     struct Model: SubmissionViewable {
         let submission: Submission?
         let submissionTypes: [SubmissionType]
+        let submissionTypesWithQuizLTIMapping: [SubmissionType]
         let allowedExtensions: [String]
 
         init(
             submission: Submission? = Submission.make(),
             submissionTypes: [SubmissionType] = [.online_text_entry],
+            submissionTypesWithQuizLTIMapping: [SubmissionType]? = nil,
             allowedExtensions: [String] = []
         ) {
             self.submission = submission
             self.submissionTypes = submissionTypes
+            self.submissionTypesWithQuizLTIMapping = submissionTypesWithQuizLTIMapping ?? submissionTypes
             self.allowedExtensions = allowedExtensions
         }
     }

--- a/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
+++ b/Core/CoreTests/Models/Viewable/SubmissionViewableTests.swift
@@ -56,6 +56,13 @@ class SubmissionViewableTests: XCTestCase {
         XCTAssertEqual(assignment.submissionTypeText, "Discussion Comment, Quiz, On Paper, No Submission, External Tool, Text Entry, Website URL, File Upload, Media Recording, or Not Graded")
     }
 
+    func testSubmissionTypeTextWithQuizLTIMapping() {
+        let assignment = Model(
+            submissionTypes: [.on_paper, .not_graded ],
+            submissionTypesWithQuizLTIMapping: [.external_tool, .online_text_entry])
+        XCTAssertEqual(assignment.submissionTypeText, "External Tool or Text Entry")
+    }
+
     func testIsSubmitted() {
         XCTAssertFalse(Model(submission: nil).isSubmitted)
         XCTAssertFalse(Model(submission: Submission.make(from: .make(submitted_at: nil))).isSubmitted)

--- a/Core/CoreTests/Modules/ModuleItemTests.swift
+++ b/Core/CoreTests/Modules/ModuleItemTests.swift
@@ -93,10 +93,10 @@ class ModuleItemTests: CoreTestCase {
     func testIsQuizLTI() {
         var item = ModuleItem.make(from: .make(quiz_lti: true))
         XCTAssertEqual(item.isQuizLTI, true)
-        
+
         item = ModuleItem.make(from: .make(quiz_lti: false))
         XCTAssertEqual(item.isQuizLTI, false)
-        
+
         item = ModuleItem.make(from: .make(quiz_lti: nil))
         XCTAssertEqual(item.isQuizLTI, false)
     }

--- a/Core/CoreTests/Modules/ModuleItemTests.swift
+++ b/Core/CoreTests/Modules/ModuleItemTests.swift
@@ -89,4 +89,15 @@ class ModuleItemTests: CoreTestCase {
         item.lockedForUser = false
         XCTAssertFalse(item.isLocked)
     }
+
+    func testIsQuizLTI() {
+        var item = ModuleItem.make(from: .make(quiz_lti: true))
+        XCTAssertEqual(item.isQuizLTI, true)
+        
+        item = ModuleItem.make(from: .make(quiz_lti: false))
+        XCTAssertEqual(item.isQuizLTI, false)
+        
+        item = ModuleItem.make(from: .make(quiz_lti: nil))
+        XCTAssertEqual(item.isQuizLTI, false)
+    }
 }

--- a/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleItems/ModuleItemDetailsViewControllerTests.swift
@@ -95,6 +95,19 @@ class ModuleItemDetailsViewControllerTests: CoreTestCase {
         XCTAssertEqual(details.tools.moduleID, "2")
         XCTAssertEqual(details.tools.moduleItemID, "3")
         XCTAssertEqual(details.name, "LTI Item Title")
+        XCTAssertEqual(details.openButton.titleLabel?.text?.lowercased().contains("quiz"), false)
+    }
+
+    func testQuizLTI() {
+        api.mock(controller.store, value: .make(
+            id: "3",
+            title: "LTI Item Title",
+            content: .externalTool("5", URL(string: "https://lti.app")!),
+            quiz_lti: true
+        ))
+        controller.view.layoutIfNeeded()
+        let details = controller.children.first as! LTIViewController
+        XCTAssertEqual(details.openButton.titleLabel?.text?.lowercased().contains("quiz"), true)
     }
 
     func testLockedForUser() {

--- a/Core/CoreTests/Modules/ModuleList/ModuleListViewControllerTests.swift
+++ b/Core/CoreTests/Modules/ModuleList/ModuleListViewControllerTests.swift
@@ -540,6 +540,20 @@ class ModuleListViewControllerTests: CoreTestCase {
         Clock.reset()
     }
 
+    func testQuizLTIIcon() {
+        api.mock(GetModulesRequest(courseID: "1", include: []), value: [.make(id: "1")])
+        api.mock(GetModuleItemsRequest(courseID: "1", moduleID: "1", include: [.content_details, .mastery_paths]), value: [
+            .make(id: "1", title: "", content: .assignment("1"), quiz_lti: false),
+            .make(id: "2", title: "", content: .assignment("2"), quiz_lti: true)
+        ])
+        loadView()
+        XCTAssertEqual(viewController.tableView.numberOfRows(inSection: 0), 2)
+        let cell0 = moduleItemCell(at: IndexPath(row: 0, section: 0))
+        XCTAssertEqual(cell0.iconView.image, .assignmentLine)
+        let cell1 = moduleItemCell(at: IndexPath(row: 1, section: 0))
+        XCTAssertEqual(cell1.iconView.image, .quizLine)
+    }
+
     func testModulesPageDisabled() {
         api.mock(viewController.courses, value: .make(id: "1", name: "Course 1", default_view: .assignments))
         api.mock(viewController.tabs, value: [.make(id: "assignments")])

--- a/Core/CoreTests/Modules/PutModuleItemPublishStateTests.swift
+++ b/Core/CoreTests/Modules/PutModuleItemPublishStateTests.swift
@@ -18,17 +18,17 @@
 
 @testable import Core
 import XCTest
+import TestsFoundation
 
 class PutModuleItemPublishStateTests: CoreTestCase {
 
     func testUpdatesPublishedStateOnModuleItem() {
-        let dbItem: ModuleItem = databaseClient.insert()
+        let dbItem = ModuleItem.make()
         dbItem.id = "testModuleItem"
         dbItem.courseID = "testCourse"
         dbItem.published = nil
-        dbItem.title = ""
-        dbItem.position = 0
         dbItem.moduleID = "testModule"
+
         let mockRequest = PutModuleItemPublishRequest(
             courseId: "testCourse",
             moduleId: "testModule",
@@ -41,6 +41,7 @@ class PutModuleItemPublishStateTests: CoreTestCase {
             response: nil,
             error: nil
         )
+
         let testee = PutModuleItemPublishState(
             courseId: "testCourse",
             moduleId: "testModule",

--- a/Core/CoreTests/Quizzes/QuizTests.swift
+++ b/Core/CoreTests/Quizzes/QuizTests.swift
@@ -57,11 +57,13 @@ class QuizTests: CoreTestCase {
     func testQuestionCountText() {
         XCTAssertEqual(Quiz.make(from: .make(question_count: 1)).questionCountText, "1")
         XCTAssertEqual(Quiz.make(from: .make(question_count: 10)).questionCountText, "10")
+        XCTAssertEqual(Quiz.make(from: .make(question_count: nil)).questionCountText, nil)
     }
 
     func testNQuestionsText() {
         XCTAssertEqual(Quiz.make(from: .make(question_count: 1)).nQuestionsText, "1 Question")
         XCTAssertEqual(Quiz.make(from: .make(question_count: 10)).nQuestionsText, "10 Questions")
+        XCTAssertEqual(Quiz.make(from: .make(question_count: nil)).nQuestionsText, nil)
     }
 
     func testTimeLimitText() {

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -89,23 +89,23 @@ class SubmissionTests: CoreTestCase {
         ]
         for (type, icon) in map {
             submission.type = type
-            XCTAssertEqual(submission.icon, icon)
+            XCTAssertEqual(submission.attemptIcon, icon)
         }
         submission.type = .media_recording
         submission.mediaComment = MediaComment.make(from: .make(media_type: .audio))
-        XCTAssertEqual(submission.icon, UIImage.audioLine)
+        XCTAssertEqual(submission.attemptIcon, UIImage.audioLine)
         submission.mediaComment?.mediaType = .video
-        XCTAssertEqual(submission.icon, UIImage.videoLine)
+        XCTAssertEqual(submission.attemptIcon, UIImage.videoLine)
 
         submission.type = .online_upload
         submission.attachments = Set([ File.make(from: .make(contentType: "application/pdf", mime_class: "pdf")) ])
-        XCTAssertEqual(submission.icon, UIImage.pdfLine)
+        XCTAssertEqual(submission.attemptIcon, UIImage.pdfLine)
 
         submission.type = .on_paper
-        XCTAssertNil(submission.icon)
+        XCTAssertNil(submission.attemptIcon)
 
         submission.type = nil
-        XCTAssertNil(submission.icon)
+        XCTAssertNil(submission.attemptIcon)
     }
 
     func testSubtitle() {
@@ -126,22 +126,22 @@ class SubmissionTests: CoreTestCase {
         ]
         for (type, subtitle) in map {
             submission.type = type
-            XCTAssertEqual(submission.subtitle, subtitle)
+            XCTAssertEqual(submission.attemptSubtitle, subtitle)
         }
         submission.type = .media_recording
         submission.mediaComment = MediaComment.make(from: .make(media_type: .audio))
-        XCTAssertEqual(submission.subtitle, "Audio")
+        XCTAssertEqual(submission.attemptSubtitle, "Audio")
         submission.mediaComment?.mediaType = .video
-        XCTAssertEqual(submission.subtitle, "Video")
+        XCTAssertEqual(submission.attemptSubtitle, "Video")
 
         submission.type = .online_upload
-        XCTAssertEqual(submission.subtitle, "1 KB")
+        XCTAssertEqual(submission.attemptSubtitle, "1 KB")
 
         submission.type = .on_paper
-        XCTAssertNil(submission.subtitle)
+        XCTAssertNil(submission.attemptSubtitle)
 
         submission.type = nil
-        XCTAssertNil(submission.subtitle)
+        XCTAssertNil(submission.attemptSubtitle)
     }
 
     func testRubricAssessments() {

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -111,7 +111,7 @@ class SubmissionTests: CoreTestCase {
     func testAttemptTitle() {
         let submission = Submission.make()
         submission.type = .discussion_topic
-        
+
         XCTAssertEqual(submission.attemptTitle, "Discussion Comment")
     }
 

--- a/Core/CoreTests/Submissions/SubmissionTests.swift
+++ b/Core/CoreTests/Submissions/SubmissionTests.swift
@@ -76,7 +76,7 @@ class SubmissionTests: CoreTestCase {
         XCTAssertNotNil(submission.mediaComment)
     }
 
-    func testIcon() {
+    func testAttemptIcon() {
         let submission = Submission.make()
         let map: [SubmissionType: UIImage] = [
             .basic_lti_launch: .ltiLine,
@@ -108,7 +108,14 @@ class SubmissionTests: CoreTestCase {
         XCTAssertNil(submission.attemptIcon)
     }
 
-    func testSubtitle() {
+    func testAttemptTitle() {
+        let submission = Submission.make()
+        submission.type = .discussion_topic
+        
+        XCTAssertEqual(submission.attemptTitle, "Discussion Comment")
+    }
+
+    func testAttemptSubtitle() {
         let submission = Submission.make(from: .make(
             attachments: [ .make(size: 1234) ],
             attempt: 1,
@@ -142,6 +149,19 @@ class SubmissionTests: CoreTestCase {
 
         submission.type = nil
         XCTAssertNil(submission.attemptSubtitle)
+    }
+
+    func testAttemptPropertiesWhenQuizLTI() {
+        let submission = Submission.make(from: .make(
+            attempt: 1,
+            discussion_entries: [ .make(message: "<p>reply<p>") ]
+        ))
+        submission.assignment = Assignment.make(from: .make(is_quiz_lti_assignment: true))
+        submission.type = .discussion_topic
+
+        XCTAssertEqual(submission.attemptIcon, .quizLine)
+        XCTAssertEqual(submission.attemptTitle, "Quiz")
+        XCTAssertEqual(submission.attemptSubtitle, "Attempt 1")
     }
 
     func testRubricAssessments() {

--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -87871,6 +87871,9 @@
         }
       }
     },
+    "Open the Quiz" : {
+
+    },
     "Other" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -63,7 +63,9 @@ class SubmissionButtonPresenter: NSObject {
             return String(localized: "View Discussion", bundle: .student)
         }
 
-        if assignment.isLTIAssignment {
+        if assignment.isQuizLTI {
+            return String(localized: "Open the Quiz", bundle: .student)
+        } else if assignment.isLTIAssignment {
             return String(localized: "Launch External Tool", bundle: .student)
         }
 

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
@@ -31,6 +31,7 @@ class SubmissionCommentFileView: UIControl {
         widthAnchor.constraint(equalToConstant: 300).isActive = true
         layer.borderColor = UIColor.borderMedium.cgColor
         layer.borderWidth = 1.0
+        iconView?.tintColor = Brand.shared.primary
         addTarget(self, action: #selector(didTapFile), for: .touchUpInside)
     }
 
@@ -52,11 +53,11 @@ class SubmissionCommentFileView: UIControl {
         accessibilityLabel = String.localizedStringWithFormat(
             String(localized: "View submission attempt %d. %@", bundle: .student),
             submission.attempt,
-            submission.type?.localizedString ?? ""
+            submission.attemptTitle ?? ""
         )
-        iconView?.image = submission.icon
-        nameLabel?.text = submission.type?.localizedString
-        sizeLabel?.text = submission.subtitle
+        iconView?.image = submission.attemptIcon
+        nameLabel?.text = submission.attemptTitle
+        sizeLabel?.text = submission.attemptSubtitle
     }
 
     @IBAction func didTapFile(_ sender: UIControl) {

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -201,7 +201,7 @@ class SubmissionDetailsPresenter {
                 launchType: .assessment,
                 assignmentID: assignmentID
             )
-            return LTIViewController.create(env: env, tools: tools)
+            return LTIViewController.create(env: env, tools: tools, isQuizLTI: assignment.isQuizLTI)
         }
 
         switch submission.type {
@@ -272,7 +272,7 @@ class SubmissionDetailsPresenter {
                 context: context,
                 url: submission.externalToolURL
             )
-            return LTIViewController.create(env: env, tools: tools)
+            return LTIViewController.create(env: env, tools: tools, isQuizLTI: false)
         case .student_annotation:
             guard let docViewerSessionURL = docViewerSessionURL else { return nil }
             return DocViewerViewController.create(

--- a/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionButton/SubmissionButtonPresenterTests.swift
@@ -75,6 +75,9 @@ class SubmissionButtonPresenterTests: StudentTestCase {
         XCTAssertEqual(presenter.buttonText(course: c, assignment: a, quiz: nil, onlineUpload: nil), "View Discussion")
 
         a.submissionTypes = [ .external_tool ]
+        a.isQuizLTI = true
+        XCTAssertEqual(presenter.buttonText(course: c, assignment: a, quiz: nil, onlineUpload: nil), "Open the Quiz")
+        a.isQuizLTI = false
         XCTAssertEqual(presenter.buttonText(course: c, assignment: a, quiz: nil, onlineUpload: nil), "Launch External Tool")
 
         presenter.arcID = .pending

--- a/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
+++ b/Student/StudentUnitTests/Submissions/SubmissionDetails/SubmissionDetailsPresenterTests.swift
@@ -169,7 +169,23 @@ class SubmissionDetailsPresenterTests: StudentTestCase {
         Submission.make(from: .make(submission_type: .external_tool))
         presenter.viewIsReady()
 
-        XCTAssert(view.embedded is LTIViewController)
+        let ltiVC = view.embedded as? LTIViewController
+        XCTAssertNotNil(ltiVC)
+
+        ltiVC?.view.layoutIfNeeded()
+        XCTAssertEqual(ltiVC?.openButton.titleLabel?.text?.lowercased().contains("quiz"), false)
+    }
+
+    func testEmbedQuizLTI() {
+        Assignment.make(from: .make(is_quiz_lti_assignment: true, submission_types: [ .external_tool ]))
+        Submission.make(from: .make(submission_type: .external_tool))
+        presenter.viewIsReady()
+
+        let ltiVC = view.embedded as? LTIViewController
+        XCTAssertNotNil(ltiVC)
+
+        ltiVC?.view.layoutIfNeeded()
+        XCTAssertEqual(ltiVC?.openButton.titleLabel?.text?.lowercased().contains("quiz"), true)
     }
 
     func testEmbedExternalToolOnlineUploadWithAttachment() {

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -121,13 +121,21 @@ struct SubmissionCommentList: View {
         ForEach(comments, id: \.id) { comment in
             SubmissionCommentListCell(
                 assignment: assignment,
-                submission: attempts.first(where: { $0.attempt == comment.attempt }) ?? submission,
+                submission: submissionForComment(comment),
                 comment: comment,
                 attempt: $attempt,
                 fileID: $fileID
             )
                 .scaleEffect(y: -1)
         }
+    }
+
+    private func submissionForComment(_ comment: SubmissionComment) -> Submission {
+        let result = attempts.first(where: { $0.attempt == comment.attempt }) ?? submission
+        if result.assignment == nil {
+            result.assignment = assignment
+        }
+        return result
     }
 
     func toolbar(containerHeight: CGFloat) -> some View {

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentListCell.swift
@@ -166,26 +166,7 @@ struct SubmissionAttempt: View {
     let action: () -> Void
 
     var icon: Image? {
-        switch submission.type {
-        case .basic_lti_launch, .external_tool:
-            return .ltiLine
-        case .discussion_topic:
-            return .discussionLine
-        case .media_recording:
-            return submission.mediaComment?.mediaType == .audio ? .audioLine : .videoLine
-        case .online_quiz:
-            return .quizLine
-        case .online_text_entry:
-            return .textLine
-        case .online_url:
-            return .linkLine
-        case .student_annotation:
-            return .annotateLine
-        case .wiki_page:
-            return .documentLine
-        case .none?, .not_graded, .on_paper, .online_upload, nil:
-            return nil
-        }
+        submission.attemptIcon.map { Image(uiImage: $0) }
     }
 
     var body: some View {
@@ -193,9 +174,9 @@ struct SubmissionAttempt: View {
             HStack(alignment: .top, spacing: 6) {
                 icon?.size(18).foregroundColor(.accentColor)
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(submission.type?.localizedString ?? "")
+                    Text(submission.attemptTitle ?? "")
                         .font(.semibold14).foregroundColor(.textDarkest)
-                    Text(submission.subtitle ?? "")
+                    Text(submission.attemptSubtitle ?? "")
                         .font(.medium12).foregroundColor(.textDark)
                         .lineLimit(1)
                 }
@@ -205,7 +186,7 @@ struct SubmissionAttempt: View {
                 .frame(width: 300)
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
         })
-            .accessibility(label: Text("View submission attempt \(submission.attempt). \(submission.type?.localizedString ?? "")", bundle: .teacher))
+            .accessibility(label: Text("View submission attempt \(submission.attempt). \(submission.attemptTitle ?? "")", bundle: .teacher))
     }
 }
 


### PR DESCRIPTION
refs: [MBL-17960](https://instructure.atlassian.net/browse/MBL-17960)
affects: Student, Teacher, Parent
release note: Improved support for New Quizzes.

## What's new
New Quizes should look like quizes, see ticket for details.
Also updated at some additional places:
- Modules screen
- Assignments screen
- Grades screen
- ToDo screen
- People Details screen
- PARENT app: Grades tab
- Assignment Details screen
- Submission Details screen (+ Comments sheet)
- Quizzes screen (not displaying untrue "0 Questions" for QuizLTIs anymore)

## What's not changed
- Notifications screen
  - not updated, because `users/self/activity_stream` doesn't provide details
  - we could check via `html_url` which contains `assignmentID`, see `ActivityStreamViewController`
  - not sure it's worth it
- Calendar Events list
  - not updated, because `planner/items` doesn't provide details
  - we could check `plannable_id` when `plannable_type` is `assignment`, see `Plannable.iconImage`
  - not sure it's worth it
- Did not add nice to have panda

## Test plan
- See ticket and above changed / not changed list.
- Test both Teacher and Student apps, they use different screens for similar things.
- Also smoke test for other type of assignments.

## TODO:
- screenshots

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product

[MBL-17960]: https://instructure.atlassian.net/browse/MBL-17960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ