### PR TITLE
Fix false positives for unknown tab format logging

### DIFF
--- a/Core/Core/Router/CourseTabUrlInteractor.swift
+++ b/Core/Core/Router/CourseTabUrlInteractor.swift
@@ -95,6 +95,13 @@ public final class CourseTabUrlInteractor {
         }
     }
 
+    /// Check for any tabs which match the Home format: "/courses/:courseID"
+    /// For example K5Subject tabs: "/courses/:courseID#schedule"
+    private func isHomeFormat(_ path: String) -> Bool {
+        let parts = path.split(separator: "/").map { String($0) }
+        return parts.count == 2 && parts[0] == "courses"
+    }
+
     private func updateEnabledTabs(with tabs: [Tab]) {
         let courseTabs = tabs.filter { $0.context.contextType == .course }
         let tabsPerCourse = Dictionary(grouping: courseTabs, by: { $0.context })
@@ -164,7 +171,10 @@ public final class CourseTabUrlInteractor {
     }
 
     private func logPathFormatIfUnknown(for tab: TabModel) {
-        guard tab.id != "home" && !isKnownPathFormat(tab.htmlUrl) else { return }
+        guard tab.id != "home"
+                && !isHomeFormat(tab.htmlUrl)
+                && !isKnownPathFormat(tab.htmlUrl)
+        else { return }
 
         RemoteLogger.shared.logError(
             name: "Unexpected Course Tab path format",

--- a/Core/CoreTests/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Router/CourseTabUrlInteractorTests.swift
@@ -268,14 +268,14 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         XCTAssertEqual(remoteLogHandler.lastErrorName, "Unexpected Course Tab path format")
     }
 
-    func test_setupEnabledTabs_whenTabIsHome_shouldNotLogIt() {
+    func test_setupEnabledTabs_whenTabIsHomeOrHasHomeFormat_shouldNotLogIt() {
         // `id: home` is not logged
         saveTab(id: "home", htmlUrl: "/courses/42/ignoring/this/url", context: .course("42"))
         XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
 
-        // home-like format with different id is logged
-        saveTab(id: "pages", htmlUrl: "/courses/42", context: .course("42"))
-        XCTAssertEqual(remoteLogHandler.lastErrorName, "Unexpected Course Tab path format")
+        // home-like format with different id is not logged
+        saveTab(id: "schedule", htmlUrl: "/courses/42", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
     }
 
     // MARK: - Cancel subscription


### PR DESCRIPTION
K5 Subject Tabs trigger logging for "Unexpected Course Tab path format", but those are false positives.
This PR is just to fix that, it doesn't touch user facing code.

[ignore-commit-lint]