### PR TITLE
Accessibility - Student /Teacher - Focus on Events List when Calendar Day gets Selected, Focus on Calendar Day Button when "Go to Today" is tapped

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
@@ -28,18 +28,13 @@ public extension Array {
     }
 
     subscript(safeIndex index: Int) -> Element? {
-        guard index < count else {
+        guard index < count && index >= 0 else {
             return nil
         }
         return self[index]
     }
 
     var nilIfEmpty: Self? { isEmpty ? nil : self }
-
-    subscript(safe index: Int) -> Element? {
-        guard (0 ..< count).contains(index) else { return nil }
-        return self[index]
-    }
 }
 
 public extension Array where Element: Equatable {

--- a/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/ArrayExtensions.swift
@@ -35,6 +35,11 @@ public extension Array {
     }
 
     var nilIfEmpty: Self? { isEmpty ? nil : self }
+
+    subscript(safe index: Int) -> Element? {
+        guard (0 ..< count).contains(index) else { return nil }
+        return self[index]
+    }
 }
 
 public extension Array where Element: Equatable {

--- a/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
@@ -158,6 +158,20 @@ class CalendarDaysViewController: UIViewController {
         }
     }
 
+    func selectedDayButton() -> CalendarDayButton? {
+        guard let week = weeksStackView.arrangedSubviews[safe: selectedWeekIndex]
+        else { return nil }
+        return week
+            .subviews
+            .compactMap({ $0 as? CalendarDayButton })
+            .first(where: { $0.isSelected })
+    }
+
+    func accessibilityFocusOnSelectedButton() {
+        guard let day = selectedDayButton() else { return }
+        UIAccessibility.post(notification: .screenChanged, argument: day)
+    }
+
     func midDate(isExpanded: Bool) -> Date {
         let week = isExpanded
             ? weeksStackView.arrangedSubviews[weeksStackView.arrangedSubviews.count / 2]

--- a/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
@@ -159,7 +159,7 @@ class CalendarDaysViewController: UIViewController {
     }
 
     func selectedDayButton() -> CalendarDayButton? {
-        guard let week = weeksStackView.arrangedSubviews[safe: selectedWeekIndex]
+        guard let week = weeksStackView.arrangedSubviews[safeIndex: selectedWeekIndex]
         else { return nil }
         return week
             .subviews

--- a/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarViewController.swift
@@ -213,6 +213,10 @@ class CalendarViewController: ScreenViewTrackableViewController {
         updateSelectedDate(date)
     }
 
+    func accessibilityFocusOnSelectedButton() {
+        days.accessibilityFocusOnSelectedButton()
+    }
+
     func animateMonthTitle(_ title: String) {
         let duration: TimeInterval = 0.185
         UIView.animate(withDuration: duration, animations: {

--- a/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
@@ -39,7 +39,7 @@ public class PlannerListViewController: UIViewController {
     var end: Date = Clock.now.startOfDay().addDays(1) // exclusive
 
     private var selectedPlannableId: String?
-    private var needsRowAccessibilityFocus: Bool = false
+    private var needsDetailsAccessibilityFocus: Bool = false
 
     var plannables: Store<GetPlannables>?
 
@@ -104,22 +104,36 @@ public class PlannerListViewController: UIViewController {
         errorView.isHidden = plannables?.error == nil
         tableView.reloadData()
         reselectRowAfterReload()
-        accessibilityFocusOnRowIfNeeded()
+        accessibilityFocusOnDetailsIfNeeded()
     }
 
-    func setNeedsRowAccessibilityFocus() {
-        needsRowAccessibilityFocus = true
+    func setNeedsDetailsAccessibilityFocus() {
+        needsDetailsAccessibilityFocus = true
     }
 
-    func accessibilityFocusOnRowIfNeeded() {
-        guard needsRowAccessibilityFocus else { return }
-        accessibilityFocusOnDefaultRow()
-        needsRowAccessibilityFocus = false
+    func accessibilityFocusOnDetailsIfNeeded() {
+        guard needsDetailsAccessibilityFocus else { return }
+        accessibilityFocusOnDetails()
+        needsDetailsAccessibilityFocus = false
     }
 
-    func accessibilityFocusOnDefaultRow() {
-        let cell = tableView.cellForRow(at: indexPathForRowToFocusOn)
-        UIAccessibility.post(notification: .screenChanged, argument: cell)
+    func accessibilityFocusOnDetails() {
+        if emptyStateView.isHidden {
+            accessibilityFocusOnDefaultRow()
+        } else {
+            let message = String(localized: "No Events Today!", bundle: .core)
+            UIAccessibility.announce(message)
+        }
+    }
+
+    private func accessibilityFocusOnDefaultRow() {
+        /// Calling this on main queue with a duration to avoid any
+        /// possible interruption caused by cell reloading or selection
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+            guard let self else { return }
+            let cell = tableView.cellForRow(at: indexPathForRowToFocusOn)
+            UIAccessibility.post(notification: .screenChanged, argument: cell)
+        }
     }
 
     private func reselectRowAfterReload() {

--- a/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
@@ -37,7 +37,9 @@ public class PlannerListViewController: UIViewController {
     let env = AppEnvironment.shared
     var start: Date = Clock.now.startOfDay() // inclusive
     var end: Date = Clock.now.startOfDay().addDays(1) // exclusive
+
     private var selectedPlannableId: String?
+    private var needsRowAccessibilityFocus: Bool = false
 
     var plannables: Store<GetPlannables>?
 
@@ -102,6 +104,22 @@ public class PlannerListViewController: UIViewController {
         errorView.isHidden = plannables?.error == nil
         tableView.reloadData()
         reselectRowAfterReload()
+        accessibilityFocusOnRowIfNeeded()
+    }
+
+    func setNeedsRowAccessibilityFocus() {
+        needsRowAccessibilityFocus = true
+    }
+
+    func accessibilityFocusOnRowIfNeeded() {
+        guard needsRowAccessibilityFocus else { return }
+        accessibilityFocusOnDefaultRow()
+        needsRowAccessibilityFocus = false
+    }
+
+    func accessibilityFocusOnDefaultRow() {
+        let cell = tableView.cellForRow(at: indexPathForRowToFocusOn)
+        UIAccessibility.post(notification: .screenChanged, argument: cell)
     }
 
     private func reselectRowAfterReload() {
@@ -113,6 +131,14 @@ public class PlannerListViewController: UIViewController {
 
         let indexPath = IndexPath(row: index, section: 0)
         tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+    }
+
+    private var indexPathForRowToFocusOn: IndexPath {
+        if let selectedPlannableId,
+           let index = plannables?.all.firstIndex(where: { $0.id == selectedPlannableId }) {
+            return IndexPath(row: index, section: 0)
+        }
+        return IndexPath(row: 0, section: 0)
     }
 }
 

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -275,10 +275,10 @@ extension PlannerViewController: CalendarViewControllerDelegate {
         updateList(
             date,
             unchanged: { listController in
-                listController?.accessibilityFocusOnDefaultRow()
+                listController?.accessibilityFocusOnDetails()
             },
             created: { listController in
-                listController.setNeedsRowAccessibilityFocus()
+                listController.setNeedsDetailsAccessibilityFocus()
             }
         )
     }

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -241,12 +241,18 @@ public class PlannerViewController: UIViewController {
     }
 
     func updateList(_ date: Date) {
-        guard !calendar.calendar.isDate(date, inSameDayAs: list.start) else { return }
+        guard !calendar.calendar.isDate(date, inSameDayAs: list.start) else {
+            (listPageController.currentPage as? PlannerListViewController)?
+                .accessibilityFocusOnDefaultRow()
+            return
+        }
+
         let newList = PlannerListViewController.create(
             start: date.startOfDay(),
             end: date.startOfDay().addDays(1),
             delegate: self
         )
+        newList.setNeedsRowAccessibilityFocus()
         newList.loadViewIfNeeded()
         newList.tableView.contentInset = list.tableView.contentInset
         listPageController.setCurrentPage(newList, direction: date < list.start ? .reverse : .forward)


### PR DESCRIPTION
refs: MBL-18323, MBL-18327
affects: Student, Teacher
release note: None.

## Test Plan

In Teacher or Student app,
1- Go to "Calendar" tab
2- Select day on Calendar.
3- Double tap on it with VoiceOver turned on.
4- Make sure focus is moved to the first or selected row of that day events list

5- With VoiceOver On, Tap on "Go to today" button on the top-right corner of Calendar tab screen.
6- Make sure focus is moved to calendar day button of today's date.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
