### PR TITLE
Parent - Manage Students - Student name as header

### DIFF
--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -117,6 +117,7 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
         }
         avatarView.name = student.first?.name ?? ""
         avatarView.url = student.first?.avatarURL
+        nameLabel.accessibilityTraits = .header
     }
 
     func updateThresholds() {


### PR DESCRIPTION
### Parent - Manage Students - Student name as header
refs: MBL-18394
affects: Parent
release note: None
test plan: VoiceOver should read student's name as a header.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
