### PR TITLE
Accessibility - Teacher - Modules - ModuleItemCell button trait

### DIFF
--- a/Core/Core/Features/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleItemCell.swift
@@ -94,6 +94,7 @@ class ModuleItemCell: UITableViewCell {
 
         updateDueLabel(item)
 
+        accessibilityTraits = .button
         accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row)"
         nameLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).nameLabel"
         dueLabel.accessibilityIdentifier = "ModuleList.\(indexPath.section).\(indexPath.row).dueLabel"


### PR DESCRIPTION
affects: Teacher
release note: None
test plan: VoiceOver should read Module Item cells as buttons on Module List screen.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
