### PR TITLE
Accessibility - Teacher - Calendar - Edit Event screen - Title field as required

### DIFF
--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -45,7 +45,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                     VStack(spacing: 0) {
                         InstUI.TextFieldCell(
                             label: Text("Title", bundle: .core),
-                            placeholder: String(localized: "Add title", bundle: .core),
+                            placeholder: String(localized: "Add title (required)", bundle: .core),
                             text: $viewModel.title
                         )
                         .focused($focusedInput, equals: .title)


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: Title field should indicate that it's a required field, both visually and with VoiceOver.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
