### PR TITLE
Accessibility - Teacher - Inbox - Compose Message - Search recipients input field

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -201,7 +201,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 .padding(.vertical, 12)
         }
         .accessibilityLabel(Text("Add recipient", bundle: .core))
-        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
         .accessibilityIdentifier("ComposeMessage.addRecipient")
     }
 
@@ -284,7 +284,9 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                     .frame(minHeight: 50)
                     .frame(maxHeight: .infinity, alignment: .center)
                     .padding(.leading, 5)
-                    .accessibilityHidden(true)
+                    .accessibilityHidden(false)
+                    .accessibilityLabel(Text("Search for recipients", bundle: .core))
+                    .accessibilityAddTraits(.isSearchField)
                     .readingFrame { frame in
                         searchTextFieldHeight = frame.height - 5
                     }
@@ -293,7 +295,6 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
             addRecipientButton
                 .frame(maxHeight: .infinity, alignment: .top)
-                .accessibilitySortPriority(2)
         }
         .animation(.easeInOut, value: model.recipients.isEmpty)
         .accessibilityElement(children: .contain)


### PR DESCRIPTION
affects: Teacher, Student
release note: None
test plan: VoiceOver should read out the "search recipient" input field as well.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
