### PR TITLE
Accessibility - Student - Focus voiceover on sync progress card

### DIFF
--- a/Core/Core/Features/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
+++ b/Core/Core/Features/Dashboard/OfflineSync/View/DashboardOfflineSyncProgressCardView.swift
@@ -21,6 +21,7 @@ import SwiftUI
 struct DashboardOfflineSyncProgressCardView: View {
     @Environment(\.viewController) private var viewController
     @ObservedObject private var viewModel: DashboardOfflineSyncProgressCardViewModel
+    @AccessibilityFocusState private var isProgressCardFocused: Bool
 
     public init(viewModel: DashboardOfflineSyncProgressCardViewModel) {
         self.viewModel = viewModel
@@ -36,6 +37,10 @@ struct DashboardOfflineSyncProgressCardView: View {
             case let .progress(progress, progressText):
                 containerCard(backgroundColor: Color.backgroundDarkest) {
                     progressView(progress, progressText)
+                }
+                .accessibilityFocused($isProgressCardFocused)
+                .onAppear {
+                    isProgressCardFocused = true
                 }
             case .hidden:
                 SwiftUI.EmptyView()


### PR DESCRIPTION
- The ticket's suggestion to announce "Sync successfully" after the user confirmed the sync start is misleading so instead I focus on the sync progress card that announces that the sync have been started and also about progress updates.

refs: [MBL-18375](https://instructure.atlassian.net/browse/MBL-18375)
affects: Student
release note: none

test plan:
- Start an offline sync.
- Voiceover focus should jump to the sync progress card after modals have been dismissed and shuld announce what's happening.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
