### PR TITLE
Use `short_name` instead of `name` for student-student interactions

### DIFF
--- a/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
@@ -27,14 +27,19 @@ struct ContextCardHeaderView: View {
 
     var body: some View {
         VStack(spacing: 10) {
-            Avatar(name: user.name, url: user.avatar_url?.rawValue, size: 80)
+            // Show short name (nickname) if user is not a teacher
+            let nameToUse = (user.email ?? "").isEmpty ? user.short_name : user.name
+
+            Avatar(name: nameToUse, url: user.avatar_url?.rawValue, size: 80)
                 .padding(20)
-            Text(User.displayName(user.shortName, pronouns: user.pronouns))
+            Text(User.displayName(nameToUse, pronouns: user.pronouns))
                 .font(.bold20)
                 .foregroundColor(.textDarkest)
                 .identifier("ContextCard.userNameLabel")
             // Only teachers can see user email addresses
             if let email = user.email {
+
+
                 Text(email)
                     .font(.regular14)
                     .foregroundColor(.textDarkest)

--- a/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
+++ b/Core/Core/People/ContextCard/Course/ContextCardHeaderView.swift
@@ -29,7 +29,7 @@ struct ContextCardHeaderView: View {
         VStack(spacing: 10) {
             Avatar(name: user.name, url: user.avatar_url?.rawValue, size: 80)
                 .padding(20)
-            Text(User.displayName(user.name, pronouns: user.pronouns))
+            Text(User.displayName(user.shortName, pronouns: user.pronouns))
                 .font(.bold20)
                 .foregroundColor(.textDarkest)
                 .identifier("ContextCard.userNameLabel")

--- a/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
+++ b/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
@@ -55,7 +55,7 @@ public struct GroupContextCardView: View {
                 VStack(spacing: 10) {
                     Avatar(name: user.name, url: user.avatarURL, size: 80)
                         .padding(20)
-                    Text(User.displayName(user.name, pronouns: user.pronouns))
+                    Text(User.displayName(user.shortName, pronouns: user.pronouns))
                         .font(.bold20)
                         .foregroundColor(.textDarkest)
                         .identifier("ContextCard.userNameLabel")

--- a/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
+++ b/Core/Core/People/ContextCard/Group/GroupContextCardView.swift
@@ -27,9 +27,13 @@ public struct GroupContextCardView: View {
     }
 
     public var body: some View {
+        // Show short name (nickname) if user is not a teacher
+        let user = model.user.first
+        let nameToUse = (user?.email ?? "").isEmpty ? user?.short_name : user?.name
+
         contextCard
             .navigationBarItems(trailing: emailButton)
-            .navigationTitle(model.user.first?.name ?? "", subtitle: model.group.first?.name)
+            .navigationTitle(nameToUse ?? "", subtitle: model.group.first?.name)
             .onAppear {
                 model.viewAppeared()
             }
@@ -53,9 +57,12 @@ public struct GroupContextCardView: View {
         } else {
             if let user = model.user.first, let group = model.group.first {
                 VStack(spacing: 10) {
-                    Avatar(name: user.name, url: user.avatarURL, size: 80)
+                    // Show short name (nickname) if user is not a teacher
+                    let nameToUse = (user.email ?? "").isEmpty ? user.short_name : user.name
+
+                    Avatar(name: nameToUse, url: user.avatarURL, size: 80)
                         .padding(20)
-                    Text(User.displayName(user.shortName, pronouns: user.pronouns))
+                    Text(User.displayName(nameToUse, pronouns: user.pronouns))
                         .font(.bold20)
                         .foregroundColor(.textDarkest)
                         .identifier("ContextCard.userNameLabel")

--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -272,9 +272,17 @@ class PeopleListCell: UITableViewCell {
     func update(user: PeopleListUser?, color: UIColor?, isOffline: Bool) {
         backgroundColor = .backgroundLightest
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)
-        avatarView.name = user?.name ?? ""
+        avatarView.name = user?.shortName ?? ""
         avatarView.url = isOffline ? nil : user?.avatarURL
-        let nameText = user.flatMap { User.displayName($0.shortName, pronouns: $0.pronouns) }
+
+        let nameText = user.flatMap { 
+            User.displayName(
+                // Students should be shown short name (nicknames) for classmates, but teachers should see real names
+                ($0.email ?? "").isEmpty ? $0.shortName : $0.name, 
+                pronouns: $0.pronouns
+            ) 
+        }
+
         nameLabel.setText(nameText, style: .textCellTitle)
         nameLabel.accessibilityIdentifier = "\(self.accessibilityIdentifier ?? "").name-label"
         let courseEnrollments = user?.enrollments.filter {

--- a/Core/Core/People/PeopleListViewController.swift
+++ b/Core/Core/People/PeopleListViewController.swift
@@ -274,7 +274,7 @@ class PeopleListCell: UITableViewCell {
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)
         avatarView.name = user?.name ?? ""
         avatarView.url = isOffline ? nil : user?.avatarURL
-        let nameText = user.flatMap { User.displayName($0.name, pronouns: $0.pronouns) }
+        let nameText = user.flatMap { User.displayName($0.shortName, pronouns: $0.pronouns) }
         nameLabel.setText(nameText, style: .textCellTitle)
         nameLabel.accessibilityIdentifier = "\(self.accessibilityIdentifier ?? "").name-label"
         let courseEnrollments = user?.enrollments.filter {


### PR DESCRIPTION
Changes `user.name` to `user.short_name` (or `user.shortName`) on the PeopleList and PeopleDetails pages when a student is viewing the details of another student.

Rational:
- This mimics the behaviour of the canvas web client (at least in my experience)
- "Short name" can also be used a "preferred name" by individuals of various demographics. It is not necessarily safe to assume that ones given name (`.name`) corresponds with how they wish to be referred as (`.short_name`).

- Teachers will still see the name as before, but it may also be worth adding the ability for them to see both a student's preferred and given names. 


Note:
- This is my first time interacting with this codebase and there are probably other changes to be made in order to stay consistent. I don't know where to look, though, and I don't have the ability to test the app on my devices.