### PR TITLE
Accessibility - Teacher - Quiz Details - Add header as trait

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/TitleSubtitleView.swift
@@ -50,6 +50,7 @@ public class TitleSubtitleView: UIView {
         view.subtitleLabel.text = ""
         view.titleLabel.accessibilityElementsHidden = true
         view.subtitleLabel.accessibilityElementsHidden = true
+        view.accessibilityTraits = [.header]
         return view
     }
 

--- a/Core/Core/Features/Assignments/AssignmentDetails/AssignmentDetailsView.swift
+++ b/Core/Core/Features/Assignments/AssignmentDetails/AssignmentDetailsView.swift
@@ -95,6 +95,7 @@ public struct AssignmentDetailsView: View, ScreenViewTrackable {
         Section {
             Text(assignment.name)
                 .font(.heavy24).foregroundColor(.textDarkest).accessibility(identifier: "AssignmentDetails.name")
+                .accessibilityAddTraits(.isHeader)
             HStack(spacing: 0) {
                 Text(assignment.pointsPossibleText)
                     .font(.medium16).foregroundColor(.textDark).accessibility(identifier: "AssignmentDetails.points")

--- a/Core/Core/Features/Quizzes/QuizDetails/Teacher/View/TeacherQuizDetailsView.swift
+++ b/Core/Core/Features/Quizzes/QuizDetails/Teacher/View/TeacherQuizDetailsView.swift
@@ -76,6 +76,7 @@ public struct TeacherQuizDetailsView<ViewModel: TeacherQuizDetailsViewModel>: Vi
             Text(viewModel.quizTitle)
                 .font(.heavy24).foregroundColor(.textDarkest)
                 .accessibility(identifier: "QuizDetails.name")
+                .accessibilityAddTraits(.isHeader)
             HStack(spacing: 0) {
                 Text(viewModel.pointsPossibleText)
                     .font(.medium16).foregroundColor(.textDark)


### PR DESCRIPTION
Accessibility - Teacher - Quiz Details - Add header as trait
refs: MBL-18296
affects: Teacher, Student
release note: None
test plan: See ticket.

Original PR: https://github.com/instructure/canvas-ios/pull/3057
(reopened due to CI issues)

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
