### PR TITLE
Accessibility - Teacher - Inbox - Compose Message - Subject label as header

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -209,6 +209,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         HStack(alignment: .center) {
             Text(model.subject.isEmpty ? model.title : model.subject)
                 .accessibilityIdentifier("ComposeMessage.subjectLabel")
+                .accessibilityAddTraits(.isHeader)
                 .multilineTextAlignment(.leading)
                 .font(.semibold22)
                 .foregroundColor(.textDarkest)


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: VoiceOver should read the subject label of a composed message as a header.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
