### PR TITLE
Accessibility - Teacher - Calendar - Day button to have weekday in label

### DIFF
--- a/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
@@ -197,9 +197,8 @@ class CalendarDayButton: UIButton {
             for (d, dot) in dotContainer.arrangedSubviews.enumerated() {
                 dot.isHidden = d >= activityDotCount
             }
-            accessibilityLabel = String.localizedStringWithFormat(
-                String(localized: "date_d_events", bundle: .core),
-                DateFormatter.localizedString(from: date, dateStyle: .long, timeStyle: .none),
+            accessibilityHint = String.localizedStringWithFormat(
+                String(localized: "d_events", bundle: .core),
                 activityDotCount
             )
         }
@@ -244,7 +243,7 @@ class CalendarDayButton: UIButton {
         let month = String(calendar.component(.month, from: date))
         let day = String(calendar.component(.day, from: date))
         accessibilityIdentifier = "PlannerCalendar.dayButton.\(year)-\(month)-\(day)"
-        accessibilityLabel = DateFormatter.localizedString(from: date, dateStyle: .long, timeStyle: .none)
+        accessibilityLabel = date.formatted(.dateTime .year() .month() .day() .weekday(.wide))
 
         translatesAutoresizingMaskIntoConstraints = false
         addSubview(circleView)

--- a/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
@@ -197,7 +197,7 @@ class CalendarDayButton: UIButton {
             for (d, dot) in dotContainer.arrangedSubviews.enumerated() {
                 dot.isHidden = d >= activityDotCount
             }
-            accessibilityHint = String.localizedStringWithFormat(
+            accessibilityValue = String.localizedStringWithFormat(
                 String(localized: "d_events", bundle: .core),
                 activityDotCount
             )

--- a/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/CalendarDaysViewController.swift
@@ -243,7 +243,7 @@ class CalendarDayButton: UIButton {
         let month = String(calendar.component(.month, from: date))
         let day = String(calendar.component(.day, from: date))
         accessibilityIdentifier = "PlannerCalendar.dayButton.\(year)-\(month)-\(day)"
-        accessibilityLabel = date.formatted(.dateTime .year() .month() .day() .weekday(.wide))
+        accessibilityLabel = date.formatted(.dateTime.year().month().day().weekday(.wide))
 
         translatesAutoresizingMaskIntoConstraints = false
         addSubview(circleView)


### PR DESCRIPTION
## Accessibility - Teacher - Calendar - Day button to have weekday in label

VoiceOver should read weekday as well alongside with the date for day buttons in Calendar.
Also I moved the event count to accessibilityHint because I think it's nicer to provide it there, but let me know if you have any concerns with it.

refs: MBL-18299
affects: Teacher, Student
release note: None
test plan: See ticket.

## Checklist

- [x] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
