### PR TITLE
Accessibility - Student - Announce successful comment sending

### DIFF
--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -33331,6 +33331,9 @@
         }
       }
     },
+    "Comment sent successfully" : {
+
+    },
     "Comments" : {
       "comment" : "View comments",
       "localizations" : {

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsPresenter.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsPresenter.swift
@@ -97,6 +97,8 @@ class SubmissionCommentsPresenter: SubmissionCommentAttemptDelegate {
         ).fetch { [weak self] comment, error in
             if error != nil || comment == nil {
                 self?.view?.showError(error ?? NSError.instructureError(String(localized: "Could not save the comment", bundle: .student)))
+            } else {
+                UIAccessibility.announce(String(localized: "Comment sent successfully", bundle: .student))
             }
         }
     }


### PR DESCRIPTION
refs: [MBL-18380](https://instructure.atlassian.net/browse/MBL-18380)
affects: Student
release note: none

test plan:
- Send a comment successfully for a submission attempt.
- Voiceover should announce if the comment was sent successfully.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet

[MBL-18380]: https://instructure.atlassian.net/browse/MBL-18380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ