### PR TITLE
Fix issue of a Masquerading user unable to pick files for assignment submission

### DIFF
--- a/Core/Core/Features/ActAsUser/ActAsUserWindow.swift
+++ b/Core/Core/Features/ActAsUser/ActAsUserWindow.swift
@@ -33,6 +33,9 @@ public class ActAsUserWindow: UIWindow {
         )
 
         super.layoutSubviews()
+
+        if isTopAnOverlayException { return }
+
         overlay.frame = bounds
         bringSubviewToFront(overlay)
         if let button = uiTestHelper {
@@ -80,6 +83,19 @@ public class ActAsUserWindow: UIWindow {
             object: nil,
             userInfo: ["style": traitCollection.userInterfaceStyle]
         )
+    }
+
+    private var isTopAnOverlayException: Bool {
+
+        if let topController = rootViewController?.topMostViewController() {
+            if topController.isOverlayException {
+                return true
+            } else if let presenting = topController.presentingViewController {
+                return presenting.isOverlayException
+            }
+        }
+
+        return false
     }
 }
 
@@ -181,5 +197,34 @@ class ActAsUserOverlay: UIView {
             return button
         }
         return nil
+    }
+}
+
+// MARK: - Overlay Exceptions
+
+private extension UIViewController {
+
+    var isOverlayException: Bool {
+        switch self {
+        case
+            is UIDocumentPickerViewController,
+            is UIImagePickerController:
+            return true
+        default:
+            break
+        }
+
+        let typeName = String(describing: type(of: self))
+
+        switch typeName {
+        case
+            "PUPhotoPickerHostViewController",
+            "CAMImagePickerCameraViewController":
+            return true
+        default:
+            break
+        }
+
+        return false
     }
 }

--- a/Core/Core/Features/ActAsUser/ActAsUserWindow.swift
+++ b/Core/Core/Features/ActAsUser/ActAsUserWindow.swift
@@ -34,7 +34,7 @@ public class ActAsUserWindow: UIWindow {
 
         super.layoutSubviews()
 
-        if isTopAnOverlayException { return }
+        if isPresentingSystemPicker { return }
 
         overlay.frame = bounds
         bringSubviewToFront(overlay)
@@ -85,17 +85,17 @@ public class ActAsUserWindow: UIWindow {
         )
     }
 
-    private var isTopAnOverlayException: Bool {
+    private var isPresentingSystemPicker: Bool {
+        guard let topController = rootViewController?.topMostViewController()
+        else { return false }
 
-        if let topController = rootViewController?.topMostViewController() {
-            if topController.isOverlayException {
-                return true
-            } else if let presenting = topController.presentingViewController {
-                return presenting.isOverlayException
-            }
+        if topController.isSystemAssetPicker {
+            return true
+        } else if let presentingController = topController.presentingViewController {
+            return presentingController.isSystemAssetPicker
+        } else {
+            return false
         }
-
-        return false
     }
 }
 
@@ -204,7 +204,7 @@ class ActAsUserOverlay: UIView {
 
 private extension UIViewController {
 
-    var isOverlayException: Bool {
+    var isSystemAssetPicker: Bool {
         switch self {
         case
             is UIDocumentPickerViewController,


### PR DESCRIPTION
refs: [MBL-18648](https://instructure.atlassian.net/browse/MBL-18648)
affects: Student, Teacher, Parent
release note: Fixes issue of a Masquerading user unable to pick files for assignment submission.

## Analysis

Probably the issue caused by a UIKit glitch whenever one of those "system-level-picker" controllers are about to be presented, caused mainly by `layoutSubviews()` overridden method on `ActAsUserWindow` attempts to tweak view hierarchy on presentation.

The resolution was to avoid those tweaks whenever a `UIDocumentPickerViewController` or host controllers of photo picker are about to be presented.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18648) description. 
Please note that the issue exist for Library selection as well, make sure to check it as this PR handle this issue as well.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18648]: https://instructure.atlassian.net/browse/MBL-18648?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ