### PR TITLE
Accessibility - Student/Teacher - ProfileMenu Settings headers and lists

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/GroupedSectionHeaderView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/GroupedSectionHeaderView.swift
@@ -32,12 +32,26 @@ public class GroupedSectionHeaderView: UITableViewHeaderFooterView {
         setup()
     }
 
-    func setup() {
+    private func setup() {
         backgroundView = UIView()
         backgroundView?.backgroundColor = .backgroundLightest
         titleLabel.textColor = .textDark
         titleLabel.font = .scaledNamedFont(.semibold12)
         contentView.addSubview(titleLabel)
         titleLabel.pin(inside: contentView, leading: 16, trailing: 16, top: 16, bottom: 6)
+        accessibilityTraits = [.header]
+    }
+
+    public override func prepareForReuse() {
+        super.prepareForReuse()
+        titleLabel.text = nil
+        accessibilityLabel = nil
+    }
+
+    /// Use this method instead of setting `titleLabel.text` directly
+    public func update(title: String, itemCount: Int) {
+        titleLabel.text = title
+        let countText = String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), itemCount)
+        accessibilityLabel = "\(title), \(countText)"
     }
 }

--- a/Core/Core/Common/CommonUI/UIViews/GroupedSectionHeaderView.swift
+++ b/Core/Core/Common/CommonUI/UIViews/GroupedSectionHeaderView.swift
@@ -51,7 +51,7 @@ public class GroupedSectionHeaderView: UITableViewHeaderFooterView {
     /// Use this method instead of setting `titleLabel.text` directly
     public func update(title: String, itemCount: Int) {
         titleLabel.text = title
-        let countText = String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), itemCount)
+        let countText = String.localizedNumberOfItems(itemCount)
         accessibilityLabel = "\(title), \(countText)"
     }
 }

--- a/Core/Core/Common/CommonUI/UIViews/ItemPickerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/ItemPickerViewController.swift
@@ -80,11 +80,16 @@ public class ItemPickerViewController: UIViewController {
         tableView.backgroundColor = .backgroundGrouped
         tableView.dataSource = self
         tableView.delegate = self
+        tableView.registerHeaderFooterView(GroupedSectionHeaderView.self, fromNib: false)
         tableView.registerCell(RightDetailTableViewCell.self)
         tableView.registerCell(SubtitleTableViewCell.self)
         tableView.separatorColor = .borderMedium
         tableView.separatorInset = .zero
         tableView.tintColor = Brand.shared.primary
+
+        tableView.isAccessibilityElement = true
+        let countText = String.localizedNumberOfItems(sections[0].items.count)
+        tableView.accessibilityLabel = "\(String(localized: "List", bundle: .core)), \(countText)"
     }
 }
 
@@ -93,8 +98,17 @@ extension ItemPickerViewController: UITableViewDataSource, UITableViewDelegate {
         return sections.count
     }
 
-    public func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        return sections[section].title
+    public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        guard let sectionTitle = sections[section].title else { return nil }
+
+        let header: GroupedSectionHeaderView = tableView.dequeueHeaderFooter()
+        let section = sections[section]
+        header.update(title: sectionTitle, itemCount: section.items.count)
+        return header
+    }
+
+    public func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        return (section == 0 && sections[section].title == nil) ? 0 : UITableView.automaticDimension
     }
 
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
@@ -81,7 +81,6 @@ extension String {
      */
     public var boolValue: Bool {
         return (self as NSString).boolValue
-
     }
 
     public var nilIfEmpty: String? {
@@ -125,6 +124,11 @@ extension String {
             throw NSError.instructureError("Failed to convert string to data using encoding \(encoding).")
         }
         return data
+    }
+
+    /// Localized string to be used when we need number of items. Example: "5 items"
+    public static func localizedNumberOfItems(_ count: Int) -> String {
+        String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), count)
     }
 }
 

--- a/Core/Core/Features/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Features/Files/View/FileList/FileListViewController.swift
@@ -524,10 +524,7 @@ class FileListCell: UITableViewCell {
         if let folder = item?.folder {
             iconView.icon = .folderSolid
             iconView.setState(locked: folder.locked, hidden: folder.hidden, unlockAt: folder.unlockAt, lockAt: folder.lockAt)
-            let sizeText = String.localizedStringWithFormat(
-                String(localized: "d_items", bundle: .core),
-                folder.filesCount + folder.foldersCount
-            )
+            let sizeText = String.localizedNumberOfItems(folder.filesCount + folder.foldersCount)
             sizeLabel.setText(sizeText, style: .textCellSupportingText)
             updateAccessibilityLabel()
             return

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -320,7 +320,7 @@ public struct GradeListView: View, ScreenViewTrackable {
 
         LazyVStack(spacing: 0, pinnedViews: .sectionHeaders) {
             ForEach(assignmentSections, id: \.id) { section in
-                let itemCountLabel = String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), section.assignments.count)
+                let itemCountLabel = String.localizedNumberOfItems(section.assignments.count)
                 AssignmentSection {
                     VStack(spacing: 0) {
                         listSectionView(title: section.title)

--- a/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
@@ -71,6 +71,11 @@ class NotificationCategoriesViewController: UIViewController, ErrorViewControlle
         refresh()
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: tableView)
+    }
+
     @objc func refresh(sender: Any? = nil) {
         let force = sender != nil
         categories.refresh(force: force)
@@ -154,7 +159,8 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         guard isNotificationsEnabled else { return nil }
         let header: GroupedSectionHeaderView = tableView.dequeueHeaderFooter()
-        header.titleLabel.text = sections[section].name
+        let section = sections[section]
+        header.update(title: section.name, itemCount: section.rows.count)
         return header
     }
 

--- a/Core/Core/Features/Profile/Settings/NotificationChannelsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationChannelsViewController.swift
@@ -62,6 +62,11 @@ class NotificationChannelsViewController: UIViewController {
         refresh()
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        UIAccessibility.post(notification: .screenChanged, argument: tableView)
+    }
+
     @objc func refresh(sender: Any? = nil) {
         channels.exhaust(while: { _ in true })
     }

--- a/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
@@ -313,7 +313,8 @@ extension ProfileSettingsViewController: UITableViewDataSource, UITableViewDeleg
 
     public func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         let header: GroupedSectionHeaderView = tableView.dequeueHeaderFooter()
-        header.titleLabel.text = sections[section].title
+        let section = sections[section]
+        header.update(title: section.title, itemCount: section.rows.count)
         return header
     }
 

--- a/Core/Core/Features/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
+++ b/Core/Core/Features/SubmitAssignmentExtension/View/SubmitAssignmentExtensionView.swift
@@ -214,7 +214,7 @@ public struct SubmitAssignmentExtensionView: View {
 
     private var filesSection: some View {
         VStack(alignment: .leading, spacing: 0) {
-            Text(String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), viewModel.previews.count))
+            Text(String.localizedNumberOfItems(viewModel.previews.count))
                 .font(.regular12)
                 .foregroundColor(.textDark)
             ScrollView(.horizontal, showsIndicators: false) {

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -83,4 +83,10 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(results.first, "<iframe param=1>content</iframe>")
         XCTAssertEqual(results.last, "<iframe></iframe>")
     }
+
+    func testLocalizedNumberOfItems() {
+        XCTAssertEqual(String.localizedNumberOfItems(1), "1 item")
+        XCTAssertEqual(String.localizedNumberOfItems(5), "5 items")
+        XCTAssertEqual(String.localizedNumberOfItems(0), "0 items")
+    }
 }


### PR DESCRIPTION
refs: [MBL-18337](https://instructure.atlassian.net/browse/MBL-18337)
affects: Student, Teacher
release note: none

## What's changed
- In ProfileMenu Settings
  - all section headers now have `header` trait
  - all section headers read the number of rows, like "Preferences, 4 items, Heading"
- In all ItemPicker screens:
  -  read the number of rows together with the first row, like: "List, 5 items, selected, Dashboard, Button"
    - it's strange but this seems to be the default behavior for UITableView when it's a11y label is provided
  - removed the empty gap above the section

NOTE: `ItemPickerViewController` is not fully improved to support multiple sections with or without titles, because it's always used with a single section, without title. It would be extra work and we won't create new screens using it, as UIKit is being phased out in the project.

## Test plan
- Verify section headers in ProfileMenu Settings works as described above 
- Verify some ItemPicker screens works as described above. Some examples:
  - any such screen in ProfileMenu Settings
  - Teacher > Course Settings > Set Home to
  - Files > File Details > Edit > Access

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product

[MBL-18337]: https://instructure.atlassian.net/browse/MBL-18337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ