### PR TITLE
Fix E2E test issue with Grading Periods Not being shown correctly on Grades Filter screen

### DIFF
--- a/Core/Core/Grades/View/GradeListView.swift
+++ b/Core/Core/Grades/View/GradeListView.swift
@@ -112,6 +112,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                                  : .textLightest)
 
         }
+        .hidden(viewModel.state == .initialLoading)
         .accessibilityLabel(Text("Filter", bundle: .core))
         .accessibilityHint(Text("Filter grades options", bundle: .core))
         .accessibilityIdentifier("GradeList.filterButton")

--- a/Student/StudentE2ETests/Grades/GradingPeriodsTests.swift
+++ b/Student/StudentE2ETests/Grades/GradingPeriodsTests.swift
@@ -22,7 +22,6 @@ class GradingPeriodsTests: E2ETestCase {
     typealias Helper = GradesHelper
 
     func testGradingPeriodsFilter() throws {
-        try XCTSkipIf(true, "Skipped because of MBL-18023.")
         // MARK: Seed the usual stuff with grading periods containing graded assignments
         let student = seeder.createUser()
         let enrollmentTerm = Helper.createEnrollmentTerm()


### PR DESCRIPTION
refs: [MBL-18084](https://instructure.atlassian.net/browse/MBL-18084)
affects: Student
release note: Fixed grade preferences screen not displaying grading periods in some cases.

## What's changed
The resolution was basically to hide the filter button on screen appearance, until the loading finishes for the first time. Subsequent reloading won't hide it again.

## Screen Recording

https://github.com/user-attachments/assets/f87380ca-2692-43bb-9fcd-c807d7150c59

## Test Plan

- Login to a student account
- Navigate to a course Grades screen
- While initial loading, filter button is not being displayed
- After first loading, on success or failure, filter button must be displayed.
- Try reloading the screen or picking a grading period from filter screen, at all cases filter button should still be displayed.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18084]: https://instructure.atlassian.net/browse/MBL-18084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ