### PR TITLE
Accessibility - Student / Teacher - Fix Student Annotation status message a11y traits

### DIFF
--- a/Core/Core/Features/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/Features/DocViewer/DocViewerViewController.swift
@@ -297,18 +297,31 @@ extension DocViewerViewController: DocViewerAnnotationProviderDelegate {
         annotationProvider?.retryFailedRequest()
     }
 
-    func annotationDidFailToSave(error: Error) { performUIUpdate {
-        self.syncAnnotationsButton.isEnabled = true
-        self.syncAnnotationsButton.backgroundColor = .backgroundDanger
-        self.syncAnnotationsButton.setTitle(String(localized: "Error Saving. Tap to retry.", bundle: .core), for: .normal)
-    } }
+    func annotationDidFailToSave(error: Error) {
+        guard let syncAnnotationsButton else { return }
 
-    func annotationSaveStateChanges(saving: Bool) { performUIUpdate {
-        self.syncAnnotationsButton.isEnabled = false
-        self.syncAnnotationsButton.backgroundColor = .backgroundLight
-        self.syncAnnotationsButton.setTitle(saving
+        let title = String(localized: "Error Saving. Tap to retry.", bundle: .core)
+
+        performUIUpdate {
+            syncAnnotationsButton.isEnabled = true
+            syncAnnotationsButton.backgroundColor = .backgroundDanger
+            syncAnnotationsButton.setTitle(title, for: .normal)
+            syncAnnotationsButton.accessibilityTraits.insert(.button)
+        }
+    }
+
+    func annotationSaveStateChanges(saving: Bool) {
+        guard let syncAnnotationsButton else { return }
+
+        let title = saving
             ? String(localized: "Saving...", bundle: .core)
-            : String(localized: "All annotations saved.", bundle: .core),
-        for: .normal)
-    } }
+            : String(localized: "All annotations saved.", bundle: .core)
+
+        performUIUpdate {
+            syncAnnotationsButton.isEnabled = false
+            syncAnnotationsButton.backgroundColor = .backgroundLight
+            syncAnnotationsButton.setTitle(title, for: .normal)
+            syncAnnotationsButton.accessibilityTraits.remove(.button)
+        }
+    }
 }

--- a/Core/CoreTests/Features/DocViewer/DocViewerViewControllerTests.swift
+++ b/Core/CoreTests/Features/DocViewer/DocViewerViewControllerTests.swift
@@ -254,15 +254,21 @@ class DocViewerViewControllerTests: CoreTestCase {
         controller.view.layoutIfNeeded()
         controller.annotationDidFailToSave(error: APIDocViewerError.tooBig)
         XCTAssertEqual(controller.syncAnnotationsButton.isEnabled, true)
+        XCTAssertEqual(controller.syncAnnotationsButton.accessibilityTraits.contains(.button), true)
         XCTAssertNoThrow(controller.syncAnnotationsButton.sendActions(for: .primaryActionTriggered))
     }
 
     func testAnnotationSaveStateChanges() {
         controller.view.layoutIfNeeded()
+
         controller.annotationSaveStateChanges(saving: true)
         XCTAssertEqual(controller.syncAnnotationsButton.isEnabled, false)
+        XCTAssertEqual(controller.syncAnnotationsButton.accessibilityTraits.contains(.button), false)
         XCTAssertEqual(controller.syncAnnotationsButton.title(for: .normal), "Saving...")
+
         controller.annotationSaveStateChanges(saving: false)
+        XCTAssertEqual(controller.syncAnnotationsButton.isEnabled, false)
+        XCTAssertEqual(controller.syncAnnotationsButton.accessibilityTraits.contains(.button), false)
         XCTAssertEqual(controller.syncAnnotationsButton.title(for: .normal), "All annotations saved.")
     }
 }


### PR DESCRIPTION
refs: [MBL-18463](https://instructure.atlassian.net/browse/MBL-18463)
affects: Student, Teacher
release note: none

Student or Teacher annotations has a status message at the top.
This should not act as a disabled button.

**NOTE:** the related error method is never used, but I've updated it anyway, didn't want to investigate deeply.

## Test plan
Verify the "Saving" or "All annotations saved" texts doesn't read "Button, Dimmed" in both places:
- Student app > Assignment with Student Annotation type > Submit Assignment screen
- Teacher app > Assignments > SpeedGrader

## Checklist
- [x] Tested on phone
- [ ] Tested on tablet

[MBL-18463]: https://instructure.atlassian.net/browse/MBL-18463?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ