### PR TITLE
Accessibility - Student /Teacher - Typehead Suggestions for Message Recipients searching

### DIFF
--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
@@ -67,13 +67,26 @@ class AddressbookRecipientViewModel: ObservableObject {
         Just(allRecipient)
             .combineLatest(searchText)
             .map { (recipients, searchText) in
-                recipients.filter { recipient in
+
+                let foundResults = recipients.filter { recipient in
                     if searchText.isEmpty {
                         true
                     } else {
                         recipient.displayName.lowercased().contains(searchText.lowercased())
                     }
                 }
+
+                if searchText.isNotEmpty {
+                    let message = foundResults.isEmpty
+                        ? String(localized: "No results found", bundle: .core)
+                        : String(
+                            format: String(localized: "%i results found!", bundle: .core),
+                            foundResults.count
+                        )
+                    UIAccessibility.post(notification: .announcement, argument: message)
+                }
+
+                return foundResults
             }
             .assign(to: &$recipients)
 

--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
@@ -77,13 +77,9 @@ class AddressbookRecipientViewModel: ObservableObject {
                 }
 
                 if searchText.isNotEmpty {
-                    let message = foundResults.isEmpty
-                        ? String(localized: "No results found", bundle: .core)
-                        : String(
-                            format: String(localized: "%i results found!", bundle: .core),
-                            foundResults.count
-                        )
-                    UIAccessibility.post(notification: .announcement, argument: message)
+                    let format = String(localized: "d_results_found", bundle: .core)
+                    let message = String.localizedStringWithFormat(format, foundResults.count)
+                    UIAccessibility.announce(message)
                 }
 
                 return foundResults

--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
@@ -98,13 +98,25 @@ class AddressbookRoleViewModel: ObservableObject {
             }
             .combineLatest(searchText)
             .map { (recipients, searchText) in
-                recipients.filter { recipient in
+                let foundResults = recipients.filter { recipient in
                     if searchText.isEmpty {
                         true
                     } else {
                         recipient.displayName.lowercased().contains(searchText.lowercased())
                     }
                 }
+
+                if searchText.isNotEmpty {
+                    let message = foundResults.isEmpty
+                        ? String(localized: "No results found", bundle: .core)
+                        : String(
+                            format: String(localized: "%i results found!", bundle: .core),
+                            foundResults.count
+                        )
+                    UIAccessibility.post(notification: .announcement, argument: message)
+                }
+
+                return foundResults
             }
             .assign(to: &$recipients)
 

--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
@@ -98,6 +98,7 @@ class AddressbookRoleViewModel: ObservableObject {
             }
             .combineLatest(searchText)
             .map { (recipients, searchText) in
+
                 let foundResults = recipients.filter { recipient in
                     if searchText.isEmpty {
                         true
@@ -107,13 +108,9 @@ class AddressbookRoleViewModel: ObservableObject {
                 }
 
                 if searchText.isNotEmpty {
-                    let message = foundResults.isEmpty
-                        ? String(localized: "No results found", bundle: .core)
-                        : String(
-                            format: String(localized: "%i results found!", bundle: .core),
-                            foundResults.count
-                        )
-                    UIAccessibility.post(notification: .announcement, argument: message)
+                    let format = String(localized: "d_results_found", bundle: .core)
+                    let message = String.localizedStringWithFormat(format, foundResults.count)
+                    UIAccessibility.announce(message)
                 }
 
                 return foundResults


### PR DESCRIPTION
refs: MBL-18353
affects: Student, Teacher
release note: None.

## Test Plan

- Go to Inbox in Teacher or Student app.
- Start a new message by tapping on "+" button. This will show "compose message" form.
- Select course, then hit "+" button shown on the side of "To" field.
- With VoiceOver turned On, start typing on search field of the shown screen.
   Also, you can tap on one of the shown roles, then starting search on that sub-screen as well.
- For both screens, when searching a message about results found must be read out as you typing. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
