### PR TITLE
Open native speedgrader from web discussion

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -519,9 +519,7 @@ extension CoreWebView: WKUIDelegate {
         for navigationAction: WKNavigationAction,
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
-        guard let from = linkDelegate?.routeLinksFrom else {
-            return nil
-        }
+        guard let from = linkDelegate?.routeLinksFrom else { return nil }
 
         let router = AppEnvironment.shared.router
 

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -519,12 +519,33 @@ extension CoreWebView: WKUIDelegate {
         for navigationAction: WKNavigationAction,
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
-        guard let from = linkDelegate?.routeLinksFrom else { return nil }
+        guard let from = linkDelegate?.routeLinksFrom else {
+            return nil
+        }
+
+        let router = AppEnvironment.shared.router
+
+        if let targetURL = navigationAction.request.url,
+           router.isRegisteredRoute(targetURL) {
+            let routeOptions = RouteOptions.modal(
+                .fullScreen,
+                isDismissable: false,
+                embedInNav: true,
+                addDoneButton: true
+            )
+            router.route(
+                to: targetURL,
+                from: from,
+                options: routeOptions
+            )
+            return nil
+        }
+
         let controller = CoreWebViewController()
         // Don't change the processPool of this configuration otherwise it will crash
         controller.webView = CoreWebView(externalConfiguration: configuration)
         controller.webView.linkDelegate = linkDelegate
-        AppEnvironment.shared.router.show(
+        router.show(
             controller,
             from: from,
             options: .modal(.formSheet, embedInNav: true, addDoneButton: true)

--- a/Core/TestsFoundation/Router/TestRouter.swift
+++ b/Core/TestsFoundation/Router/TestRouter.swift
@@ -17,7 +17,7 @@
 //
 
 import XCTest
-import Core
+@testable import Core
 
 public class TestRouter: Router {
     public init() {
@@ -57,6 +57,12 @@ public class TestRouter: Router {
 
     public override func match(_ url: URLComponents, userInfo: [String: Any]? = nil) -> UIViewController? {
         return routes[url]?()
+    }
+
+    public override func isRegisteredRoute(_ url: URLComponents) -> Bool {
+        routes.keys.contains { route in
+            route.path == url.path
+        }
     }
 
     public var routeExpectation = XCTestExpectation(description: "route")

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		CF67D00C2B18E9A1009D826A /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CF67D00B2B18E9A1009D826A /* InfoPlist.xcstrings */; };
 		CF67D00E2B18E9A1009D826A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CF67D00D2B18E9A1009D826A /* Localizable.xcstrings */; };
 		CF67D0102B18E9A1009D826A /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CF67D00F2B18E9A1009D826A /* Localizable.xcstrings */; };
+		CF93FCB82D5A5AF600C4538F /* SpeedGraderAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF93FCB72D5A5AF000C4538F /* SpeedGraderAssembly.swift */; };
 		CFAA40232AE2633A002C7AAE /* PSPDFKit in Frameworks */ = {isa = PBXBuildFile; productRef = CFAA40222AE2633A002C7AAE /* PSPDFKit */; };
 		CFD96BA72719A44800A38E66 /* StudentAnnotationSubmissionViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD96BA62719A44800A38E66 /* StudentAnnotationSubmissionViewerViewModel.swift */; };
 		CFD96BA92719A60600A38E66 /* StudentAnnotationSubmissionViewerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFD96BA82719A60600A38E66 /* StudentAnnotationSubmissionViewerViewModelTests.swift */; };
@@ -315,6 +316,7 @@
 		CF67D00B2B18E9A1009D826A /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		CF67D00D2B18E9A1009D826A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		CF67D00F2B18E9A1009D826A /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		CF93FCB72D5A5AF000C4538F /* SpeedGraderAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderAssembly.swift; sourceTree = "<group>"; };
 		CFD96BA62719A44800A38E66 /* StudentAnnotationSubmissionViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentAnnotationSubmissionViewerViewModel.swift; sourceTree = "<group>"; };
 		CFD96BA82719A60600A38E66 /* StudentAnnotationSubmissionViewerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StudentAnnotationSubmissionViewerViewModelTests.swift; sourceTree = "<group>"; };
 		D063D27A1B3640208ABF74D4 /* libz.tbd */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libz.tbd; path = usr/lib/libz.tbd; sourceTree = SDKROOT; };
@@ -487,6 +489,7 @@
 				CFD96BA62719A44800A38E66 /* StudentAnnotationSubmissionViewerViewModel.swift */,
 				7DCA320B2541D38F00458651 /* URLSubmissionViewer.swift */,
 				B4707B042B1DDF7900F67CA8 /* SubmissionCommentListViewModel.swift */,
+				CF93FCB72D5A5AF000C4538F /* SpeedGraderAssembly.swift */,
 			);
 			path = SpeedGrader;
 			sourceTree = "<group>";
@@ -1173,6 +1176,7 @@
 			files = (
 				7D0D7AE2251E6E6C00550AEC /* SubmissionListViewController.swift in Sources */,
 				7D64A96323620A27004EAEDF /* Status.swift in Sources */,
+				CF93FCB82D5A5AF600C4538F /* SpeedGraderAssembly.swift in Sources */,
 				7D3DC0C0252291B400B0EBC1 /* SubmissionFilterPickerViewController.swift in Sources */,
 				7D7126C425374457000DEDE4 /* SubmissionCommentList.swift in Sources */,
 				7DCA320C2541D38F00458651 /* URLSubmissionViewer.swift in Sources */,

--- a/Teacher/Teacher/Routes.swift
+++ b/Teacher/Teacher/Routes.swift
@@ -165,19 +165,39 @@ let router = Router(routes: [
             )
     },
 
-    RouteHandler("/courses/:courseID/assignments/:assignmentID/submissions/:userID") { url, params, _, env in
-        guard let context = Context(path: url.path) else { return nil }
-        guard let assignmentID = params["assignmentID"], let userID = params["userID"] else { return nil }
-        let filter = url.queryItems?.first { $0.name == "filter" }? .value?.components(separatedBy: ",").compactMap {
-            GetSubmissions.Filter(rawValue: $0)
-        } ?? []
-        return SpeedGraderViewController(
+    RouteHandler("/courses/:courseID/gradebook/speed_grader") { url, _, _, env in
+        guard
+            let context = Context(path: url.path),
+            let assignmentID = url.queryValue(for: "assignment_id")
+        else { return nil }
+
+        return SpeedGraderAssembly.makeSpeedGraderViewController(
+            context: context,
+            assignmentID: assignmentID,
+            userID: url.queryValue(for: "student_id"),
             env: env,
+            filter: [])
+    },
+
+    RouteHandler("/courses/:courseID/assignments/:assignmentID/submissions/:userID") { url, params, _, env in
+        guard
+            let context = Context(path: url.path),
+            let assignmentID = params["assignmentID"],
+            let userID = params["userID"]
+        else { return nil }
+
+        let filter = url
+            .queryValue(for: "filter")?
+            .components(separatedBy: ",")
+            .compactMap {
+                GetSubmissions.Filter(rawValue: $0)
+            } ?? []
+        return SpeedGraderAssembly.makeSpeedGraderViewController(
             context: context,
             assignmentID: assignmentID,
             userID: userID,
-            filter: filter
-        )
+            env: env,
+            filter: filter)
     },
 
     RouteHandler("/courses/:courseID/attendance/:toolID") { _, params, _ in

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderAssembly.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderAssembly.swift
@@ -1,0 +1,39 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import UIKit
+
+public enum SpeedGraderAssembly {
+
+    public static func makeSpeedGraderViewController(
+        context: Context,
+        assignmentID: String,
+        userID: String?,
+        env: AppEnvironment,
+        filter: [GetSubmissions.Filter]
+    ) -> UIViewController {
+        SpeedGraderViewController(
+            env: env,
+            context: context,
+            assignmentID: assignmentID,
+            userID: userID ?? SpeedGraderViewController.AllUsersUserID,
+            filter: filter
+        )
+    }
+}

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderAssembly.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderAssembly.swift
@@ -28,11 +28,13 @@ public enum SpeedGraderAssembly {
         env: AppEnvironment,
         filter: [GetSubmissions.Filter]
     ) -> UIViewController {
-        SpeedGraderViewController(
+        let normalizedUserId = SpeedGraderViewController.normalizeUserID(userID)
+
+        return SpeedGraderViewController(
             env: env,
             context: context,
             assignmentID: assignmentID,
-            userID: userID ?? SpeedGraderViewController.AllUsersUserID,
+            userID: normalizedUserId,
             filter: filter
         )
     }

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -21,6 +21,7 @@ import UIKit
 import Core
 
 class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewControllerDataSource {
+    static let AllUsersUserID = "speedgrader"
     typealias Page = CoreHostingController<SubmissionGrader>
 
     let assignmentID: String
@@ -49,7 +50,7 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
         self.assignmentID = assignmentID
         self.context = context
         self.filter = filter
-        self.userID = userID == "speedgrader" ? nil : userID
+        self.userID = userID == Self.AllUsersUserID ? nil : userID
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -118,6 +119,12 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
         }
 
         updatePages()
+
+        // SpeedGrader is by design not embedded into a navigation controller.
+        // However, when navigating to this screen from CoreWebView's link handler
+        // it automatically wraps it into a navigation controller and adds a Done button.
+        // To avoid displaying double Close/Done buttons and an extra navigation bar hide it.
+        navigationController?.setNavigationBarHidden(true, animated: true)
     }
 
     var isLoading: Bool {

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -21,7 +21,7 @@ import UIKit
 import Core
 
 class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewControllerDataSource {
-    static let AllUsersUserID = "speedgrader"
+    internal static let AllUsersUserID = "speedgrader"
     typealias Page = CoreHostingController<SubmissionGrader>
 
     let assignmentID: String

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderViewController.swift
@@ -200,4 +200,13 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
             }
         }
     }
+
+    /// Helper function to help normalize user ids coming from webview urls
+    static func normalizeUserID(_ userID: String?) -> String {
+        if let userID, userID.containsOnlyNumbers {
+            return userID
+        }
+
+        return SpeedGraderViewController.AllUsersUserID
+    }
 }

--- a/Teacher/TeacherTests/RoutesTests.swift
+++ b/Teacher/TeacherTests/RoutesTests.swift
@@ -73,6 +73,7 @@ class RoutesTests: XCTestCase {
         XCTAssert(router.match("/courses/2/discussion_topics/3/entries/4/replies") is DiscussionReplyViewController)
         XCTAssert(router.match("/courses/1/assignments/1/submissions") is SubmissionListViewController)
         XCTAssert(router.match("/courses/1/assignments/1/submissions/1") is SpeedGraderViewController)
+        XCTAssert(router.match("/courses/1/gradebook/speed_grader?assignment_id=1") is SpeedGraderViewController)
         XCTAssert(router.match("/courses/1/quizzes") is QuizListViewController)
         XCTAssert(router.match("/courses/1/quizzes/2") is CoreHostingController<TeacherQuizDetailsView<TeacherQuizDetailsViewModelLive>>)
         XCTAssert(router.match("/courses/1/quizzes/2/preview") is CoreHostingController<QuizPreviewView>)

--- a/Teacher/TeacherTests/SpeedGrader/SpeedGraderViewControllerTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/SpeedGraderViewControllerTests.swift
@@ -83,4 +83,23 @@ class SpeedGraderViewControllerTests: TeacherTestCase {
         // THEN
         XCTAssertEqual(controller.submissions.all.count, 1)
     }
+
+    func test_normalizeUserID() {
+        XCTAssertEqual(
+            SpeedGraderViewController.normalizeUserID(nil),
+            SpeedGraderViewController.AllUsersUserID
+        )
+        XCTAssertEqual(
+            SpeedGraderViewController.normalizeUserID(":student"),
+            SpeedGraderViewController.AllUsersUserID
+        )
+        XCTAssertEqual(
+            SpeedGraderViewController.normalizeUserID("ABC"),
+            SpeedGraderViewController.AllUsersUserID
+        )
+        XCTAssertEqual(
+            SpeedGraderViewController.normalizeUserID("123"),
+            "123"
+        )
+    }
 }


### PR DESCRIPTION
refs: [MBL-17942](https://instructure.atlassian.net/browse/MBL-17942)
affects: Teacher
release note: SpeedGrader now correctly opens from graded discussions.

test plan:
- Create a graded discussion.
- Post a comment as a student and as a non-student user.
- Open the discussion from the teacher app.
- Open SpeedGrader from the main post of the discussion.
- SpeedGrader should open.
- Open SpeedGrader from a post of a student.
- SpeedGrader should open focused on that student.
- Open SpeedGrader from a post of a teacher.
- SpeedGrader should open with a no submissions remark.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/5219f68f-664d-4a01-b459-d65512b4d5b3" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/8302bcb1-1feb-4417-a56e-bc4d7c9d9943" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [x] Tested on tablet
- [ ] Approve from product


[MBL-17942]: https://instructure.atlassian.net/browse/MBL-17942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ