### PR TITLE
Accessibility - Teacher/Student - Add discussion save announcement

### DIFF
--- a/Core/Core/Features/Discussions/Editor/ViewModel/DiscussionCreateWebViewModel.swift
+++ b/Core/Core/Features/Discussions/Editor/ViewModel/DiscussionCreateWebViewModel.swift
@@ -25,6 +25,7 @@ public struct DiscussionCreateWebViewModel: EmbeddedWebPageViewModel {
 
     private let router: Router
     private let newDiscussionPushSource: UIViewController?
+    private let isAnnouncement: Bool
 
     /// - parameters:
     ///   - newDiscussionPushSource: If this variable is present then after creating a discussion,
@@ -41,6 +42,7 @@ public struct DiscussionCreateWebViewModel: EmbeddedWebPageViewModel {
                                     : []
         self.router = router
         self.newDiscussionPushSource = newDiscussionPushSource
+        self.isAnnouncement = isAnnouncement
     }
 
     public func leadingNavigationButton(host: UIViewController) -> InstUI.NavigationBarButton? {
@@ -94,10 +96,18 @@ public struct DiscussionCreateWebViewModel: EmbeddedWebPageViewModel {
         }
 
         router.dismiss(webViewController) { [router, newDiscussionPushSource] in
+            announceDiscussionCreated()
+
             if let newDiscussionPushSource {
                 router.route(to: discussionUrl, from: newDiscussionPushSource, options: .detail)
             }
         }
+    }
+
+    private func announceDiscussionCreated() {
+        let message = isAnnouncement ? String(localized: "Announcement created", bundle: .core)
+                                     : String(localized: "Discussion created", bundle: .core)
+        UIAccessibility.announce(message)
     }
 }
 


### PR DESCRIPTION
- The ticket was about saving and edited discussion but since that is a webview we can't improve it from our side.
- Instead I added an announcement to the end of the creation flow when we dismiss the create dialog.

refs: [MBL-18423](https://instructure.atlassian.net/browse/MBL-18423)
affects: Teacher, Student
release note: none

test plan:
- Create a new discussion and announcement.
- Check if the correct announcement is made after a successful save.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet


[MBL-18423]: https://instructure.atlassian.net/browse/MBL-18423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ