### PR TITLE
Fix translations localizable json

### DIFF
--- a/scripts/translations/localizables.json
+++ b/scripts/translations/localizables.json
@@ -1,10 +1,9 @@
 [
-  "Core/Core/Localizable.xcstrings",
-  "CanvasCore/CanvasCore/Localizable.xcstrings",
+  "Core/Core/Resources/Localizable.xcstrings",
   "Parent/Parent/InfoPlist.xcstrings",
   "Parent/Parent/Localizable.xcstrings",
-  "rn/Teacher/ios/Teacher/InfoPlist.xcstrings",
-  "rn/Teacher/ios/Teacher/Localizable.xcstrings",
+  "Teacher/Teacher/InfoPlist.xcstrings",
+  "Teacher/Teacher/Localizable.xcstrings",
   "Student/Student/InfoPlist.xcstrings",
   "Student/Student/Localizable.xcstrings",
   "Student/SubmitAssignment/InfoPlist.xcstrings",


### PR DESCRIPTION
### This should fix localizable.json for the translations scripts to upload them correctly.

affects: Student, Teacher, Parent
release note: None
test plan: Translations should be okay.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
