### PR TITLE
Accessibility - Parent - Course List - Button trait for cells

### DIFF
--- a/Parent/Parent/Courses/CourseListViewController.swift
+++ b/Parent/Parent/Courses/CourseListViewController.swift
@@ -111,6 +111,7 @@ class CourseListCell: UITableViewCell {
         backgroundColor = .backgroundLightest
         let id = course?.id ?? ""
         accessibilityIdentifier = "course_cell_\(id)"
+        accessibilityTraits = .button
 
         nameLabel.accessibilityIdentifier = "course_title_\(id)"
         nameLabel.setText(course?.name, style: .textCellTitle)


### PR DESCRIPTION
### Accessibility - Parent - Course List - Button trait for cells
refs: MBL-18401
affects: Parent
release note: None
test plan: VoiceOver should read cells as buttons.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product
