### PR TITLE
Accessibility - All Apps - Menu Button - Add closed state

### DIFF
--- a/Core/Core/Features/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Features/Dashboard/Container/View/DashboardContainerView.swift
@@ -137,6 +137,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         .frame(width: 44, height: 44).padding(.leading, -6)
         .identifier("Dashboard.profileButton")
         .accessibility(label: Text("Profile Menu", bundle: .core))
+        .accessibilityValue(Text("Closed", bundle: .core))
     }
 
     @ViewBuilder

--- a/Core/Core/Features/Dashboard/Container/View/DashboardContainerView.swift
+++ b/Core/Core/Features/Dashboard/Container/View/DashboardContainerView.swift
@@ -136,8 +136,7 @@ public struct DashboardContainerView: View, ScreenViewTrackable {
         }
         .frame(width: 44, height: 44).padding(.leading, -6)
         .identifier("Dashboard.profileButton")
-        .accessibility(label: Text("Profile Menu", bundle: .core))
-        .accessibilityValue(Text("Closed", bundle: .core))
+        .accessibility(label: Text("Profile Menu, Closed", bundle: .core, comment: "Accessibility text describing the Profile Menu button and its state"))
     }
 
     @ViewBuilder

--- a/Core/Core/Features/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Features/Dashboard/K5/View/K5DashboardView.swift
@@ -56,8 +56,9 @@ public struct K5DashboardView: View {
                 Image.hamburgerSolid
                     .foregroundColor(Color(Brand.shared.navTextColor))
             })
-                .identifier("Dashboard.profileButton")
-                .accessibility(label: Text("Profile Menu", bundle: .core))
+            .identifier("Dashboard.profileButton")
+            .accessibility(label: Text("Profile Menu", bundle: .core))
+            .accessibilityValue(Text("Closed", bundle: .core))
         )
     }
 

--- a/Core/Core/Features/Dashboard/K5/View/K5DashboardView.swift
+++ b/Core/Core/Features/Dashboard/K5/View/K5DashboardView.swift
@@ -57,8 +57,7 @@ public struct K5DashboardView: View {
                     .foregroundColor(Color(Brand.shared.navTextColor))
             })
             .identifier("Dashboard.profileButton")
-            .accessibility(label: Text("Profile Menu", bundle: .core))
-            .accessibilityValue(Text("Closed", bundle: .core))
+            .accessibility(label: Text("Profile Menu, Closed", bundle: .core, comment: "Accessibility text describing the Profile Menu button and its state"))
         )
     }
 

--- a/Core/Core/Features/Inbox/View/InboxView.swift
+++ b/Core/Core/Features/Inbox/View/InboxView.swift
@@ -213,8 +213,7 @@ public struct InboxView: View, ScreenViewTrackable {
         }
         .frame(width: 44, height: 44).padding(.leading, -6)
         .identifier("Inbox.profileButton")
-        .accessibility(label: Text("Profile Menu", bundle: .core))
-        .accessibilityValue(Text("Closed", bundle: .core))
+        .accessibility(label: Text("Profile Menu, Closed", bundle: .core, comment: "Accessibility text describing the Profile Menu button and its state"))
     }
 
     private var newMessageButton: some View {

--- a/Core/Core/Features/Inbox/View/InboxView.swift
+++ b/Core/Core/Features/Inbox/View/InboxView.swift
@@ -214,6 +214,7 @@ public struct InboxView: View, ScreenViewTrackable {
         .frame(width: 44, height: 44).padding(.leading, -6)
         .identifier("Inbox.profileButton")
         .accessibility(label: Text("Profile Menu", bundle: .core))
+        .accessibilityValue(Text("Closed", bundle: .core))
     }
 
     private var newMessageButton: some View {

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -69,6 +69,7 @@ public class PlannerViewController: UIViewController {
 
         profileButton.accessibilityIdentifier = "PlannerCalendar.profileButton"
         profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .core)
+        profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
 
         addButton.target = self
         addButton.action = nil

--- a/Core/Core/Features/Todos/TodoListViewController.swift
+++ b/Core/Core/Features/Todos/TodoListViewController.swift
@@ -66,6 +66,7 @@ public class TodoListViewController: ScreenViewTrackableViewController, ErrorVie
         errorView.retryButton.addTarget(self, action: #selector(refresh), for: .primaryActionTriggered)
 
         profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .core)
+        profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
 
         tableView.backgroundColor = .backgroundLightest
         tableView.refreshControl = CircleRefreshControl()

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -146,6 +146,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
     func updateBadgeCount() {
         profileButton.addBadge(number: badgeCount, color: currentColor)
         profileButton.accessibilityLabel = String(localized: "Settings", bundle: .parent)
+        profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
         if badgeCount > 0 {
             profileButton.accessibilityHint = String.localizedStringWithFormat(
                 String(localized: "conversation_unread_messages", bundle: .core),

--- a/Parent/Parent/Localizable.xcstrings
+++ b/Parent/Parent/Localizable.xcstrings
@@ -3587,6 +3587,9 @@
         }
       }
     },
+    "Closed" : {
+
+    },
     "Compose Message" : {
       "localizations" : {
         "ar" : {

--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -32283,6 +32283,9 @@
         }
       }
     },
+    "Closed" : {
+
+    },
     "Closed for Comments" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -93917,6 +93920,9 @@
           }
         }
       }
+    },
+    "Profile Menu" : {
+
     },
     "Questions:" : {
       "localizations" : {

--- a/Student/Student/Notifications/ActivityStreamViewController.swift
+++ b/Student/Student/Notifications/ActivityStreamViewController.swift
@@ -73,6 +73,8 @@ class ActivityStreamViewController: ScreenViewTrackableViewController {
         setupTableView()
         emptyStateHeader.text = String(localized: "No Notifications", bundle: .student)
         emptyStateSubHeader.text = String(localized: "There's nothing to be notified of yet.", bundle: .student)
+        profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .core)
+        profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
         refreshData()
     }
 


### PR DESCRIPTION
- I only added the closed state to the menu button because when the menu is opened the button is not reachable so its closed state would be never heard.
- I tried to re-use strings from the Core project in Parent and Student but despite I added the Core bundle it still got localized in those projects.

refs: [MBL-18372](https://instructure.atlassian.net/browse/MBL-18372)
affects: Student, Teacher, Parent
release note: none

test plan:
- Test if profile button on all tabs announce its closed state.

[MBL-18372]: https://instructure.atlassian.net/browse/MBL-18372?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ