### PR TITLE
Accessibility - Parent - Move Focus to Student Avatar on When activating a Tab

### DIFF
--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -294,6 +294,10 @@ extension DashboardViewController: UITabBarControllerDelegate {
     ) -> (any UIViewControllerAnimatedTransitioning)? {
         InstUI.TabChangeTransition()
     }
+
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        UIAccessibility.post(notification: .layoutChanged, argument: dropdownButton)
+    }
 }
 
 class StudentButton: UIButton {


### PR DESCRIPTION
refs: MBL-18400
affects: Parent
release note: None.

## Test Plan

In Parent app, switch between tabs with VoiceOver On, double tap on the focused tab, focus should move to student avatar view. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
