### PR TITLE
Accessibility - Teacher - Submissions List - Make traits explicit

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/FilterHeaderView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/FilterHeaderView.swift
@@ -38,12 +38,14 @@ public class FilterHeaderView: UITableViewHeaderFooterView {
         titleLabel.textColor = .textDarkest
         titleLabel.font = .scaledNamedFont(.heavy24)
         titleLabel.numberOfLines = 2
+        titleLabel.accessibilityTraits = [ .header ]
         contentView.addSubview(titleLabel)
         titleLabel.pin(inside: contentView, leading: 16, trailing: nil, top: 16, bottom: 8)
         filterButton.setTitle(String(localized: "Filter", bundle: .core), for: .normal)
         filterButton.setTitleColor(Brand.shared.linkColor, for: .normal)
         filterButton.titleLabel?.font = .scaledNamedFont(.medium16)
         filterButton.translatesAutoresizingMaskIntoConstraints = false
+        filterButton.accessibilityTraits = [ .button ]
         contentView.addSubview(filterButton)
         NSLayoutConstraint.activate([
             filterButton.firstBaselineAnchor.constraint(equalTo: titleLabel.firstBaselineAnchor),


### PR DESCRIPTION
- When submissions list was opened for the first time neither the label nor the header had the heading trait.
- I was able to get the header trait on the filter button by opening the filter screen and closing it with done.
- I think because this view was used as a header in a tableview this caused it to get the heading label on all subviews.
- Adding traits explicitly seemed to solved the issue.

refs: [MBL-18342](https://instructure.atlassian.net/browse/MBL-18342)
affects: Teacher
release note: none

test plan:
- Make sure filter button on submissions list never has heading trait.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet


[MBL-18342]: https://instructure.atlassian.net/browse/MBL-18342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ