### PR TITLE
Always enable Grades and Discussions tab links

### DIFF
--- a/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
+++ b/Core/Core/Common/CommonModels/Router/CourseTabUrlInteractor.swift
@@ -83,22 +83,35 @@ public final class CourseTabUrlInteractor {
             return true
         }
 
-        // it's a tab, if it matches any of the enabled tabs allow it, otherwise block it
+        // if it's a tab that can only be hidden but never disabled -> allow it
+        if isHideOnlyTab(relativePath) {
+            return true
+        }
+
+        // it's a tab that may be disabled, if it matches any of the enabled tabs allow it, otherwise block it
         return enabledTabs.contains(relativePath)
     }
 
     /// Expects relative paths, with "/api/v1" already stripped
     private func isKnownPathFormat(_ path: String) -> Bool {
-        let parts = path.split(separator: "/").map { String($0) }
+        let parts = path.splitUsingSlash
         return CourseTabFormat.allCases.contains {
             $0.isMatch(for: parts)
         }
     }
 
+    /// Checks for tabs which can't be disabled, only hidden.
+    /// These tabs should always be allowed to visit, they are simply removed from the Course Tab list.
+    private func isHideOnlyTab(_ path: String) -> Bool {
+        let parts = path.splitUsingSlash
+        return parts.count == 3
+            && (parts[2] == "discussion_topics" || parts[2] == "grades")
+    }
+
     /// Check for any tabs which match the Home format: "/courses/:courseID"
     /// For example K5Subject tabs: "/courses/:courseID#schedule"
     private func isHomeFormat(_ path: String) -> Bool {
-        let parts = path.split(separator: "/").map { String($0) }
+        let parts = path.splitUsingSlash
         return parts.count == 2 && parts[0] == "courses"
     }
 
@@ -233,6 +246,12 @@ private enum CourseTabFormat: CaseIterable {
             // example: "/courses/42/external_tools/1234"
             return parts.count == 4 && parts[2] == "external_tools"
         }
+    }
+}
+
+private extension String {
+    var splitUsingSlash: [String] {
+        split(separator: "/").map { String($0) }
     }
 }
 

--- a/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
@@ -297,6 +297,8 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/front_page")), true)
     }
 
+    // MARK: - Log unknown formats
+
     func test_setupEnabledTabs_whenPathFormatIsUnknown_shouldLogIt() {
         // known path formats are not logged
         saveTab(id: "stuff", htmlUrl: "/courses/42/stuff", context: .course("42"))
@@ -320,6 +322,12 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
 
     func test_setupEnabledTabs_whenTabIsSettings_shouldNotLogIt() {
         saveTab(id: "settings", htmlUrl: "/courses/42/settings", context: .course("42"))
+        XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
+    }
+
+    func test_setupEnabledTabs_whenTabHasLTILaunchRequestFormat_shouldNotLogIt() {
+        saveTab(id: "someId", htmlUrl: "/courses/42/lti/basic_lti_launch_request/123", context: .course("42"))
+        saveTab(id: "someId", htmlUrl: "/courses/42/lti/basic_lti_launch_request/123?resource_link_fragment=nav", context: .course("42"))
         XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
     }
 

--- a/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
@@ -87,6 +87,17 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/0/stuff")), true)
     }
 
+    // MARK: - Hide only tabs
+
+    func test_isAllowedUrl_whenUrlIsHideOnlyTab_shouldAllow() {
+        saveTab(htmlUrl: "/courses/42/_something_", context: .course("42"))
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/discussion_topics")), true)
+
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/not_grades_or_discussuions")), false)
+    }
+
     // MARK: - UserInfo
 
     func test_isAllowedUrlWithUserInfo_whenBlockDisabledTabIsFalse_shouldAllowDisabledTab() {

--- a/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/CourseTabUrlInteractorTests.swift
@@ -40,10 +40,10 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     func test_isAllowedUrl_whenNotSetup_shouldAllowAll() {
         testee = .init()
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/discussion_topics?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/discussion_topics")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/discussion_topics")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unkown_thing")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/users?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/users")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unknown_thing")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/1234")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/1234/")), true)
 
@@ -53,14 +53,14 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     // MARK: - Enabled / Disabled tabs
 
     func test_isAllowedUrl_whenSetupWithTabs_shouldAllowOnlyEnabledTabs() {
-        saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/stuff", context: .course("42"))
         saveTab(htmlUrl: "/courses/42/users", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), true)
 
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/modules")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unkown_thing")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/unknown_thing")), false)
 
         verifyUnrelatedURLsAreAllowed()
     }
@@ -68,32 +68,32 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     func test_isAllowedUrl_whenUrlIsNotCourseTab_shouldAllow() {
         saveTab(htmlUrl: "/courses/42/_something_", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("/groups/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/groups/42/stuff")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/users/self/files")), true)
         XCTAssertEqual(testee.isAllowedUrl(.make("/users/42/settings")), true)
     }
 
     func test_isAllowedUrl_whenTabIsDisabledInAnotherCourse_shouldBlockOnlyForThatCourse() {
-        saveTab(htmlUrl: "/courses/7/not_grades", context: .course("7"))
-        saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/7/not_stuff", context: .course("7"))
+        saveTab(htmlUrl: "/courses/42/stuff", context: .course("42"))
 
         // tab disabled in course -> block
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/7/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/7/stuff")), false)
 
         // tab enabled in course -> allow
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), true)
 
         // tab in unknown course -> allow
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/0/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/0/stuff")), true)
     }
 
     // MARK: - UserInfo
 
     func test_isAllowedUrlWithUserInfo_whenBlockDisabledTabIsFalse_shouldAllowDisabledTab() {
-        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/not_stuff", context: .course("42"))
 
         let isAllowedUrl = testee.isAllowedUrl(
-            .make("/courses/42/grades"),
+            .make("/courses/42/stuff"),
             userInfo: [CourseTabUrlInteractor.blockDisabledTabUserInfoKey: false]
         )
         XCTAssertEqual(isAllowedUrl, true)
@@ -102,10 +102,10 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     }
 
     func test_isAllowedUrlWithUserInfo_whenBlockDisabledTabIsTrue_shouldBlockDisabledTab() {
-        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/not_stuff", context: .course("42"))
 
         let isAllowedUrl = testee.isAllowedUrl(
-            .make("/courses/42/grades"),
+            .make("/courses/42/stuff"),
             userInfo: [CourseTabUrlInteractor.blockDisabledTabUserInfoKey: true]
         )
         XCTAssertEqual(isAllowedUrl, false)
@@ -114,10 +114,10 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     }
 
     func test_isAllowedUrlWithUserInfo_whenBlockDisabledTabIsNotSet_shouldBlockDisabledTab() {
-        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/not_stuff", context: .course("42"))
 
         let isAllowedUrl = testee.isAllowedUrl(
-            .make("/courses/42/grades"),
+            .make("/courses/42/stuff"),
             userInfo: [:]
         )
         XCTAssertEqual(isAllowedUrl, false)
@@ -128,62 +128,62 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
     // MARK: - Tab Format rules
 
     func test_isAllowedUrl_whenTabIsDisabled_shouldBlockAllVariants() {
-        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/not_stuff", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/stuff?per_page=100&include%5B%5D=sections&no_verifiers=1")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff?display=borderless")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff#foo")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/stuff")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff/")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/stuff")), false)
     }
 
     func test_isAllowedUrl_whenTabIsEnabled_shouldAllowAllVariants() {
-        saveTab(htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/stuff", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/stuff?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff/")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/stuff")), true)
     }
 
     func test_isAllowedUrl_whenTabWithQueryIsEnabled_shouldAllowAllVariants() {
-        saveTab(htmlUrl: "/courses/42/grades?display=borderless", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/stuff?display=borderless", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/stuff?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff/")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/stuff")), true)
     }
 
     func test_isAllowedUrl_whenTabWithFragmentIsEnabled_shouldAllowAllVariants() {
-        saveTab(htmlUrl: "/courses/42/grades#foo", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/stuff#foo", context: .course("42"))
 
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/grades?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades?display=borderless")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#foo")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/grades#bar")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/")), true)
-        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/grades")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/api/v1/courses/42/stuff?per_page=100&include%5B%5D=sections&no_verifiers=1")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff?display=borderless")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff#foo")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("https://stuff.instructure.com/courses/42/stuff#bar")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/api/v1/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff/")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("courses/42/stuff")), true)
     }
 
     func test_isAllowedUrl_whenTabIsDisabled_shouldAllowSubpages() {
-        saveTab(htmlUrl: "/courses/42/not_grades", context: .course("42"))
+        saveTab(htmlUrl: "/courses/42/not_stuff", context: .course("42"))
 
         // subpage -> allow
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades/123")), true)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff/123")), true)
 
         // tab -> block
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), false)
     }
 
     func test_isAllowedUrl_whenTabIsDisabled_shouldAllowNonTabNavigationPaths() {
@@ -247,7 +247,7 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
             id: "people",
             html_url: URL(string: "/courses/42/modules")!,
             full_url: URL(string: "/courses/42/pages")!,
-            url: URL(string: "/courses/42/grades")!
+            url: URL(string: "/courses/42/stuff")!
         )
         let tab: Tab = databaseClient.insert()
         tab.save(apiTab, in: databaseClient, context: .course("42"))
@@ -257,7 +257,7 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
 
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/users")), false)
         XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/pages")), false)
-        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/grades")), false)
+        XCTAssertEqual(testee.isAllowedUrl(.make("/courses/42/stuff")), false)
     }
 
     func test_setupEnabledTabs_whenTabIsNotCourse_shouldIgnore() {
@@ -288,12 +288,12 @@ final class CourseTabUrlInteractorTests: CoreTestCase {
 
     func test_setupEnabledTabs_whenPathFormatIsUnknown_shouldLogIt() {
         // known path formats are not logged
-        saveTab(id: "grades", htmlUrl: "/courses/42/grades", context: .course("42"))
+        saveTab(id: "stuff", htmlUrl: "/courses/42/stuff", context: .course("42"))
         saveTab(id: "syllabus", htmlUrl: "/courses/42/assignments/syllabus", context: .course("42"))
         XCTAssertEqual(remoteLogHandler.lastErrorName, nil)
 
         // unknown path format is logged
-        saveTab(id: "pages", htmlUrl: "/courses/42/tabs/grades", context: .course("42"))
+        saveTab(id: "pages", htmlUrl: "/courses/42/tabs/stuff", context: .course("42"))
         XCTAssertEqual(remoteLogHandler.lastErrorName, "Unexpected Course Tab path format")
     }
 


### PR DESCRIPTION
refs: [MBL-18581](https://instructure.atlassian.net/browse/MBL-18581)
affects: Student
release note: Fixed a bug where hidden tabs were not handled correctly.

## What's changed
- Grades and Discussions tabs are no longer disabled for access via direct links (like the rest of the tabs), but only hidden from the list of tabs (as they were already).
- Excluded LTI launch request format from logging.
  - Not adding it to known tab formats at the moment, just excluding from logging

## Test plan
- Disable Grades, Discussion and some other tabs (as a Teacher or Admin)
- Create links for these tabs on a page, or message, or anywhere in the app
  - for Discussions: `.../courses/42/discussion_topics`
  - for Grades: `.../courses/42/grades`
- Verify these links open their respective screens in the app
- Verify links for other disabled tabs are still disabled
- Verify links for other enabled tabs are still enabled

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18581]: https://instructure.atlassian.net/browse/MBL-18581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ