### PR TITLE
Add Back toolbar button to QuizLTI webview

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/UIBarButtonItemWithCompletion.swift
+++ b/Core/Core/Common/CommonUI/UIViews/UIBarButtonItemWithCompletion.swift
@@ -27,6 +27,23 @@ public class UIBarButtonItemWithCompletion: UIBarButtonItem {
         self.actionHandler = actionHandler
     }
 
+    convenience init(
+        image: UIImage?,
+        landscapeImagePhone: UIImage?,
+        style: UIBarButtonItem.Style,
+        actionHandler: (() -> Void)?
+    ) {
+        self.init(
+            image: image,
+            landscapeImagePhone: landscapeImagePhone,
+            style: style,
+            target: nil,
+            action: #selector(buttonDidTap)
+        )
+        self.target = self
+        self.actionHandler = actionHandler
+    }
+
     @objc func buttonDidTap(sender: UIBarButtonItem) {
         actionHandler?()
     }

--- a/Core/Core/Common/Extensions/UIKit/UIBarButtonItemExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIBarButtonItemExtensions.swift
@@ -26,14 +26,15 @@ public extension UIBarButtonItem {
         appearance.setTitleTextAttributes(attributes, for: .normal)
     }
 
-    static func back(target: Any, action: Selector) -> UIBarButtonItem {
+    static func back(actionHandler: @escaping () -> Void) -> UIBarButtonItem {
         let config = UIImage.SymbolConfiguration(weight: .semibold)
         let backImage = UIImage(systemName: "chevron.backward", withConfiguration: config)
-        let barButton = UIBarButtonItem(image: backImage,
-                                        landscapeImagePhone: backImage,
-                                        style: .plain,
-                                        target: target,
-                                        action: action)
+        let barButton = UIBarButtonItemWithCompletion(
+            image: backImage,
+            landscapeImagePhone: backImage,
+            style: .plain,
+            actionHandler: actionHandler
+        )
         barButton.imageInsets = .init(top: 0, left: -7.5, bottom: 0, right: 0)
         barButton.landscapeImagePhoneInsets = .init(top: 0, left: -8, bottom: 0, right: 0)
         return barButton

--- a/Core/Core/Features/Dashboard/Container/View/DashboardContainerViewController.swift
+++ b/Core/Core/Features/Dashboard/Container/View/DashboardContainerViewController.swift
@@ -40,7 +40,10 @@ public class DashboardContainerViewController: CoreNavigationController {
     }
 
     override public func show(_ vc: UIViewController, sender: Any?) {
-        vc.addNavigationButton(.back(target: self, action: #selector(pop)), side: .left)
+        vc.addNavigationButton(
+            .back { [weak self] in self?.popViewController(animated: true) },
+            side: .left
+        )
 
         let split = makeSplitViewController(masterViewController: vc)
         let container = UIViewController()
@@ -72,11 +75,6 @@ public class DashboardContainerViewController: CoreNavigationController {
     }
 
     // MARK: - Private Methods
-
-    @objc
-    private func pop() {
-        popViewController(animated: true)
-    }
 
     private func makeSplitViewController(masterViewController: UIViewController) -> UIViewController {
         let split = splitViewControllerFactory()

--- a/Core/Core/Features/LTI/LTITools.swift
+++ b/Core/Core/Features/LTI/LTITools.swift
@@ -185,6 +185,7 @@ public class LTITools: NSObject {
                 controller.webView.load(URLRequest(url: url))
                 controller.title = String(localized: "Quiz", bundle: .core)
                 controller.addDoneButton(side: .right)
+                controller.setupBackToolbarButton()
                 env.router.show(controller, from: view, options: .modal(.overFullScreen, embedInNav: true)) {
                     completionHandler(true)
                 }

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewFullScreenVideoSupportTests.swift
@@ -97,7 +97,7 @@ class CoreWebViewFullScreenVideoSupportTests: XCTestCase {
     }
 }
 
-class MockWebView: CoreWebView {
+private class MockWebView: CoreWebView {
     var mockedFullscreenState: FullscreenState? {
         willSet {
             willChangeValue(for: \.fullscreenState)

--- a/Core/CoreTests/Common/CommonUI/UIViews/UIBarButtonItemWithCompletionTests.swift
+++ b/Core/CoreTests/Common/CommonUI/UIViews/UIBarButtonItemWithCompletionTests.swift
@@ -20,7 +20,7 @@
 import XCTest
 
 class UIBarButtonItemWithCompletionTests: XCTestCase {
-    func testProperties() {
+    func testPropertiesWithTitle() {
         let title = "title"
         let style = UIBarButtonItem.Style.done
         let view = UIBarButtonItemWithCompletion(
@@ -32,13 +32,44 @@ class UIBarButtonItemWithCompletionTests: XCTestCase {
         XCTAssertEqual(view.style, style)
     }
 
-    func testCompletion() {
+    func testPropertiesWithImage() {
+        let image1 = UIImage(systemName: "heart.fill")
+        let image2 = UIImage(systemName: "chevron.backward")
+        let style = UIBarButtonItem.Style.done
+        let view = UIBarButtonItemWithCompletion(
+            image: image1,
+            landscapeImagePhone: image2,
+            style: style,
+            actionHandler: {}
+        )
+        XCTAssertEqual(view.image, image1)
+        XCTAssertEqual(view.landscapeImagePhone, image2)
+        XCTAssertEqual(view.style, style)
+    }
+
+    func testCompletionWithTitle() {
         let expectation = expectation(description: "Completion gets called")
         let completion: () -> Void = {
             expectation.fulfill()
         }
 
         let view = UIBarButtonItemWithCompletion(title: nil, actionHandler: completion)
+        view.buttonDidTap(sender: view)
+        waitForExpectations(timeout: 0.1)
+    }
+
+    func testCompletionWithImage() {
+        let expectation = expectation(description: "Completion gets called")
+        let completion: () -> Void = {
+            expectation.fulfill()
+        }
+
+        let view = UIBarButtonItemWithCompletion(
+            image: UIImage(),
+            landscapeImagePhone: UIImage(),
+            style: .plain,
+            actionHandler: completion
+        )
         view.buttonDidTap(sender: view)
         waitForExpectations(timeout: 0.1)
     }

--- a/Core/CoreTests/Common/Extensions/UIKit/UIBarButtonItemExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UIBarButtonItemExtensionsTests.swift
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import Core
+@testable import Core
 import XCTest
 
 class UIBarButtonItemExtensionsTests: XCTestCase {
@@ -25,12 +25,15 @@ class UIBarButtonItemExtensionsTests: XCTestCase {
         let config = UIImage.SymbolConfiguration(weight: .semibold)
         let backImage = UIImage(systemName: "chevron.backward", withConfiguration: config)
 
-        let testee = UIBarButtonItem.back(target: self, action: #selector(testBackButton))
+        var actionCallsCount = 0
+        let testee = UIBarButtonItem.back { actionCallsCount += 1 }
 
         XCTAssertEqual(testee.image, backImage)
         XCTAssertEqual(testee.landscapeImagePhone, backImage)
-        XCTAssertEqual(testee.target as? UIBarButtonItemExtensionsTests, self)
-        XCTAssertEqual(testee.action, #selector(testBackButton))
         XCTAssertEqual(testee.style, .plain)
+
+        (testee as? UIBarButtonItemWithCompletion)?.buttonDidTap(sender: .init())
+
+        XCTAssertEqual(actionCallsCount, 1)
     }
 }

--- a/Parent/Parent/Assignments/View/ParentSubmissionViewController.swift
+++ b/Parent/Parent/Assignments/View/ParentSubmissionViewController.swift
@@ -31,14 +31,12 @@ class ParentSubmissionViewController: UINavigationController {
 
         let controller = CoreWebViewController(features: [.hideHideCanvasMenus])
         controller.addDoneButton()
+        controller.setupBackToolbarButton()
         controller.title = String(localized: "Submission", bundle: .core)
         self.webView = controller.webView
 
         super.init(rootViewController: controller)
 
-        controller.toolbarItems = [
-            .back(target: self, action: #selector(forwardBackActionToViewModel))
-        ]
         controller.webView.linkDelegate = self
 
         addLoadingIndicator(to: controller.view)
@@ -51,13 +49,6 @@ class ParentSubmissionViewController: UINavigationController {
             .hideLoadingIndicator
             .sink { [weak self] _ in
                 self?.hideLoadingIndicator()
-            }
-            .store(in: &subscriptions)
-
-        viewModel
-            .showWebBackNavigationButton
-            .sink { [weak self] showBackNavigationButton in
-                self?.setToolbarHidden(!showBackNavigationButton, animated: true)
             }
             .store(in: &subscriptions)
     }
@@ -97,11 +88,6 @@ class ParentSubmissionViewController: UINavigationController {
             progressView.centerYAnchor.constraint(equalTo: parent.centerYAnchor, constant: 0)
         ])
         self.loadingIndicator = progressView
-    }
-
-    @objc
-    private func forwardBackActionToViewModel() {
-        viewModel.didTapNavigateWebBackButton.send(())
     }
 }
 

--- a/Parent/Parent/Assignments/ViewModel/ParentSubmissionViewModel.swift
+++ b/Parent/Parent/Assignments/ViewModel/ParentSubmissionViewModel.swift
@@ -23,10 +23,6 @@ import WebKit
 class ParentSubmissionViewModel {
     // MARK: - Outputs
     public let hideLoadingIndicator = PassthroughSubject<Void, Never>()
-    public let showWebBackNavigationButton = CurrentValueSubject<Bool, Never>(false)
-
-    // MARK: - Inputs
-    public let didTapNavigateWebBackButton = PassthroughSubject<Void, Never>()
 
     // MARK: - Private
     private let interactor: ParentSubmissionInteractor
@@ -48,8 +44,6 @@ class ParentSubmissionViewModel {
     ) {
         self.viewController = viewController
 
-        handleWebBackButtonTap(webView: webView)
-        showBackNavigationButtonIfWebViewCanGoBack(webView: webView)
         handleFeedbackViewLoadResult(viewController: viewController, webView: webView)
     }
 
@@ -67,27 +61,6 @@ class ParentSubmissionViewModel {
                 }
 
             } receiveValue: { _ in }
-            .store(in: &subscriptions)
-    }
-
-    private func handleWebBackButtonTap(
-        webView: WKWebView
-    ) {
-        didTapNavigateWebBackButton
-            .sink { [weak webView] in
-                webView?.goBack()
-            }
-            .store(in: &subscriptions)
-    }
-
-    private func showBackNavigationButtonIfWebViewCanGoBack(
-        webView: WKWebView
-    ) {
-        webView
-            .publisher(for: \.canGoBack)
-            .sink { [weak showWebBackNavigationButton] canGoBack in
-                showWebBackNavigationButton?.send(canGoBack)
-            }
             .store(in: &subscriptions)
     }
 

--- a/Parent/ParentUnitTests/Assignments/ViewModel/ParentSubmissionViewModelTests.swift
+++ b/Parent/ParentUnitTests/Assignments/ViewModel/ParentSubmissionViewModelTests.swift
@@ -86,28 +86,6 @@ class ParentSubmissionViewModelTests: ParentTestCase {
         wait(for: [didHideLoadingIndicator], timeout: 1)
         subscription.cancel()
     }
-
-    func testUpdatesShowWebBackNavigationButtonState() {
-        mockInteractor.feedbackViewLoadShouldFail = false
-
-        let testee = ParentSubmissionViewModel(
-            interactor: mockInteractor,
-            router: router
-        )
-        testee.viewDidLoad(viewController: host, webView: mockWebView)
-
-        // WHEN
-        mockWebView.mockedCanGoBackResult = true
-
-        // THEN
-        XCTAssertSingleOutputEquals(testee.showWebBackNavigationButton, true)
-
-        // WHEN
-        mockWebView.mockedCanGoBackResult = false
-
-        // THEN
-        XCTAssertSingleOutputEquals(testee.showWebBackNavigationButton, false)
-    }
 }
 
 private class MockParentSubmissionInteractor: ParentSubmissionInteractor {
@@ -133,19 +111,6 @@ private class MockParentSubmissionInteractor: ParentSubmissionInteractor {
 }
 
 private class MockWebView: WKWebView {
-    var mockedCanGoBackResult = false {
-        willSet {
-            willChangeValue(for: \.canGoBack)
-        }
-        didSet {
-            didChangeValue(for: \.canGoBack)
-        }
-    }
-
-    override var canGoBack: Bool {
-        mockedCanGoBackResult
-    }
-
     init() {
         let config = WKWebViewConfiguration()
         config.websiteDataStore = .nonPersistent()


### PR DESCRIPTION
refs: [MBL-18184](https://instructure.atlassian.net/browse/MBL-18184)
affects: Student, Teacher, Parent
release note: none

QuizLTI back button at the bottom toolbar is now visible when the webview is navigated forward (which means there is someting to go back to)

## Test plan
Verify back button appears when QuizLTI webview navigates to another screen and disappears when tapping back.
Smoke test back navigation works from Module to Dashboard.

## Screenshots TODO
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode