### PR TITLE
Accessibility - Teacher - Add send action announcements to SpeedGrader send comment button

### DIFF
--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -28516,6 +28516,9 @@
         }
       }
     },
+    "Sent successfully" : {
+
+    },
     "Similarity Score" : {
       "localizations" : {
         "ar" : {

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -188,8 +188,12 @@ struct SubmissionCommentList: View {
             attempt: commentAttempt
         ).fetch { comment, error in
             if error != nil || comment == nil {
+                let genericErrorMessage = String(localized: "Could not save the comment.", bundle: .teacher)
                 self.comment = text
-                self.error = error.map { Text($0.localizedDescription) } ?? Text("Could not save the comment.", bundle: .teacher)
+                self.error = error.map { Text($0.localizedDescription) } ?? Text(genericErrorMessage)
+                UIAccessibility.announce(genericErrorMessage)
+            } else {
+                UIAccessibility.announce(String(localized: "Sent successfully", bundle: .teacher))
             }
         }
     }


### PR DESCRIPTION
refs: [MBL-18471](https://instructure.atlassian.net/browse/MBL-18471)
affects: Teacher
release note: none

test plan:
- Check if sending a comment from SpeedGrader announce the failure and success result of the sending.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet

[MBL-18471]: https://instructure.atlassian.net/browse/MBL-18471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ