### PR TITLE
Accessibility - Teacher - Calendar - Today button should have the date

### DIFF
--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -213,7 +213,6 @@ public class PlannerViewController: UIViewController {
         currentlyDisplayedToday = date
         todayButton.image = makeTodayIcon(text: date.dayString)
 
-
         // Update accessibilityLabel with today's date
         let dateFormatter = DateFormatter()
         dateFormatter.setLocalizedDateFormatFromTemplate("dd MMMM")

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -212,14 +212,7 @@ public class PlannerViewController: UIViewController {
 
         currentlyDisplayedToday = date
         todayButton.image = makeTodayIcon(text: date.dayString)
-
-        // Update accessibilityLabel with today's date
-        let dateFormatter = DateFormatter()
-        dateFormatter.setLocalizedDateFormatFromTemplate("dd MMMM")
-        let todayString = dateFormatter.string(from: date)
-        if let aLabel = todayButton.accessibilityLabel {
-            todayButton.accessibilityLabel = "\(aLabel), \(todayString)"
-        }
+        todayButton.accessibilityHint = date.formatted(.dateTime .day() .month(.wide))
     }
 
     private func makeTodayIcon(text: String) -> UIImage {

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -212,7 +212,7 @@ public class PlannerViewController: UIViewController {
 
         currentlyDisplayedToday = date
         todayButton.image = makeTodayIcon(text: date.dayString)
-        todayButton.accessibilityHint = date.formatted(.dateTime .day() .month(.wide))
+        todayButton.accessibilityHint = date.formatted(.dateTime.day().month(.wide))
     }
 
     private func makeTodayIcon(text: String) -> UIImage {

--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -212,6 +212,15 @@ public class PlannerViewController: UIViewController {
 
         currentlyDisplayedToday = date
         todayButton.image = makeTodayIcon(text: date.dayString)
+
+
+        // Update accessibilityLabel with today's date
+        let dateFormatter = DateFormatter()
+        dateFormatter.setLocalizedDateFormatFromTemplate("dd MMMM")
+        let todayString = dateFormatter.string(from: date)
+        if let aLabel = todayButton.accessibilityLabel {
+            todayButton.accessibilityLabel = "\(aLabel), \(todayString)"
+        }
     }
 
     private func makeTodayIcon(text: String) -> UIImage {


### PR DESCRIPTION
## Accessibility - Teacher - Calendar - Today button should have the date

refs: MBL-18297
affects: Teacher, Student
release note: None
test plan: Accessibility label of Today button should contain today's date in short format (February 21).

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
