### PR TITLE
Parent - TeacherChat - EditRecipients - set accessibilityTraits of RecipientCell

### DIFF
--- a/Core/Core/Features/Conversations/EditComposeRecipientsViewController.swift
+++ b/Core/Core/Features/Conversations/EditComposeRecipientsViewController.swift
@@ -109,7 +109,9 @@ extension EditComposeRecipientsViewController: UITableViewDataSource, UITableVie
         )
         cell.avatarView.name = person.fullName
         cell.avatarView.url = person.avatarURL
-        cell.isSelected = selectedRecipients.contains(person)
+        let isSelected = selectedRecipients.contains(person)
+        cell.isSelected = isSelected
+        cell.setAccessibilityTraitsSelected(isSelected)
         cell.selectedView.isHidden = !cell.isSelected
         cell.selectedView.layoutIfNeeded()
         return cell
@@ -162,6 +164,7 @@ class RecipientCell: UITableViewCell {
 
     func initialize() {
         backgroundColor = .backgroundLightest
+        accessibilityTraits = .button
     }
 
     override func layoutSubviews() {
@@ -170,5 +173,13 @@ class RecipientCell: UITableViewCell {
             corners: UIRectCorner.allCorners,
             radius: selectedView.frame.size.width / 2
         )
+    }
+
+    func setAccessibilityTraitsSelected(_ isSelected: Bool) {
+        if isSelected {
+            accessibilityTraits.insert(.selected)
+        } else {
+            accessibilityTraits.remove(.selected)
+        }
     }
 }


### PR DESCRIPTION
### Parent - TeacherChat - EditRecipients - set accessibilityTraits of RecipientCell

VoiceOver should read the row items (cells) of EditRecipients screen as "Button" in TeacherChat.
Also, "Selected" accessibilityTraits should be used if the cell is selected.
See ticket for further understanding.

refs: MBL-18361
affects: Parent
release note: None
test plan: See ticket.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
