### PR TITLE
Fix issue of Root Account unable to access Child PDFs for annotation submissions

### DIFF
--- a/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModel.swift
+++ b/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModel.swift
@@ -29,8 +29,18 @@ public class StudentAnnotationSubmissionViewModel: ObservableObject {
     public let navBar: (title: String, subtitle: String, color: UIColor, closeButtonTitle: String)
 
     private let submissionUseCase: CreateSubmission
+    private let env: AppEnvironment
 
-    public init(documentURL: URL, courseID: String, assignmentID: String, userID: String, annotatableAttachmentID: String?, assignmentName: String, courseColor: UIColor) {
+    public init(
+        documentURL: URL,
+        courseID: String,
+        assignmentID: String,
+        userID: String,
+        annotatableAttachmentID: String?,
+        assignmentName: String,
+        courseColor: UIColor,
+        environment: AppEnvironment
+    ) {
         self.documentURL = documentURL
         self.navBar = (title: String(localized: "Student Annotation", bundle: .student),
                        subtitle: assignmentName,
@@ -41,12 +51,13 @@ public class StudentAnnotationSubmissionViewModel: ObservableObject {
                                                   userID: userID,
                                                   submissionType: .student_annotation,
                                                   annotatableAttachmentID: annotatableAttachmentID)
+        self.env = environment
     }
 
     public func postSubmission() {
         doneButton = Self.makeDoneButton(isSaving: true)
 
-        submissionUseCase.fetch { submission, _, error in performUIUpdate {
+        submissionUseCase.fetch(environment: env) { submission, _, error in performUIUpdate {
             self.doneButton = Self.makeDoneButton(isSaving: false)
 
             if submission != nil {

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -194,11 +194,12 @@ class SubmissionButtonPresenter: NSObject {
                                                                  userID: userID,
                                                                  annotatableAttachmentID: assignment.annotatableAttachmentID,
                                                                  assignmentName: assignment.name,
-                                                                 courseColor: course.color)
+                                                                 courseColor: course.color,
+                                                                 environment: env)
             let submissionView = StudentAnnotationSubmissionView(viewModel: viewModel)
 
             performUIUpdate {
-                let hostingView = CoreHostingController(submissionView)
+                let hostingView = CoreHostingController(submissionView, env: self.env)
                 self.env.router.show(hostingView, from: view, options: .modal(.fullScreen, isDismissable: false, embedInNav: true, addDoneButton: false))
             }
         }

--- a/Student/StudentUnitTests/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModelTests.swift
+++ b/Student/StudentUnitTests/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionViewModelTests.swift
@@ -22,13 +22,16 @@ import TestsFoundation
 import XCTest
 
 class StudentAnnotationSubmissionViewModelTests: StudentTestCase {
-    private let testee = StudentAnnotationSubmissionViewModel(documentURL: URL(string: "a.b")!,
-                                                              courseID: "123",
-                                                              assignmentID: "321",
-                                                              userID: "111",
-                                                              annotatableAttachmentID: "3",
-                                                              assignmentName: "Test Assignment",
-                                                              courseColor: UIColor(hexString: "#BEEF00")!)
+    private lazy var testee = StudentAnnotationSubmissionViewModel(
+        documentURL: URL(string: "a.b")!,
+        courseID: "123",
+        assignmentID: "321",
+        userID: "111",
+        annotatableAttachmentID: "3",
+        assignmentName: "Test Assignment",
+        courseColor: UIColor(hexString: "#BEEF00")!,
+        environment: env
+    )
 
     func testDocumentURL() {
         XCTAssertEqual(testee.documentURL, URL(string: "a.b")!)


### PR DESCRIPTION
refs: [MBL-18642](https://instructure.atlassian.net/browse/MBL-18642)
affects: Student
release note: Fixes issue of Root Account unable to access Child PDFs for annotation submissions

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18642) description.

First login with root account on a master build then using the PR build posted here to perform the following steps:

1- Login with as a student to Root account.
2- Go to Course "Tracy Test 03" > Assignments > "Annotated Thing for ..."
3- Hit "Submit Assignment"
4- Upon that, on **PR build** you should be able **to see** a PDF file that you can annotate for submission.
     While on `master` build, you'd get the following screen.
     
![Screenshot 2025-03-11 at 3 50 14 PM](https://github.com/user-attachments/assets/58152984-3002-4bf9-993d-79cdae9fe68c)

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18642]: https://instructure.atlassian.net/browse/MBL-18642?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ