### PR TITLE
Accessibility - Student - GradeList - Section header to contain list count

### DIFF
--- a/Core/Core/Features/Grades/Model/Entities/GradeListData.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradeListData.swift
@@ -32,7 +32,7 @@ public struct GradeListData: Identifiable, Equatable {
 
     struct AssignmentSections: Identifiable, Equatable {
         var id: String
-        let title: String?
+        let title: String
         var assignments: [Assignment]
     }
 }

--- a/Core/Core/Features/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeListInteractor.swift
@@ -233,7 +233,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
                 assignmentSections.append(
                     GradeListData.AssignmentSections(
                         id: assignment.assignmentGroupID ?? UUID.string,
-                        title: assignment.assignmentGroupSectionName,
+                        title: assignment.assignmentGroupSectionName ?? "",
                         assignments: [assignment]
                     )
                 )

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -320,19 +320,14 @@ public struct GradeListView: View, ScreenViewTrackable {
 
         LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
             ForEach(assignmentSections, id: \.id) { section in
+                let itemCountLabel = String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), section.assignments.count)
                 AssignmentSection {
                     VStack(spacing: 0) {
                         listSectionView(title: section.title)
                             .frame(height: 40)
                             .paddingStyle(.horizontal, .standard)
                     }
-                    .accessibilityLabel(
-                        String(
-                            localized: "\(section.title ?? ""), \(section.assignments.count) items",
-                            bundle: .core
-                        )
-                    )
-
+                    .accessibilityLabel("\(section.title), \(itemCountLabel)")
                 } content: {
                     ForEach(section.assignments, id: \.id) { assignment in
                         VStack(alignment: .leading, spacing: 0) {

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -326,7 +326,12 @@ public struct GradeListView: View, ScreenViewTrackable {
                             .frame(height: 40)
                             .paddingStyle(.horizontal, .standard)
                     }
-                    .accessibilityLabel(section.title ?? "")
+                    .accessibilityLabel(
+                        String(
+                            localized: "\(section.title ?? ""), \(section.assignments.count) items",
+                            bundle: .core
+                        )
+                    )
 
                 } content: {
                     ForEach(section.assignments, id: \.id) { assignment in

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -327,7 +327,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                             .frame(height: 40)
                             .paddingStyle(.horizontal, .standard)
                     }
-                    .accessibilityLabel("\(section.title), \(itemCountLabel)")
+                    .accessibilityLabel(Text(verbatim: "\(section.title), \(itemCountLabel)"))
                 } content: {
                     ForEach(section.assignments, id: \.id) { assignment in
                         VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
### Accessibility - Student - GradeList - Section header to contain list count
refs: MBL-18469
affects: Student, Parent
release note: None
test plan: VoiceOver should read section headers with list count.

The ticket wants the list count to be available for the user when using VoiceOver. It assumes we use UITableView but this screen is SwiftUI so I thought it might be a good idea here to extend the accessibilityLabel of the section headers instead.
Let me know if this is not the right or desired solution or if it's not the correct way to solve this issue.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
