### PR TITLE
Accessibility - Student/Teacher - Refocus VoiceOver to DatePicker after selection is finished

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -38,7 +38,6 @@ extension InstUI {
         private let errorMessage: String?
         private let isClearable: Bool
 
-        @State private var trackingPopoverID = Foundation.UUID().uuidString
         @Binding private var date: Date?
 
         public init(
@@ -148,7 +147,7 @@ extension InstUI {
                 displayedComponents: components,
                 label: {}
             )
-            .accessibilityRefocusingOnPopoverDismissal(trackingPopoverID)
+            .accessibilityRefocusingOnPopoverDismissal()
         }
 
         @ViewBuilder

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -37,8 +37,8 @@ extension InstUI {
         private let validUntil: Date
         private let errorMessage: String?
         private let isClearable: Bool
-        private let trackingPopoverID: String?
 
+        @State private var trackingPopoverID = Foundation.UUID().uuidString
         @Binding private var date: Date?
 
         public init(
@@ -49,7 +49,6 @@ extension InstUI {
             validFrom: Date = .distantPast,
             validUntil: Date = .distantFuture,
             errorMessage: String? = nil,
-            trackingPopoverID: String? = nil,
             isClearable: Bool = false
         ) {
             self.label = label
@@ -59,7 +58,6 @@ extension InstUI {
             self.validFrom = validFrom
             self.validUntil = validUntil
             self.errorMessage = errorMessage
-            self.trackingPopoverID = trackingPopoverID
             self.isClearable = isClearable
         }
 
@@ -144,18 +142,13 @@ extension InstUI {
             case .dateAndTime: [.date, .hourAndMinute]
             }
 
-            let datePickerView = DatePicker(
+            DatePicker(
                 selection: binding,
                 in: validFrom...validUntil,
                 displayedComponents: components,
                 label: {}
             )
-
-            if let trackingPopoverID {
-                datePickerView.accessibilityRefocusingOnPopoverDismissal(trackingPopoverID)
-            } else {
-                datePickerView
-            }
+            .accessibilityRefocusingOnPopoverDismissal(trackingPopoverID)
         }
 
         @ViewBuilder

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -37,6 +37,7 @@ extension InstUI {
         private let validUntil: Date
         private let errorMessage: String?
         private let isClearable: Bool
+        private let trackingPopoverID: String?
 
         @Binding private var date: Date?
 
@@ -48,6 +49,7 @@ extension InstUI {
             validFrom: Date = .distantPast,
             validUntil: Date = .distantFuture,
             errorMessage: String? = nil,
+            trackingPopoverID: String? = nil,
             isClearable: Bool
         ) {
             self.label = label
@@ -57,6 +59,7 @@ extension InstUI {
             self.validFrom = validFrom
             self.validUntil = validUntil
             self.errorMessage = errorMessage
+            self.trackingPopoverID = trackingPopoverID
             self.isClearable = isClearable
         }
 
@@ -110,12 +113,19 @@ extension InstUI {
                 get: { date ?? defaultDate },
                 set: { newDate in date = newDate }
             )
-            DatePicker(
+
+            let datePickerView = DatePicker(
                 selection: binding,
                 in: validFrom...validUntil,
                 displayedComponents: components,
                 label: {}
             )
+
+            if let trackingPopoverID {
+                datePickerView.accessibilityRefocusingOnPopoverDismissal(trackingPopoverID)
+            } else {
+                datePickerView
+            }
         }
 
         private var components: DatePicker<Label>.Components {

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -144,7 +144,7 @@ extension InstUI {
             case .dateAndTime: [.date, .hourAndMinute]
             }
 
-            DatePicker(
+            let datePickerView = DatePicker(
                 selection: binding,
                 in: validFrom...validUntil,
                 displayedComponents: components,

--- a/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
+++ b/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
@@ -27,11 +27,9 @@ struct A11yRefocusingOnPopoverDismissalViewModifier: ViewModifier {
 
     @AccessibilityFocusState
     private var isAccFocused: Bool
-    private let trackingPopoverID: String
 
-    init(trackingPopoverID: String) {
-        self.trackingPopoverID = trackingPopoverID
-    }
+    @State
+    private var trackingPopoverID: String = Foundation.UUID().uuidString
 
     func body(content: Content) -> some View {
         content
@@ -69,11 +67,7 @@ struct A11yRefocusingOnPopoverDismissalViewModifier: ViewModifier {
 extension View {
 
     /// Refocuses VoiceOver after popover dismissal to the element which activated it. Common examples are `DatePicker`s & `Menu`s
-    /// - parameters:
-    ///    - trackingPopoverID: This ID is used to distinguish popover source when there are multiple elements on screen that can activate popovers. It is important to pass a _distinct_ & **stable** value even if you have one single element on screen that can activate popover.
-    public func accessibilityRefocusingOnPopoverDismissal(_ trackingPopoverID: String) -> some View {
-        modifier(
-            A11yRefocusingOnPopoverDismissalViewModifier(trackingPopoverID: trackingPopoverID)
-        )
+    public func accessibilityRefocusingOnPopoverDismissal() -> some View {
+        modifier(A11yRefocusingOnPopoverDismissalViewModifier())
     }
 }

--- a/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
+++ b/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
@@ -96,5 +96,5 @@ public enum A11YPopoverFocus {
     private class DefaultTracking: A11YPopoverFocusTracking {
         var lastFocused: String?
     }
-    public static var tracking: A11YPopoverFocusTracking = DefaultTracking()
+    public internal(set) static var tracking: A11YPopoverFocusTracking = DefaultTracking()
 }

--- a/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
+++ b/Core/Core/Common/CommonUI/ViewModifiers/A11yRefocusingOnPopoverDismissalViewModifier.swift
@@ -1,0 +1,82 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Combine
+import SwiftUI
+
+struct A11yRefocusingOnPopoverDismissalViewModifier: ViewModifier {
+    // Apple use this value for area where user can tap to dismiss pop-overs
+    static let popoverDismissRegionAccessibilityID = "PopoverDismissRegion"
+
+    private static var latestFocused = [String]()
+
+    @AccessibilityFocusState
+    private var isAccFocused: Bool
+
+    private let trackingPopoverID: String
+    init(trackingPopoverID: String) {
+        self.trackingPopoverID = trackingPopoverID
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .accessibilityFocused($isAccFocused)
+            .onChange(of: isAccFocused) { focused in
+                if focused {
+                    Self.latestFocused.append(trackingPopoverID)
+                }
+            }
+            .onReceive(didDismissPopover) {
+                guard Self.latestFocused.last == trackingPopoverID else { return }
+
+                isAccFocused = true
+                Self.latestFocused.removeAll()
+            }
+    }
+
+    private var didDismissPopover: AnyPublisher<Void, Never> {
+        NotificationCenter
+            .default
+            .publisher(for: UIAccessibility.elementFocusedNotification)
+            .filter({ notif in
+                guard let info = notif.userInfo,
+                      let popupView = info[UIAccessibility.unfocusedElementUserInfoKey] as? UIAccessibilityElement
+                else { return false }
+                return popupView.accessibilityIdentifier == Self.popoverDismissRegionAccessibilityID
+            })
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - View Helper
+
+extension View {
+
+    /// Refocuses VoiceOver after popover dismissal to the element which activated it. Common examples are `DatePicker`s & `Menu`s
+    /// - parameters:
+    ///    - trackingPopoverID: This ID is used to distinguish popover source when there are multiple elements on screen that can activate popovers. It is important to pass a distinct value even if you have only single element on screen that can activate popover.
+    public func accessibilityRefocusingOnPopoverDismissal(_ trackingPopoverID: String) -> some View {
+        modifier(
+            A11yRefocusingOnPopoverDismissalViewModifier(
+                trackingPopoverID: trackingPopoverID
+            )
+        )
+    }
+}

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -53,8 +53,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         InstUI.DatePickerCell(
                             label: Text("Date", bundle: .core),
                             date: $viewModel.date,
-                            mode: .dateOnly,
-                            trackingPopoverID: "date-picker"
+                            mode: .dateOnly
                         )
 
                         InstUI.ToggleCell(label: Text("All Day", bundle: .core), value: $viewModel.isAllDay)
@@ -64,8 +63,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                                 label: Text("From", bundle: .core)
                                     .accessibilityLabel(Text("Start time", bundle: .core)),
                                 date: $viewModel.startTime,
-                                mode: .timeOnly,
-                                trackingPopoverID: "from-time-picker"
+                                mode: .timeOnly
                             )
 
                             InstUI.DatePickerCell(
@@ -73,8 +71,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                                     .accessibilityLabel(Text("End time", bundle: .core)),
                                 date: $viewModel.endTime,
                                 mode: .timeOnly,
-                                errorMessage: viewModel.endTimeErrorMessage,
-                                trackingPopoverID: "to-time-picker"
+                                errorMessage: viewModel.endTimeErrorMessage
                             )
                         }
 

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -54,6 +54,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                             label: Text("Date", bundle: .core),
                             date: $viewModel.date,
                             mode: .dateOnly,
+                            trackingPopoverID: "date-picker",
                             isClearable: false
                         )
 
@@ -64,6 +65,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                                 label: Text("From", bundle: .core),
                                 date: $viewModel.startTime,
                                 mode: .timeOnly,
+                                trackingPopoverID: "from-time-picker",
                                 isClearable: false
                             )
 
@@ -72,6 +74,7 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                                 date: $viewModel.endTime,
                                 mode: .timeOnly,
                                 errorMessage: viewModel.endTimeErrorMessage,
+                                trackingPopoverID: "to-time-picker",
                                 isClearable: false
                             )
                         }


### PR DESCRIPTION
refs: [MBL-18312](https://instructure.atlassian.net/browse/MBL-18312)
affects: Student, Teacher
release note: None.

This solution can be considered as a "hacky" solution, as it is being dependent on a UIKit value (`popoverDismissRegionAccessibilityID`) that was not officially declared in documentation for that use. Though upon testing, it turned out it serves our need perfectly. 

The main challenge of this work is to detect when popover is being presented, and which UI element caused it. While there is no way (officially documented by Apple) to tell that for `DatePicker`, in order to solve this, I had to rely on tracking a fixed ID of contributing elements in a global list, and use that to distinguish the source of popover upon dismissal.

## Test Plan

When activating DatePicker fields using VoiceOver on `Edit Event` screen, focus must be moved to them upon finishing with selection.

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18312]: https://instructure.atlassian.net/browse/MBL-18312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ