### PR TITLE
Parent - Grade List - Section header button trait

### DIFF
--- a/Core/Core/Features/Grades/View/AssignmentSection.swift
+++ b/Core/Core/Features/Grades/View/AssignmentSection.swift
@@ -55,8 +55,6 @@ struct AssignmentSection<Header: View, Content: View>: View {
                 .background(Color.backgroundLightest)
             }
             .accessibilityElement(children: .combine)
-            .accessibilityRemoveTraits(.isButton)
-            .accessibilityAddTraits(.isHeader)
             .accessibilityHint(isExpanded
                                ? String(localized: "expanded", bundle: .core)
                                : String(localized: "collapsed", bundle: .core)


### PR DESCRIPTION
### Parent - Grade List - Section header button trait
refs: MBL-18395
affects: Student, Parent
release note: None
test plan: VoiceOver should read section headers as button.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
