### PR TITLE
Accessibility - Student - AssignmentDetails - Navigation bar title as header

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
@@ -48,8 +48,9 @@ public class TitleSubtitleView: UIView {
         let view = loadFromXib()
         view.titleLabel.text = ""
         view.subtitleLabel.text = ""
-        view.titleLabel.accessibilityElementsHidden = true
-        view.subtitleLabel.accessibilityElementsHidden = true
+        view.titleLabel.accessibilityElementsHidden = false
+        view.subtitleLabel.accessibilityElementsHidden = false
+        view.accessibilityTraits = [.header]
         return view
     }
 


### PR DESCRIPTION
affects: Student, Teacher
release note: None
test plan: VoiceOver should announce the navigation bar title as header.

VoiceOver should announce the navigation bar title on the AssignmentDetails screen (also QuizDetails, etc) as a "header".

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
