### PR TITLE
Accessibility - Teacher - Submission - Grades - Add header trait to "Grade" and "Rubric" labels

### DIFF
--- a/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
@@ -39,6 +39,7 @@ struct RubricAssessor: View {
             VStack(alignment: .leading, spacing: 0) {
                 Text("Rubric", bundle: .teacher)
                     .font(.heavy24).foregroundColor(.textDarkest)
+                    .accessibilityAddTraits(.isHeader)
                 Text("\(currentScore, specifier: "%g") out of \(assignment.rubricPointsPossible ?? 0, specifier: "%g")", bundle: .teacher)
                     .font(.medium14).foregroundColor(.textDark)
             }

--- a/Teacher/Teacher/SpeedGrader/SubmissionGrades.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionGrades.swift
@@ -75,6 +75,7 @@ struct SubmissionGrades: View {
                 VStack(spacing: 0) {
                     HStack(spacing: 0) {
                         Text("Grade", bundle: .teacher)
+                            .accessibilityAddTraits(.isHeader)
                         Spacer()
                         if isSaving {
                             ProgressView()


### PR DESCRIPTION
### Accessibility - Teacher - Submission - Grades - Add header trait to "Grade" and "Rubric" labels
refs: MBL-18438
affects: Teacher
release note: None
test plan: VoiceOver should read "Grade" and "Rubric" labels as headers.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
