### PR TITLE
Accessibility - Student - Lists Count Announcement For Offline Content Screen

### DIFF
--- a/Core/Core/Features/CourseSync/Common/ViewModel/OfflineListCellViewModel.swift
+++ b/Core/Core/Features/CourseSync/Common/ViewModel/OfflineListCellViewModel.swift
@@ -21,6 +21,7 @@ import SwiftUI
 class OfflineListCellViewModel: ObservableObject {
 
     let cellStyle: OfflineListCellView.ListCellStyle
+    let followingListCount: Int?
     let title: String
     let subtitle: String?
     let selectionState: OfflineListCellView.SelectionState
@@ -31,6 +32,7 @@ class OfflineListCellViewModel: ObservableObject {
     let state: OfflineListCellView.State
 
     init(cellStyle: OfflineListCellView.ListCellStyle,
+         followingListCount: Int? = nil,
          title: String,
          subtitle: String? = nil,
          selectionState: OfflineListCellView.SelectionState = .deselected,
@@ -41,6 +43,7 @@ class OfflineListCellViewModel: ObservableObject {
          progress: Float? = nil,
          state: OfflineListCellView.State) {
         self.cellStyle = cellStyle
+        self.followingListCount = followingListCount
         self.title = title
         self.subtitle = subtitle
         self.selectionState = selectionState
@@ -134,28 +137,31 @@ class OfflineListCellViewModel: ObservableObject {
             }
         }
 
-        var finalText = ""
+        var finalTextParts: [String] = []
+
+        if let listCount = followingListCount {
+            let countText = String.localizedNumberOfItems(listCount)
+            let listLabel = "\(String(localized: "List", bundle: .core)), \(countText)"
+            finalTextParts.append(listLabel)
+        }
 
         if !titleText.isEmpty {
-            finalText.append(titleText)
+            finalTextParts.append(titleText)
         }
 
         if !selectionText.isEmpty {
-            finalText.append(", ")
-            finalText.append(selectionText)
+            finalTextParts.append(selectionText)
         }
 
         if !collapseText.isEmpty {
-            finalText.append(", ")
-            finalText.append(collapseText)
+            finalTextParts.append(collapseText)
         }
 
         if !progressText.isEmpty {
-            finalText.append(", ")
-            finalText.append(progressText)
+            finalTextParts.append(progressText)
         }
 
-        return finalText
+        return finalTextParts.joined(separator: ", ")
     }
 
 }

--- a/Core/Core/Features/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSelector/View/CourseSyncSelectorView.swift
@@ -143,14 +143,19 @@ struct CourseSyncSelectorView: View {
                 VStack(spacing: 0) {
                     switch cell {
                     case let .item(item):
-                        OfflineListCellView(OfflineListCellViewModel(cellStyle: item.cellStyle,
-                                                       title: item.title,
-                                                       subtitle: item.subtitle,
-                                                       selectionState: item.selectionState,
-                                                       isCollapsed: item.isCollapsed,
-                                                       selectionDidToggle: item.selectionDidToggle,
-                                                       collapseDidToggle: item.collapseDidToggle,
-                                                       state: .idle))
+                        OfflineListCellView(
+                            OfflineListCellViewModel(
+                                cellStyle: item.cellStyle,
+                                followingListCount: item.followingListCount,
+                                title: item.title,
+                                subtitle: item.subtitle,
+                                selectionState: item.selectionState,
+                                isCollapsed: item.isCollapsed,
+                                selectionDidToggle: item.selectionDidToggle,
+                                collapseDidToggle: item.collapseDidToggle,
+                                state: .idle
+                            )
+                        )
                     case .empty:
                         emptyCourse
                     }

--- a/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
@@ -29,6 +29,13 @@ extension CourseSyncSelectorViewModel {
             case .item(let item): return item.id
             }
         }
+
+        var item: Item? {
+            guard case .item(let item) = self else {
+                return nil
+            }
+            return item
+        }
     }
 
     struct Item: Hashable, Identifiable {

--- a/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
@@ -40,6 +40,7 @@ extension CourseSyncSelectorViewModel {
         let selectionState: OfflineListCellView.SelectionState
         var isCollapsed: Bool?
         let cellStyle: OfflineListCellView.ListCellStyle
+        var followingListCount: Int?
 
         fileprivate(set) var selectionDidToggle: (() -> Void)?
         fileprivate(set) var collapseDidToggle: (() -> Void)?
@@ -71,8 +72,9 @@ extension Array where Element == CourseSyncEntry {
 
         var cells: [CourseSyncSelectorViewModel.Cell] = []
 
-        for course in self {
+        for (courseIndex, course) in enumerated() {
             var courseItem = course.makeViewModelItem()
+            courseItem.followingListCount = courseIndex == 0 ? count : nil
             courseItem.selectionDidToggle = {
                 let selectionState: OfflineListCellView.SelectionState = course.selectionState == .selected || course.selectionState == .partiallySelected ? .deselected : .selected
                 interactor?.setSelected(selection: .course(course.id), selectionState: selectionState)
@@ -91,11 +93,12 @@ extension Array where Element == CourseSyncEntry {
                 continue
             }
 
-            for tab in course.tabs {
+            for (tabIndex, tab) in course.tabs.enumerated() {
                 guard tab.type != .additionalContent else {
                     continue
                 }
                 var tabItem = tab.makeViewModelItem()
+                tabItem.followingListCount = tabIndex == 0 ? course.tabs.count : nil
                 tabItem.selectionDidToggle = {
                     let selectionState: OfflineListCellView.SelectionState = tab.selectionState == .selected || tab.selectionState == .partiallySelected ? .deselected : .selected
                     interactor?.setSelected(selection: .tab(course.id, tab.id), selectionState: selectionState)
@@ -117,8 +120,10 @@ extension Array where Element == CourseSyncEntry {
                     continue
                 }
 
-                for file in course.files {
+                for (fileIndex, file) in course.files.enumerated() {
+
                     var fileItem = file.makeViewModelItem()
+                    fileItem.followingListCount = fileIndex == 0 ? course.files.count : nil
                     fileItem.selectionDidToggle = {
                         interactor?.setSelected(selection: .file(course.id, file.id), selectionState: file.selectionState == .selected ? .deselected : .selected)
                     }

--- a/Core/CoreTests/Features/CourseSync/Common/ViewModel/OfflineListCellViewModelTests.swift
+++ b/Core/CoreTests/Features/CourseSync/Common/ViewModel/OfflineListCellViewModelTests.swift
@@ -195,4 +195,16 @@ class OfflineListCellViewModelTests: CoreTestCase {
         )
         XCTAssertEqual(testee2.accessibilityText, "Title Subtitle, Downloading")
     }
+
+    func testAccessiblityText_FollowingList() {
+        let testee = OfflineListCellViewModel(
+            cellStyle: .listAccordionHeader,
+            followingListCount: 6,
+            title: "Title",
+            subtitle: "Subtitle",
+            state: .downloaded
+        )
+
+        XCTAssertEqual(testee.accessibilityText, "List, 6 items, Title Subtitle")
+    }
 }

--- a/Core/CoreTests/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -90,6 +90,79 @@ class CourseSyncSelectorViewModelItemTests: XCTestCase {
         XCTAssertEqual([course].makeViewModelItems(interactor: mockInteractor).count, 2)
     }
 
+    func test_followingList_counts() {
+        var courses = [
+            CourseSyncEntry(
+                name: "course1", id: "course-1", hasFrontPage: false,
+                tabs: [
+                    .init(id: "0", name: "Assignments", type: .assignments),
+                    .init(id: "1", name: "Pages", type: .pages),
+                    .init(id: "2", name: "Files", type: .files)
+                ],
+                files: [
+                    .make(id: "1", displayName: "test1.txt"),
+                    .make(id: "2", displayName: "test2.txt")
+                ]
+            ),
+            CourseSyncEntry(
+                name: "course2", id: "course-2", hasFrontPage: false,
+                tabs: [
+                    .init(id: "6", name: "Modules", type: .modules),
+                    .init(id: "8", name: "Announcments", type: .announcements)
+                ],
+                files: []
+            ),
+            CourseSyncEntry(
+                name: "course3", id: "course-3", hasFrontPage: false,
+                tabs: [
+                    .init(id: "89", name: "Grades", type: .grades),
+                    .init(id: "64", name: "Syllabus", type: .syllabus),
+                    .init(id: "18", name: "Files", type: .files)
+                ],
+                files: [
+                    .make(id: "34", displayName: "test34.txt")
+                ]
+            )
+        ]
+
+        // When
+        courses.indices.forEach { i in courses[i].isCollapsed = true }
+        var cells = courses.makeViewModelItems(interactor: mockInteractor)
+
+        // Then
+        XCTAssertEqual(cells.count, 3)
+        XCTAssertEqual(cells[0].item?.followingListCount, 3)
+
+        XCTAssertNil(cells[1].item?.followingListCount)
+        XCTAssertNil(cells[2].item?.followingListCount)
+
+        // When
+        courses.indices.forEach { i in
+            var course = courses[i]
+            course.isCollapsed = false
+            course.tabs.indices.forEach { ti in
+                course.tabs[ti].isCollapsed = false
+            }
+            courses[i] = course
+        }
+        cells = courses.makeViewModelItems(interactor: mockInteractor)
+
+        // Then
+        XCTAssertEqual(cells.count, 14)
+
+        let expectedFollowingListIndices = [
+            (0, 3), (1, 3), (4, 2), (7, 2), (10, 3), (13, 1)
+        ]
+
+        for (i, cell) in cells.enumerated() {
+            if let expectedCount = expectedFollowingListIndices.first(where: { $0.0 == i })?.1 {
+                XCTAssertEqual(cell.item?.followingListCount, expectedCount)
+            } else {
+                XCTAssertNil(cell.item?.followingListCount)
+            }
+        }
+    }
+
     func testExpandedEmptyCourse() {
         var course = CourseSyncEntry(name: "test", id: "testID", hasFrontPage: false, tabs: [], files: [])
         course.isCollapsed = false


### PR DESCRIPTION
refs: MBL-18373
affects: Student
release note: None

## Test Plan

First: Navigate to "Offline Content" screen for all courses
1- Make sure to turn Mobile Offline mode for your test account.
2- On Student app, in Dashboard screen, tap on 3-dots button on the right-left corner. 
3- Choose "Manage Offline Content"

Second: Upon loading, make sure the first item of each expandable list has "_**List, ? items, ..**_" prefix read out when focused via VoiceOver.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
