### PR TITLE
Fix flaky unit tests

### DIFF
--- a/Core/Core/Features/CourseSync/Common/Model/CourseSyncCleanupInteractor.swift
+++ b/Core/Core/Features/CourseSync/Common/Model/CourseSyncCleanupInteractor.swift
@@ -17,6 +17,7 @@
 //
 
 import Combine
+import CombineSchedulers
 
 public struct CourseSyncCleanupInteractor {
     private let applicationOfflineFolder: URL
@@ -43,9 +44,9 @@ public struct CourseSyncCleanupInteractor {
     }
 
     /// Deletes offline folders with all files inside them on a background thread.
-    public func clean() -> AnyPublisher<Void, Never> {
+    public func clean(scheduler: AnySchedulerOf<DispatchQueue> = .global()) -> AnyPublisher<Void, Never> {
         Just(())
-            .receive(on: DispatchQueue.global())
+            .receive(on: scheduler)
             .handleEvents(receiveOutput: {
                 try? FileManager.default.removeItem(at: applicationOfflineFolder)
 

--- a/Core/CoreTests/Features/CourseSync/Common/Model/CourseSyncCleanupInteractorTests.swift
+++ b/Core/CoreTests/Features/CourseSync/Common/Model/CourseSyncCleanupInteractorTests.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import CombineSchedulers
 import Core
 import XCTest
 
@@ -37,7 +38,7 @@ class CourseSyncCleanupInteractorTests: XCTestCase {
 
         // MARK: - WHEN
         let testee = CourseSyncCleanupInteractor(appGroup: "group.com.instructure.icanvas", session: mockSession)
-        XCTAssertFinish(testee.clean(), timeout: 1)
+        XCTAssertFinish(testee.clean(scheduler: .main), timeout: 1)
 
         // MARK: - THEN
         XCTAssertFalse(FileManager.default.fileExists(atPath: dbURL.path))
@@ -60,7 +61,7 @@ class CourseSyncCleanupInteractorTests: XCTestCase {
 
         // MARK: - WHEN
         let testee = CourseSyncCleanupInteractor(appGroup: nil, session: mockSession)
-        XCTAssertFinish(testee.clean())
+        XCTAssertFinish(testee.clean(scheduler: .main))
 
         // MARK: - THEN
         XCTAssertFalse(FileManager.default.fileExists(atPath: dbURL.path))

--- a/Core/CoreTests/Features/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
+++ b/Core/CoreTests/Features/Files/FileSubmission/Model/FileSubmissionAssemblyTests.swift
@@ -111,7 +111,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 1)
     }
 
     func testBackgroundURLSessionCompletionWithOngoingTasks() {
@@ -133,7 +133,7 @@ class FileSubmissionAssemblyTests: CoreTestCase {
             expectation.fulfill()
         }
 
-        waitForExpectations(timeout: 0.1)
+        waitForExpectations(timeout: 1)
     }
 
     func testCancelDeletesSubmission() {

--- a/Core/TestsFoundation/Helpers/CombineTestExtensions.swift
+++ b/Core/TestsFoundation/Helpers/CombineTestExtensions.swift
@@ -27,7 +27,7 @@ public extension XCTestCase {
     func XCTAssertCompletableSingleOutputEquals<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
         _ expectedOutput: Output,
-        timeout: TimeInterval = 0.1
+        timeout: TimeInterval = 1
     ) where Output: Equatable, Failure: Error {
         let outputExpectation = expectation(description: "Output received from publisher")
         outputExpectation.expectedFulfillmentCount = 1
@@ -54,7 +54,7 @@ public extension XCTestCase {
      */
     func XCTAssertFirstValueAndCompletion<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
-        timeout: TimeInterval = 0.1,
+        timeout: TimeInterval = 1,
         assertions: @escaping (Output) -> Void
     ) where Failure: Error {
         let outputExpectation = expectation(description: "Output received from publisher")
@@ -82,7 +82,7 @@ public extension XCTestCase {
     func XCTAssertSingleOutputEquals<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
         _ expectedOutput: Output,
-        timeout: TimeInterval = 0.1
+        timeout: TimeInterval = 1
     ) where Output: Equatable, Failure: Error {
         let outputExpectation = expectation(description: "Output received from publisher")
         outputExpectation.expectedFulfillmentCount = 1
@@ -106,7 +106,7 @@ public extension XCTestCase {
      */
     func XCTAssertFirstValue<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
-        timeout: TimeInterval = 0.1,
+        timeout: TimeInterval = 1,
         assertions: @escaping (Output) -> Void
     ) where Failure: Error {
         let outputExpectation = expectation(description: "Output received from publisher")
@@ -132,7 +132,7 @@ public extension XCTestCase {
      */
     func XCTAssertFinish<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
-        timeout: TimeInterval = 0.1
+        timeout: TimeInterval = 1
     ) where Failure: Error {
         let finishExpectation = expectation(description: "Publisher finished")
         finishExpectation.expectedFulfillmentCount = 1
@@ -154,7 +154,7 @@ public extension XCTestCase {
     func XCTAssertFailure<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
         assertOnOutput: Bool = true,
-        timeout: TimeInterval = 0.1
+        timeout: TimeInterval = 1
     ) where Failure: Error {
         let finishExpectation = expectation(description: "Publisher failed")
         finishExpectation.expectedFulfillmentCount = 1
@@ -178,7 +178,7 @@ public extension XCTestCase {
 
     func XCTAssertNoOutput<Output, Failure>(
         _ publisher: any Publisher<Output, Failure>,
-        timeout: TimeInterval = 0.1
+        timeout: TimeInterval = 1
     ) where Failure: Error {
         let noValueExpectation = expectation(description: "Publisher sent no value.")
         noValueExpectation.isInverted = true

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -42,9 +42,11 @@ class DashboardViewControllerTests: ParentTestCase {
         vc.view.layoutIfNeeded()
         vc.viewWillAppear(false)
 
+        waitUntil(1, shouldFail: true) {
+            vc.dropdownButton.accessibilityLabel == "Current student: Short Name (Pro/Noun). Tap to switch students"
+        }
         XCTAssertEqual(vc.avatarView.name, "Full Name")
         XCTAssertEqual(vc.titleLabel.text, "Short Name (Pro/Noun)")
-        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Short Name (Pro/Noun). Tap to switch students")
         XCTAssertEqual(vc.studentListStack.arrangedSubviews.count, students.count + 1) // + add button
         XCTAssertEqual(vc.headerView.backgroundColor?.hexString, vc.currentColor.darkenToEnsureContrast(against: .textLightest.variantForLightMode).hexString)
 
@@ -62,12 +64,13 @@ class DashboardViewControllerTests: ParentTestCase {
         XCTAssertEqual(vc.studentListHiddenHeight.isActive, false)
 
         (vc.studentListStack.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
-        drainMainQueue() // Wait for animation to complete
+
+        waitUntil(1, shouldFail: true) {
+            vc.dropdownButton.accessibilityLabel == "Current student: Bob. Tap to switch students"
+        }
         XCTAssertEqual(vc.studentListHiddenHeight.isActive, true)
-        // FIXME: always fails locally, always works on CI
         XCTAssertEqual(vc.avatarView.name, "Bob")
         XCTAssertEqual(vc.titleLabel.text, "Bob")
-        XCTAssertEqual(vc.dropdownButton.accessibilityLabel, "Current student: Bob. Tap to switch students")
         XCTAssertEqual(vc.studentListStack.arrangedSubviews.count, students.count + 1) // + add button
 
         (vc.studentListStack.arrangedSubviews.last as? UIButton)?.sendActions(for: .primaryActionTriggered)

--- a/Student/Student/Assignments/AssignmentDetails/Reminders/Model/Notifications/AssignmentNotificationHelpers.swift
+++ b/Student/Student/Assignments/AssignmentDetails/Reminders/Model/Notifications/AssignmentNotificationHelpers.swift
@@ -36,7 +36,6 @@ public extension Sequence where Element == UNNotificationRequest {
                 return userInfo[Keys.assignmentId.rawValue] as? String == assignmentId
             }()
             return hasCourseId && hasAssignmentId && hasUserId
-
         }
     }
 

--- a/Student/StudentUnitTests/Assignments/AssignmentDetails/Reminders/Model/AssignmentRemindersInteractorLiveTests.swift
+++ b/Student/StudentUnitTests/Assignments/AssignmentDetails/Reminders/Model/AssignmentRemindersInteractorLiveTests.swift
@@ -81,7 +81,10 @@ class AssignmentRemindersInteractorLiveTests: StudentTestCase {
         testee.contextDidUpdate.send(context)
 
         // THEN
-        waitUntil(shouldFail: true) {
+        waitUntil(
+            shouldFail: true,
+            failureMessage: "Reminders are not in chronological order: \(testee.reminders.value)"
+        ) {
             testee.reminders.value == [
                 .init(id: "2", title: "1 minute before"),
                 .init(id: "3", title: "2 minutes before"),


### PR DESCRIPTION
- `AssignmentRemindersInteractorLiveTests.swift`: Improved failure messages in `waitUntil` call to provide better debugging information since I was unable to reproduce the error locally.
- `CourseSyncCleanupInteractor.swift`: Modified the `clean` method to accept a custom scheduler parameter because testing file availability from mixed threads seemed to be unreliable.
- Increased timeouts for multiple assertions and for Combine assertions in general because timeout is a main source of flakyness.

refs: MBL-18578
affects: none
release note: none

test plan:
- Unit tests should pass.