### PR TITLE
Accessibility - Parent - Course Details - Remove heading trait from course tab button

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/HorizontalMenuViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/HorizontalMenuViewController.swift
@@ -183,7 +183,7 @@ extension HorizontalMenuViewController: UICollectionViewDataSource, UICollection
             cell.title?.textColor = delegate?.menuItemDefaultColor
             cell.selectionColor = delegate?.menuItemSelectedColor
             cell.isAccessibilityElement = true
-            cell.accessibilityTraits = [.button, .header]
+            cell.accessibilityTraits = [.button]
             cell.accessibilityIdentifier = delegate?.accessibilityIdentifier(at: indexPath)
             cell.accessibilityLabel = cell.title?.text
             if indexPath == selectedIndexPath {


### PR DESCRIPTION
refs: [MBL-18414](https://instructure.atlassian.net/browse/MBL-18414)
affects: Parent
release note: none

test plan:
- Ensure course tab buttons don't have heading trait.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet


[MBL-18414]: https://instructure.atlassian.net/browse/MBL-18414?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ