### PR TITLE
Accessibility - Chat/Inbox - Add title to attachment picker

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/BottomSheetPickerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/BottomSheetPickerViewController.swift
@@ -37,26 +37,12 @@ public class BottomSheetPickerViewController: UIViewController {
 
     public override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
 
-    public static func create(title: String? = nil) -> BottomSheetPickerViewController {
+    public static func create() -> BottomSheetPickerViewController {
         let controller = BottomSheetPickerViewController()
         controller.modalPresentationStyle = .custom
         controller.modalPresentationCapturesStatusBarAppearance = true
         controller.transitioningDelegate = BottomSheetTransitioningDelegate.shared
-        if let title {
-            controller.addTitle(title)
-        }
         return controller
-    }
-
-    private func addTitle(_ title: String) {
-        loadViewIfNeeded()
-        titleLabel.font = .scaledNamedFont(.regular14)
-        titleLabel.textColor = .textDark
-        titleLabel.textAlignment = .center
-        titleLabel.text = title
-        titleLabel.accessibilityLabel = title
-        titleLabel.accessibilityTraits = .header
-        mainStackView.insertArrangedSubview(titleLabel, at: 0)
     }
 
     public override func viewDidLoad() {
@@ -64,9 +50,21 @@ public class BottomSheetPickerViewController: UIViewController {
         view.backgroundColor = UIColor {
             $0.isDarkInterface ? .backgroundLight : .backgroundLightest
         }
+
+        // Adding title
+        titleLabel.font = .scaledNamedFont(.regular14)
+        titleLabel.textColor = .textDark
+        titleLabel.textAlignment = .center
+        titleLabel.text = title
+        titleLabel.accessibilityLabel = title
+        titleLabel.accessibilityTraits = .header
+        mainStackView.addArrangedSubview(titleLabel)
+
+        // Adding stack of buttons
         mainStackView.addArrangedSubview(stackView)
         stackView.axis = .vertical
 
+        // Attaching to view
         view.addSubview(mainStackView)
         mainStackView.axis = .vertical
         mainStackView.spacing = stackViewSpacing
@@ -79,11 +77,10 @@ public class BottomSheetPickerViewController: UIViewController {
 
     private func calculateFrameSize() {
         loadViewIfNeeded()
-        frameSize = 0
+        frameSize = titleLabel.sizeThatFits(CGSize(width: view.bounds.size.width, height: .greatestFiniteMagnitude)).height
         stackView.arrangedSubviews.forEach {
             frameSize += $0.sizeThatFits(CGSize(width: view.bounds.size.width, height: .greatestFiniteMagnitude)).height
         }
-        frameSize += titleLabel.sizeThatFits(CGSize(width: view.bounds.size.width, height: .greatestFiniteMagnitude)).height
     }
 
     public override func viewWillLayoutSubviews() {

--- a/Core/Core/Common/CommonUI/UIViews/BottomSheetPickerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/BottomSheetPickerViewController.swift
@@ -28,18 +28,34 @@ public struct BottomSheetAction {
 public class BottomSheetPickerViewController: UIViewController {
     let env = AppEnvironment.shared
     public private(set) var actions: [BottomSheetAction] = []
+    let titleView = UILabel()
     let stackView = UIStackView()
 
     public override var preferredStatusBarStyle: UIStatusBarStyle { .lightContent }
 
     private var buttonHeight: CGFloat = 0
 
-    public static func create() -> BottomSheetPickerViewController {
+    public static func create(title: String? = nil) -> BottomSheetPickerViewController {
         let controller = BottomSheetPickerViewController()
         controller.modalPresentationStyle = .custom
         controller.modalPresentationCapturesStatusBarAppearance = true
         controller.transitioningDelegate = BottomSheetTransitioningDelegate.shared
+        controller.addTitle(title)
         return controller
+    }
+
+    private func addTitle(_ title: String?) {
+        guard let title = title else {
+            return
+        }
+        titleView.font = .scaledNamedFont(.regular14)
+        titleView.textColor = .textDark
+        titleView.textAlignment = .center
+        titleView.text = title
+        titleView.accessibilityLabel = title
+        titleView.accessibilityTraits = .header
+        stackView.addArrangedSubview(titleView)
+        buttonHeight += titleView.sizeThatFits(CGSize(width: view.bounds.size.width, height: .greatestFiniteMagnitude)).height
     }
 
     public override func viewDidLoad() {
@@ -49,7 +65,7 @@ public class BottomSheetPickerViewController: UIViewController {
         }
         view.addSubview(stackView)
         stackView.axis = .vertical
-        stackView.pin(inside: view, leading: nil, trailing: nil, top: 8, bottom: nil)
+        stackView.pin(inside: view, leading: nil, trailing: nil, top: 8, bottom: 18)
         stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor).isActive = true
         stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor).isActive = true
         stackView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
@@ -58,8 +74,8 @@ public class BottomSheetPickerViewController: UIViewController {
 
     public override func viewWillLayoutSubviews() {
         super.viewWillLayoutSubviews()
-        let topPadding: CGFloat = 8
-        view.frame.size.height = topPadding + buttonHeight + view.safeAreaInsets.bottom
+        let magicNumber: CGFloat = 36
+        view.frame.size.height = magicNumber + buttonHeight + view.safeAreaInsets.bottom
     }
 
     public func addAction(image: UIImage?, title: String, accessibilityIdentifier: String? = nil, action: @escaping () -> Void = {}) {

--- a/Core/Core/Features/Files/View/FilePicker/FilePicker.swift
+++ b/Core/Core/Features/Files/View/FilePicker/FilePicker.swift
@@ -42,9 +42,8 @@ public class FilePicker: NSObject {
     }
 
     public func pick(from: UIViewController) {
-        let sheet = BottomSheetPickerViewController.create(
-            title: String(localized: "Select Attachment Type", bundle: .core)
-        )
+        let sheet = BottomSheetPickerViewController.create()
+        sheet.title = String(localized: "Select Attachment Type", bundle: .core)
 
         sheet.addAction(image: .audioLine, title: String(localized: "Record Audio", bundle: .core)) { [weak self] in
             let controller = AudioRecorderViewController.create()

--- a/Core/Core/Features/Files/View/FilePicker/FilePicker.swift
+++ b/Core/Core/Features/Files/View/FilePicker/FilePicker.swift
@@ -42,7 +42,9 @@ public class FilePicker: NSObject {
     }
 
     public func pick(from: UIViewController) {
-        let sheet = BottomSheetPickerViewController.create()
+        let sheet = BottomSheetPickerViewController.create(
+            title: String(localized: "Select Attachment Type", bundle: .core)
+        )
 
         sheet.addAction(image: .audioLine, title: String(localized: "Record Audio", bundle: .core)) { [weak self] in
             let controller = AudioRecorderViewController.create()

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -240,6 +240,7 @@ final class ComposeMessageViewModel: ObservableObject {
 
     private func showDialog(viewController: WeakViewController) {
         let sheet = BottomSheetPickerViewController.create()
+        sheet.title = String(localized: "Select Attachment Type", bundle: .core)
 
         sheet.addAction(
             image: .documentLine,

--- a/Core/CoreTests/Common/CommonUI/UIViews/BottomSheetPickerViewControllerTests.swift
+++ b/Core/CoreTests/Common/CommonUI/UIViews/BottomSheetPickerViewControllerTests.swift
@@ -30,9 +30,9 @@ class BottomSheetPickerViewControllerTests: CoreTestCase {
         }
         controller.addAction(image: .xLine, title: "Cancel")
 
-        (controller.stackView.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
+        (controller.buttonStackView.arrangedSubviews[1] as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertFalse(addCalled)
-        (controller.stackView.arrangedSubviews[0] as? UIButton)?.sendActions(for: .primaryActionTriggered)
+        (controller.buttonStackView.arrangedSubviews[0] as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(addCalled)
         controller.viewWillLayoutSubviews()
         XCTAssertEqual(controller.view.frame.height, 148)

--- a/Core/CoreTests/Common/CommonUI/UIViews/BottomSheetPickerViewControllerTests.swift
+++ b/Core/CoreTests/Common/CommonUI/UIViews/BottomSheetPickerViewControllerTests.swift
@@ -35,6 +35,6 @@ class BottomSheetPickerViewControllerTests: CoreTestCase {
         (controller.stackView.arrangedSubviews[0] as? UIButton)?.sendActions(for: .primaryActionTriggered)
         XCTAssertTrue(addCalled)
         controller.viewWillLayoutSubviews()
-        XCTAssertEqual(controller.view.frame.height, 120)
+        XCTAssertEqual(controller.view.frame.height, 148)
     }
 }


### PR DESCRIPTION
## Accessibility - Parent - Chat - Add title to attachment picker

refs: MBL-18358
affects: Student, Teacher, Parent
release note: None

- Added title label in BottomSheetPickerViewController.
- Fixed another bug that caused fonts not scaling dynamically.
- Set title for this screen in all apps too (not only Parent).

## Test Plan

Originally, the ticket was about providing a solution for the VoiceOver users to know the count of the list items, but according to the product decision we will rather put a title/heading on screens like this one instead of a list count label.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/77d0701c-6ff2-4f59-968d-e5e55c008cac" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f3fc97a5-7614-46af-acca-724fef8e27c2" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
