### PR TITLE
Accessibility - Parent - Fixes Accessibility Focus Order of Recipients Field of Parent's Compose Message Form

### DIFF
--- a/Core/Core/Features/Conversations/ComposeRecipientsView.swift
+++ b/Core/Core/Features/Conversations/ComposeRecipientsView.swift
@@ -122,6 +122,8 @@ class ComposeRecipientsView: UIView {
         }
         placeholder.isHidden = !pills.isEmpty
         placeholder.setNeedsLayout()
+
+        updateAccessibilityOrder()
     }
 
     override func layoutSubviews() {
@@ -148,6 +150,20 @@ class ComposeRecipientsView: UIView {
 
         additionalRecipients.frame.origin.x = next.x
     }
+
+    private func updateAccessibilityOrder() {
+        if additionalRecipients.isHidden {
+            // Follow visual order of elements shown on screen
+            accessibilityElements = nil
+        } else {
+            var elements = [Any?]()
+            elements.append(placeholder)
+            elements.append(contentsOf: pills)
+            elements.append(additionalRecipients)
+            elements.append(editButton)
+            accessibilityElements = elements.compactMap({ $0 })
+        }
+    }
 }
 
 class ComposeRecipientView: UIView {
@@ -157,6 +173,7 @@ class ComposeRecipientView: UIView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        isAccessibilityElement = true
 
         backgroundColor = .backgroundLight
         layer.cornerRadius = 20
@@ -188,11 +205,15 @@ class ComposeRecipientView: UIView {
         avatarView.name = recipient.name
         avatarView.url = recipient.avatarURL
         nameLabel.text = recipient.displayName
-        nameLabel.accessibilityIdentifier = "Compose.recipientName.\(recipient.id)"
-        roleLabel.accessibilityIdentifier = "Compose.recipientRole.\(recipient.id)"
-        roleLabel.text = ListFormatter.localizedString(from: recipient.commonCourses
+
+        let role = ListFormatter.localizedString(from: recipient.commonCourses
             .filter { $0.courseID == context?.id }
             .compactMap { Role(rawValue: $0.role)?.description() }
         )
+        roleLabel.text = role
+
+        nameLabel.accessibilityIdentifier = "Compose.recipientName.\(recipient.id)"
+        roleLabel.accessibilityIdentifier = "Compose.recipientRole.\(recipient.id)"
+        accessibilityLabel = [recipient.displayName, role].compactMap({ $0 }).joined(separator: ", ")
     }
 }


### PR DESCRIPTION
refs: [MBL-18356](https://instructure.atlassian.net/browse/MBL-18356)
affects: Parent
release note: None

## Test Plan

In Parent app, go to Inbox section from Side Menu. Then try compose a message for some course.
Turn on VoiceOver on the Compose Message screen, and validate the ordering of recipients field in both states (expanded and collapsed).

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18356]: https://instructure.atlassian.net/browse/MBL-18356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ