### PR TITLE
Accessibility - Teacher - Calendar - Font size on Edit Event screen

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -62,33 +62,17 @@ extension InstUI {
 
         public var body: some View {
             VStack(spacing: 0) {
-                HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
-                    if dynamicTypeSize > .accessibility3 {
-                        VStack(alignment: .leading) {
-                            label
-                                .textStyle(.cellLabel)
-
-                            if date != nil {
-                                datePicker
-                            } else {
-                                placeholderButtons
-                            }
-                        }
-                    } else {
-                        label
-                            .textStyle(.cellLabel)
-
-                        if date != nil {
-                            datePicker
-                        } else {
-                            placeholderButtons
-                        }
+                ViewThatFits {
+                    HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
+                        dateRow
                     }
-                    if isClearable {
-                        clearButton
+                    .frame(minHeight: 36) // To always have the same height despite datepicker visibility
+
+                    VStack(alignment: .leading) {
+                        dateRow
                     }
+                    .frame(minHeight: 36) // To always have the same height despite datepicker visibility
                 }
-                .frame(minHeight: 36) // To always have the same height despite datepicker visibility
 
                 if let errorMessage {
                     Text(errorMessage)
@@ -104,6 +88,21 @@ extension InstUI {
             .padding(.bottom, 7)
 
             InstUI.Divider()
+        }
+
+        @ViewBuilder
+        private var dateRow: some View {
+            label
+                .textStyle(.cellLabel)
+
+            if date != nil {
+                datePicker
+            } else {
+                placeholderButtons
+            }
+            if isClearable {
+                clearButton
+            }
         }
 
         @ViewBuilder

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -63,15 +63,28 @@ extension InstUI {
         public var body: some View {
             VStack(spacing: 0) {
                 HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
-                    label
-                        .textStyle(.cellLabel)
+                    if dynamicTypeSize > .accessibility3 {
+                        VStack(alignment: .leading) {
+                            label
+                                .textStyle(.cellLabel)
 
-                    if date != nil {
-                        datePicker
-                    } else {
-                        placeholderButtons
+                            if date != nil {
+                                datePicker
+                            } else {
+                                placeholderButtons
+                            }
+                        }
                     }
+                    else {
+                        label
+                            .textStyle(.cellLabel)
 
+                        if date != nil {
+                            datePicker
+                        } else {
+                            placeholderButtons
+                        }
+                    }
                     if isClearable {
                         clearButton
                     }
@@ -105,7 +118,7 @@ extension InstUI {
                 in: validFrom...validUntil,
                 displayedComponents: components,
                 label: {}
-            )
+            ).lineLimit(0)
         }
 
         private var components: DatePicker<Label>.Components {

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -74,8 +74,7 @@ extension InstUI {
                                 placeholderButtons
                             }
                         }
-                    }
-                    else {
+                    } else {
                         label
                             .textStyle(.cellLabel)
 

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -94,14 +94,15 @@ extension InstUI {
         private var dateRow: some View {
             label
                 .textStyle(.cellLabel)
-
-            if date != nil {
-                datePicker
-            } else {
-                placeholderButtons
-            }
-            if isClearable {
-                clearButton
+            HStack {
+                if date != nil {
+                    datePicker
+                } else {
+                    placeholderButtons
+                }
+                if isClearable {
+                    clearButton
+                }
             }
         }
 

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -66,13 +66,11 @@ extension InstUI {
                     HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
                         dateRow
                     }
-                    .frame(minHeight: 36) // To always have the same height despite datepicker visibility
-
                     VStack(alignment: .leading) {
                         dateRow
                     }
-                    .frame(minHeight: 36) // To always have the same height despite datepicker visibility
                 }
+                .frame(minHeight: 36) // To always have the same height despite datepicker visibility
 
                 if let errorMessage {
                     Text(errorMessage)

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -117,7 +117,7 @@ extension InstUI {
                 in: validFrom...validUntil,
                 displayedComponents: components,
                 label: {}
-            ).lineLimit(0)
+            )
         }
 
         private var components: DatePicker<Label>.Components {

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -140,7 +140,6 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                             focusedInput = .details
                         }
                 }
-                .frame(minHeight: geometry.size.height)
             }
         }
         .navigationTitle(viewModel.pageTitle)

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -139,6 +139,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                             focusedInput = .details
                         }
                 }
+                .frame(minHeight: geometry.size.height)
             }
         }
         .navigationTitle(viewModel.pageTitle)

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -139,7 +139,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                             focusedInput = .details
                         }
                 }
-                .frame(minHeight: geometry.size.height)
+                .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
             }
         }
         .navigationTitle(viewModel.pageTitle)

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -123,7 +123,6 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         .id("details")
                         .focused($focusedInput, equals: .details)
                     }
-                    .frame(maxWidth: geometry.size.width)
                     .animation(.default, value: viewModel.isAllDay)
 
                     // defocus inputs when otherwise non-tappable area is tapped

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -123,6 +123,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         .id("details")
                         .focused($focusedInput, equals: .details)
                     }
+                    .frame(maxWidth: geometry.size.width)
                     .animation(.default, value: viewModel.isAllDay)
 
                     // defocus inputs when otherwise non-tappable area is tapped

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
@@ -35,7 +35,7 @@ struct EditCustomFrequencyScreen: View, ScreenViewTrackable {
     }
 
     var body: some View {
-        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { geometry in
+        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { _ in
             VStack(alignment: .leading, spacing: 0) {
                 InstUI.LabelCell(
                     label: Text("Repeats every", bundle: .core)
@@ -72,7 +72,6 @@ struct EditCustomFrequencyScreen: View, ScreenViewTrackable {
                     endModeDetailsCell(endMode)
                 }
             }
-            .frame(maxWidth: geometry.size.width)
         }
         .navigationTitle(viewModel.pageTitle)
         .navBarItems(

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
@@ -35,7 +35,7 @@ struct EditCustomFrequencyScreen: View, ScreenViewTrackable {
     }
 
     var body: some View {
-        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { _ in
+        InstUI.BaseScreen(state: viewModel.state, config: viewModel.screenConfig) { geometry in
             VStack(alignment: .leading, spacing: 0) {
                 InstUI.LabelCell(
                     label: Text("Repeats every", bundle: .core)
@@ -72,6 +72,7 @@ struct EditCustomFrequencyScreen: View, ScreenViewTrackable {
                     endModeDetailsCell(endMode)
                 }
             }
+            .frame(maxWidth: geometry.size.width)
         }
         .navigationTitle(viewModel.pageTitle)
         .navBarItems(

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -85,7 +85,7 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
                         focusedInput = .details
                     }
             }
-            .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
+            .frame(minHeight: geometry.size.height)
         }
         .navigationTitle(viewModel.pageTitle)
         .navBarItems(

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -85,7 +85,7 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
                         focusedInput = .details
                     }
             }
-            .frame(minHeight: geometry.size.height)
+            .frame(maxWidth: geometry.size.width, minHeight: geometry.size.height)
         }
         .navigationTitle(viewModel.pageTitle)
         .navBarItems(


### PR DESCRIPTION
affects: Student, Teacher
release note: None
test plan: No text should get cut off on EditCalendarEventScreen when font size is increased to the maximum.

I'm not quite pleased with the solution so any suggestion is appreciated.

Before:

https://github.com/user-attachments/assets/36bebf75-d38e-4d7a-a92d-187b65ffc92c

After:

https://github.com/user-attachments/assets/791b8c7c-11e1-4157-bb27-d7a064f73276

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
