### PR TITLE
Fix disabled Home page in SplitView details

### DIFF
--- a/Core/Core/Assignments/AssignmentList/View/AssignmentListScreen.swift
+++ b/Core/Core/Assignments/AssignmentList/View/AssignmentListScreen.swift
@@ -128,9 +128,12 @@ public struct AssignmentListScreen: View, ScreenViewTrackable {
         }
     }
 
-    private func setupDefaultSplitDetailView(_ route: String) {
-        guard let defaultViewProvider = controller.value as? DefaultViewProvider, defaultViewProvider.defaultViewRoute != route else { return }
-        defaultViewProvider.defaultViewRoute = route
+    private func setupDefaultSplitDetailView(_ routeUrl: String) {
+        guard let defaultViewProvider = controller.value as? DefaultViewProvider,
+              defaultViewProvider.defaultViewRoute?.url != routeUrl
+        else { return }
+
+        defaultViewProvider.defaultViewRoute = .init(url: routeUrl)
     }
 }
 

--- a/Core/Core/Courses/CourseDetails/View/CourseDetailsView.swift
+++ b/Core/Core/Courses/CourseDetails/View/CourseDetailsView.swift
@@ -186,8 +186,16 @@ public struct CourseDetailsView: View, ScreenViewTrackable {
     }
 
     private func setupDefaultSplitDetailView(_ url: URL?) {
-        if let defaultViewProvider = controller.value as? DefaultViewProvider, defaultViewProvider.defaultViewRoute != url?.absoluteString {
-            defaultViewProvider.defaultViewRoute = url?.absoluteString
+        let routeUrl = url?.absoluteString
+        guard let defaultViewProvider = controller.value as? DefaultViewProvider,
+              defaultViewProvider.defaultViewRoute?.url != routeUrl
+        else { return }
+
+        defaultViewProvider.defaultViewRoute = routeUrl.map {
+            .init(
+                url: $0,
+                userInfo: [CourseTabUrlInteractor.blockDisabledTabUserInfoKey: false]
+            )
         }
     }
 }

--- a/Core/Core/Grades/GradeListAssembly.swift
+++ b/Core/Core/Grades/GradeListAssembly.swift
@@ -57,7 +57,7 @@ public enum GradListAssembly {
             router: env.router
         )
         let viewController = CoreHostingController(GradeListView(viewModel: viewModel))
-        viewController.defaultViewRoute = "/empty"
+        viewController.defaultViewRoute = .init(url: "/empty")
         return viewController
     }
 

--- a/Core/Core/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Modules/ModuleList/ModuleListViewController.swift
@@ -353,8 +353,8 @@ extension ModuleListViewController: MasteryPathDelegate {
 
 extension ModuleListViewController: DefaultViewProvider {
 
-    public var defaultViewRoute: String? {
-        get { "/empty" }
+    public var defaultViewRoute: DefaultViewRouteParameters? {
+        get { .init(url: "/empty") }
         // swiftlint:disable:next unused_setter_value
         set {}
     }

--- a/Core/Core/Router/DefaultViewProvider.swift
+++ b/Core/Core/Router/DefaultViewProvider.swift
@@ -22,7 +22,17 @@
  View controllers implementing this protocol can provide a default view for such situations.
  */
 public protocol DefaultViewProvider: UIViewController {
-    var defaultViewRoute: String? { get set }
+    var defaultViewRoute: DefaultViewRouteParameters? { get set }
+}
+
+public struct DefaultViewRouteParameters {
+    let url: String
+    let userInfo: [String: Any]?
+
+    public init(url: String, userInfo: [String : Any]? = nil) {
+        self.url = url
+        self.userInfo = userInfo
+    }
 }
 
 extension UIViewController {
@@ -42,7 +52,12 @@ extension UIViewController {
             return
         }
 
-        AppEnvironment.shared.router.route(to: defaultRoute, from: self, options: .detail)
+        AppEnvironment.shared.router.route(
+            to: defaultRoute.url,
+            userInfo: defaultRoute.userInfo,
+            from: self,
+            options: .detail
+        )
     }
 
     private func isAddedToSplitViewController() -> Bool {

--- a/Core/Core/Router/DefaultViewProvider.swift
+++ b/Core/Core/Router/DefaultViewProvider.swift
@@ -29,7 +29,7 @@ public struct DefaultViewRouteParameters {
     let url: String
     let userInfo: [String: Any]?
 
-    public init(url: String, userInfo: [String : Any]? = nil) {
+    public init(url: String, userInfo: [String: Any]? = nil) {
         self.url = url
         self.userInfo = userInfo
     }

--- a/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
+++ b/Core/Core/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
@@ -52,7 +52,7 @@ public class CoreHostingController<Content: View>: UIHostingController<CoreHosti
 
     // MARK: - Public Properties
     public var navigationBarStyle = UINavigationBar.Style.color(nil) // not applied until changed
-    public var defaultViewRoute: String? {
+    public var defaultViewRoute: DefaultViewRouteParameters? {
         didSet {
             showDefaultDetailViewIfNeeded()
         }

--- a/Core/Core/UIViews/CoreSplitViewController.swift
+++ b/Core/Core/UIViews/CoreSplitViewController.swift
@@ -112,11 +112,11 @@ extension CoreSplitViewController: UISplitViewControllerDelegate {
            nav.viewControllers.count > 1,
            let defaultViewProvider = nav.viewControllers.last as? DefaultViewProvider,
            let defaultRoute = defaultViewProvider.defaultViewRoute,
-           let defaultViewController = AppEnvironment.shared.router.match(defaultRoute, userInfo: nil) {
+           let defaultViewController = AppEnvironment.shared.router.match(defaultRoute.url, userInfo: defaultRoute.userInfo) {
             let detailNavController = CoreNavigationController(rootViewController: defaultViewController)
             detailNavController.syncStyles(from: nav, to: detailNavController)
 
-            if let routeTemplate = AppEnvironment.shared.router.template(for: defaultRoute) {
+            if let routeTemplate = AppEnvironment.shared.router.template(for: defaultRoute.url) {
                 RemoteLogger.shared.logBreadcrumb(route: routeTemplate, viewController: defaultViewController)
             }
 

--- a/Core/CoreTests/Router/DefaultViewProviderTests.swift
+++ b/Core/CoreTests/Router/DefaultViewProviderTests.swift
@@ -48,8 +48,8 @@ class DefaultViewProviderTests: CoreTestCase {
 }
 
 class MockDefaultViewProviderViewController: UIViewController, DefaultViewProvider {
-    var defaultViewRoute: String? {
-        get { "/empty" }
+    var defaultViewRoute: DefaultViewRouteParameters? {
+        get { .init(url: "/empty") }
         set {}
     }
 }


### PR DESCRIPTION
refs: [MBL-18180](https://instructure.atlassian.net/browse/MBL-18180)
affects: Student
release note: Fixed course home page not shown automatically in some cases on iPads.

## Test plan
- Verify on iPad Course Home showing a disabled tab loads automatically (see ticket)
- Verify on iPad AssignmentList screen
  - not opening an assignment automatically
  - opening an assignment once selected
- Verify on iPhone (non split view) Course Home showing a disabled tab loads once selected

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18180]: https://instructure.atlassian.net/browse/MBL-18180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ