### PR TITLE
Accessibility - Teacher - Submissions - List cells button trait

### DIFF
--- a/Teacher/Teacher/Submissions/SubmissionListViewController.swift
+++ b/Teacher/Teacher/Submissions/SubmissionListViewController.swift
@@ -238,6 +238,7 @@ class SubmissionListCell: UITableViewCell {
     }
 
     func update(_ assignment: Assignment?, submission: Submission?, row: Int) {
+        accessibilityTraits = .button
         accessibilityIdentifier = "SubmissionListCell.\(submission?.userID ?? "")"
         backgroundColor = .backgroundLightest
         if assignment?.anonymizeStudents != false {


### PR DESCRIPTION
affects: Teacher
release note: None
test plan: VoiceOver should read Submission cells as buttons on Submission List screen.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
