### PR TITLE
Accessibility - Teacher - Speedgrader Grades-Comments-Files tabs

### DIFF
--- a/Core/Core/Common/CommonUI/SwiftUIViews/SegmentedPicker.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/SegmentedPicker.swift
@@ -76,6 +76,8 @@ public struct SegmentedPicker<Element, Content>: View where Content: View {
                         ) { dimensions in
                             dimensions[HorizontalAlignment.center]
                         }
+                        .accessibilityAddTraits(selectedIndex == index ? [.isSelected] : [])
+                        .accessibilityValue(Text("\(index + 1) of \(data.indices.count)", bundle: .core, comment: "Example: 1 of 3"))
                     }
 
                     if index != data.count - 1 {


### PR DESCRIPTION
refs: [MBL-18443](https://instructure.atlassian.net/browse/MBL-18443)
affects: Teacher
release note: none

- Tried to use the iOS17+ trait `isTabBar` in our custom `SegmentedPicker`, without any success
- Ended up trying to replicate the tab bar a11y behavior:
  - "Selected" state is read for the current tab
  - "# of 3" is read for each tab, but in this order: `"Grades, 1 of 3, Button"` instead of `"Grades, Tab, 1 of 3"`

Some other examples in the app:
- Student > Submission > Comments/Files/Rubric tabs: uses `UISegmentedControl`, reads `"Comments, Button, 1 of 3"`
- main TabBar: uses `UITabBarController`, reads `"Dashboard, Tab, 1 of 5"`

## Test plan
Verify the Speedgrader Grades/Comments/Files tabs read out the selected state and the tab number as described above.

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product

[MBL-18443]: https://instructure.atlassian.net/browse/MBL-18443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ