### PR TITLE
Accessibility - DatePickerCell

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -62,30 +62,33 @@ extension InstUI {
 
         public var body: some View {
             VStack(spacing: 0) {
-                ViewThatFits {
-                    HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
-                        dateRow
+                VStack(spacing: 0) {
+                    ViewThatFits {
+                        HStack(spacing: InstUI.Styles.Padding.standard.rawValue) {
+                            dateRow
+                        }
+                        VStack(alignment: .leading) {
+                            dateRow
+                        }
                     }
-                    VStack(alignment: .leading) {
-                        dateRow
-                    }
-                }
-                .frame(minHeight: 36) // To always have the same height despite datepicker visibility
+                    .frame(minHeight: 36) // To always have the same height despite datepicker visibility
 
-                if let errorMessage {
-                    Text(errorMessage)
-                        .textStyle(.errorMessage)
-                        .frame(maxWidth: .infinity, alignment: .trailing)
-                        .padding(.top, 8)
+                    if let errorMessage {
+                        Text(errorMessage)
+                            .textStyle(.errorMessage)
+                            .frame(maxWidth: .infinity, alignment: .trailing)
+                            .padding(.top, 8)
+                    }
                 }
+                .paddingStyle(.leading, .standard)
+                .paddingStyle(.trailing, .standard)
+                // best effort estimations to match the height of other cells, correcting for DatePicker
+                .padding(.top, 5)
+                .padding(.bottom, 7)
+                .accessibilityElement(children: .contain)
+
+                InstUI.Divider()
             }
-            .paddingStyle(.leading, .standard)
-            .paddingStyle(.trailing, .standard)
-            // best effort estimations to match the height of other cells, correcting for DatePicker
-            .padding(.top, 5)
-            .padding(.bottom, 7)
-
-            InstUI.Divider()
         }
 
         @ViewBuilder

--- a/Core/Core/Common/Extensions/Foundation/DateExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/DateExtensions.swift
@@ -218,6 +218,10 @@ public extension Date {
         DateFormatter.localizedString(from: self, dateStyle: .medium, timeStyle: .none)
     }
 
+    var timeOnlyString: String {
+        formatted(.dateTime.hour().minute())
+    }
+
     var dateTimeString: String {
         DateFormatter.localizedString(from: self, dateStyle: .medium, timeStyle: .short)
     }

--- a/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
@@ -139,6 +139,14 @@ extension String {
         // even when language & region both are set to a language which doesn't (like Danish)
         return "\(listText), \(countText)"
     }
+
+    /// Localized string to be used for error messages intended for accessibility usage. Adds some context for VoiceOver users that this is an error.
+    /// The `errorMessage` itself is expected to be localized already.
+    /// Example: "Error: Invalid start time"
+    public static func localizedAccessibilityErrorMessage(_ errorMessage: String) -> String {
+        let format = String(localized: "Error: %@", bundle: .core, comment: "Example: 'Error: Invalid start time'")
+        return String.localizedStringWithFormat(format, errorMessage)
+    }
 }
 
 extension ReferenceWritableKeyPath {

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -53,26 +53,25 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
                         InstUI.DatePickerCell(
                             label: Text("Date", bundle: .core),
                             date: $viewModel.date,
-                            mode: .dateOnly,
-                            isClearable: false
+                            mode: .dateOnly
                         )
 
                         InstUI.ToggleCell(label: Text("All Day", bundle: .core), value: $viewModel.isAllDay)
 
                         if !viewModel.isAllDay {
                             InstUI.DatePickerCell(
-                                label: Text("From", bundle: .core),
+                                label: Text("From", bundle: .core)
+                                    .accessibilityLabel(Text("Start time", bundle: .core)),
                                 date: $viewModel.startTime,
-                                mode: .timeOnly,
-                                isClearable: false
+                                mode: .timeOnly
                             )
 
                             InstUI.DatePickerCell(
-                                label: Text("To", bundle: .core),
+                                label: Text("To", bundle: .core)
+                                    .accessibilityLabel(Text("End time", bundle: .core)),
                                 date: $viewModel.endTime,
                                 mode: .timeOnly,
-                                errorMessage: viewModel.endTimeErrorMessage,
-                                isClearable: false
+                                errorMessage: viewModel.endTimeErrorMessage
                             )
                         }
 

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCustomFrequencyScreen.swift
@@ -156,8 +156,7 @@ struct EditCustomFrequencyScreen: View, ScreenViewTrackable {
             date: $viewModel.endDate,
             mode: .dateOnly,
             defaultDate: Clock.now.addYears(1),
-            validFrom: viewModel.proposedDate,
-            isClearable: false
+            validFrom: viewModel.proposedDate
         )
     }
 

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -42,7 +42,7 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
                 VStack(spacing: 0) {
                     InstUI.TextFieldCell(
                         label: Text("Title", bundle: .core),
-                        placeholder: String(localized: "Add title", bundle: .core),
+                        placeholder: String(localized: "Add title (required)", bundle: .core),
                         text: $viewModel.title
                     )
                     .focused($focusedInput, equals: .title)

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -50,8 +50,7 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
 
                     InstUI.DatePickerCell(
                         label: Text("Date", bundle: .core),
-                        date: $viewModel.date,
-                        isClearable: false
+                        date: $viewModel.date
                     )
                     .accessibilityIdentifier("Calendar.Todo.datePicker")
 

--- a/Core/CoreTests/Common/Extensions/Foundation/DateExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/DateExtensionsTests.swift
@@ -114,6 +114,10 @@ class DateExtensionsTests: XCTestCase {
         XCTAssertEqual(DateComponents(calendar: .current, timeZone: .current, year: 2000, month: 12, day: 25).date?.dateOnlyString, "Dec 25, 2000")
     }
 
+    func testTimeOnlyString() {
+        XCTAssertEqual(Date.make(year: 2000, month: 12, day: 25, hour: 11, minute: 45).timeOnlyString, "11:45 AM")
+    }
+
     func testRelativeDateOnlyString() {
         XCTAssertEqual(DateComponents(calendar: .current, timeZone: .current, year: 2000, month: 12, day: 25).date?.relativeDateOnlyString, "Dec 25, 2000")
         XCTAssertEqual(Date.now.relativeDateOnlyString, "Today")

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -94,4 +94,9 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(String.localizedAccessibilityListCount(1), "List, 1 item")
         XCTAssertEqual(String.localizedAccessibilityListCount(5), "List, 5 items")
     }
+
+    func testLocalizedAccessibilityErrorMessage() {
+        XCTAssertEqual(String.localizedAccessibilityErrorMessage("Some error description"), "Error: Some error description")
+        XCTAssertEqual(String.localizedAccessibilityErrorMessage(""), "Error: ")
+    }
 }


### PR DESCRIPTION
refs: [MBL-18334](https://instructure.atlassian.net/browse/MBL-18334)
affects: Student, Teacher
release note: none

## What's changed
Ticket's recommendation is a bit unclear.
Initial recommendation from UX was to combine DatePickerCell's label with the actual datepicker button.
It would be okay for date-only or time-only cases, but not really for the date-time case.
Instead the following had been decided (which matches native iOS Calendar app):
- First focus is the label, which now includes the date/time as well: "Start time, 2025. 02. 12. at 13:13"
  - and the error message (if present)
- Next focus is the date-picker (if present): "Date picker, 2025. 02. 12., Button, Collapsed, Double-tap to expand"
- Next focus is the time-picker (if present): "Time picker, 13:13, Button, Collapsed, Double-tap to expand"
- Next focus is the clear button (if present): "Clear date, Button"

## Known issues
- when both date and time pickers are present, the "Date picker" and "Time picker" words are not read for some reason. This is the native DatePicker components behavior, which can't be customized
- selecting later Start time then the current End time displays an error message in End time a11y label, but it's not read to the user, only when End time label gets focused. Also not announcing it instantly when value changes.
- somewhat related to the above: dismissing a picker's popup focuses the Cancel button at the top. Tried to focus the cell's label instead, but couldn't hook on the "dismiss popup" action of the picker.

## Test plan
- Verify "From" label reads as "Start time, [time]"
- Verify "To" label reads as "End time, [time]"
- Verify "To" label also reads the visible error message when Start time is earlier then End time

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18334]: https://instructure.atlassian.net/browse/MBL-18334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ