### PR TITLE
Accessibility - Add number of items to a11y label in AssignmentList sections

### DIFF
--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentGroupView.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentGroupView.swift
@@ -55,11 +55,12 @@ public struct AssignmentGroupView: View {
             Spacer()
             Image.arrowOpenUpLine
                 .size(uiScale.iconScale * 16)
-                .rotationEffect(isExpanded ? .degrees(0) : .degrees(180))
+                .rotationEffect(isExpanded ? .degrees(0) : .degrees(-180))
                 .accessibilityHidden(true)
                 .animation(.smooth, value: isExpanded)
         }
         .accessibilityAddTraits(.isHeader)
+        .accessibilityLabel(Text(verbatim: "\(viewModel.name), \(String.localizedNumberOfItems(viewModel.assignments.count))"))
         .accessibilityHint(
             isExpanded
                 ? String(localized: "Expanded", bundle: .core)


### PR DESCRIPTION
refs: [MBL-18480](https://instructure.atlassian.net/browse/MBL-18480)
affects: Student, Teacher
release note: none

## Test plan
Verify AssignmentList section headers read out number of items

## Checklist
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product

[MBL-18480]: https://instructure.atlassian.net/browse/MBL-18480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ