### PR TITLE
Accessibility - Student - SubmissionComments - Provide valid labels for textView

### DIFF
--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -120556,6 +120556,9 @@
         }
       }
     },
+    "Text Field" : {
+
+    },
     "Text Submission" : {
       "comment" : "Generic name for a submission entered online.",
       "extractionState" : "manual",

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -66,7 +66,9 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale
         addCommentButton.accessibilityLabel = String(localized: "Send comment", bundle: .student)
-        addCommentTextView.accessibilityLabel = String(localized: "Add a comment or reply to previous comments", bundle: .student)
+        addCommentTextView.accessibilityLabel = String(localized: "Comment", bundle: .student)
+        addCommentTextView.accessibilityValue = String(localized: "Text Field", bundle: .student)
+        addCommentTextView.accessibilityHint = String(localized: "Add a comment or reply to previous comments", bundle: .student)
         addCommentTextView.placeholder = String(localized: "Comment", bundle: .student)
         addCommentTextView.placeholderColor = .textDark
         addCommentTextView.font(.scaledNamedFont(.regular16), lineHeight: .body)
@@ -284,7 +286,11 @@ extension SubmissionCommentsViewController: UITableViewDataSource, UITableViewDe
 
 extension SubmissionCommentsViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
-        addCommentButton.isEnabled = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        let textIsNotEmpty = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        if textIsNotEmpty {
+            addCommentTextView.accessibilityLabel = textView.text
+        }
+        addCommentButton.isEnabled = textIsNotEmpty
         addCommentButton.alpha = addCommentButton.isEnabled ? 1 : 0.5
         textView.adjustHeight(to: 10, heightConstraints: addCommentTextViewHeightConstraint)
     }

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -289,6 +289,8 @@ extension SubmissionCommentsViewController: UITextViewDelegate {
         let textIsNotEmpty = !(textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
         if textIsNotEmpty {
             addCommentTextView.accessibilityLabel = textView.text
+        } else {
+            addCommentTextView.accessibilityLabel = String(localized: "Comment", bundle: .student)
         }
         addCommentButton.isEnabled = textIsNotEmpty
         addCommentButton.alpha = addCommentButton.isEnabled ? 1 : 0.5


### PR DESCRIPTION
## Accessibility - Student - SubmissionComments - Provide valid labels for textView

Now the accessibilityLabel changes on editing of the textView. Also instead of the long accessibilityLabel now "Comment" is the default but I kept the previous long label as accessibilityHint.

refs: MBL-18386
affects: Student
release note: None
test plan: See ticket.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
