### PR TITLE
Accessibility - Add focus activation after tab is activated in SpeedGrader

### DIFF
--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentList.swift
@@ -40,6 +40,8 @@ struct SubmissionCommentList: View {
     @State var showMediaOptions = false
     @State var showCommentLibrary = false
 
+    @AccessibilityFocusState private var focusedTab: SubmissionGrader.GraderTab?
+
     init(
         assignment: Assignment,
         submission: Submission,
@@ -48,7 +50,8 @@ struct SubmissionCommentList: View {
         fileID: Binding<String?>,
         showRecorder: Binding<MediaCommentType?>,
         enteredComment: Binding<String>,
-        commentLibrary: SubmissionCommentLibraryViewModel
+        commentLibrary: SubmissionCommentLibraryViewModel,
+        focusedTab: AccessibilityFocusState<SubmissionGrader.GraderTab?>
     ) {
         self.assignment = assignment
         self.submission = submission
@@ -58,6 +61,7 @@ struct SubmissionCommentList: View {
         self._comment = enteredComment
         self.attempts = attempts
         self.commentLibrary = commentLibrary
+        self._focusedTab = focusedTab
 
         _viewModel = StateObject(wrappedValue: SubmissionCommentListViewModel(
             attempt: attempt.wrappedValue,
@@ -163,6 +167,7 @@ struct SubmissionCommentList: View {
                 containerHeight: containerHeight
             )
                 .padding(EdgeInsets(top: 4, leading: 0, bottom: 4, trailing: 16))
+                .accessibilityFocused($focusedTab, equals: .comments)
         }
             .background(Color.backgroundLight)
     }

--- a/Teacher/Teacher/SpeedGrader/SubmissionGrader.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionGrader.swift
@@ -58,6 +58,8 @@ struct SubmissionGrader: View {
     @State private var studentAnnotationViewModel: StudentAnnotationSubmissionViewerViewModel
     @State private var selectedIndex = 0
 
+    @AccessibilityFocusState private var focusedTab: GraderTab?
+
     private var selected: Submission { attempts.first { attempt == $0.attempt } ?? submission }
     private var file: File? {
         selected.attachments?.first { fileID == $0.id } ??
@@ -266,10 +268,14 @@ struct SubmissionGrader: View {
                     if drawerState == .min {
                         snapDrawerTo(.mid)
                     }
+                    let newTab = SubmissionGrader.GraderTab(rawValue: newValue ?? 0)!
                     withAnimation(.default) {
-                        tab = SubmissionGrader.GraderTab(rawValue: newValue ?? 0)!
+                        tab = newTab
                     }
                     controller.view.endEditing(true)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        focusedTab = tab
+                    }
                 }
             ),
             selectionAlignment: .bottom,
@@ -299,6 +305,7 @@ struct SubmissionGrader: View {
                     fileID = $0
                     snapDrawerTo(.min)
                 })
+
                 let isGradesOnScreen = isGraderTabOnScreen(.grades, isDrawer: isDrawer)
                 VStack(spacing: 0) {
                     SubmissionGrades(assignment: assignment, containerHeight: geometry.size.height, submission: submission)
@@ -308,6 +315,8 @@ struct SubmissionGrader: View {
                 .frame(width: geometry.size.width, height: geometry.size.height)
                 .accessibilityElement(children: isGradesOnScreen ? .contain : .ignore)
                 .accessibility(hidden: !isGradesOnScreen)
+                .accessibilityFocused($focusedTab, equals: .grades)
+
                 let isCommentsOnScreen = isGraderTabOnScreen(.comments, isDrawer: isDrawer)
                 VStack(spacing: 0) {
                     SubmissionCommentList(
@@ -318,7 +327,8 @@ struct SubmissionGrader: View {
                         fileID: drawerFileID,
                         showRecorder: $showRecorder,
                         enteredComment: $enteredComment,
-                        commentLibrary: commentLibrary
+                        commentLibrary: commentLibrary,
+                        focusedTab: _focusedTab
                     )
                     .clipped()
                     if showRecorder != .video || drawerState == .min {
@@ -329,6 +339,7 @@ struct SubmissionGrader: View {
                 .background(Color.backgroundLight)
                 .accessibilityElement(children: isCommentsOnScreen ? .contain : .ignore)
                 .accessibility(hidden: !isCommentsOnScreen)
+
                 let isFilesOnScreen = isGraderTabOnScreen(.files, isDrawer: isDrawer)
                 VStack(spacing: 0) {
                     SubmissionFileList(submission: selected, fileID: drawerFileID)
@@ -338,6 +349,7 @@ struct SubmissionGrader: View {
                 .frame(width: geometry.size.width, height: geometry.size.height)
                 .accessibilityElement(children: isFilesOnScreen ? .contain : .ignore)
                 .accessibility(hidden: !isFilesOnScreen)
+                .accessibilityFocused($focusedTab, equals: .files)
             }
             .frame(width: geometry.size.width, alignment: .leading)
             .background(Color.backgroundLightest)


### PR DESCRIPTION
refs: MBL-18442
affects: Teacher
release note: none

test plan:
- Activating a grader tab should automatically move the voiceover focus to its content.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet