### PR TITLE
Accessibility - Parent - Dashboard - Rename "Settings" button to "Profile menu" button

### DIFF
--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -146,7 +146,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
 
     func updateBadgeCount() {
         profileButton.addBadge(number: badgeCount, color: currentColor)
-        profileButton.accessibilityLabel = String(localized: "Settings", bundle: .parent)
+        profileButton.accessibilityLabel = String(localized: "Profile menu", bundle: .parent)
         profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
         if badgeCount > 0 {
             profileButton.accessibilityHint = String.localizedStringWithFormat(

--- a/Parent/Parent/Dashboard/DashboardViewController.swift
+++ b/Parent/Parent/Dashboard/DashboardViewController.swift
@@ -146,7 +146,7 @@ class DashboardViewController: ScreenViewTrackableViewController, ErrorViewContr
 
     func updateBadgeCount() {
         profileButton.addBadge(number: badgeCount, color: currentColor)
-        profileButton.accessibilityLabel = String(localized: "Profile menu", bundle: .parent)
+        profileButton.accessibilityLabel = String(localized: "Profile Menu", bundle: .parent)
         profileButton.accessibilityValue = String(localized: "Closed", bundle: .core)
         if badgeCount > 0 {
             profileButton.accessibilityHint = String.localizedStringWithFormat(

--- a/Parent/Parent/Localizable.xcstrings
+++ b/Parent/Parent/Localizable.xcstrings
@@ -12561,6 +12561,9 @@
         }
       }
     },
+    "Profile Menu" : {
+
+    },
     "QR Code" : {
       "localizations" : {
         "ar" : {
@@ -14356,6 +14359,7 @@
       }
     },
     "Settings" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
+++ b/Parent/ParentUnitTests/Dashboard/DashboardViewControllerTests.swift
@@ -55,7 +55,7 @@ class DashboardViewControllerTests: ParentTestCase {
         XCTAssert(vc.tabsController.viewControllers?[1] is PlannerViewController)
         XCTAssert(vc.tabsController.viewControllers?[2] is ObserverAlertListViewController)
 
-        XCTAssertEqual(vc.profileButton.accessibilityLabel, "Settings")
+        XCTAssertEqual(vc.profileButton.accessibilityLabel, "Profile Menu")
         XCTAssertEqual(vc.profileButton.accessibilityHint, "3 unread conversations")
         vc.profileButton.sendActions(for: .primaryActionTriggered)
         XCTAssert(router.lastRoutedTo("/profile", withOptions: .modal()))


### PR DESCRIPTION
### Accessibility - Parent - Dashboard - Rename "Settings" button to "Profile menu" button

refs: MBL-18398
affects: Parent
release note: None
test plan: VoiceOver should read profile button as "Profile menu, button" instead of "Settings, button" to be consistent with the other 2 apps.

## Checklist

- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
