### PR TITLE
Accessibility - Teacher - QuizDetails - Title as Header

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
@@ -50,6 +50,7 @@ public class TitleSubtitleView: UIView {
         view.subtitleLabel.text = ""
         view.titleLabel.accessibilityElementsHidden = true
         view.subtitleLabel.accessibilityElementsHidden = true
+        view.accessibilityTraits = [.header]
         return view
     }
 

--- a/Core/Core/Features/Quizzes/QuizDetails/Teacher/View/TeacherQuizDetailsView.swift
+++ b/Core/Core/Features/Quizzes/QuizDetails/Teacher/View/TeacherQuizDetailsView.swift
@@ -76,6 +76,7 @@ public struct TeacherQuizDetailsView<ViewModel: TeacherQuizDetailsViewModel>: Vi
             Text(viewModel.quizTitle)
                 .font(.heavy24).foregroundColor(.textDarkest)
                 .accessibility(identifier: "QuizDetails.name")
+                .accessibilityAddTraits(.isHeader)
             HStack(spacing: 0) {
                 Text(viewModel.pointsPossibleText)
                     .font(.medium16).foregroundColor(.textDark)


### PR DESCRIPTION
affects: Teacher
release note: None
test plan: VoiceOver should read the title of a Quiz as header on Quiz Details screen.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
