### PR TITLE
Fix Navigation Bar issues

### DIFF
--- a/Core/Core/Features/Courses/SmartSearch/View/CourseSmartSearchFilterEditorView.swift
+++ b/Core/Core/Features/Courses/SmartSearch/View/CourseSmartSearchFilterEditorView.swift
@@ -70,7 +70,10 @@ public struct CourseSmartSearchFilterEditorView: View {
                     }
                 }
             }
-            .navigationBarStyle(.modal)
+            // Not using `.navigationBarStyle(.modal)` here, because that sets the navigatonBar's background color of its `CoreHostingViewController`,
+            // and this screen (the only one in the whole project) is being presented via the `.sheet()` modifier instead of `router(show:)`
+            // AND expected to have a Navigation Bar as well. That would turn the presenting screen's NavigationBar background color to white as well.
+            .environment(\.navBarColors, .init(style: .modal))
         }
         .tint(contextColor)
     }

--- a/Core/Core/Features/Login/LoginQRCodeTutorialViewController.swift
+++ b/Core/Core/Features/Login/LoginQRCodeTutorialViewController.swift
@@ -27,20 +27,21 @@ class LoginQRCodeTutorialViewController: UIViewController {
     weak var delegate: LoginQRCodeTutorialDelegate?
 
     static func create() -> LoginQRCodeTutorialViewController {
-        return loadFromStoryboard()
+        let vc = loadFromStoryboard()
+        let next = UIBarButtonItem(
+            title: String(localized: "Next", bundle: .core),
+            style: .plain,
+            target: vc,
+            action: #selector(done(_:))
+        )
+        vc.addNavigationButton(next, side: .right)
+        return vc
     }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         navigationItem.title = String(localized: "Locate QR Code", bundle: .core)
-        let next = UIBarButtonItem(
-            title: String(localized: "Next", bundle: .core),
-            style: .plain,
-            target: self,
-            action: #selector(done(_:))
-        )
-        addNavigationButton(next, side: .right)
     }
 
     @objc func done(_ sender: UIBarButtonItem) {

--- a/Core/Core/Features/Login/PairWithStudentQRCodeTutorialViewController.swift
+++ b/Core/Core/Features/Login/PairWithStudentQRCodeTutorialViewController.swift
@@ -28,7 +28,16 @@ public class PairWithStudentQRCodeTutorialViewController: UIViewController {
     weak var delegate: PairWithStudentQRCodeTutorialDelegate?
 
     static func create() -> PairWithStudentQRCodeTutorialViewController {
-        return loadFromStoryboard()
+        let vc = loadFromStoryboard()
+        let next = UIBarButtonItem(
+            title: String(localized: "Next", bundle: .core),
+            style: .plain,
+            target: vc,
+            action: #selector(done(_:))
+        )
+        next.accessibilityIdentifier = "PairWithStudentQRCodeTutorial.nextButton"
+        vc.addNavigationButton(next, side: .right)
+        return vc
     }
 
     public override func viewDidLoad() {
@@ -40,14 +49,6 @@ public class PairWithStudentQRCodeTutorialViewController: UIViewController {
         If your student doesn't see the option to create a pairing code, you'll need to reach out to your school to create your account.
         """, bundle: .core)
         headerLabel.accessibilityIdentifier = "PairWithStudentQRCodeTutorial.headerLabel"
-        let next = UIBarButtonItem(
-            title: String(localized: "Next", bundle: .core),
-            style: .plain,
-            target: self,
-            action: #selector(done(_:))
-        )
-        next.accessibilityIdentifier = "PairWithStudentQRCodeTutorial.nextButton"
-        addNavigationButton(next, side: .right)
     }
 
     @objc func done(_ sender: UIBarButtonItem) {


### PR DESCRIPTION
refs: [MBL-18640](https://instructure.atlassian.net/browse/MBL-18640)
affects: Student, Teacher, Parent
release note: none

(No notes, because the cause of the issue is also not released yet)

- Fix Next button missing on QR Login screen on iOS 17
- Fix Next button missing on Pair With Student QR Login screen on iOS 17
- Fix SmartSearch Results screen nav bar turning white when Filter is presented

## Test plan
Test both on iOS 17 & 18

Student + Teacher
- Reach Login screen, tap "QR Login" button
- Verify Next button is visible and working on QR code screen

Parent
- Reach Login screen, tap "QR Login" button
- Check both options (with and without Canvas Account)
- Verify Next button is visible and working on QR code screen (in both cases)

Student
- Reach SmartSearch in a Course
- Tap filter icon (without searching for a text)
- Verify the Filter screen's navigation bar background is the usual whiteish modal bg color
- Verify the original screen's navigation bar background is unchanged (course colored)
- Close the Filter screen, enter some text, tap Search
- Tap filter icon on the results screen
- Verify the same (this is a different screen under the hood, make sure to verify both cases)

## Checklist
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested on iOS 17
- [x] Tested on iOS 18
- [ ] Tested in dark mode
- [x] Tested in light mode

[MBL-18640]: https://instructure.atlassian.net/browse/MBL-18640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ