### PR TITLE
Fix swiftui webview not loading string content 

### DIFF
--- a/Core/Core/Common/CommonUI/SwiftUIViews/WebView.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/WebView.swift
@@ -139,8 +139,12 @@ public struct WebView: UIViewRepresentable {
             context.coordinator.loaded = source
             switch source {
             case .html(let html):
-                webView.loadFileURL(URL.Directories.documents, allowingReadAccessTo: URL.Directories.documents)
-                webView.loadHTMLString(html, baseURL: baseURL)
+                webView.loadFileURL(
+                    URL.Directories.documents,
+                    allowingReadAccessTo: URL.Directories.documents
+                ) { _ in
+                    webView.loadHTMLString(html, baseURL: baseURL)
+                }
             case .request(let request):
                 webView.load(request)
             case nil:

--- a/Student/StudentE2ETests/Announcements/AnnouncementsTests.swift
+++ b/Student/StudentE2ETests/Announcements/AnnouncementsTests.swift
@@ -69,13 +69,16 @@ class AnnouncementsTests: E2ETestCase {
         // MARK: Check visibility toggle and dismiss button of the announcement notificaiton
         let toggleButton = AccountNotifications.toggleButton(notification: globalAnnouncement).waitUntil(.visible)
         XCTAssertTrue(toggleButton.isVisible)
+        XCTAssertEqual(toggleButton.label, "\(globalAnnouncement.subject), Tap to view announcement")
         var dismissButton = AccountNotifications.dismissButton(notification: globalAnnouncement).waitUntil(.vanish)
         XCTAssertTrue(dismissButton.isVanished)
 
         // MARK: Tap the toggle button and check visibility of dismiss button again
         toggleButton.hit()
         dismissButton = dismissButton.waitUntil(.visible)
+        XCTAssertEqual(toggleButton.label, "Hide content for \(globalAnnouncement.subject)")
         XCTAssertTrue(dismissButton.isVisible)
+        XCTAssertEqual(dismissButton.label, "Dismiss \(globalAnnouncement.subject)")
 
         // MARK: Check the message of the announcement
         let announcementMessage = Helper.notificationMessage(announcement: globalAnnouncement).waitUntil(.visible)

--- a/Teacher/TeacherE2ETests/Announcements/AnnouncementsTests.swift
+++ b/Teacher/TeacherE2ETests/Announcements/AnnouncementsTests.swift
@@ -77,14 +77,17 @@ class AnnouncementsTests: E2ETestCase {
 
         // MARK: Check visibility toggle and dismiss button of the announcement notificaiton
         let toggleButton = AccountNotifications.toggleButton(notification: globalAnnouncement).waitUntil(.visible)
-        var dismissButton = AccountNotifications.dismissButton(notification: globalAnnouncement).waitUntil(.vanish)
         XCTAssertTrue(toggleButton.isVisible)
+        XCTAssertEqual(toggleButton.label, "\(globalAnnouncement.subject), Tap to view announcement")
+        var dismissButton = AccountNotifications.dismissButton(notification: globalAnnouncement).waitUntil(.vanish)
         XCTAssertTrue(dismissButton.isVanished)
 
         // MARK: Tap the toggle button and check visibility of dismiss button again
         toggleButton.hit()
         dismissButton = dismissButton.waitUntil(.visible)
+        XCTAssertEqual(toggleButton.label, "Hide content for \(globalAnnouncement.subject)")
         XCTAssertTrue(dismissButton.isVisible)
+        XCTAssertEqual(dismissButton.label, "Dismiss \(globalAnnouncement.subject)")
 
         // MARK: Check the message of the announcement
         let announcementMessage = Helper.notificationMessage(announcement: globalAnnouncement).waitUntil(.visible)


### PR DESCRIPTION
refs: MBL-18561
affects: Student, Teacher
release note: none

(no release note, because the issue this one fixes was not released yet)

test plan:
- Create a global announcement.
- Start apps.
- Tap on the announcement on dashboard to view its contents.
- Content should appear.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
