### PR TITLE
New Quiz LTI in dedicated web view

### DIFF
--- a/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -255,6 +255,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
             id: assignment.first?.externalToolContentID,
             url: nil,
             launchType: "assessment",
+            isQuizLTI: assignment.first?.isQuizLTI,
             assignmentID: assignmentID,
             from: controller.value
         )

--- a/Core/Core/CoreWebView/Model/Features/HideReturnButtonInQuizLTI.swift
+++ b/Core/Core/CoreWebView/Model/Features/HideReturnButtonInQuizLTI.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+private class HideReturnButtonInQuizLTI: CoreWebViewFeature {
+    private let script: String = {
+        let css = """
+            a[data-automation="sdk-return-button"] {
+                display: none;
+            }
+        """
+
+        let cssString = css.components(separatedBy: .newlines).joined()
+        return """
+           var element = document.createElement('style');
+           element.innerHTML = '\(cssString)';
+           document.head.appendChild(element);
+        """
+    }()
+
+    public override init() {}
+
+    override func apply(on webView: CoreWebView) {
+        webView.addScript(script)
+    }
+}
+
+public extension CoreWebViewFeature {
+
+    /// This feature hides the "Return" button in QuizLTI webviews, based on it's `data-automation` id.
+    /// The button normally leads the user back to the course home,
+    ///  but in the app we can dismiss the screen natively and the "Return" button navigation would cause issues.
+    static var hideReturnButtonInQuizLTI: CoreWebViewFeature {
+        HideReturnButtonInQuizLTI()
+    }
+}

--- a/Core/Core/Courses/CourseDetails/ViewModel/Cells/LTICellViewModel.swift
+++ b/Core/Core/Courses/CourseDetails/ViewModel/Cells/LTICellViewModel.swift
@@ -43,6 +43,7 @@ class LTICellViewModel: CourseDetailsCellViewModel {
             id: nil,
             url: url,
             launchType: nil,
+            isQuizLTI: false,
             assignmentID: nil,
             from: viewController.value
         )

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -178,7 +178,10 @@ public class LTITools: NSObject {
             let url = response.url.appendingQueryItems(URLQueryItem(name: "platform", value: "mobile"))
 
             if isQuizLTI == true {
-                let controller = CoreWebViewController(features: [.invertColorsInDarkMode])
+                let controller = CoreWebViewController(features: [
+                    .invertColorsInDarkMode,
+                    .hideReturnButtonInQuizLTI
+                ])
                 controller.webView.load(URLRequest(url: url))
                 controller.title = String(localized: "Quiz", bundle: .core)
                 controller.addDoneButton(side: .right)

--- a/Core/Core/LTI/LTITools.swift
+++ b/Core/Core/LTI/LTITools.swift
@@ -28,6 +28,7 @@ public class LTITools: NSObject {
     let id: String?
     let url: URL?
     let launchType: GetSessionlessLaunchURLRequest.LaunchType?
+    let isQuizLTI: Bool? // This is optional because not all entry points provide this info
     let assignmentID: String?
     let moduleID: String?
     let moduleItemID: String?
@@ -45,12 +46,12 @@ public class LTITools: NSObject {
         )
     }
 
-    @objc
     public static func launch(
         context: String?,
         id: String?,
         url: URL?,
         launchType: String?,
+        isQuizLTI: Bool?,
         assignmentID: String?,
         from view: UIViewController,
         animated: Bool = true,
@@ -61,6 +62,7 @@ public class LTITools: NSObject {
             id: id,
             url: url,
             launchType: launchType.flatMap { GetSessionlessLaunchURLRequest.LaunchType(rawValue: $0) },
+            isQuizLTI: isQuizLTI,
             assignmentID: assignmentID
         )
         tools.presentTool(from: view, animated: animated, completionHandler: completionHandler)
@@ -72,6 +74,7 @@ public class LTITools: NSObject {
         id: String? = nil,
         url: URL? = nil,
         launchType: GetSessionlessLaunchURLRequest.LaunchType? = nil,
+        isQuizLTI: Bool?,
         assignmentID: String? = nil,
         moduleID: String? = nil,
         moduleItemID: String? = nil,
@@ -82,6 +85,7 @@ public class LTITools: NSObject {
         self.id = id
         self.url = url
         self.launchType = launchType
+        self.isQuizLTI = isQuizLTI
         self.assignmentID = assignmentID
         self.moduleID = moduleID
         self.moduleItemID = moduleItemID
@@ -99,6 +103,7 @@ public class LTITools: NSObject {
                 env: env,
                 context: context,
                 url: url,
+                isQuizLTI: nil,
                 resourceLinkLookupUUID: resourceLinkUUID
             )
             return
@@ -107,7 +112,8 @@ public class LTITools: NSObject {
                 env: env,
                 context: .course(courseID),
                 id: toolID,
-                launchType: .course_navigation
+                launchType: .course_navigation,
+                isQuizLTI: nil
             )
             return
         } else {
@@ -157,19 +163,29 @@ public class LTITools: NSObject {
     }
 
     public func presentTool(from view: UIViewController, animated: Bool = true, completionHandler: ((Bool) -> Void)? = nil) {
-        getSessionlessLaunch { [weak view, originalUrl = url, env] response in
+        getSessionlessLaunch { [weak view, originalUrl = url, env, isQuizLTI] response in
             guard let view else { return }
             guard let response = response else {
                 completionHandler?(false)
                 return
             }
+
             Analytics.shared.logEvent("external_tool_launched", parameters: ["launchUrl": response.url])
             let completionHandler = { [weak self] (success: Bool) in
                 self?.markModuleItemRead()
                 completionHandler?(success)
             }
             let url = response.url.appendingQueryItems(URLQueryItem(name: "platform", value: "mobile"))
-            if response.name == "Google Apps" {
+
+            if isQuizLTI == true {
+                let controller = CoreWebViewController(features: [.invertColorsInDarkMode])
+                controller.webView.load(URLRequest(url: url))
+                controller.title = String(localized: "Quiz", bundle: .core)
+                controller.addDoneButton(side: .right)
+                env.router.show(controller, from: view, options: .modal(.overFullScreen, embedInNav: true)) {
+                    completionHandler(true)
+                }
+            } else if response.name == "Google Apps" {
                 let controller = GoogleCloudAssignmentViewController(url: url)
                 self.env.router.show(controller, from: view, options: .modal(.overFullScreen, embedInNav: true, addDoneButton: true)) {
                     completionHandler(true)

--- a/Core/Core/LTI/View/LTIViewController.swift
+++ b/Core/Core/LTI/View/LTIViewController.swift
@@ -26,7 +26,6 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
 
     private var env: AppEnvironment = .defaultValue
     public var tools: LTITools!
-    public var isQuizLTI: Bool!
     public var name: String?
     public var color: UIColor?
     public var titleSubtitleView: TitleSubtitleView = TitleSubtitleView.create()
@@ -44,10 +43,9 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
         return tools.context.id
     }
 
-    public static func create(env: AppEnvironment, tools: LTITools, isQuizLTI: Bool, name: String? = nil) -> Self {
+    public static func create(env: AppEnvironment, tools: LTITools, name: String? = nil) -> Self {
         let controller = loadFromStoryboard()
         controller.tools = tools
-        controller.isQuizLTI = isQuizLTI
         controller.name = name
         controller.env = env
         return controller
@@ -67,6 +65,7 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
                 }
             }
         }
+        let isQuizLTI = tools.isQuizLTI ?? false
         descriptionLabel.text = isQuizLTI
             ? String(localized: "This quiz opens in a web browser. Select \"Open the Quiz\" to proceed.", bundle: .core)
             : String(localized: "This page can only be viewed from a web browser.", bundle: .core)

--- a/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -147,10 +147,11 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
                 id: toolID,
                 url: url,
                 launchType: .module_item,
+                isQuizLTI: item.isQuizLTI,
                 moduleID: moduleID,
                 moduleItemID: itemID
             )
-            return LTIViewController.create(env: env, tools: tools, isQuizLTI: item.isQuizLTI, name: item.title)
+            return LTIViewController.create(env: env, tools: tools, name: item.title)
         default:
             guard let url = item.url else { return nil }
             let preparedURL = url.appendingOrigin("module_item_details")

--- a/Core/Core/Profile/SideMenu/SideMenuMainSection.swift
+++ b/Core/Core/Profile/SideMenu/SideMenuMainSection.swift
@@ -123,7 +123,7 @@ struct SideMenuMainSection: View {
         guard let url = url else { return }
         let dashboard = self.dashboard
         env.router.dismiss(controller) {
-            LTITools(url: url).presentTool(from: dashboard, animated: true)
+            LTITools(url: url, isQuizLTI: false).presentTool(from: dashboard, animated: true)
         }
     }
 }

--- a/Core/Core/Studio/Model/StudioAPIAuthInteractor.swift
+++ b/Core/Core/Studio/Model/StudioAPIAuthInteractor.swift
@@ -120,7 +120,7 @@ public class StudioAPIAuthInteractorLive: StudioAPIAuthInteractor {
             }
             .mapErrorToAuthError(mapUnknownErrorsTo: StudioAPIAuthError.failedToGetLTIs)
             .flatMap { (webURL, baseURL) in
-                LTITools(url: webURL)
+                LTITools(url: webURL, isQuizLTI: false)
                     .getSessionlessLaunchURL()
                     .mapError { _ in StudioAPIAuthError.failedToGetLaunchURL }
                     .map { (webLaunchURL: $0, apiBaseURL: baseURL) }

--- a/Core/CoreTests/CoreWebView/Model/Features/HideReturnButtonInQuizLTITests.swift
+++ b/Core/CoreTests/CoreWebView/Model/Features/HideReturnButtonInQuizLTITests.swift
@@ -1,0 +1,54 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2024-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import Core
+
+class HideReturnButtonInQuizLTITests: XCTestCase {
+
+    func testDisplayStyleSetToNone() {
+        let mockLinkDelegate = MockCoreWebViewLinkDelegate()
+        let webView = CoreWebView(features: [.hideReturnButtonInQuizLTI])
+        webView.linkDelegate = mockLinkDelegate
+        webView.loadHTMLString(
+            """
+            <a data-automation="sdk-return-button" href="/courses/42" class="test-return-button">
+              <span class="css-z2mgls-baseButton__content">
+                <span class="css-11xkk0o-baseButton__children">Return</span>
+              </span>
+            </a>
+            """
+        )
+        wait(for: [mockLinkDelegate.navigationFinishedExpectation], timeout: 10)
+
+        let jsEvaluated = expectation(description: "JS evaluated")
+        webView.evaluateJavaScript(
+            """
+            const returnButton = document.getElementsByClassName('test-return-button')[0];
+            const computedStyle = window.getComputedStyle(returnButton);
+            computedStyle.getPropertyValue('display');
+            """
+        ) { result, error in
+            XCTAssertEqual(result as? String, "none")
+            XCTAssertNil(error)
+            jsEvaluated.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+    }
+}

--- a/Core/CoreTests/LTI/LTIToolsTests.swift
+++ b/Core/CoreTests/LTI/LTIToolsTests.swift
@@ -90,6 +90,7 @@ class LTIToolsTests: CoreTestCase {
             id: nil,
             url: nil,
             launchType: nil,
+            isQuizLTI: nil,
             assignmentID: nil,
             moduleItemID: nil
         )
@@ -138,6 +139,7 @@ class LTIToolsTests: CoreTestCase {
             id: nil,
             url: nil,
             launchType: nil,
+            isQuizLTI: nil,
             assignmentID: nil,
             moduleItemID: nil
         )
@@ -184,7 +186,7 @@ class LTIToolsTests: CoreTestCase {
     }
 
     func testPresentToolInSafariProper() {
-        let tools = LTITools()
+        let tools = LTITools(isQuizLTI: nil)
         let request = GetSessionlessLaunchURLRequest(context: tools.context,
                                                      id: nil,
                                                      url: nil,
@@ -200,8 +202,24 @@ class LTIToolsTests: CoreTestCase {
         XCTAssertNil(router.presented)
     }
 
+    func testPresentQuizLTI() throws {
+        let tools = LTITools(isQuizLTI: true)
+        let request = GetSessionlessLaunchURLRequest(context: tools.context,
+                                                     id: nil,
+                                                     url: nil,
+                                                     assignmentID: nil,
+                                                     moduleItemID: nil,
+                                                     launchType: nil,
+                                                     resourceLinkLookupUUID: nil)
+        let url = URL(string: "https://canvas.instructure.com")!
+        api.mock(request, value: .make(name: "Google Apps", url: url))
+        tools.presentTool(from: mockView, animated: true)
+        let controller = try XCTUnwrap(router.presented as? CoreWebViewController)
+        XCTAssertTrue(router.lastRoutedTo(viewController: controller, from: mockView, withOptions: .modal(.overFullScreen, embedInNav: true)))
+    }
+
     func testPresentGoogleApp() throws {
-        let tools = LTITools()
+        let tools = LTITools(isQuizLTI: nil)
         let request = GetSessionlessLaunchURLRequest(context: tools.context,
                                                      id: nil,
                                                      url: nil,
@@ -218,7 +236,7 @@ class LTIToolsTests: CoreTestCase {
 
     func testPresentStudio() throws {
         let url = URL(string: "https://canvas.instructure.com?custom_arc_launch_type=global_nav")!
-        let tools = LTITools(url: url)
+        let tools = LTITools(url: url, isQuizLTI: nil)
         let request = GetSessionlessLaunchURLRequest(context: tools.context,
                                                      id: nil,
                                                      url: url,
@@ -242,7 +260,7 @@ class LTIToolsTests: CoreTestCase {
 
     func testMarksModuleItemAsRead() {
         api.mock(PostMarkModuleItemRead(courseID: "1", moduleID: "2", moduleItemID: "3"))
-        let tools = LTITools(context: .course("1"), launchType: .module_item, moduleID: "2", moduleItemID: "3")
+        let tools = LTITools(context: .course("1"), launchType: .module_item, isQuizLTI: nil, moduleID: "2", moduleItemID: "3")
         let request = GetSessionlessLaunchURLRequest(context: tools.context,
                                                      id: nil,
                                                      url: nil,
@@ -268,6 +286,7 @@ class LTIToolsTests: CoreTestCase {
             id: nil,
             url: url,
             launchType: nil,
+            isQuizLTI: nil,
             assignmentID: nil,
             moduleItemID: nil
         )

--- a/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
+++ b/Core/CoreTests/LTI/View/LTIViewControllerTests.swift
@@ -24,8 +24,8 @@ import SafariServices
 
 class LTIViewControllerTests: CoreTestCase {
     func testLayout() {
-        let tools = LTITools(id: "1")
-        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false)
+        let tools = LTITools(id: "1", isQuizLTI: nil)
+        let controller = LTIViewController.create(env: environment, tools: tools)
         var task = api.mock(tools.request, value: .make(name: "So Descriptive", url: .make()))
         task.suspend()
 
@@ -49,30 +49,30 @@ class LTIViewControllerTests: CoreTestCase {
     }
 
     func testName() {
-        let tools = LTITools(env: environment, id: "1")
-        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false, name: "Fancy Tool")
+        let tools = LTITools(env: environment, id: "1", isQuizLTI: nil)
+        let controller = LTIViewController.create(env: environment, tools: tools, name: "Fancy Tool")
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.nameLabel.text, "Fancy Tool")
     }
 
     func testCourseSubtitle() {
         let course = APICourse.make(id: "1", name: "Fancy Course")
-        let tools = LTITools(env: environment, context: .course(course.id.value))
-        let controller = LTIViewController.create(env: environment, tools: tools, isQuizLTI: false)
+        let tools = LTITools(env: environment, context: .course(course.id.value), isQuizLTI: nil)
+        let controller = LTIViewController.create(env: environment, tools: tools)
         api.mock(controller.courses!, value: course)
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.titleSubtitleView.subtitle, "Fancy Course")
     }
 
     func testTextsWhenIsQuizLTI() {
-        let controller = LTIViewController.create(env: environment, tools: .init(), isQuizLTI: true)
+        let controller = LTIViewController.create(env: environment, tools: .init(isQuizLTI: true))
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.descriptionLabel.text?.lowercased().contains("quiz"), true)
         XCTAssertEqual(controller.openButton.titleLabel?.text?.lowercased().contains("quiz"), true)
     }
 
     func testTextsWhenIsNotQuizLTI() {
-        let controller = LTIViewController.create(env: environment, tools: .init(), isQuizLTI: false)
+        let controller = LTIViewController.create(env: environment, tools: .init(isQuizLTI: false))
         controller.view.layoutIfNeeded()
         XCTAssertEqual(controller.descriptionLabel.text?.lowercased().contains("quiz"), false)
         XCTAssertEqual(controller.openButton.titleLabel?.text?.lowercased().contains("quiz"), false)

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -233,7 +233,7 @@ let router = Router(routes: [
     RouteHandler("/courses/:courseID/external_tools/:toolID") { _, params, _ in
         guard let courseID = params["courseID"], let toolID = params["toolID"] else { return nil }
         guard let vc = AppEnvironment.shared.window?.rootViewController?.topMostViewController() else { return nil }
-        let tools = LTITools(context: .course(courseID), id: toolID)
+        let tools = LTITools(context: .course(courseID), id: toolID, isQuizLTI: nil)
         tools.presentTool(from: vc, animated: true)
         return nil
     },

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -127,6 +127,7 @@ class SubmissionButtonPresenter: NSObject {
                 context: .course(courseID),
                 id: assignment.externalToolContentID,
                 launchType: .assessment,
+                isQuizLTI: assignment.isQuizLTI,
                 assignmentID: assignment.id
             ).presentTool(from: view, animated: true)
         case .discussion_topic:

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsPresenter.swift
@@ -199,9 +199,10 @@ class SubmissionDetailsPresenter {
                 env: env,
                 context: context,
                 launchType: .assessment,
+                isQuizLTI: assignment.isQuizLTI,
                 assignmentID: assignmentID
             )
-            return LTIViewController.create(env: env, tools: tools, isQuizLTI: assignment.isQuizLTI)
+            return LTIViewController.create(env: env, tools: tools)
         }
 
         switch submission.type {
@@ -270,9 +271,10 @@ class SubmissionDetailsPresenter {
             let tools = LTITools(
                 env: env,
                 context: context,
-                url: submission.externalToolURL
+                url: submission.externalToolURL,
+                isQuizLTI: false
             )
-            return LTIViewController.create(env: env, tools: tools, isQuizLTI: false)
+            return LTIViewController.create(env: env, tools: tools)
         case .student_annotation:
             guard let docViewerSessionURL = docViewerSessionURL else { return nil }
             return DocViewerViewController.create(

--- a/Teacher/Teacher/Attendance/RollCallSession.swift
+++ b/Teacher/Teacher/Attendance/RollCallSession.swift
@@ -79,7 +79,9 @@ class RollCallSession: NSObject, WKNavigationDelegate {
 
     func start() {
         guard case .fetchingLaunchURL = state else { return }
-        LTITools(env: env, context: context, id: toolID, launchType: .course_navigation).getSessionlessLaunchURL { url in
+
+        let ltiTools = LTITools(env: env, context: context, id: toolID, launchType: .course_navigation, isQuizLTI: false)
+        ltiTools.getSessionlessLaunchURL { url in
             if let url = url {
                 self.launch(url: url)
             } else {


### PR DESCRIPTION
refs: [MBL-17982](https://instructure.atlassian.net/browse/MBL-17982)
affects: Student
release note: QuizLTIs now open internally.

## What's changed
- New Quizzes (= Quiz LTIs) now open in webview, instead of internal browser
- The "Return" button had been removed from the Quiz pages (based on `data-automation` id)
  - Since we already have a native "Done" button, this was preferred option instead of fixing the return navigation
- The Quiz pages now respect dark/light mode preferences

## Known issues
- There is no back navigation after the user taps on a link or a button within the LTI pages. This is the result of using webview instead of a browser window.
- QuizLTI session seem to have 5sec send interval. When you tap Done to dismiss the screen quickly after a change, then the change may not get persisted. This is reproducible on the web, as well. The "Return" button didn't help with this.
- Dynamic font size changes are not supported.

## Test Plan
- Verify new quizzes open in internal webviews, and work as expected
- Verify none of the pages have "Return" buttons which lead to Course Home
- Verify dark mode works as expected

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/27a1e524-765f-4f68-9e39-9f506836f65c" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/1446324d-475d-4ac2-a546-c3452c516a5a" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b8601c89-775e-425a-b56b-f733058a1ca0" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/c0fd31f0-d917-4a03-ae48-abd3aff62559" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/d639628f-dd5d-43af-979b-c2f7d6e42a1e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/179d0286-8342-40a2-b43d-127342043243" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] A11y checked
- [ ] Tested on phone @ iOS 18
- [x] Tested on phone @ iOS 17
- [x] Tested on tablet @ iOS 18
- [ ] Tested on tablet @ iOS 17
- [x] Tested in dark mode
- [x] Tested in light mode

[MBL-17982]: https://instructure.atlassian.net/browse/MBL-17982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ