### PR TITLE
Disabled tab link with query

### DIFF
--- a/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
+++ b/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
@@ -111,7 +111,7 @@ public final class CourseTabUrlInteractor {
                 guard let htmlURL = tab.htmlURL else { return nil }
                 return TabModel(
                     id: tab.id,
-                    htmlUrl: htmlURL.absoluteString,
+                    htmlUrl: htmlURL.removingQueryAndFragment().absoluteString,
                     apiBaseUrlHost: tab.apiBaseURL?.host()
                 )
             }
@@ -232,5 +232,18 @@ private enum CourseTabFormat: CaseIterable {
             // example: "/courses/42/external_tools/1234"
             return parts.count == 4 && parts[2] == "external_tools"
         }
+    }
+}
+
+private extension URL {
+    func removingQueryAndFragment() -> URL {
+        guard var components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return self
+        }
+
+        components.query = nil
+        components.fragment = nil
+
+        return components.url ?? self
     }
 }

--- a/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
+++ b/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
@@ -172,6 +172,7 @@ public final class CourseTabUrlInteractor {
 
     private func logPathFormatIfUnknown(for tab: TabModel) {
         guard tab.id != "home"
+                && tab.id != "settings" // Teachers logging into Student app have this enabled tab, no need to log it
                 && !isHomeFormat(tab.htmlUrl)
                 && !isKnownPathFormat(tab.htmlUrl)
         else { return }

--- a/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
@@ -307,6 +307,11 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
     }
 
+    func test_setupEnabledTabs_whenTabIsSettings_shouldNotLogIt() {
+        saveTab(id: "settings", htmlUrl: "/courses/42/settings", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
+    }
+
     // MARK: - Cancel subscription
 
     func test_cancelTabSubscription_shouldNotReactToTabObjectChanges() {

--- a/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
@@ -131,6 +131,8 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
 
         XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), false)
         XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), false)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), false)
@@ -141,6 +143,33 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
 
         XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), true)
+    }
+
+    func test_isAllowedUrl_whenTabWithQueryIsEnabled_shouldAllowAllVariants() {
+        saveTab(htmlUrl: "/courses/42/grades?display=borderless", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), true)
+    }
+
+    func test_isAllowedUrl_whenTabWithFragmentIsEnabled_shouldAllowAllVariants() {
+        saveTab(htmlUrl: "/courses/42/grades#foo", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#bar")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)


### PR DESCRIPTION
refs: [MBL-18180](https://instructure.atlassian.net/browse/MBL-18180)
affects: Student
release note: Fixed external tool link being disabled in some cases.

This is a fix for a reopened ticket. The issue was that the enabled tabs list returned from backend contained the `?display=borderless` query in the `html_url` and this was not handled properly. Now all query and fragment are removed from these URLs before parsing them.

Also removed logging of `settings` tab as an `Unexpected Course Tab path format`, which was logged when teachers log into Student app. This is a known case, removed from logging to make actual exceptions visible in the logs.

## Test plan
Verify external tool link "Aleks" works for student linked in [ticket comment](https://instructure.atlassian.net/browse/MBL-18180?focusedCommentId=2313620).
Verify no "The page has been disabled for this course." snackbar appears.
**NOTE:** If you are acting as a student there, take care not to modify anything, as it is a LIVE account with actual students.

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18180]: https://instructure.atlassian.net/browse/MBL-18180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ