### PR TITLE
Accessibility - Teacher - Inbox - Compose Message - Subject and Body input labels

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -339,7 +339,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 .focused($focusedInput, equals: .subject)
                 .submitLabel(.done)
                 .accessibilityLabel(Text("Subject Input", bundle: .core))
-                .accessibilityHint(Text("Enter a subject for your message.", bundle: .core))
+                .accessibilityHint(Text("Enter a subject for your message", bundle: .core))
                 .accessibilityIdentifier("ComposeMessage.subjectInput")
         }
         .disabled(model.isSubjectDisabled)

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -338,7 +338,8 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 .textInputAutocapitalization(.sentences)
                 .focused($focusedInput, equals: .subject)
                 .submitLabel(.done)
-                .accessibility(label: Text("Subject", bundle: .core))
+                .accessibilityLabel(Text("Subject Input", bundle: .core))
+                .accessibilityHint(Text("Enter a subject for your message.", bundle: .core))
                 .accessibilityIdentifier("ComposeMessage.subjectInput")
         }
         .disabled(model.isSubjectDisabled)
@@ -415,7 +416,8 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
             .foregroundColor(.textDarkest)
             .padding(.horizontal, defaultHorizontalPaddingValue)
             .frame(minHeight: 60)
-            .accessibility(label: Text("Message", bundle: .core))
+            .accessibilityLabel(Text("Message Input", bundle: .core))
+            .accessibilityHint(Text("Write your message here", bundle: .core))
             .accessibilityIdentifier("ComposeMessage.body")
         }
         .disabled(model.isMessageDisabled)


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: On Compose Message screen, subject and body elements should indicate themselves as input fields for VoiceOver.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
