### PR TITLE
Accessibility - Teacher - Submissions - Treat title in navbar as header

### DIFF
--- a/Teacher/Teacher/Submissions/SubmissionListViewController.swift
+++ b/Teacher/Teacher/Submissions/SubmissionListViewController.swift
@@ -74,6 +74,7 @@ class SubmissionListViewController: ScreenViewTrackableViewController, ColoredNa
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         setupTitleViewInNavbar(title: String(localized: "Submissions", bundle: .teacher))
+        titleSubtitleView.accessibilityTraits = .header
 
         emptyMessageLabel.text = String(localized: "It seems there aren't any valid submissions to grade.", bundle: .teacher)
         emptyTitleLabel.text = String(localized: "No Submissions", bundle: .teacher)


### PR DESCRIPTION
affects: Teacher
release note: None
test plan: VoiceOver should treat the title in the middle of the navigation bar as a header.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
