### PR TITLE
Accessibility - Parent - Move focus to percent label when Grades tab is selected

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/HorizontalMenuViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/HorizontalMenuViewController.swift
@@ -281,6 +281,10 @@ extension HorizontalMenuViewController: UICollectionViewDataSource, UICollection
         }
     }
 
+    public func viewForMenuItem(at indexPath: IndexPath) -> UIView? {
+        return menu?.cellForItem(at: indexPath)
+    }
+
     /**
      When VoiceOver focus moves from `menu` to `pages` the scroll offset on `pages` resets to 0, no matter which menu item is selected. The same applies if the focus moves from the tab bar up to `pages`, in this case the scroll offset moves to the last page. This method sets back the scroll offset to show the selected menu item's content.
      */

--- a/Parent/Parent/Courses/CourseDetailsViewController.swift
+++ b/Parent/Parent/Courses/CourseDetailsViewController.swift
@@ -260,4 +260,21 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
             return String(localized: "Summary", bundle: .parent)
         }
     }
+
+    func didSelectMenuItem(at: IndexPath) {
+        guard let menuItem = MenuItem(rawValue: at.row) else { return }
+
+        let targetVC: UIViewController? = switch menuItem {
+        case .grades:
+            gradesViewController
+        case .syllabus:
+            syllabusViewController
+        case .summary:
+            summaryViewController
+        }
+
+        if let vc = targetVC {
+            UIAccessibility.post(notification: .screenChanged, argument: vc)
+        }
+    }
 }

--- a/Parent/Parent/Courses/CourseDetailsViewController.swift
+++ b/Parent/Parent/Courses/CourseDetailsViewController.swift
@@ -275,6 +275,9 @@ extension CourseDetailsViewController: HorizontalPagedMenuDelegate {
 
         if let vc = targetVC {
             UIAccessibility.post(notification: .screenChanged, argument: vc)
+        } else {
+            let itemView = viewForMenuItem(at: at)
+            UIAccessibility.post(notification: .screenChanged, argument: itemView)
         }
     }
 }


### PR DESCRIPTION
refs: [MBL-18415](https://instructure.atlassian.net/browse/MBL-18415)
affects: Parent
release note: None

## Test Plan

In Parent app, tap on any course of those shown on Courses tab.
With VoiceOver on, switch between tabs, when tab is selected (Grades, Syllabus, or Summary) focus should move to the first element shown on those screens.

### Known issue:
For tab details page of `CoreWebViewController`, like "Front Page", when selected accessibility focus stay on the same tab button. It doesn't move to the first element of the shown web view. Not sure if this should belong to this scope, as it would require observing when web content is fully loaded, then after that move focus to it, which -to me- could lead to a bloated code for the task. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18415]: https://instructure.atlassian.net/browse/MBL-18415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ