### PR TITLE
Fix the issue of detail view of SplitViewController when switching out-in the app

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/CoreSplitViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/CoreSplitViewController.swift
@@ -17,12 +17,17 @@
 //
 
 import UIKit
+import Combine
 
 public class CoreSplitViewController: UISplitViewController {
+
+    private var subscriptions = Set<AnyCancellable>()
+    private var preBackgroundedSecondaryController: UIViewController?
 
     public override init(nibName: String? = nil, bundle: Bundle? = nil) {
         super.init(nibName: nibName, bundle: bundle)
         delegate = self
+        setupBackgroundStateObservers()
     }
 
     required init?(coder: NSCoder) {
@@ -30,7 +35,36 @@ public class CoreSplitViewController: UISplitViewController {
     }
 
     public override func viewDidLoad() {
+        super.viewDidLoad()
         preferredDisplayMode = .oneBesideSecondary
+    }
+
+    private func setupBackgroundStateObservers() {
+        NotificationCenter
+            .default
+            .publisher(for: UIApplication.didEnterBackgroundNotification)
+            .mapToVoid()
+            .sink { [weak self] in
+                self?.saveCurrentSecondaryController()
+            }
+            .store(in: &subscriptions)
+
+        NotificationCenter
+            .default
+            .publisher(for: UIApplication.willEnterForegroundNotification)
+            .mapToVoid()
+            .sink { [weak self] in
+                self?.removePreBackgroundedSecondaryController()
+            }
+            .store(in: &subscriptions)
+    }
+
+    private func saveCurrentSecondaryController() {
+        preBackgroundedSecondaryController = viewControllers.last
+    }
+
+    private func removePreBackgroundedSecondaryController() {
+        preBackgroundedSecondaryController = nil
     }
 
     public override var prefersStatusBarHidden: Bool {
@@ -90,6 +124,9 @@ extension CoreSplitViewController: UISplitViewControllerDelegate {
     }
 
     public func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
+
+        guard preBackgroundedSecondaryController == nil else { return false }
+
         if let nav = secondaryViewController as? UINavigationController {
             // swiftlint:disable:next unused_optional_binding
             if let _ = nav.topViewController as? EmptyViewController {
@@ -106,6 +143,8 @@ extension CoreSplitViewController: UISplitViewControllerDelegate {
     }
 
     public func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
+
+        if let secondaryView = preBackgroundedSecondaryController { return secondaryView }
 
         // Setup default detail view provided by the master view controller
         if let nav = primaryViewController as? UINavigationController,

--- a/Core/Core/Common/CommonUI/UIViews/CoreSplitViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/CoreSplitViewController.swift
@@ -22,6 +22,11 @@ import Combine
 public class CoreSplitViewController: UISplitViewController {
 
     private var subscriptions = Set<AnyCancellable>()
+
+    /// Introduced to get around the issue where SplitViewController
+    /// report collapse then expansion when app is put to background.
+    /// This property is used to cache secondary controller to be returned
+    /// on expansion state configuration (secondary separation delegate's method)
     private var preBackgroundedSecondaryController: UIViewController?
 
     public override init(nibName: String? = nil, bundle: Bundle? = nil) {
@@ -144,6 +149,7 @@ extension CoreSplitViewController: UISplitViewControllerDelegate {
 
     public func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController) -> UIViewController? {
 
+        // Return cached secondary controller when called on background
         if let secondaryView = preBackgroundedSecondaryController { return secondaryView }
 
         // Setup default detail view provided by the master view controller

--- a/Core/CoreTests/Features/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
+++ b/Core/CoreTests/Features/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
@@ -111,7 +111,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 1)
     }
 
     func testBackgroundURLSessionCompletionWithOngoingTasks() {


### PR DESCRIPTION
refs: MBL-18549
affects: Student, Teacher
release note: Fixed the issue where app doesn't refresh shown page properly after switching to another app

## Issue Analysis

Upon testing on an isolated case, turned out that `UISplitViewController` always report collapse then expansion whenever app is put to background. For that, `CoreSplitViewController` in that case calls delegate's methods of:

`func splitViewController(_ splitViewController: UISplitViewController, separateSecondaryFrom primaryViewController: UIViewController)` upon **expansion**.

`func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController)` upon **collapsing**.

Which causes the unnecessary disruption on SplitView, although nothing was actually changed from that perspective.

To get around this issue, a new property `preBackgroundedSecondaryController` to cache secondary view controller when the app is about to be backgrounded. And use that in the expansion delegate's method, instead of executing the `DefaultViewProvider` logic there, which assumes a real expansion is going on. 

One note though, I think we need to rethink the protocol `DefaultViewProvider` as the main way to extract a secondary view controller in case of expansion. Apparently, it is not being utilized in course details except for home and assignments tabs. 

## Test Plan

See [ticket](https://instructure.atlassian.net/browse/MBL-18549)'s description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
