### PR TITLE
Accessibility - Student - Announce recipient removal

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -320,6 +320,7 @@ final class ComposeMessageViewModel: ObservableObject {
             .sink { [weak self] recipient in
                 self?.allRecipients.value.append(recipient)
                 self?.selectedRecipients.value.removeAll { $0 == recipient }
+                UIAccessibility.announce(String(localized: "Removed successfully", bundle: .core))
             }
             .store(in: &subscriptions)
 


### PR DESCRIPTION
refs: [MBL-18364](https://instructure.atlassian.net/browse/MBL-18364)
affects: Student, Teacher
release note: none

test plan:
- On the inbox compose screen remove a previously added search recipient by double tapping on it.
- Voiceover should announce the successful removal.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet