### PR TITLE
File share submission fails after user change

### DIFF
--- a/Core/Core/Features/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/Features/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -70,7 +70,7 @@ public struct SubmitAssignmentExtensionView: View {
             .padding(.horizontal, 20)
         }
         .navigationBarGlobal()
-        .navigationTitleStyled(title)
+        .navigationTitleStyled(titleView)
         .navigationBarTitleDisplayMode(.inline)
         .navBarItems(leading: cancelButton, trailing: submitButton)
         .onDisappear {
@@ -78,8 +78,23 @@ public struct SubmitAssignmentExtensionView: View {
         }
     }
 
+    private var titleView: some View {
+        VStack(spacing: 1) {
+            title
+            if let userName = env.currentSession?.userName {
+                Text(userName)
+                    .font(.regular12)
+                    .foregroundColor(.textDark)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
     private var title: Text {
-        Text("Canvas Student", bundle: .core).font(.semibold17).foregroundColor(.textDarkest)
+        Text("Canvas Student", bundle: .core)
+            .font(.semibold16)
+            .foregroundColor(.textDarkest)
     }
 
     @ViewBuilder

--- a/Student/SubmitAssignment/SubmitAssignmentViewController.swift
+++ b/Student/SubmitAssignment/SubmitAssignmentViewController.swift
@@ -23,12 +23,7 @@ import Social
 
 @objc(SubmitAssignmentViewController)
 class SubmitAssignmentViewController: UIViewController {
-    /**
-     The share extension process doesn't terminate in case we have a background upload and the user starts another one.
-     The system just creates a new instance of this viewcontroller so we shouldn't create a new assembly but re-use this
-     mainly because of the single background url session it manages.
-    */
-    private static let submissionAssembly: FileSubmissionAssembly = .makeShareExtensionAssembly()
+
     private var attachmentCopyService: AttachmentCopyService!
     private var attachmentSubmissionService: AttachmentSubmissionService!
     private var viewModel: SubmitAssignmentExtensionViewModel!
@@ -47,9 +42,9 @@ class SubmitAssignmentViewController: UIViewController {
          otherwise the CoreData stack will be re-initialized resulting in strange errors.
         */
         if currentSession != lastApplicationSession {
-            if let lastApplicationSession = lastApplicationSession {
+            if let lastApplicationSession {
                 AppEnvironment.shared.userDidLogin(session: lastApplicationSession)
-            } else if let currentSession = currentSession {
+            } else if let currentSession {
                 AppEnvironment.shared.userDidLogout(session: currentSession)
             }
         }
@@ -62,11 +57,18 @@ class SubmitAssignmentViewController: UIViewController {
 
         // extensionContext is nil in init so we have to initialize here
         attachmentCopyService = AttachmentCopyService(extensionContext: extensionContext)
-        attachmentSubmissionService = AttachmentSubmissionService(submissionAssembly: Self.submissionAssembly)
+
+        /// The share extension process doesn't terminate in case we have a background upload and the user starts another one.
+        /// The system just creates a new instance of this viewcontroller. We create a new assembly _after_ logging in
+        /// to handle the case when the current user is changed in the app.
+        let submissionAssembly: FileSubmissionAssembly = .makeShareExtensionAssembly()
+        attachmentSubmissionService = AttachmentSubmissionService(submissionAssembly: submissionAssembly)
+
         viewModel = SubmitAssignmentExtensionViewModel(
             attachmentCopyService: attachmentCopyService,
             submissionService: attachmentSubmissionService,
-            shareCompleted: shareCompleted)
+            shareCompleted: shareCompleted
+        )
         embed(CoreHostingController(SubmitAssignmentExtensionView(viewModel: viewModel)), in: view)
     }
 


### PR DESCRIPTION
refs: [MBL-18149](https://instructure.atlassian.net/browse/MBL-18149)
affects: Student
release note: Fixed file share submission failure after user change.

## What's changed
- Fixed the issue when upload failed after user change
  - Recreated `FileSubmissionAssembly` for each submission screen instead of reusing static one
- Added the current user's name as a subtitle in the navigation bar

## Known issues
- It was like this before, but multiple simultaneous submissions from the extension can result in one of them getting lost:
  - start an upload from extension, dismiss the screen
  - open the Student app, observe upload is in progress
  - start another upload from extension
  - Both uploads will finish together with Success, but one of them might get lost
- It was like this before, but Upload progress bar on Student app Dashboard will reset when the screen is refreshed via PTR.

## Test plan
- Verify file submissions work even when changing users, see ticket for details.
- Verify file submission works as before (cancel, dismiss, error message on failure, progress in Student app, etc.)
  - If an issue is found try to reproduce it on a build before this PR (see known issues, as well)

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested on iOS 17
- [ ] Tested on iOS 18

[MBL-18149]: https://instructure.atlassian.net/browse/MBL-18149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ