### PR TITLE
Accessibility - Student - Submissions Comments - Add title to media attachment type picker

### DIFF
--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -103044,6 +103044,9 @@
         }
       }
     },
+    "Select Attachment Type" : {
+
+    },
     "Select file(s)" : {
       "comment" : "Title for a file picker window",
       "extractionState" : "manual",

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -96,7 +96,8 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
     }
 
     @IBAction func addMediaButtonPressed(_ sender: UIButton) {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        let title = String(localized: "Select Attachment Type", bundle: .student)
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .actionSheet)
         alert.addAction(AlertAction(String(localized: "Record Audio", bundle: .student), style: .default) { _ in
             AudioRecorderViewController.requestPermission { [weak self] allowed in
                 guard let self = self else { return }


### PR DESCRIPTION
- The ticket wanted voiceover to announce this action sheet as a list but this is a `UIAlertController` which isn't configurable in terms of accessibility so I added a title there to make it more explicit that there's a list of options to choose from.

refs: [MBL-18389](https://instructure.atlassian.net/browse/MBL-18389)
affects: Student
release note: none

test plan:
- Check if the "Add media attachment" button has a title on the submission comment screen.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product


[MBL-18389]: https://instructure.atlassian.net/browse/MBL-18389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ