### PR TITLE
Fix issue Consortia root account unable to see Front Page content when set as course home page

### DIFF
--- a/Core/Core/Features/Courses/CourseDetails/Model/CourseHomeProperties.swift
+++ b/Core/Core/Features/Courses/CourseDetails/Model/CourseHomeProperties.swift
@@ -34,13 +34,13 @@ extension CourseDefaultView {
     }
 
     func homeRoute(courseID: String) -> URL? {
-        var route = "courses/\(courseID)/\(rawValue)"
+        var route = "/courses/\(courseID)/\(rawValue)"
 
         switch self {
         case .feed:
-            route = "courses/\(courseID)/activity_stream"
+            route = "/courses/\(courseID)/activity_stream"
         case .wiki:
-            route = "courses/\(courseID)/pages/front_page"
+            route = "/courses/\(courseID)/pages/front_page"
         default:
             break
         }

--- a/Core/CoreTests/Features/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
+++ b/Core/CoreTests/Features/Courses/CourseDetails/Model/CourseHomePropertiesTests.swift
@@ -30,10 +30,10 @@ class CourseHomePropertiesTests: XCTestCase {
     }
 
     func testHomeRoute() {
-        XCTAssertEqual(CourseDefaultView.assignments.homeRoute(courseID: "123"), URL(string: "courses/123/assignments"))
-        XCTAssertEqual(CourseDefaultView.feed.homeRoute(courseID: "123"), URL(string: "courses/123/activity_stream"))
-        XCTAssertEqual(CourseDefaultView.modules.homeRoute(courseID: "123"), URL(string: "courses/123/modules"))
-        XCTAssertEqual(CourseDefaultView.syllabus.homeRoute(courseID: "123"), URL(string: "courses/123/syllabus"))
-        XCTAssertEqual(CourseDefaultView.wiki.homeRoute(courseID: "123"), URL(string: "courses/123/pages/front_page"))
+        XCTAssertEqual(CourseDefaultView.assignments.homeRoute(courseID: "123"), URL(string: "/courses/123/assignments"))
+        XCTAssertEqual(CourseDefaultView.feed.homeRoute(courseID: "123"), URL(string: "/courses/123/activity_stream"))
+        XCTAssertEqual(CourseDefaultView.modules.homeRoute(courseID: "123"), URL(string: "/courses/123/modules"))
+        XCTAssertEqual(CourseDefaultView.syllabus.homeRoute(courseID: "123"), URL(string: "/courses/123/syllabus"))
+        XCTAssertEqual(CourseDefaultView.wiki.homeRoute(courseID: "123"), URL(string: "/courses/123/pages/front_page"))
     }
 }

--- a/Core/CoreTests/Features/Courses/CourseDetails/ViewModel/CourseDetailsViewModelTests.swift
+++ b/Core/CoreTests/Features/Courses/CourseDetails/ViewModel/CourseDetailsViewModelTests.swift
@@ -109,7 +109,7 @@ class CourseDetailsViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.courseColor.hexString, UIColor(hexString: "#FF0000")!.ensureContrast(against: .backgroundLightest).hexString)
         XCTAssertEqual(testee.homeLabel, nil)
         XCTAssertEqual(testee.homeSubLabel, "Syllabus")
-        XCTAssertEqual(testee.homeRoute, URL(string: "courses/1/syllabus")!)
+        XCTAssertEqual(testee.homeRoute, URL(string: "/courses/1/syllabus")!)
 
         XCTAssertTrue(testee.showHome)
         XCTAssertFalse(testee.showSettings)


### PR DESCRIPTION
refs: [MBL-18551](https://instructure.atlassian.net/browse/MBL-18551)
affects: Student
release note: Fixed course home front page not visible in some cases.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18551) description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18551]: https://instructure.atlassian.net/browse/MBL-18551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ