### PR TITLE
Accessibility - Parent - Dashboard - Dropdown button accessibility

### DIFF
--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -70,8 +70,6 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
-        dropdownButton.isAccessibilityElement = false
-        dropdownButton.accessibilityElementsHidden = true
         addStudentView.layer.addDropShadow()
         addStudentView.isHidden = true
         avatarView.isHidden = true
@@ -154,9 +152,6 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
                 badgeCount
             )
         }
-
-        dropdownButton.isAccessibilityElement = true
-        dropdownButton.accessibilityElementsHidden = false
     }
 
     func updateCurrentStudent(_ oldValue: Core.User?) {

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -70,6 +70,8 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
 
+        dropdownButton.isAccessibilityElement = false
+        dropdownButton.accessibilityElementsHidden = true
         addStudentView.layer.addDropShadow()
         addStudentView.isHidden = true
         avatarView.isHidden = true
@@ -152,6 +154,9 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
                 badgeCount
             )
         }
+
+        dropdownButton.isAccessibilityElement = true
+        dropdownButton.accessibilityElementsHidden = false
     }
 
     func updateCurrentStudent(_ oldValue: Core.User?) {
@@ -177,9 +182,10 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
             let displayName = Core.User.displayName(student.shortName, pronouns: student.pronouns)
             titleLabel.text = displayName
             dropdownButton.accessibilityLabel = String.localizedStringWithFormat(
-                String(localized: "Current student: %@. Tap to switch students", bundle: .parent),
+                String(localized: "Current student: %@", bundle: .parent),
                 displayName
             )
+            dropdownButton.accessibilityHint = String(localized: "Tap to switch students")
         } else {
             avatarView.isHidden = true
             titleLabel.text = String(localized: "Add Student", bundle: .parent)

--- a/Parent/Parent/Localizable.xcstrings
+++ b/Parent/Parent/Localizable.xcstrings
@@ -5124,7 +5124,11 @@
         }
       }
     },
+    "Current student: %@" : {
+
+    },
     "Current student: %@. Tap to switch students" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -15877,6 +15881,9 @@
           }
         }
       }
+    },
+    "Tap to switch students" : {
+
     },
     "The linked item is no longer available." : {
       "localizations" : {

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -44,7 +44,8 @@ class DashboardViewControllerTests: ParentTestCase {
 
         XCTAssertEqual(vc.avatarView.name, "Full Name")
         XCTAssertEqual(vc.titleLabel.text, "Short Name (Pro/Noun)")
-        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Short Name (Pro/Noun). Tap to switch students")
+        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Short Name (Pro/Noun)")
+        XCTAssertEqual(vc.dropdownButton.accessibilityHint, "Tap to switch students")
         XCTAssertEqual(vc.studentListStack.arrangedSubviews.count, students.count + 1) // + add button
         XCTAssertEqual(vc.headerView.backgroundColor?.hexString, vc.currentColor.darkenToEnsureContrast(against: .textLightest.variantForLightMode).hexString)
 
@@ -67,7 +68,8 @@ class DashboardViewControllerTests: ParentTestCase {
         // FIXME: always fails locally, always works on CI
         XCTAssertEqual(vc.avatarView.name, "Bob")
         XCTAssertEqual(vc.titleLabel.text, "Bob")
-        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Bob. Tap to switch students")
+        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Bob")
+        XCTAssertEqual(vc.dropdownButton.accessibilityHint, "Tap to switch students")
         XCTAssertEqual(vc.studentListStack.arrangedSubviews.count, students.count + 1) // + add button
 
         (vc.studentListStack.arrangedSubviews.last as? UIButton)?.sendActions(for: .primaryActionTriggered)


### PR DESCRIPTION
refs: MBL-18397
affects: Parent
release note: None
test plan: Dropdown button should be accessible by VoiceOver and not as last element of the screen.

Originally the ticket was about the dropdown button not being accessible by VoiceOver but as I checked it already was, it was just the last element of the screen that VoiceOver read. Now it's the first one. I think profile button should be the first one here but I didn't manage to find a way to change the priority order of the elements.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
