### PR TITLE
Accessibility - Teacher - Discussions - Title as header

### DIFF
--- a/Core/Core/Common/CommonUI/Presenter/ColoredNavViewProtocol.swift
+++ b/Core/Core/Common/CommonUI/Presenter/ColoredNavViewProtocol.swift
@@ -31,6 +31,7 @@ extension ColoredNavViewProtocol {
     public func setupTitleViewInNavbar(title: String) {
         navigationItem.titleView = titleSubtitleView
         titleSubtitleView.title = title
+        titleSubtitleView.accessibilityTraits = .header
     }
 
     public func updateNavBar(subtitle: String?, color: UIColor?) {


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: VoiceOver should read the title in Discussions List screen as a header.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
