### PR TITLE
Fix long press on rubric

### DIFF
--- a/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
@@ -233,7 +233,7 @@ struct RubricAssessor: View {
         private let tooltip: String
         private let content: Content
 
-        @GestureState private var showTooltip = false
+        @State private var showTooltip = false
         private let containerFrame: CGRect
 
         init(isOn: Binding<Bool>, tooltip: String = "", containerFrame: CGRect = .null, @ViewBuilder content: () -> Content) {
@@ -258,12 +258,11 @@ struct RubricAssessor: View {
                 )
                 .accessibility(addTraits: isOn ? [.isButton, .isSelected] : .isButton)
                 .onTapGesture { isOn.toggle() }
-                .gesture(LongPressGesture(minimumDuration: .infinity)
-                    .updating($showTooltip) { _, state, transation in
-                        transation.animation = .spring(response: 0.2, dampingFraction: 0.6)
-                        state = true
+                .onLongPressGesture(perform: {}, onPressingChanged: { isLongPressing in
+                    withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
+                        showTooltip = isLongPressing
                     }
-                )
+                })
                 .overlay(!showTooltip || tooltip.isEmpty ? nil :
                     GeometryReader { geometry in
                         let bubbleToCircleOffset: CGFloat = 16
@@ -301,8 +300,7 @@ struct RubricAssessor: View {
                             // Alignment must match the guides we use above otherwise they don't get called
                             .frame(width: maxWidth, height: maxHeight, alignment: .bottomLeading)
                     }
-                    .transition(.scale),
-                    alignment: .bottomLeading)
+                    .transition(.scale.combined(with: .opacity)), alignment: .bottomLeading)
         }
     }
 


### PR DESCRIPTION
### What's new?
- We used a deprecated long press method on rubric views that no longer works on iOS 18. I updated to use an up-to-date version of this method.
- I also added a fade animation to the already existing scale animation so when using an Apple pencil it's no longer visible that the tooltip scales down to a comically small size because it fades out in the meantime.

refs: MBL-18567
affects: Teacher
release note: Fixed long tap gesture on rubric ratings in SpeedGrader.

test plan:
- As the teacher create an assignment that has a rubric associated to it.
- Log in to the Canvas Teacher app on an iOS device.
- Open the assignment.
- Navigate to the Submissions section and select a student to grade.
- Swipe up to open the grade details section.
- Tap and hold on one of the rubric ratings.
- The rating's title should be revealed.

## Checklist

- [ ] Tested on iOS 17
- [ ] Tested on iOS 18
