### PR TITLE
Improve Assignments screen a11y

### DIFF
--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
@@ -79,7 +79,10 @@ public struct AssignmentListScreen: View, ScreenViewTrackable {
                         .foregroundStyle(Color(.textDarkest))
                 }
                 .padding(.vertical, 8)
-                .accessibility(addTraits: .isHeader)
+                .accessibilityElement()
+                .accessibilityLabel(Text("Selected grading period:", bundle: .core))
+                .accessibilityValue(text)
+                .accessibilityRemoveTraits(.isHeader)
             },
             content: { }
         )


### PR DESCRIPTION
refs: [MBL-18472](https://instructure.atlassian.net/browse/MBL-18472)
affects: Student, Teacher
release note: none

## What's changed
- Combined "Grading Period" title and the selected value together
  - The colon was needed, because when the selection is "All" it read them together without a pause
- Removed heading trait

## Test plan
Verify on Assignments screen, Grading Period: [value] reads together and without "Heading"

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet