### PR TITLE
Resolve the issue of GradingPeriods not getting persisted properly per Course in the Database

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
@@ -48,4 +48,13 @@ public extension Array where Element: Equatable {
             append(element)
         }
     }
+
+    func removingDuplicates() -> Self {
+        var copy = [Element]()
+        for elm in self {
+            if copy.contains(elm) { continue }
+            copy.append(elm)
+        }
+        return copy
+    }
 }

--- a/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
@@ -51,9 +51,9 @@ public extension Array where Element: Equatable {
 
     func removingDuplicates() -> Self {
         var copy = [Element]()
-        for elm in self {
-            if copy.contains(elm) { continue }
-            copy.append(elm)
+        for element in self {
+            if copy.contains(element) { continue }
+            copy.append(element)
         }
         return copy
     }

--- a/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentListViewModel.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentListViewModel.swift
@@ -135,7 +135,7 @@ public class AssignmentListViewModel: ObservableObject {
         loadAssignmentListPreferences()
         featureFlags.refresh()
         course.refresh()
-        gradingPeriods.refresh(force: true)
+        gradingPeriods.refresh()
     }
 
     // MARK: - Functions

--- a/Core/Core/Features/Dashboard/K5/ViewModel/Grades/K5GradesViewModel.swift
+++ b/Core/Core/Features/Dashboard/K5/ViewModel/Grades/K5GradesViewModel.swift
@@ -61,12 +61,17 @@ public class K5GradesViewModel: ObservableObject {
                                         courseID: $0.id,
                                         hideGradeBar: hideQuantitativeData)
         }
-        var gradingPeriodModels = courses.compactMap { $0.gradingPeriods }.flatMap { $0 }
-        gradingPeriodModels.sort(by: {
-            guard let date0 = $0.startDate, let date1 = $1.startDate else { return false }
-            return date0 < date1
-        })
-        gradingPeriods.append(contentsOf: gradingPeriodModels.map { K5GradingPeriod(periodID: $0.id, title: $0.title) })
+        var courseGradingPeriods = courses
+            .compactMap { $0.gradingPeriods }
+            .flatMap { $0 }
+            .sorted(by: {
+                guard let date0 = $0.startDate, let date1 = $1.startDate else { return false }
+                return date0 < date1
+            })
+            .map { K5GradingPeriod(periodID: $0.id, title: $0.title) }
+            .removingDuplicates()
+
+        gradingPeriods.append(contentsOf: courseGradingPeriods)
         finishRefresh()
     }
 

--- a/Core/Core/Features/Grades/Model/Entities/GradingPeriod.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingPeriod.swift
@@ -31,7 +31,12 @@ public final class GradingPeriod: NSManagedObject {
 
     @discardableResult
     public static func save(_ item: APIGradingPeriod, courseID: String, in context: NSManagedObjectContext) -> GradingPeriod {
-        let predicate = NSPredicate(format: "%K == %@", (\GradingPeriod.id).string, item.id.value)
+
+        let predicate = NSCompoundPredicate(type: .and, subpredicates: [
+            NSPredicate(format: "%K == %@", (\GradingPeriod.id).string, item.id.value),
+            NSPredicate(format: "%K == %@", (\GradingPeriod.courseID).string, courseID)
+        ])
+
         let model: GradingPeriod = context.fetch(predicate).first ?? context.insert()
         model.id = item.id.value
         model.title = item.title


### PR DESCRIPTION
refs: [MBL-18150](https://instructure.atlassian.net/browse/MBL-18150)
affects: Student, Teacher
release note: none

## Cause of the issue.

In Canvas Web, grading periods are defined per account.

While in the app, the first point at which GradingPeriods are being fetched is in `Course.save()` method.
https://github.com/instructure/canvas-ios/blob/dd7302c583be57bfd321fb2a33a28857b89102f2/Core/Core/Features/Courses/Course.swift#L96

You can see that the implementation gives the notion that we have a GradingPeriod per course which is not correct.

The issue was actually caused by overriding the value of `GradingPeriod.courseID` whenever it get saved for a specific course in that `Course.save()` method, this because we are relying only on `GradingPeriod.id` to identify the object on the database.

The current fix solves the issue if there was a previous agreement to persist GradingPeriod per course, but that's not the case perhaps we need to give it further consideration.

## Test Plan

See ticket's [description](https://instructure.atlassian.net/browse/MBL-18150). And this [comment](https://instructure.atlassian.net/browse/MBL-18150?focusedCommentId=2304056).

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18150]: https://instructure.atlassian.net/browse/MBL-18150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ