### PR TITLE
Fix AnnouncementDetails showing DiscussionDetails by default on iPad

### DIFF
--- a/Core/Core/Features/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Features/Discussions/AnnouncementListViewController.swift
@@ -125,7 +125,8 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
         errorView.isHidden = topics.state != .error
         tableView.reloadData()
 
-        if !selectedFirstTopic, topics.state != .loading, let url = topics.first?.htmlURL {
+        if !selectedFirstTopic, topics.state != .loading, let id = topics.first?.id {
+            let url = "\(context.pathComponent)/announcements/\(id)"
             selectedFirstTopic = true
             if splitViewController?.isCollapsed == false, !isInSplitViewDetail {
                 env.router.route(to: url, from: self, options: .detail)


### PR DESCRIPTION
## Fix AnnouncementDetails showing DiscussionDetails by default on iPad

refs: MBL-18654
affects: Student, Teacher
release note: None
test plan: Test if announcements are displayed properly.

## Checklist

- [x] Tested on tablet
