### PR TITLE
Accessibility - Inbox Recipients list count

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/ItemPickerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/ItemPickerViewController.swift
@@ -88,8 +88,7 @@ public class ItemPickerViewController: UIViewController {
         tableView.tintColor = Brand.shared.primary
 
         tableView.isAccessibilityElement = true
-        let countText = String.localizedNumberOfItems(sections[0].items.count)
-        tableView.accessibilityLabel = "\(String(localized: "List", bundle: .core)), \(countText)"
+        tableView.accessibilityLabel = String.localizedAccessibilityListCount(sections[0].items.count)
     }
 }
 

--- a/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
@@ -130,6 +130,15 @@ extension String {
     public static func localizedNumberOfItems(_ count: Int) -> String {
         String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), count)
     }
+
+    /// Localized string to be used as `accessibilityLabel` for lists without a section header. Example: "List, 5 items"
+    public static func localizedAccessibilityListCount(_ count: Int) -> String {
+        let listText = String(localized: "List", bundle: .core)
+        let countText = String.localizedNumberOfItems(count)
+        // It's okay to not translate the comma, because VoiceOver (with captions enabled) uses commas for separation,
+        // even when language & region both are set to a language which doesn't (like Danish)
+        return "\(listText), \(countText)"
+    }
 }
 
 extension ReferenceWritableKeyPath {

--- a/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItem.swift
@@ -74,9 +74,9 @@ extension Array where Element == CourseSyncEntry {
 
         for (courseIndex, course) in enumerated() {
             var courseItem = course.makeViewModelItem()
-            courseItem.accessibilityLabelPrefix = courseIndex == 0
-                ? count.accessibilityPrefixForListOfCount
-                : nil
+            if courseIndex == 0 {
+                courseItem.accessibilityLabelPrefix = String.localizedAccessibilityListCount(count)
+            }
             courseItem.selectionDidToggle = {
                 let selectionState: OfflineListCellView.SelectionState = course.selectionState == .selected || course.selectionState == .partiallySelected ? .deselected : .selected
                 interactor?.setSelected(selection: .course(course.id), selectionState: selectionState)
@@ -100,9 +100,9 @@ extension Array where Element == CourseSyncEntry {
                     continue
                 }
                 var tabItem = tab.makeViewModelItem()
-                tabItem.accessibilityLabelPrefix = tabIndex == 0
-                ? course.tabs.count.accessibilityPrefixForListOfCount
-                    : nil
+                if tabIndex == 0 {
+                    tabItem.accessibilityLabelPrefix = String.localizedAccessibilityListCount(course.tabs.count)
+                }
                 tabItem.selectionDidToggle = {
                     let selectionState: OfflineListCellView.SelectionState = tab.selectionState == .selected || tab.selectionState == .partiallySelected ? .deselected : .selected
                     interactor?.setSelected(selection: .tab(course.id, tab.id), selectionState: selectionState)
@@ -127,9 +127,9 @@ extension Array where Element == CourseSyncEntry {
                 for (fileIndex, file) in course.files.enumerated() {
 
                     var fileItem = file.makeViewModelItem()
-                    fileItem.accessibilityLabelPrefix = fileIndex == 0
-                        ? course.files.count.accessibilityPrefixForListOfCount
-                        : nil
+                    if fileIndex == 0 {
+                        fileItem.accessibilityLabelPrefix = String.localizedAccessibilityListCount(course.files.count)
+                    }
                     fileItem.selectionDidToggle = {
                         interactor?.setSelected(selection: .file(course.id, file.id), selectionState: file.selectionState == .selected ? .deselected : .selected)
                     }
@@ -139,13 +139,6 @@ extension Array where Element == CourseSyncEntry {
         }
 
         return cells
-    }
-}
-
-extension Int {
-    var accessibilityPrefixForListOfCount: String {
-        let countText = String.localizedNumberOfItems(self)
-        return "\(String(localized: "List", bundle: .core)), \(countText)"
     }
 }
 

--- a/Core/Core/Features/Inbox/Addressbook/View/AddressbookRecipientView.swift
+++ b/Core/Core/Features/Inbox/Addressbook/View/AddressbookRecipientView.swift
@@ -33,7 +33,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
 
     public var body: some View {
         ScrollView {
-            peopleView
+            listView
         }
         .searchable(
             text: Binding { viewModel.searchText.value } set: { viewModel.searchText.send($0) },
@@ -60,16 +60,20 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
         .accessibilityIdentifier("Inbox.addRecipient.done")
     }
 
-    private var peopleView: some View {
+    private var listView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            if viewModel.isAllRecipientButtonVisible { allRecipient }
+            if viewModel.isAllRecipientButtonVisible {
+                allRecipientsRow
+            }
             ForEach(viewModel.recipients, id: \.self) { user in
-                personRowView(user)
+                recipientRow(user)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String.localizedAccessibilityListCount(viewModel.listCount))
     }
 
-    private func personRowView(_ recipient: Recipient) -> some View {
+    private func recipientRow(_ recipient: Recipient) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Button(action: {
                 viewModel.recipientDidTap.send(recipient)
@@ -97,7 +101,7 @@ public struct AddressbookRecipientView: View, ScreenViewTrackable {
         }
     }
 
-    private var allRecipient: some View {
+    private var allRecipientsRow: some View {
             VStack(alignment: .leading, spacing: 0) {
                 Button(action: {
                     viewModel.recipientDidTap.send(viewModel.allRecipient)

--- a/Core/Core/Features/Inbox/Addressbook/View/AddressbookRoleView.swift
+++ b/Core/Core/Features/Inbox/Addressbook/View/AddressbookRoleView.swift
@@ -39,11 +39,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
             case .loading:
                 loadingIndicator
             case .data:
-                if viewModel.isRolesViewVisible {
-                    rolesView
-                } else {
-                    peopleView
-                }
+                listView
             case .empty, .error:
                 Text("There was an error loading recipients.\nPull to refresh to try again.", bundle: .core)
                     .foregroundColor(.textDark)
@@ -87,15 +83,26 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
         }
     }
 
-    private var peopleView: some View {
+    private var listView: some View {
         VStack(alignment: .leading, spacing: 0) {
-            ForEach(viewModel.recipients, id: \.self) { user in
-                personRowView(user)
+            if viewModel.isRolesViewVisible {
+                if viewModel.isAllRecipientButtonVisible {
+                    allRecipientsRow
+                }
+                ForEach(viewModel.roles, id: \.self) { role in
+                    roleRow(role)
+                }
+            } else {
+                ForEach(viewModel.recipients, id: \.self) { user in
+                    recipientRow(user)
+                }
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(String.localizedAccessibilityListCount(viewModel.listCount))
     }
 
-    private func personRowView(_ recipient: Recipient) -> some View {
+    private func recipientRow(_ recipient: Recipient) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Button(action: {
                 viewModel.didTapRecipient.send(recipient)
@@ -122,16 +129,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
         }
     }
 
-    private var rolesView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            if viewModel.isAllRecipientButtonVisible { allRecipient }
-            ForEach(viewModel.roles, id: \.self) { role in
-                roleRowView(role)
-            }
-        }
-    }
-
-    private func roleRowView(_ role: String) -> some View {
+    private func roleRow(_ role: String) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             Button(action: {
                 viewModel.didTapRole.send((roleName: role, recipients: viewModel.roleRecipients[role] ?? [], controller: controller))
@@ -168,7 +166,7 @@ struct AddressbookRoleView: View, ScreenViewTrackable {
         }
     }
 
-    private var allRecipient: some View {
+    private var allRecipientsRow: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button(action: {
                 viewModel.didTapRecipient.send(viewModel.allRecipient)

--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModel.swift
@@ -31,6 +31,10 @@ class AddressbookRecipientViewModel: ObservableObject {
         searchText.value.isEmpty && canSelectAllRecipient
     }
 
+    public var listCount: Int {
+        recipients.count + (isAllRecipientButtonVisible ? 1 : 0)
+    }
+
     public let title = String(localized: "Select Recipients", bundle: .core)
     public let roleName: String
 

--- a/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
+++ b/Core/Core/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModel.swift
@@ -41,6 +41,14 @@ class AddressbookRoleViewModel: ObservableObject {
         Recipient(ids: recipients.flatMap { $0.ids }, name: "All in \(recipientContext.name)", avatarURL: nil)
     }
 
+    public var listCount: Int {
+        if isRolesViewVisible {
+            roles.count + (isAllRecipientButtonVisible ? 1 : 0)
+        } else {
+            recipients.count
+        }
+    }
+
     public let title = String(localized: "Select Recipients", bundle: .core)
     public let recipientContext: RecipientContext
 

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -89,4 +89,9 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(String.localizedNumberOfItems(5), "5 items")
         XCTAssertEqual(String.localizedNumberOfItems(0), "0 items")
     }
+
+    func testLocalizedAccessibilityListCount() {
+        XCTAssertEqual(String.localizedAccessibilityListCount(1), "List, 1 item")
+        XCTAssertEqual(String.localizedAccessibilityListCount(5), "List, 5 items")
+    }
 }

--- a/Core/CoreTests/Features/CourseSync/Common/ViewModel/OfflineListCellViewModelTests.swift
+++ b/Core/CoreTests/Features/CourseSync/Common/ViewModel/OfflineListCellViewModelTests.swift
@@ -201,10 +201,10 @@ class OfflineListCellViewModelTests: CoreTestCase {
             cellStyle: .listAccordionHeader,
             title: "Title",
             subtitle: "Subtitle",
-            accessibilityLabelPrefix: 6.accessibilityPrefixForListOfCount,
+            accessibilityLabelPrefix: "some prefix",
             state: .downloaded
         )
 
-        XCTAssertEqual(testee.accessibilityText, "List, 6 items, Title Subtitle")
+        XCTAssertEqual(testee.accessibilityText, "some prefix, Title Subtitle")
     }
 }

--- a/Core/CoreTests/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncSelector/ViewModel/CourseSyncSelectorViewModelItemTests.swift
@@ -131,7 +131,7 @@ class CourseSyncSelectorViewModelItemTests: XCTestCase {
 
         // Then
         XCTAssertEqual(cells.count, 3)
-        XCTAssertEqual(cells[0].item?.accessibilityLabelPrefix, 3.accessibilityPrefixForListOfCount)
+        XCTAssertEqual(cells[0].item?.accessibilityLabelPrefix, String.localizedAccessibilityListCount(3))
 
         XCTAssertNil(cells[1].item?.accessibilityLabelPrefix)
         XCTAssertNil(cells[2].item?.accessibilityLabelPrefix)
@@ -156,7 +156,7 @@ class CourseSyncSelectorViewModelItemTests: XCTestCase {
 
         for (i, cell) in cells.enumerated() {
             if let expectedCount = expectedFollowingListIndices.first(where: { $0.0 == i })?.1 {
-                XCTAssertEqual(cell.item?.accessibilityLabelPrefix, expectedCount.accessibilityPrefixForListOfCount)
+                XCTAssertEqual(cell.item?.accessibilityLabelPrefix, String.localizedAccessibilityListCount(expectedCount))
             } else {
                 XCTAssertNil(cell.item?.accessibilityLabelPrefix)
             }

--- a/Core/CoreTests/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/Addressbook/ViewModel/AddressbookRecipientViewModelTests.swift
@@ -23,23 +23,18 @@ import Combine
 import CombineExt
 
 class AddressbookRecipientViewModelTests: CoreTestCase {
-    var testee: AddressbookRecipientViewModel!
+
+    private var testee: AddressbookRecipientViewModel!
+    private var recipients: [SearchRecipient] = []
 
     override func setUp() {
         super.setUp()
-        let recipients: [SearchRecipient] = [
+        recipients = [
             .save(.make(id: "1", name: "Recipient 1", common_courses: ["Course 1": ["TeacherEnrollment"]]), filter: "", in: environment.database.viewContext),
             .save(.make(id: "2", name: "Recipient 2", common_courses: ["Course 1": ["StudentEnrollment"]]), filter: "", in: environment.database.viewContext),
             .save(.make(id: "3", name: "Recipient 3", common_courses: ["Course 1": ["ObserverEnrollment"]]), filter: "", in: environment.database.viewContext)
         ]
-        testee = AddressbookRecipientViewModel(
-            router: environment.router,
-            roleName: "Students",
-            recipients: recipients.map { Recipient(searchRecipient: $0) },
-            canSelectAllRecipient: true,
-            recipientDidSelect: PassthroughRelay<Recipient>(),
-            selectedRecipients: CurrentValueSubject<[Recipient], Never>([])
-        )
+        testee = makeViewModel(canSelectAllRecipient: true)
     }
 
     func testInitState() {
@@ -57,5 +52,25 @@ class AddressbookRecipientViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.recipients.first?.displayName, "Recipient 1")
         XCTAssertEqual(testee.recipients.first?.ids, ["1"])
         XCTAssertNil(testee.recipients.first?.avatarURL)
+    }
+
+    func test_listCount_whenCanSelectAllRecipients() {
+        XCTAssertEqual(testee.listCount, 4)
+    }
+
+    func test_listCount_whenCanNotSelectAllRecipients() {
+        testee = makeViewModel(canSelectAllRecipient: false)
+        XCTAssertEqual(testee.listCount, 3)
+    }
+
+    private func makeViewModel(canSelectAllRecipient: Bool) -> AddressbookRecipientViewModel {
+        .init(
+            router: environment.router,
+            roleName: "Students",
+            recipients: recipients.map { Recipient(searchRecipient: $0) },
+            canSelectAllRecipient: canSelectAllRecipient,
+            recipientDidSelect: .init(),
+            selectedRecipients: .init([])
+        )
     }
 }

--- a/Core/CoreTests/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/Addressbook/ViewModel/AddressbookRoleViewModelTests.swift
@@ -96,6 +96,31 @@ class AddressbookRoleViewModelTests: CoreTestCase {
         testee.searchText.value = "Test"
         XCTAssertFalse(testee.isAllRecipientButtonVisible)
     }
+
+    func testListCount() {
+        let recipients: [SearchRecipient] = [
+            .save(.make(id: "1", name: "T01", common_courses: ["Course 1": ["TeacherEnrollment"]]), filter: "", in: databaseClient),
+            .save(.make(id: "2", name: "S01", common_courses: ["Course 1": ["StudentEnrollment"]]), filter: "", in: databaseClient),
+            .save(.make(id: "3", name: "S02", common_courses: ["Course 1": ["StudentEnrollment"]]), filter: "", in: databaseClient),
+            .save(.make(id: "4", name: "S03", common_courses: ["Course 1": ["StudentEnrollment"]]), filter: "", in: databaseClient),
+            .save(.make(id: "5", name: "P01", common_courses: ["Course 1": ["ObserverEnrollment"]]), filter: "", in: databaseClient),
+            .save(.make(id: "6", name: "P02", common_courses: ["Course 1": ["ObserverEnrollment"]]), filter: "", in: databaseClient)
+        ]
+        mockInteractor.recipients.value = recipients
+
+        testee.searchText.value = ""
+        mockInteractor.canSelectAllRecipient.value = true
+        XCTAssertEqual(testee.listCount, 4)
+
+        mockInteractor.canSelectAllRecipient.value = false
+        XCTAssertEqual(testee.listCount, 3)
+
+        testee.searchText.value = "0"
+        XCTAssertEqual(testee.listCount, 6)
+
+        testee.searchText.value = "S0"
+        XCTAssertEqual(testee.listCount, 3)
+    }
 }
 
 private class AddressbookInteractorMock: AddressbookInteractor {

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -193,7 +193,7 @@ struct SubmissionCommentList: View {
                 self.error = error.map { Text($0.localizedDescription) } ?? Text(genericErrorMessage)
                 UIAccessibility.announce(genericErrorMessage)
             } else {
-                UIAccessibility.announce(String(localized: "Sent successfully", bundle: .teacher))
+                UIAccessibility.announce(String(localized: "Comment sent successfully", bundle: .teacher))
             }
         }
     }


### PR DESCRIPTION
refs: [MBL-18348](https://instructure.atlassian.net/browse/MBL-18348)
affects: Student, Teacher
release note: none

- Added "List, # items" to the first element of both Recipients screens
- Added `String.localizedAccessibilityListCount()` for this
  - Updated existing usages
- Updated Submission Comment Sent a11y label

## Test plan
Verify list count is read for Recipients screens (both when showing list of roles, and list of recipients)
Verify list counts are still read properly on Offline Sync screen

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18348]: https://instructure.atlassian.net/browse/MBL-18348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ