### PR TITLE
Accessibility - Student - AssignmentDetails - Attempts date button traits handling

### DIFF
--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -501,6 +501,8 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             attemptDateButton.changesSelectionAsPrimaryAction = true
             attemptDateButton.showsMenuAsPrimaryAction = true
             attemptDateButton.menu = UIMenu(children: items)
+        } else {
+            attemptDateButton.accessibilityTraits = .staticText
         }
 
         attemptDateButton?.configuration = buttonConfig


### PR DESCRIPTION
### Accessibility - Student - AssignmentDetails - Attempts date button traits handling
refs: MBL-18457
affects: Student
release note: None
test plan: VoiceOver should read attempts date as a button only if it is really a button.

Previously that attemptsDateButton was read by VoiceOver as a "button" even if it was not active/clickable and that could be misleading to the user. Now if the button is not active then we set the accessibilityTraits of the button to staticText.

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
