### PR TITLE
Accessibility - Teacher - Calendar - Filter events button label

### DIFF
--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -98,7 +98,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
 
         filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.regular16)
-        filterButton.accessibilityLabel = String(localized: "Filter events", bundle: .core)
+        filterButton.accessibilityLabel = String(localized: "Filter events by Calendars", bundle: .core)
 
         dropdownView.transform = CGAffineTransform(rotationAngle: 4 * .pi)
 

--- a/Core/CoreTests/Features/Planner/CalendarMain/CalendarViewControllerTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarMain/CalendarViewControllerTests.swift
@@ -63,17 +63,17 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
         XCTAssertEqual(controller.monthButton.isSelected, true)
         XCTAssertEqual(height > deselectedHeight, true)
 
-        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events")
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events by Calendars")
         XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars")
         controller.filterButton.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(willFilter)
         calendarCount = 1
         controller.refresh()
-        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events")
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events by Calendars")
         XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars")
         calendarCount = 7
         controller.refresh()
-        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events")
+        XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events by Calendars")
         XCTAssertEqual(controller.filterButton.title(for: .normal), "Calendars")
 
         controller.calendarDidSelectDate(DateComponents(calendar: .current, year: 2020, month: 1, day: 16).date!)


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: VoiceOver should read "Calendars" button as "Filter events by Calendars" instead of "Filter events".

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
