### PR TITLE
Fix tests

### DIFF
--- a/Core/Core/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/CoreWebView/View/CoreWebView.swift
@@ -341,7 +341,6 @@ open class CoreWebView: WKWebView {
         fileLoadNavigation = loadFileURL(url, allowingReadAccessTo: urlDirectory)
     }
 
-
     private func checkFileLoadNavigationAndExecuteCallback(finishedNavigation: WKNavigation) {
         if finishedNavigation == fileLoadNavigation {
             fileLoadNavigation = nil

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -158,19 +158,6 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         webView.handle("like") { [weak self] message in self?.handleLike(message) }
         webView.handle("moreOptions") { [weak self] message in self?.handleMoreOptions(message) }
         webView.handle("ready") { [weak self] _ in self?.ready() }
-        let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
-            sessionId: env.currentSession?.uniqueID ?? "",
-            courseId: course.first?.id ?? "",
-            sectionName: isAnnouncement ? OfflineFolderPrefix.announcements.rawValue : OfflineFolderPrefix.discussions.rawValue,
-            resourceId: topicID
-        )
-        webView.loadFileURL(URL.Directories.documents, allowingReadAccessTo: URL.Directories.documents)
-        webView.loadHTMLString(
-            "<style>\(DiscussionHTML.css)</style>",
-            baseURL: offlineModeInteractor?.isOfflineModeEnabled() == true ?
-                rootURL :
-                env.api.baseURL.appendingPathComponent("\(context.pathComponent)/discussion_topics/\(topicID)")
-        )
 
         if showRepliesToEntryID != nil {
             titleSubtitleView.title = isAnnouncement
@@ -189,6 +176,26 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         entries.refresh()
         permissions.refresh()
         groups.exhaust(force: true)
+
+        let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
+            sessionId: env.currentSession?.uniqueID ?? "",
+            courseId: course.first?.id ?? "",
+            sectionName: isAnnouncement ? OfflineFolderPrefix.announcements.rawValue : OfflineFolderPrefix.discussions.rawValue,
+            resourceId: topicID
+        )
+        webView.loadFileURL(
+            URL.Directories.documents,
+            allowingReadAccessTo: URL.Directories.documents
+        ) { [weak self] in
+            guard let self else { return }
+
+            webView.loadHTMLString(
+                "<style>\(DiscussionHTML.css)</style>",
+                baseURL: offlineModeInteractor?.isOfflineModeEnabled() == true ?
+                    rootURL :
+                    env.api.baseURL.appendingPathComponent("\(context.pathComponent)/discussion_topics/\(topicID)")
+            )
+        }
     }
 
     public override func viewWillAppear(_ animated: Bool) {
@@ -331,19 +338,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         topicID = childID
         isReady = false
         isRendered = false
-        let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
-            sessionId: env.currentSession?.uniqueID ?? "",
-            courseId: course.first?.id ?? "",
-            sectionName: isAnnouncement ? OfflineFolderPrefix.announcements.rawValue : OfflineFolderPrefix.discussions.rawValue,
-            resourceId: topic.id
-        )
-        webView.loadFileURL(URL.Directories.documents, allowingReadAccessTo: URL.Directories.documents)
-        webView.loadHTMLString(
-            "<style>\(DiscussionHTML.css)</style>",
-            baseURL: offlineModeInteractor?.isOfflineModeEnabled() == true ?
-                rootURL :
-                env.api.baseURL.appendingPathComponent("\(context.pathComponent)/discussion_topics/\(topicID)")
-        )
+
         entries = env.subscribe(GetDiscussionView(context: context, topicID: topicID)) { [weak self] in
             self?.update()
         }
@@ -360,6 +355,26 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         group.refresh()
         permissions.refresh()
         self.topic.refresh(force: true)
+
+        let rootURL = URL.Paths.Offline.courseSectionResourceFolderURL(
+            sessionId: env.currentSession?.uniqueID ?? "",
+            courseId: course.first?.id ?? "",
+            sectionName: isAnnouncement ? OfflineFolderPrefix.announcements.rawValue : OfflineFolderPrefix.discussions.rawValue,
+            resourceId: topic.id
+        )
+        webView.loadFileURL(
+            URL.Directories.documents,
+            allowingReadAccessTo: URL.Directories.documents
+        ) { [weak self] in
+            guard let self else { return }
+
+            webView.loadHTMLString(
+                "<style>\(DiscussionHTML.css)</style>",
+                baseURL: offlineModeInteractor?.isOfflineModeEnabled() == true ?
+                    rootURL :
+                    env.api.baseURL.appendingPathComponent("\(context.pathComponent)/discussion_topics/\(topicID)")
+            )
+        }
         return false
     }
 

--- a/Core/Core/Discussions/DiscussionDetailsViewController.swift
+++ b/Core/Core/Discussions/DiscussionDetailsViewController.swift
@@ -186,7 +186,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         webView.loadFileURL(
             URL.Directories.documents,
             allowingReadAccessTo: URL.Directories.documents
-        ) { [weak self] in
+        ) { [weak self] _ in
             guard let self else { return }
 
             webView.loadHTMLString(
@@ -365,7 +365,7 @@ public class DiscussionDetailsViewController: ScreenViewTrackableViewController,
         webView.loadFileURL(
             URL.Directories.documents,
             allowingReadAccessTo: URL.Directories.documents
-        ) { [weak self] in
+        ) { [weak self] _ in
             guard let self else { return }
 
             webView.loadHTMLString(

--- a/Core/Core/Extensions/InstColorExtensions.swift
+++ b/Core/Core/Extensions/InstColorExtensions.swift
@@ -36,17 +36,17 @@ public extension UIColor {
 }
 
 public extension Color {
-    static let textDanger = Color(.textDanger)
-    static let textDark = Color(.textDark)
-    static let textDarkest = Color(.textDarkest)
-    static let textInfo = Color(.textInfo)
-    static let textLight = Color(.textLight)
-    static let textLightest = Color(.textLightest)
-    static let textLink = Color(.textLink)
-    static let textMasquerade = Color(.textMasquerade)
-    static let textPlaceholder = Color(.textPlaceholder)
-    static let textSuccess = Color(.textSuccess)
-    static let textWarning = Color(.textWarning)
+    static let textDanger = Color(uiColor: .textDanger)
+    static let textDark = Color(uiColor: .textDark)
+    static let textDarkest = Color(uiColor: .textDarkest)
+    static let textInfo = Color(uiColor: .textInfo)
+    static let textLight = Color(uiColor: .textLight)
+    static let textLightest = Color(uiColor: .textLightest)
+    static let textLink = Color(uiColor: .textLink)
+    static let textMasquerade = Color(uiColor: .textMasquerade)
+    static let textPlaceholder = Color(uiColor: .textPlaceholder)
+    static let textSuccess = Color(uiColor: .textSuccess)
+    static let textWarning = Color(uiColor: .textWarning)
 }
 
 // MARK: - Background Colors
@@ -68,19 +68,19 @@ public extension UIColor {
 }
 
 public extension Color {
-    static let backgroundDanger = Color(.backgroundDanger)
-    static let backgroundDark = Color(.backgroundDark)
-    static let backgroundDarkest = Color(.backgroundDarkest)
-    static let backgroundGrouped = Color(.backgroundGrouped)
-    static let backgroundGroupedCell = Color(.backgroundGroupedCell)
-    static let backgroundInfo = Color(.backgroundInfo)
-    static let backgroundLight = Color(.backgroundLight)
-    static let backgroundLightest = Color(.backgroundLightest)
-    static let backgroundLightestElevated = Color(.backgroundLightestElevated)
-    static let backgroundMasquerade = Color(.backgroundMasquerade)
-    static let backgroundMedium = Color(.backgroundMedium)
-    static let backgroundSuccess = Color(.backgroundSuccess)
-    static let backgroundWarning = Color(.backgroundWarning)
+    static let backgroundDanger = Color(uiColor: .backgroundDanger)
+    static let backgroundDark = Color(uiColor: .backgroundDark)
+    static let backgroundDarkest = Color(uiColor: .backgroundDarkest)
+    static let backgroundGrouped = Color(uiColor: .backgroundGrouped)
+    static let backgroundGroupedCell = Color(uiColor: .backgroundGroupedCell)
+    static let backgroundInfo = Color(uiColor: .backgroundInfo)
+    static let backgroundLight = Color(uiColor: .backgroundLight)
+    static let backgroundLightest = Color(uiColor: .backgroundLightest)
+    static let backgroundLightestElevated = Color(uiColor: .backgroundLightestElevated)
+    static let backgroundMasquerade = Color(uiColor: .backgroundMasquerade)
+    static let backgroundMedium = Color(uiColor: .backgroundMedium)
+    static let backgroundSuccess = Color(uiColor: .backgroundSuccess)
+    static let backgroundWarning = Color(uiColor: .backgroundWarning)
 }
 
 // MARK: - Border Colors
@@ -100,17 +100,17 @@ public extension UIColor {
 }
 
 public extension Color {
-    static let borderDanger = Color(.borderDanger)
-    static let borderDark = Color(.borderDark)
-    static let borderDarkest = Color(.borderDarkest)
-    static let borderDebug = Color(.borderDebug)
-    static let borderInfo = Color(.borderInfo)
-    static let borderLight = Color(.borderLight)
-    static let borderLightest = Color(.borderLightest)
-    static let borderMasquerade = Color(.borderMasquerade)
-    static let borderMedium = Color(.borderMedium)
-    static let borderSuccess = Color(.borderSuccess)
-    static let borderWarning = Color(.borderWarning)
+    static let borderDanger = Color(uiColor: .borderDanger)
+    static let borderDark = Color(uiColor: .borderDark)
+    static let borderDarkest = Color(uiColor: .borderDarkest)
+    static let borderDebug = Color(uiColor: .borderDebug)
+    static let borderInfo = Color(uiColor: .borderInfo)
+    static let borderLight = Color(uiColor: .borderLight)
+    static let borderLightest = Color(uiColor: .borderLightest)
+    static let borderMasquerade = Color(uiColor: .borderMasquerade)
+    static let borderMedium = Color(uiColor: .borderMedium)
+    static let borderSuccess = Color(uiColor: .borderSuccess)
+    static let borderWarning = Color(uiColor: .borderWarning)
 }
 
 // MARK: - Course Colors
@@ -131,18 +131,18 @@ public extension UIColor {
 }
 
 public extension Color {
-    static let course1 = Color(.course1)
-    static let course2 = Color(.course2)
-    static let course3 = Color(.course3)
-    static let course4 = Color(.course4)
-    static let course5 = Color(.course5)
-    static let course6 = Color(.course6)
-    static let course7 = Color(.course7)
-    static let course8 = Color(.course8)
-    static let course9 = Color(.course9)
-    static let course10 = Color(.course10)
-    static let course11 = Color(.course11)
-    static let course12 = Color(.course12)
+    static let course1 = Color(uiColor: .course1)
+    static let course2 = Color(uiColor: .course2)
+    static let course3 = Color(uiColor: .course3)
+    static let course4 = Color(uiColor: .course4)
+    static let course5 = Color(uiColor: .course5)
+    static let course6 = Color(uiColor: .course6)
+    static let course7 = Color(uiColor: .course7)
+    static let course8 = Color(uiColor: .course8)
+    static let course9 = Color(uiColor: .course9)
+    static let course10 = Color(uiColor: .course10)
+    static let course11 = Color(uiColor: .course11)
+    static let course12 = Color(uiColor: .course12)
 }
 
 // MARK: - iOS Specific Colors
@@ -152,5 +152,5 @@ public extension UIColor {
 }
 
 public extension Color {
-    static let disabledGray = Color(.disabledGray)
+    static let disabledGray = Color(uiColor: .disabledGray)
 }

--- a/Core/Core/Extensions/ResultExtensions.swift
+++ b/Core/Core/Extensions/ResultExtensions.swift
@@ -52,3 +52,10 @@ public extension Result {
 extension Result where Success == Void {
     public static var success: Result { .success(()) }
 }
+
+extension Result where Success == Void {
+
+    public init(error: Failure?) {
+        self = (error == nil) ? .success(()) : .failure(error!)
+    }
+}

--- a/Core/CoreTests/CoreWebView/View/CoreWebViewFileLoadTests.swift
+++ b/Core/CoreTests/CoreWebView/View/CoreWebViewFileLoadTests.swift
@@ -1,0 +1,167 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import WebKit
+import XCTest
+
+class CoreWebViewFileURLLoadTests: CoreTestCase {
+    /// Static so the internal mock class can access it.
+    private static let mockFileLoadNavigation =  WKNavigation()
+    /// Declaring these navigation objects inside a method causes a crash.
+    private let unknownNavigation = WKNavigation()
+    private let testee = MockWebView()
+
+    func testCallbackOnProvisionalNavigationFail() {
+        let completionExpectation = expectation(description: "callback executed")
+        testee.loadFileURL(
+            workingDirectory,
+            allowingReadAccessTo: workingDirectory
+        ) {
+            completionExpectation.fulfill()
+            XCTAssertTrue(Thread.isMainThread)
+        }
+
+        // WHEN
+        testee.webView(
+            testee,
+            didFailProvisionalNavigation: Self.mockFileLoadNavigation,
+            withError: NSError.internalError()
+        )
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCallbackOnNavigationFail() {
+        let completionExpectation = expectation(description: "callback executed")
+        testee.loadFileURL(
+            workingDirectory,
+            allowingReadAccessTo: workingDirectory
+        ) {
+            completionExpectation.fulfill()
+            XCTAssertTrue(Thread.isMainThread)
+        }
+
+        // WHEN
+        testee.webView(
+            testee,
+            didFail: Self.mockFileLoadNavigation,
+            withError: NSError.internalError()
+        )
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func testCallbackOnNavigationFinish() {
+        let completionExpectation = expectation(description: "callback executed")
+        testee.loadFileURL(
+            workingDirectory,
+            allowingReadAccessTo: workingDirectory
+        ) {
+            completionExpectation.fulfill()
+            XCTAssertTrue(Thread.isMainThread)
+        }
+
+        // WHEN
+        testee.webView(
+            testee,
+            didFinish: Self.mockFileLoadNavigation
+        )
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func testNoCallbackOnUnknownNavigation() {
+        let noCallbackExpectation = expectation(description: "callback not executed")
+        noCallbackExpectation.isInverted = true
+        testee.loadFileURL(
+            workingDirectory,
+            allowingReadAccessTo: workingDirectory
+        ) {
+            noCallbackExpectation.fulfill()
+        }
+
+        // WHEN
+        testee.webView(
+            testee,
+            didFinish: unknownNavigation
+        )
+        testee.webView(
+            testee,
+            didFail: unknownNavigation,
+            withError: NSError.internalError()
+        )
+        testee.webView(
+            testee,
+            didFailProvisionalNavigation: unknownNavigation,
+            withError: NSError.internalError()
+        )
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func testNoMultipleCallbacks() {
+        let completionExpectation = expectation(description: "callback executed")
+        testee.loadFileURL(
+            workingDirectory,
+            allowingReadAccessTo: workingDirectory
+        ) {
+            completionExpectation.fulfill()
+            XCTAssertTrue(Thread.isMainThread)
+        }
+
+        // WHEN
+        testee.webView(
+            testee,
+            didFailProvisionalNavigation: Self.mockFileLoadNavigation,
+            withError: NSError.internalError()
+        )
+        testee.webView(
+            testee,
+            didFail: Self.mockFileLoadNavigation,
+            withError: NSError.internalError()
+        )
+        testee.webView(
+            testee,
+            didFinish: Self.mockFileLoadNavigation
+        )
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+}
+
+extension CoreWebViewFileURLLoadTests {
+
+    private class MockWebView: CoreWebView {
+
+        /// We override this for two reasons:
+        /// - To prevent the actual load happening that interferes with the test
+        /// - To control the returned navigation object
+        override func loadFileURL(
+            _ url: URL,
+            allowingReadAccessTo directory: URL
+        ) -> WKNavigation {
+            mockFileLoadNavigation
+        }
+    }
+}

--- a/Core/CoreTests/CoreWebView/View/CoreWebViewFileLoadTests.swift
+++ b/Core/CoreTests/CoreWebView/View/CoreWebViewFileLoadTests.swift
@@ -32,9 +32,10 @@ class CoreWebViewFileURLLoadTests: CoreTestCase {
         testee.loadFileURL(
             workingDirectory,
             allowingReadAccessTo: workingDirectory
-        ) {
+        ) { result in
             completionExpectation.fulfill()
             XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(result.error as NSError?, NSError.internalError())
         }
 
         // WHEN
@@ -53,9 +54,10 @@ class CoreWebViewFileURLLoadTests: CoreTestCase {
         testee.loadFileURL(
             workingDirectory,
             allowingReadAccessTo: workingDirectory
-        ) {
+        ) { result in
             completionExpectation.fulfill()
             XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(result.error as NSError?, NSError.internalError())
         }
 
         // WHEN
@@ -74,9 +76,11 @@ class CoreWebViewFileURLLoadTests: CoreTestCase {
         testee.loadFileURL(
             workingDirectory,
             allowingReadAccessTo: workingDirectory
-        ) {
+        ) { result in
             completionExpectation.fulfill()
             XCTAssertTrue(Thread.isMainThread)
+            XCTAssertNil(result.error)
+            XCTAssertNotNil(result.value)
         }
 
         // WHEN
@@ -95,8 +99,9 @@ class CoreWebViewFileURLLoadTests: CoreTestCase {
         testee.loadFileURL(
             workingDirectory,
             allowingReadAccessTo: workingDirectory
-        ) {
+        ) { result in
             noCallbackExpectation.fulfill()
+            XCTAssertEqual(result.error as NSError?, NSError.internalError())
         }
 
         // WHEN
@@ -124,9 +129,10 @@ class CoreWebViewFileURLLoadTests: CoreTestCase {
         testee.loadFileURL(
             workingDirectory,
             allowingReadAccessTo: workingDirectory
-        ) {
+        ) { result in
             completionExpectation.fulfill()
             XCTAssertTrue(Thread.isMainThread)
+            XCTAssertEqual(result.error as NSError?, NSError.internalError())
         }
 
         // WHEN

--- a/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -49,7 +49,10 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
 
     func waitForWebView() {
         let webView = self.webView
-        let exp = expectation(for: NSPredicate(key: #keyPath(MockWebView.runningCount), equals: 0), evaluatedWith: webView) { () -> Bool in
+        let exp = expectation(
+            for: NSPredicate(key: #keyPath(MockWebView.runningCount), equals: 0),
+            evaluatedWith: webView
+        ) {
             webView.url != nil && !webView.isLoading
         }
         wait(for: [exp], timeout: 9)

--- a/Core/CoreTests/Extensions/InstColorExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/InstColorExtensionsTests.swift
@@ -36,17 +36,17 @@ class InstColorExtensionTests: XCTestCase {
         XCTAssertEqual(UIColor.textPlaceholder, UIColor(resource: .textPlaceholder))
         XCTAssertEqual(UIColor.textLink, UIColor(resource: .textLink))
 
-        XCTAssertEqual(Color.textMasquerade, Color(.textMasquerade))
-        XCTAssertEqual(Color.textDanger, Color(.textDanger))
-        XCTAssertEqual(Color.textDark, Color(.textDark))
-        XCTAssertEqual(Color.textDarkest, Color(.textDarkest))
-        XCTAssertEqual(Color.textInfo, Color(.textInfo))
-        XCTAssertEqual(Color.textLight, Color(.textLight))
-        XCTAssertEqual(Color.textLightest, Color(.textLightest))
-        XCTAssertEqual(Color.textSuccess, Color(.textSuccess))
-        XCTAssertEqual(Color.textWarning, Color(.textWarning))
-        XCTAssertEqual(Color.textPlaceholder, Color(.textPlaceholder))
-        XCTAssertEqual(Color.textLink, Color(.textLink))
+        testHexColorEquality(UIColor.textMasquerade, Color.textMasquerade)
+        testHexColorEquality(UIColor.textDanger, Color.textDanger)
+        testHexColorEquality(UIColor.textDark, Color.textDark)
+        testHexColorEquality(UIColor.textDarkest, Color.textDarkest)
+        testHexColorEquality(UIColor.textInfo, Color.textInfo)
+        testHexColorEquality(UIColor.textLight, Color.textLight)
+        testHexColorEquality(UIColor.textLightest, Color.textLightest)
+        testHexColorEquality(UIColor.textSuccess, Color.textSuccess)
+        testHexColorEquality(UIColor.textWarning, Color.textWarning)
+        testHexColorEquality(UIColor.textPlaceholder, Color.textPlaceholder)
+        testHexColorEquality(UIColor.textLink, Color.textLink)
     }
 
     func testBackgroundColors() {
@@ -64,19 +64,19 @@ class InstColorExtensionTests: XCTestCase {
         XCTAssertEqual(UIColor.backgroundSuccess, UIColor(resource: .backgroundSuccess))
         XCTAssertEqual(UIColor.backgroundWarning, UIColor(resource: .backgroundWarning))
 
-        XCTAssertEqual(Color.backgroundDanger, Color(.backgroundDanger))
-        XCTAssertEqual(Color.backgroundDark, Color(.backgroundDark))
-        XCTAssertEqual(Color.backgroundDarkest, Color(.backgroundDarkest))
-        XCTAssertEqual(Color.backgroundGrouped, Color(.backgroundGrouped))
-        XCTAssertEqual(Color.backgroundGroupedCell, Color(.backgroundGroupedCell))
-        XCTAssertEqual(Color.backgroundInfo, Color(.backgroundInfo))
-        XCTAssertEqual(Color.backgroundLight, Color(.backgroundLight))
-        XCTAssertEqual(Color.backgroundLightest, Color(.backgroundLightest))
-        XCTAssertEqual(Color.backgroundLightestElevated, Color(.backgroundLightestElevated))
-        XCTAssertEqual(Color.backgroundMasquerade, Color(.backgroundMasquerade))
-        XCTAssertEqual(Color.backgroundMedium, Color(.backgroundMedium))
-        XCTAssertEqual(Color.backgroundSuccess, Color(.backgroundSuccess))
-        XCTAssertEqual(Color.backgroundWarning, Color(.backgroundWarning))
+        testHexColorEquality(UIColor.backgroundDanger, Color.backgroundDanger)
+        testHexColorEquality(UIColor.backgroundDark, Color.backgroundDark)
+        testHexColorEquality(UIColor.backgroundDarkest, Color.backgroundDarkest)
+        testHexColorEquality(UIColor.backgroundGrouped, Color.backgroundGrouped)
+        testHexColorEquality(UIColor.backgroundGroupedCell, Color.backgroundGroupedCell)
+        testHexColorEquality(UIColor.backgroundInfo, Color.backgroundInfo)
+        testHexColorEquality(UIColor.backgroundLight, Color.backgroundLight)
+        testHexColorEquality(UIColor.backgroundLightest, Color.backgroundLightest)
+        testHexColorEquality(UIColor.backgroundLightestElevated, Color.backgroundLightestElevated)
+        testHexColorEquality(UIColor.backgroundMasquerade, Color.backgroundMasquerade)
+        testHexColorEquality(UIColor.backgroundMedium, Color.backgroundMedium)
+        testHexColorEquality(UIColor.backgroundSuccess, Color.backgroundSuccess)
+        testHexColorEquality(UIColor.backgroundWarning, Color.backgroundWarning)
     }
 
     func testBorderColors() {
@@ -92,17 +92,17 @@ class InstColorExtensionTests: XCTestCase {
         XCTAssertEqual(UIColor.borderSuccess, UIColor(resource: .borderSuccess))
         XCTAssertEqual(UIColor.borderWarning, UIColor(resource: .borderWarning))
 
-        XCTAssertEqual(Color.borderDanger, Color(.borderDanger))
-        XCTAssertEqual(Color.borderDark, Color(.borderDark))
-        XCTAssertEqual(Color.borderDarkest, Color(.borderDarkest))
-        XCTAssertEqual(Color.borderDebug, Color(.borderDebug))
-        XCTAssertEqual(Color.borderInfo, Color(.borderInfo))
-        XCTAssertEqual(Color.borderLight, Color(.borderLight))
-        XCTAssertEqual(Color.borderLightest, Color(.borderLightest))
-        XCTAssertEqual(Color.borderMasquerade, Color(.borderMasquerade))
-        XCTAssertEqual(Color.borderMedium, Color(.borderMedium))
-        XCTAssertEqual(Color.borderSuccess, Color(.borderSuccess))
-        XCTAssertEqual(Color.borderWarning, Color(.borderWarning))
+        testHexColorEquality(UIColor.borderDanger, Color.borderDanger)
+        testHexColorEquality(UIColor.borderDark, Color.borderDark)
+        testHexColorEquality(UIColor.borderDarkest, Color.borderDarkest)
+        testHexColorEquality(UIColor.borderDebug, Color.borderDebug)
+        testHexColorEquality(UIColor.borderInfo, Color.borderInfo)
+        testHexColorEquality(UIColor.borderLight, Color.borderLight)
+        testHexColorEquality(UIColor.borderLightest, Color.borderLightest)
+        testHexColorEquality(UIColor.borderMasquerade, Color.borderMasquerade)
+        testHexColorEquality(UIColor.borderMedium, Color.borderMedium)
+        testHexColorEquality(UIColor.borderSuccess, Color.borderSuccess)
+        testHexColorEquality(UIColor.borderWarning, Color.borderWarning)
     }
 
     func testCourseColors() {
@@ -119,22 +119,35 @@ class InstColorExtensionTests: XCTestCase {
         XCTAssertEqual(UIColor.course11, UIColor(resource: .course11))
         XCTAssertEqual(UIColor.course12, UIColor(resource: .course12))
 
-        XCTAssertEqual(Color.course1, Color(.course1))
-        XCTAssertEqual(Color.course2, Color(.course2))
-        XCTAssertEqual(Color.course3, Color(.course3))
-        XCTAssertEqual(Color.course4, Color(.course4))
-        XCTAssertEqual(Color.course5, Color(.course5))
-        XCTAssertEqual(Color.course6, Color(.course6))
-        XCTAssertEqual(Color.course7, Color(.course7))
-        XCTAssertEqual(Color.course8, Color(.course8))
-        XCTAssertEqual(Color.course9, Color(.course9))
-        XCTAssertEqual(Color.course10, Color(.course10))
-        XCTAssertEqual(Color.course11, Color(.course11))
-        XCTAssertEqual(Color.course12, Color(.course12))
+        testHexColorEquality(UIColor.course1, Color.course1)
+        testHexColorEquality(UIColor.course2, Color.course2)
+        testHexColorEquality(UIColor.course3, Color.course3)
+        testHexColorEquality(UIColor.course4, Color.course4)
+        testHexColorEquality(UIColor.course5, Color.course5)
+        testHexColorEquality(UIColor.course6, Color.course6)
+        testHexColorEquality(UIColor.course7, Color.course7)
+        testHexColorEquality(UIColor.course8, Color.course8)
+        testHexColorEquality(UIColor.course9, Color.course9)
+        testHexColorEquality(UIColor.course10, Color.course10)
+        testHexColorEquality(UIColor.course11, Color.course11)
+        testHexColorEquality(UIColor.course12, Color.course12)
     }
 
     func testIOSSpecificColors() {
         XCTAssertEqual(UIColor.disabledGray, UIColor(resource: .disabledGray))
-        XCTAssertEqual(Color.disabledGray, Color(.disabledGray))
+        testHexColorEquality(UIColor.disabledGray, Color.disabledGray)
+    }
+
+    func testHexColorEquality(_ uiColor: UIColor, _ color: Color) {
+        XCTAssertEqual(
+            uiColor.variantForLightMode.hexString,
+            color.variantForLightMode.hexString,
+            "\(uiColor)"
+        )
+        XCTAssertEqual(
+            uiColor.variantForDarkMode.hexString,
+            color.variantForDarkMode.hexString,
+            "\(uiColor)"
+        )
     }
 }

--- a/Core/CoreTests/Extensions/ResultExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/ResultExtensionsTests.swift
@@ -48,4 +48,14 @@ class ResultExtensionsTests: XCTestCase {
 
         XCTAssertEqual(testee.isSuccess, true)
     }
+
+    func testErrorInitializer() {
+        var testee: Result<Void, Error> = .init(error: nil)
+        XCTAssertEqual(testee.isSuccess, true)
+        XCTAssertNil(testee.error)
+
+        testee = .init(error: TestConstants.error)
+        XCTAssertEqual(testee.isFailure, true)
+        XCTAssertEqual(testee.error as NSError?, TestConstants.error)
+    }
 }

--- a/Core/CoreTests/Extensions/URLExtensionsTests.swift
+++ b/Core/CoreTests/Extensions/URLExtensionsTests.swift
@@ -149,8 +149,8 @@ class URLExtensionsTests: XCTestCase {
     }
 
     func testMakesRelativePath() throws {
-        var testee = URL(string: "folder/file")!
-        var result = try testee.makeRelativePath(toBaseUrl: URL(string: "folder")!)
+        let testee = URL(string: "folder/file")!
+        let result = try testee.makeRelativePath(toBaseUrl: URL(string: "folder")!)
         XCTAssertEqual(result, "file")
 
         XCTAssertThrowsError(try testee.makeRelativePath(toBaseUrl: URL(string: "anotherFolder")!)) { error in

--- a/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
+++ b/Core/CoreTests/Search/CoreSearchHostingControllerTests.swift
@@ -115,6 +115,10 @@ class CoreSearchHostingControllerTests: CoreTestCase {
         )
 
         textField.text = "Example"
+        /// `controller.searchContext.searchText` only updates when the text is changed or the text field resignes being a first responder.
+        /// None of these happen in the test reliably so we simulate the resign first responder action that is triggered
+        /// by the `textFieldShouldReturn` delegate method.
+        textField.delegate?.textFieldDidEndEditing?(textField)
         _ = textField.delegate?.textFieldShouldReturn?(textField)
 
         XCTAssertEqual(controller.searchContext.searchText.value, "Example")


### PR DESCRIPTION
There were two failures:
- One related to old discussions that caused our custom JS code not to execute. It seems the issue was that we didn't wait until the directory load navigation finished and we started loading html content immediately. I created a helper loader method in CoreWebView that calls back with a completion block when the navigation finishes and used this in the discussion view controller to load the actual content only after the first load have finished. We use the synchronous file load method in other places in the app but I didn't touch those to reduce the scope. I could only reproduce this issue on iOS 18.2.
- The other issue was that SwiftUI colors created from the asset catalog color resource had slightly different hex codes compared to their UIColor counterpart. I don't know what caused this but I've modified the logic to create Colors from UIColors instead and that solved the issue, the root cause is unknown.

refs: MBL-18545
affects: Student, Teacher, Parent
release note: none
test plan:
- Sanity test if colors are okay.
- Test if discussions/announcements still work in offline mode.

## Checklist

- [x] Tested on iOS 17
- [ ] Tested on iOS 18
