### PR TITLE
Fix flaky tests

### DIFF
--- a/Core/Core/Planner/Model/API/APICalendarEvent.swift
+++ b/Core/Core/Planner/Model/API/APICalendarEvent.swift
@@ -133,8 +133,8 @@ public struct GetCalendarEventsRequest: APIRequestable {
 
     public init(
         contexts: [Context]? = nil,
-        startDate: Date = Clock.now.addYears(-2),
-        endDate: Date = Clock.now.addYears(1),
+        startDate: Date = Clock.now.addYears(-2).startOfDay(),
+        endDate: Date = Clock.now.addYears(1).endOfDay(),
         calendar: Calendar = .current,
         timeZone: TimeZone = .current,
         type: CalendarEventType = .event,

--- a/Core/CoreTests/BackgroundActivity/BackgroundActivityTests.swift
+++ b/Core/CoreTests/BackgroundActivity/BackgroundActivityTests.swift
@@ -25,13 +25,10 @@ class BackgroundActivityTests: XCTestCase {
     let mockProcessManager = MockProcessManager()
     var subscriptions = Set<AnyCancellable>()
 
-    override func setUp() {
-        super.setUp()
-        mockProcessManager.reset()
-    }
-
     override func tearDown() {
         subscriptions.removeAll()
+        mockProcessManager.expireActivity()
+        mockProcessManager.reset()
         super.tearDown()
     }
 
@@ -66,8 +63,8 @@ class BackgroundActivityTests: XCTestCase {
         testee
             .start(abortHandler: {})
             .sink { completion in
-                futureFinished.fulfill()
                 result = completion
+                futureFinished.fulfill()
             }
             .store(in: &subscriptions)
 

--- a/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractorLiveTests.swift
+++ b/Core/CoreTests/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractorLiveTests.swift
@@ -21,7 +21,6 @@ import XCTest
 
 class CourseSyncSyllabusInteractorLiveTests: CoreTestCase {
 
-    // FIXME: flaky test (both locally and on CI)
     func testSuccessfulFetch() {
         mockSyllabusContent()
         mockSyllabusSummary()

--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -44,7 +44,7 @@
     "Core\/Extensions\/UISplitViewControllerExtensions.swift",
     "Core\/Extensions\/UITabBarControllerExtensions.swift",
     "Core\/Extensions\/UINavigationControllerExtensions.swift",
-	"Core\/Core\/Planner\/CalendarMain"
+    "Core\/Core\/Planner\/CalendarMain"
   ],
   "ignoreContent": [
     "makeUIViewController(context:",

--- a/scripts/coverage/config.json
+++ b/scripts/coverage/config.json
@@ -8,13 +8,10 @@
     "Window.\\w+$",
     "TabBar.\\w+$",
     "\\/Views\\/",
-    "CanvasCore\/",
     "Frameworks\/",
     "Parent\/",
-    "Pods\\/",
     "\/SwiftUIViews\/",
     "\/ViewModifiers\/",
-    "Student\/Canvas\/",
     "UITestHelpers\/",
     "\/Teacher\/SpeedGrader\/",
     "SubmissionButtonPresenter.swift",
@@ -46,7 +43,8 @@
     "Core\/InstUI\/",
     "Core\/Extensions\/UISplitViewControllerExtensions.swift",
     "Core\/Extensions\/UITabBarControllerExtensions.swift",
-    "Core\/Extensions\/UINavigationControllerExtensions.swift"
+    "Core\/Extensions\/UINavigationControllerExtensions.swift",
+	"Core\/Core\/Planner\/CalendarMain"
   ],
   "ignoreContent": [
     "makeUIViewController(context:",


### PR DESCRIPTION
### Changes
- Improved `BackgroundActivityTests` not to be flaky. The expectation was fulfilled before the tested property got a value and the test teardown didn't terminate a background queue.
- Rounded the default dates on `GetCalendarEventsRequest` because it included the current minutes/seconds and that caused flakyness in `CourseSyncSyllabusInteractorLiveTests` if the second component of the current time have changed between the mock setup and the test execution.
- Updated the code coverage ignore file by removing no longer existing paths and excluding the swiftui based calendar code that is not yet production ready.

 [ignore-commit-lint]