### PR TITLE
Accessibility - Calendar - Add accessibilityValue to "Show a month at a time" button to indicate if expanded or collapsed

### DIFF
--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -95,9 +95,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
         // trailing = 8 (text-image spacing) + 20 (image width) + 4 (image right padding)
         monthButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 32)
         monthButton.accessibilityLabel = String(localized: "Show a month at a time", bundle: .core)
-        monthButton.accessibilityValue = {
-            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
-        }()
+        updateMonthButtonAccessibilityValue()
 
         filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.regular16)
@@ -149,9 +147,15 @@ class CalendarViewController: ScreenViewTrackableViewController {
 
     @IBAction func toggleExpanded() {
         setExpanded(!isExpanded)
-        monthButton.accessibilityValue = {
-            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
-        }()
+        updateMonthButtonAccessibilityValue()
+    }
+
+    private func updateMonthButtonAccessibilityValue() {
+//        monthButton.accessibilityValue = {
+//            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
+//        }()
+
+        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
     }
 
     func setExpanded(_ flag: Bool) {

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -151,7 +151,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
     }
 
     private func updateMonthButtonAccessibilityValue() {
-        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
+        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle: .core)
     }
 
     func setExpanded(_ flag: Bool) {

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -151,10 +151,6 @@ class CalendarViewController: ScreenViewTrackableViewController {
     }
 
     private func updateMonthButtonAccessibilityValue() {
-//        monthButton.accessibilityValue = {
-//            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
-//        }()
-
         monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
     }
 

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -94,7 +94,6 @@ class CalendarViewController: ScreenViewTrackableViewController {
         monthButton.configuration?.background.backgroundColor = .clear
         // trailing = 8 (text-image spacing) + 20 (image width) + 4 (image right padding)
         monthButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 32)
-        monthButton.accessibilityLabel = String(localized: "Show a month at a time", bundle: .core)
         updateMonthButtonAccessibilityValue()
 
         filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
@@ -151,12 +150,15 @@ class CalendarViewController: ScreenViewTrackableViewController {
     }
 
     private func updateMonthButtonAccessibilityValue() {
-        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle: .core)
+        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded, Show a month at a time", bundle: .core) : String(localized: "Collapsed, Show a month at a time", bundle: .core)
+    }
+
+    private func updateMonthButtonAccessibilityLabel(with label: String) {
+        monthButton.accessibilityLabel = label
     }
 
     func setExpanded(_ flag: Bool) {
         isExpanded = flag
-        monthButton.isSelected = flag
         UIView.animate(withDuration: 0.3, animations: updateExpanded)
     }
 
@@ -189,6 +191,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
         yearLabel.text = yearFormatter.string(from: selectedDate)
 
         let monthTitle = monthFormatter.string(from: selectedDate)
+        updateMonthButtonAccessibilityLabel(with: monthTitle)
         if monthButton.title(for: .normal) != monthTitle {
             animateMonthTitle(monthTitle)
         }

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -95,6 +95,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
         // trailing = 8 (text-image spacing) + 20 (image width) + 4 (image right padding)
         monthButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 32)
         monthButton.accessibilityLabel = String(localized: "Show a month at a time", bundle: .core)
+        monthButton.accessibilityValue = { isExpanded ? "Expanded" : "Collapsed" }()
 
         filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.regular16)
@@ -146,6 +147,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
 
     @IBAction func toggleExpanded() {
         setExpanded(!isExpanded)
+        monthButton.accessibilityValue = { isExpanded ? "Expanded" : "Collapsed" }()
     }
 
     func setExpanded(_ flag: Bool) {

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -95,7 +95,9 @@ class CalendarViewController: ScreenViewTrackableViewController {
         // trailing = 8 (text-image spacing) + 20 (image width) + 4 (image right padding)
         monthButton.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 32)
         monthButton.accessibilityLabel = String(localized: "Show a month at a time", bundle: .core)
-        monthButton.accessibilityValue = { isExpanded ? "Expanded" : "Collapsed" }()
+        monthButton.accessibilityValue = {
+            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
+        }()
 
         filterButton.setTitle(String(localized: "Calendars", bundle: .core), for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.regular16)
@@ -147,7 +149,9 @@ class CalendarViewController: ScreenViewTrackableViewController {
 
     @IBAction func toggleExpanded() {
         setExpanded(!isExpanded)
-        monthButton.accessibilityValue = { isExpanded ? "Expanded" : "Collapsed" }()
+        monthButton.accessibilityValue = {
+            isExpanded ? String(localized: "Expanded", bundle: .core) : String(localized: "Collapsed", bundle:.core)
+        }()
     }
 
     func setExpanded(_ flag: Bool) {

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -150,7 +150,7 @@ class CalendarViewController: ScreenViewTrackableViewController {
     }
 
     private func updateMonthButtonAccessibilityValue() {
-        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded, Show a month at a time", bundle: .core) : String(localized: "Collapsed, Show a month at a time", bundle: .core)
+        monthButton.accessibilityValue = isExpanded ? String(localized: "Expanded, Showing a month at a time", bundle: .core) : String(localized: "Collapsed, Showing a week at a time", bundle: .core)
     }
 
     private func updateMonthButtonAccessibilityLabel(with label: String) {

--- a/Core/CoreTests/Features/Planner/CalendarMain/CalendarViewControllerTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarMain/CalendarViewControllerTests.swift
@@ -56,11 +56,9 @@ class CalendarViewControllerTests: CoreTestCase, CalendarViewControllerDelegate 
             "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
         ])
 
-        XCTAssertEqual(controller.monthButton.accessibilityLabel, "Show a month at a time")
-        XCTAssertEqual(controller.monthButton.isSelected, false)
+        XCTAssertEqual(controller.monthButton.accessibilityLabel, "January")
         let deselectedHeight = height
         controller.monthButton.sendActions(for: .primaryActionTriggered)
-        XCTAssertEqual(controller.monthButton.isSelected, true)
         XCTAssertEqual(height > deselectedHeight, true)
 
         XCTAssertEqual(controller.filterButton.accessibilityLabel, "Filter events by Calendars")


### PR DESCRIPTION
Add accessibilityValue to "Show a month at a time" button to indicate if expanded or collapsed.
refs: MBL-18301
affects: Student, Teacher
release note: None
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
