### PR TITLE
Parent - TeacherChat - Compose screen - add accessibilityHint to input fields

### DIFF
--- a/Core/Core/Features/Conversations/ComposeViewController.swift
+++ b/Core/Core/Features/Conversations/ComposeViewController.swift
@@ -108,7 +108,6 @@ public class ComposeViewController: UIViewController, ErrorViewController {
             attributes: [ .foregroundColor: UIColor.textDark ]
         )
         subjectField.accessibilityLabel = String(localized: "Subject", bundle: .core)
-        subjectField.accessibilityHint = String(localized: "Text Field", bundle: .core)
 
         recipientsView.editButton.addTarget(self, action: #selector(editRecipients), for: .primaryActionTriggered)
         course?.refresh()

--- a/Core/Core/Features/Conversations/ComposeViewController.swift
+++ b/Core/Core/Features/Conversations/ComposeViewController.swift
@@ -101,12 +101,14 @@ public class ComposeViewController: UIViewController, ErrorViewController {
         bodyView.textColor = .textDarkest
         bodyView.textContainerInset = UIEdgeInsets(top: 15.5, left: 11, bottom: 15, right: 11)
         bodyView.accessibilityLabel = String(localized: "Message", bundle: .core)
+        bodyView.accessibilityHint = String(localized: "Text Field", bundle: .core)
 
         subjectField.attributedPlaceholder = NSAttributedString(
             string: String(localized: "Subject", bundle: .core),
             attributes: [ .foregroundColor: UIColor.textDark ]
         )
         subjectField.accessibilityLabel = String(localized: "Subject", bundle: .core)
+        subjectField.accessibilityHint = String(localized: "Text Field", bundle: .core)
 
         recipientsView.editButton.addTarget(self, action: #selector(editRecipients), for: .primaryActionTriggered)
         course?.refresh()


### PR DESCRIPTION
### Parent - TeacherChat - Compose screen - add accessibilityHint to input fields

Ideally all input fields should have an accessibility trait as "text field" or "text input" or something like that, and most cases VoiceOver recognises these elements correctly, but for UITextView and UITextField it just doesn't work like that.
Since there is no accessibility trait that we could add to these for this case (textField or textInput) I added it as an accessibilityHint. VoiceOver reads it like it was a trait but it's a hint instead. I made some research and investigated what could be done and found no better solution than this one, but I'm open to any ideas. My guess is that UIKit text inputs have some issues with being accessible (the internet says other devs experienced similar accessibility issues with these components).

refs: MBL-18368
affects: Parent
release note: None
test plan: VoiceOver should read both "subject" and "body" input fields as "text field".

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
