### PR TITLE
Accessibility - Parent - Chat - EditComposeRecipients - title label as header

### DIFF
--- a/Core/Core/Features/Conversations/EditComposeRecipientsViewController.swift
+++ b/Core/Core/Features/Conversations/EditComposeRecipientsViewController.swift
@@ -58,6 +58,7 @@ class EditComposeRecipientsViewController: UIViewController {
         view.backgroundColor = .backgroundLightest
         view.frame.size.height = 304
         titleLabel.text = String(localized: "Recipients", bundle: .core)
+        titleLabel.accessibilityTraits = .header
         teachers.exhaust(force: false)
         tas.exhaust(force: false)
     }


### PR DESCRIPTION
### Accessibility - Parent - Chat - EditComposeRecipients - title label as header
refs: MBL-18357
affects: Parent
release note: None
test plan: VoiceOver should read title label as a header.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
