### PR TITLE
Accessibility - Add support for webviews to change their font size based on the device's setting

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/DefaultWKWebViewConfiguration.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/DefaultWKWebViewConfiguration.swift
@@ -36,5 +36,9 @@ public extension WKWebViewConfiguration {
         allowsPictureInPictureMediaPlayback = true
         allowsAirPlayForMediaPlayback = true
         processPool = CoreWebView.processPool
+
+        // This is to make -webkit-text-size-adjust work on iPads.
+        // https://trac.webkit.org/changeset/261940/webkit
+        defaultWebpagePreferences.preferredContentMode = .mobile
     }
 }

--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSize.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSize.swift
@@ -68,7 +68,7 @@ private extension UIContentSizeCategory {
             .accessibilityLarge,
             .accessibilityExtraLarge,
             .accessibilityExtraExtraLarge,
-            .accessibilityExtraExtraExtraLarge,
+            .accessibilityExtraExtraExtraLarge
         ]
     }
 

--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSize.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSize.swift
@@ -1,0 +1,134 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+internal class DynamicFontSize: CoreWebViewFeature {
+    private var script: String {
+        let css = """
+        body {
+            -webkit-text-size-adjust: \(percentScale) !important
+        }
+        """
+
+        let cssString = css.components(separatedBy: .newlines).joined()
+        return """
+           var element = document.createElement('style');
+           element.innerHTML = '\(cssString)';
+           document.head.appendChild(element);
+        """
+    }
+    private var percentScale: String {
+        let scale = Int(100 * UIScreen.main.traitCollection.preferredContentSizeCategory.fontScale)
+        return "\(scale)%"
+    }
+
+    public override init() {}
+
+    override func apply(on webView: CoreWebView) {
+        webView.addScript(script)
+    }
+}
+
+extension CoreWebViewFeature {
+
+    /**
+     This feature adds a CSS override that re-scales fonts based on the system's dynamic font size setting.
+     Note: it doesn't re-apply the scale if the dynamic size setting change while the webview is already presented.
+     */
+    public static var dynamicFontSize: CoreWebViewFeature {
+        DynamicFontSize()
+    }
+}
+
+private extension UIContentSizeCategory {
+    static var allCases: [UIContentSizeCategory] {
+        [
+            .extraSmall,
+            .small,
+            .medium,
+            .large,
+            .extraLarge,
+            .extraExtraLarge,
+            .extraExtraExtraLarge,
+            .accessibilityMedium,
+            .accessibilityLarge,
+            .accessibilityExtraLarge,
+            .accessibilityExtraExtraLarge,
+            .accessibilityExtraExtraExtraLarge,
+        ]
+    }
+
+    var fontScale: CGFloat {
+        switch self {
+        case .extraSmall: return 0.87
+        case .small: return 0.94
+        case .medium: return 0.95
+        case .large: return 1.0
+        case .extraLarge: return 1.07
+        case .extraExtraLarge: return 1.2
+        case .extraExtraExtraLarge: return 1.33
+        case .accessibilityMedium: return 1.55
+        case .accessibilityLarge: return 1.81
+        case .accessibilityExtraLarge: return 2.2
+        case .accessibilityExtraExtraLarge: return 2.58
+        case .accessibilityExtraExtraExtraLarge: return 2.82
+        default: return 1.0
+        }
+    }
+}
+
+/// The purpose of this preview is to get an estimation of how each content size category affects font size.
+/// You need to modify the fontScale values above until the two strings are the same size.
+@available(iOS 17.0, *)
+#Preview(traits: .fixedLayout(width: 400, height: 1200)) {
+    let referenceFontSize: CGFloat = 16.0
+
+    let verticalStack = UIStackView()
+    verticalStack.axis = .vertical
+
+    for contentSizeCategory in UIContentSizeCategory.allCases {
+        let scale = contentSizeCategory.fontScale
+        let scaledFontSize = referenceFontSize * scale
+        let percentageString = String(format: "%.0f%%", scale * 100)
+
+        let categoryTitle = UILabel()
+        categoryTitle.text = "\(contentSizeCategory.rawValue.deletingPrefix("UICTContentSizeCategory")) - \(percentageString)"
+        verticalStack.addArrangedSubview(categoryTitle)
+
+        let systemFont = UIFontMetrics(forTextStyle: .body)
+            .scaledFont(
+                for: UIFont.systemFont(ofSize: referenceFontSize),
+                compatibleWith: UITraitCollection(preferredContentSizeCategory: contentSizeCategory)
+            )
+        let systemSizedLabel = UILabel()
+        systemSizedLabel.font = systemFont
+        systemSizedLabel.text = "Lorem Ipsum"
+        verticalStack.addArrangedSubview(systemSizedLabel)
+
+        let scaledSizeLabel = UILabel()
+        scaledSizeLabel.font = UIFont.systemFont(ofSize: scaledFontSize)
+        scaledSizeLabel.text = "Lorem Ipsum"
+
+        verticalStack.addArrangedSubview(scaledSizeLabel)
+
+        let divider = UIView()
+        divider.heightAnchor.constraint(equalToConstant: 20).isActive = true
+        verticalStack.addArrangedSubview(divider)
+    }
+
+    return verticalStack
+}

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -257,7 +257,7 @@ open class CoreWebView: WKWebView {
         let style = Typography.Style.body
         // This is to avoid double scaling both from the font and from the script.
         let isDynamicFontScalingEnabled = features.contains { $0 is DynamicFontSize }
-        let uiFont = isDynamicFontScalingEnabled ? UIFont.applicationFont(ofSize: 16, weight: .regular)
+        let uiFont = isDynamicFontScalingEnabled ? Typography.Style.unscaledBodyUIFont
                                                  : style.uiFont
         let marginsDisabled = features.contains { $0 is DisableDefaultBodyMargin }
 

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -255,7 +255,10 @@ open class CoreWebView: WKWebView {
         let font: String
         let fontCSS: String
         let style = Typography.Style.body
-        let uiFont = style.uiFont
+        // This is to avoid double scaling both from the font and from the script.
+        let isDynamicFontScalingEnabled = features.contains { $0 is DynamicFontSize }
+        let uiFont = isDynamicFontScalingEnabled ? UIFont.applicationFont(ofSize: 16, weight: .regular)
+                                                 : style.uiFont
         let marginsDisabled = features.contains { $0 is DisableDefaultBodyMargin }
 
         if AppEnvironment.shared.k5.isK5Enabled {

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -73,6 +73,7 @@ open class CoreWebView: WKWebView {
 
     public init(features: [CoreWebViewFeature], configuration: WKWebViewConfiguration = .defaultConfiguration) {
         configuration.applyDefaultSettings()
+        let features = features + [.dynamicFontSize]
         features.forEach { $0.apply(on: configuration) }
 
         super.init(frame: .zero, configuration: configuration)

--- a/Core/Core/Common/CommonUI/Typography/Typography.swift
+++ b/Core/Core/Common/CommonUI/Typography/Typography.swift
@@ -86,6 +86,7 @@ public struct Typography {
 
         public var uiFont: UIFont { UIFont.scaledNamedFont(fontName) }
         public var font: Font { Font(uiFont) }
+        public static var unscaledBodyUIFont: UIFont { UIFont.applicationFont(ofSize: 16, weight: .regular) }
 
         private var k5: Bool { AppEnvironment.shared.k5.isK5Enabled }
     }

--- a/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
@@ -126,6 +126,12 @@ extension String {
         return data
     }
 
+    /// - returns: A new string without the given prefix. If the string doesn't have the given prefix this method will return the unmodified string.
+    public func deletingPrefix(_ prefix: String) -> String {
+        guard hasPrefix(prefix) else { return self }
+        return String(dropFirst(prefix.count))
+    }
+
     /// Localized string to be used when we need number of items. Example: "5 items"
     public static func localizedNumberOfItems(_ count: Int) -> String {
         String.localizedStringWithFormat(String(localized: "d_items", bundle: .core), count)

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSizeTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/Model/Features/DynamicFontSizeTests.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+class DynamicFontSizeTests: XCTestCase {
+
+    func testCSSOverride() {
+        let mockLinkDelegate = MockCoreWebViewLinkDelegate()
+        let webView = CoreWebView(features: [.disableZoom])
+        webView.linkDelegate = mockLinkDelegate
+        webView.loadHTMLString("<div>Test</div>")
+        wait(for: [mockLinkDelegate.navigationFinishedExpectation], timeout: 10)
+        let jsEvaluated = expectation(description: "JS evaluated")
+        let js = """
+            const body = document.body;
+            const styles = getComputedStyle(body);
+            const textSizeAdjust = styles.getPropertyValue('-webkit-text-size-adjust');
+            textSizeAdjust
+            """
+        let testee = CoreWebViewFeature.dynamicFontSize
+
+        // WHEN
+        testee.apply(on: webView)
+
+        // THEN
+        webView.evaluateJavaScript(js) { result, error in
+            XCTAssertEqual(result as! String, "100%")
+            XCTAssertNil(error)
+            jsEvaluated.fulfill()
+        }
+        waitForExpectations(timeout: 10)
+    }
+}

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewTests.swift
@@ -298,4 +298,16 @@ class CoreWebViewTests: CoreTestCase {
             animated: true
         ))
     }
+
+    func test_addsDynamicFontFeature_whenLoaded() {
+        var testee = CoreWebView(features: [])
+        XCTAssertEqual(testee.features.count, 1)
+        XCTAssertTrue(testee.features.first is DynamicFontSize)
+
+        testee = CoreWebView()
+        XCTAssertEqual(testee.features.count, 0)
+
+        testee = CoreWebView(frame: .zero)
+        XCTAssertEqual(testee.features.count, 0)
+    }
 }

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -88,7 +88,7 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Canvas1".deletingPrefix("Canvas"), "1")
         XCTAssertEqual("1Canvas1".deletingPrefix("Canvas"), "1Canvas1")
     }
-    
+
     func testLocalizedNumberOfItems() {
         XCTAssertEqual(String.localizedNumberOfItems(1), "1 item")
         XCTAssertEqual(String.localizedNumberOfItems(5), "5 items")

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -84,6 +84,11 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual(results.last, "<iframe></iframe>")
     }
 
+    func testDeletesPrefix() {
+        XCTAssertEqual("Canvas1".deletingPrefix("Canvas"), "1")
+        XCTAssertEqual("1Canvas1".deletingPrefix("Canvas"), "1Canvas1")
+    }
+    
     func testLocalizedNumberOfItems() {
         XCTAssertEqual(String.localizedNumberOfItems(1), "1 item")
         XCTAssertEqual(String.localizedNumberOfItems(5), "5 items")


### PR DESCRIPTION
### What's new?
- There's a new `CoreWebView` feature to dynamically adjust the font size in of the html content based on the system's dynamic font size settings.
- Since dynamic size category is an enum without values (*) I had to come up with a mapping to manually figure out the font scale for each enum value. For this I created a preview and I tweaked the scales until it matched the system font's size.

refs: MBL-18628
affects: Student, Parent, Teacher
release note: none

test plan:
- Test if webviews follow the device's dynamic font size.
- Note that webviews doesn't dynamically refresh when the font size is changed while on screen.

(*) Actually we can see in the control center the associated percentage values for each category but if I resize the font by that amount they don't match the font size determined by the system when using the dynamic size enum. Maybe the font sizing in the preview isn't correct?
<img src="https://github.com/user-attachments/assets/0b0fccd2-c6f8-4eb3-b667-ba8a5b14e655" width=30% height=30%>

## Screenshots

<table>
<tr><th>Preview for mapping</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b8a8f796-39bc-4390-aeb8-3255edcc8dd1" width=30% height=30%></td>
</tr>
</table>

## Checklist

- [ ] Tested on iOS 17
- [x] Tested on iOS 18