### PR TITLE
Fix issue of Total Grades Restricted for Concluded Courses

### DIFF
--- a/Core/Core/Courses/Course.swift
+++ b/Core/Core/Courses/Course.swift
@@ -256,12 +256,22 @@ extension Course {
         return enrollments?.contains { $0.isTeacher } == true
     }
 
-    func enrollmentForGrades(userId: String?) -> Enrollment? {
-        enrollments?.first {
-            $0.state == .active &&
-            $0.userID == userId &&
-            $0.type.lowercased().contains("student") &&
-            $0.id == nil
+    func enrollmentForGrades(userId: String?, includingCompleted: Bool = false) -> Enrollment? {
+        func first(of state: EnrollmentState) -> Enrollment? {
+            enrollments?.first {
+                $0.state == state &&
+                $0.userID == userId &&
+                $0.type.lowercased().contains("student") &&
+                $0.id == nil
+            }
+        }
+
+        if let enrollment = first(of: .active) {
+            return enrollment
+        } else if includingCompleted {
+            return first(of: .completed)
+        } else {
+            return nil
         }
     }
 }

--- a/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
+++ b/Core/CoreTests/Grades/GradeListInteractorLiveTests.swift
@@ -104,7 +104,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
                 userID: currentSession.userID,
                 gradingPeriodID: gradingPeriodID,
                 types: ["StudentEnrollment"],
-                states: [.active]
+                states: [.active, .completed]
             ),
             value: [
                 .make(
@@ -686,7 +686,7 @@ class GradeListInteractorLiveTests: CoreTestCase {
                 userID: currentSession.userID,
                 gradingPeriodID: gradingPeriodID,
                 types: ["StudentEnrollment"],
-                states: [.active]
+                states: [.active, .completed]
             ),
             value: [
                 .make(

--- a/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
+++ b/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
@@ -117,6 +117,8 @@ class CoreSearchHostingControllerTests: CoreTestCase {
         textField.text = "Example"
         _ = textField.delegate?.textFieldShouldReturn?(textField)
 
+        drainMainQueue(thoroughness: 10)
+
         XCTAssertEqual(controller.searchContext.searchText.value, "Example")
         XCTAssertSingleOutputEquals(submitted, "Example")
 

--- a/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
+++ b/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
@@ -117,8 +117,6 @@ class CoreSearchHostingControllerTests: CoreTestCase {
         textField.text = "Example"
         _ = textField.delegate?.textFieldShouldReturn?(textField)
 
-        drainMainQueue(thoroughness: 10)
-
         XCTAssertEqual(controller.searchContext.searchText.value, "Example")
         XCTAssertSingleOutputEquals(submitted, "Example")
 


### PR DESCRIPTION
refs: [MBL-18151](https://instructure.atlassian.net/browse/MBL-18151)
affects: Student
release note: Fixed grades screen not showing total grades for concluded enrollments.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18151) description.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/37b65856-13ee-403b-aa46-6b8e88be34bb" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/38609d6f-2e43-409a-8d80-9bf0fa0b740a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18151]: https://instructure.atlassian.net/browse/MBL-18151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ