### PR TITLE
Accessibility - Student - SubmissionDetails - Set VoiceOver focus on changing tabs on drawer

### DIFF
--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -86,6 +86,9 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         keyboard = KeyboardTransitioning(view: view, space: keyboardSpace)
+        DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
+            UIAccessibility.post(notification: .screenChanged, argument: self.tableView.visibleCells.first)
+         }
     }
 
     @IBAction func addCommentButtonPressed(_ sender: UIButton) {

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -203,6 +203,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         if let drawer = drawer, drawer.height == 0 {
             drawer.moveTo(height: drawer.midDrawerHeight, velocity: 1)
         }
+        UIAccessibility.post(notification: .screenChanged, argument: drawerContentViewController)
     }
 
     @IBAction func pickerButtonTapped(_ sender: Any) {


### PR DESCRIPTION
## Accessibility - Student - SubmissionDetails - Set VoiceOver focus on changing tabs on drawer

refs: MBL-18385
affects: Student
release note: None

## Test Plan
As per the ticket, in case we are on another tab (Files) and we tap on Comments tab then the VoiceOver focus should move to the comments (ticket wants it to move to the first comment on the list, but I thought it's better to move it to the latest comment).

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
