### PR TITLE
Update UIKit based disclosure indicators

### DIFF
--- a/Core/Core/Common/Extensions/UIKit/UITableViewCellExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UITableViewCellExtensions.swift
@@ -38,4 +38,11 @@ public extension UITableViewCell {
         self.contentView.alpha = isAvailable ? 1 : 0.3
         self.isUserInteractionEnabled = isUserInteractionEnabled
     }
+
+    func setupInstDisclosureIndicator() {
+        let image = UIImageView(image: UIImage.arrowOpenRightLine)
+        image.frame = CGRect(x: 0, y: 0, width: 16, height: 16)
+        image.tintColor = .textDark
+        accessoryView = image
+    }
 }

--- a/Core/Core/Features/Conferences/ConferenceListViewController.swift
+++ b/Core/Core/Features/Conferences/ConferenceListViewController.swift
@@ -158,6 +158,11 @@ class ConferenceListCell: UITableViewCell {
     @IBOutlet weak var statusLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(_ conference: Conference?, color: UIColor?) {
         backgroundColor = .backgroundLightest
         iconView.icon = .conferences

--- a/Core/Core/Features/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Features/Discussions/AnnouncementListViewController.swift
@@ -200,6 +200,11 @@ class AnnouncementListCell: UITableViewCell {
     @IBOutlet weak var iconImageView: AccessIconView!
     @IBOutlet weak var titleLabel: UILabel!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(topic: DiscussionTopic?, isTeacher: Bool, color: UIColor?) {
         iconImageView.icon = .announcementLine
         if isTeacher {

--- a/Core/Core/Features/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Features/Discussions/DiscussionListViewController.swift
@@ -299,6 +299,7 @@ class DiscussionListCell: UITableViewCell {
         pointsDot.setText(pointsDot.text, style: .textCellBottomLabel)
         repliesDot.setText(repliesDot.text, style: .textCellBottomLabel)
         statusDot.setText(statusDot.text, style: .textCellBottomLabel)
+        setupInstDisclosureIndicator()
     }
 
     func update(topic: DiscussionTopic?, isTeacher: Bool, color: UIColor?) {
@@ -353,6 +354,5 @@ class DiscussionListCell: UITableViewCell {
         unreadDot.isHidden = false
         dateLabel.isHidden = false
         isUserInteractionEnabled = true
-        accessoryType = .disclosureIndicator
     }
 }

--- a/Core/Core/Features/ErrorReports/ErrorReportViewController.storyboard
+++ b/Core/Core/Features/ErrorReports/ErrorReportViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -13,11 +13,11 @@
             <objects>
                 <viewController storyboardIdentifier="ErrorReportViewController" title="Report a Problem" modalPresentationStyle="formSheet" useStoryboardIdentifierAsRestorationIdentifier="YES" id="PvC-F6-8XD" customClass="ErrorReportViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="07N-bz-ibZ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="D7T-zY-mIK">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="603"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="E5e-lJ-7Bu">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="215"/>
@@ -151,10 +151,10 @@
                                                                 </constraints>
                                                                 <userDefinedRuntimeAttributes>
                                                                     <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="textDark"/>
-                                                                    <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightSolid"/>
+                                                                    <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightLine"/>
                                                                 </userDefinedRuntimeAttributes>
                                                             </imageView>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sJ2-KZ-oWP" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sJ2-KZ-oWP" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
                                                                 <rect key="frame" x="0.0" y="0.0" width="375" height="54"/>
                                                                 <inset key="contentEdgeInsets" minX="72" minY="0.0" maxX="36" maxY="0.0"/>
                                                                 <state key="normal" title="Select One"/>
@@ -195,7 +195,7 @@
                                                         <rect key="frame" x="0.0" y="165" width="375" height="50"/>
                                                         <subviews>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Describe the problem" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SsP-Ma-rdc" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                <rect key="frame" x="16" y="12" width="156.5" height="19.5"/>
+                                                                <rect key="frame" x="16" y="12" width="164.5" height="20.5"/>
                                                                 <accessibility key="accessibilityConfiguration">
                                                                     <bool key="isElement" value="NO"/>
                                                                 </accessibility>
@@ -249,6 +249,7 @@
                                 </constraints>
                             </scrollView>
                         </subviews>
+                        <viewLayoutGuide key="safeArea" id="4eN-vB-wr0"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
                             <constraint firstItem="D7T-zY-mIK" firstAttribute="leading" secondItem="4eN-vB-wr0" secondAttribute="leading" id="Hh8-aM-dPu"/>
@@ -258,7 +259,6 @@
                             <constraint firstItem="E5e-lJ-7Bu" firstAttribute="trailing" secondItem="4eN-vB-wr0" secondAttribute="trailing" id="tnX-bA-QyM"/>
                             <constraint firstItem="4eN-vB-wr0" firstAttribute="trailing" secondItem="D7T-zY-mIK" secondAttribute="trailing" id="yXe-2K-9Vb"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="4eN-vB-wr0"/>
                     </view>
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
                     <nil key="simulatedBottomBarMetrics"/>

--- a/Core/Core/Features/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Features/Files/View/FileList/FileListViewController.swift
@@ -513,6 +513,11 @@ class FileListCell: UITableViewCell {
 
     private var fileID: String?
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(item: FolderItem?, color: UIColor?, isOffline: Bool, isAvailable: Bool) {
         fileID = item?.id
         if isOffline {

--- a/Core/Core/Features/Modules/MasteryPaths/MasteryPathAssignmentCell.xib
+++ b/Core/Core/Features/Modules/MasteryPaths/MasteryPathAssignmentCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="16096" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="16086"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -35,7 +35,7 @@
                             <rect key="frame" x="40" y="0.0" width="321" height="52"/>
                             <subviews>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mJm-Y4-6rx" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="321" height="35"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="321" height="31.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -45,7 +45,7 @@
                                     </userDefinedRuntimeAttributes>
                                 </label>
                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tDm-eb-rI0" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="35" width="321" height="17"/>
+                                    <rect key="frame" x="0.0" y="31.5" width="321" height="20.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -62,14 +62,15 @@
                                 <constraint firstAttribute="width" constant="16" id="CUK-3X-jAs"/>
                             </constraints>
                             <userDefinedRuntimeAttributes>
-                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightSolid"/>
-                                <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="borderMedium"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightLine"/>
+                                <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="textDark"/>
                             </userDefinedRuntimeAttributes>
                         </imageView>
                     </subviews>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                 </stackView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="Fug-F3-Sai"/>
             <constraints>
                 <constraint firstItem="Fug-F3-Sai" firstAttribute="trailing" secondItem="tW6-CX-oKy" secondAttribute="trailing" constant="16" id="8eJ-ho-Moo"/>
                 <constraint firstItem="tW6-CX-oKy" firstAttribute="top" secondItem="Fpb-xb-lBG" secondAttribute="top" constant="16" id="Zis-9x-Hcg"/>
@@ -77,7 +78,6 @@
                 <constraint firstAttribute="bottom" secondItem="tW6-CX-oKy" secondAttribute="bottom" constant="16" id="s6n-a6-Pbp"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <viewLayoutGuide key="safeArea" id="Fug-F3-Sai"/>
             <point key="canvasLocation" x="-433" y="-111"/>
         </view>
     </objects>

--- a/Core/Core/Features/Pages/PageList/PageListViewController.storyboard
+++ b/Core/Core/Features/Pages/PageList/PageListViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="dark"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,15 +15,15 @@
             <objects>
                 <viewController storyboardIdentifier="PageListViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="JGx-7A-Apd" customClass="PageListViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="xd4-nP-FkO">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="f1i-hN-714">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="574"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="554"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="zel-h8-3v4" customClass="ListBackgroundView" customModule="Core" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="239.5" width="375" height="245.5"/>
+                                    <rect key="frame" x="0.0" y="250.5" width="375" height="245.5"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ksX-Wo-aaV" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
@@ -97,7 +97,7 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationWidth="10" reuseIdentifier="PageListFrontPageCell" id="bvq-Al-4Yo" customClass="PageListFrontPageCell" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="375" height="119.5"/>
+                                        <rect key="frame" x="0.0" y="50" width="375" height="119.5"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bvq-Al-4Yo" id="fSH-Ma-RNS">
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="119.5"/>
@@ -132,15 +132,15 @@
                                                                 <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
-                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowOpenRightSolid" translatesAutoresizingMaskIntoConstraints="NO" id="MRG-6a-5mX" customClass="IconView" customModule="Core" customModuleProvider="target">
+                                                        <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="arrowOpenRightLine" translatesAutoresizingMaskIntoConstraints="NO" id="MRG-6a-5mX" customClass="IconView" customModule="Core" customModuleProvider="target">
                                                             <rect key="frame" x="301" y="31" width="16" height="16"/>
-                                                            <color key="tintColor" red="0.54509803921568623" green="0.58823529411764708" blue="0.61960784313725492" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="tintColor" name="textDark"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="16" id="2B6-At-L9y"/>
                                                                 <constraint firstAttribute="width" constant="16" id="feS-ZN-ZwY"/>
                                                             </constraints>
                                                             <userDefinedRuntimeAttributes>
-                                                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightSolid"/>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="arrowOpenRightLine"/>
                                                                 <userDefinedRuntimeAttribute type="string" keyPath="iconColorName" value="textDark"/>
                                                             </userDefinedRuntimeAttributes>
                                                         </imageView>
@@ -178,10 +178,10 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationWidth="10" reuseIdentifier="PageListCell" id="K47-fz-UXy" customClass="PageListCell" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="164" width="375" height="53"/>
+                                        <rect key="frame" x="0.0" y="169.5" width="375" height="53"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="K47-fz-UXy" id="h18-Ci-Mgd">
-                                            <rect key="frame" x="0.0" y="0.0" width="350.5" height="53"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="348.5" height="53"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yZj-us-baR" customClass="AccessIconView" customModule="Core" customModuleProvider="target">
@@ -192,7 +192,7 @@
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="SYx-zd-ZSF">
-                                                    <rect key="frame" x="58" y="8.5" width="284.5" height="36.5"/>
+                                                    <rect key="frame" x="58" y="8.5" width="282.5" height="36.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Page Title" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qIt-LP-q9h" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="75" height="19.5"/>
@@ -265,41 +265,15 @@
             <point key="canvasLocation" x="-391.304347826087" y="89.673913043478265"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="1s1-Cn-Jrv">
-            <size key="intrinsicContentSize" width="101.5" height="24"/>
-        </designable>
-        <designable name="MRG-6a-5mX">
-            <size key="intrinsicContentSize" width="24" height="24"/>
-        </designable>
-        <designable name="V3l-L4-N2h">
-            <size key="intrinsicContentSize" width="300" height="162"/>
-        </designable>
-        <designable name="Zla-nM-E34">
-            <size key="intrinsicContentSize" width="245" height="19.5"/>
-        </designable>
-        <designable name="bRn-mG-uYY">
-            <size key="intrinsicContentSize" width="21" height="21"/>
-        </designable>
-        <designable name="oQL-N1-MIR">
-            <size key="intrinsicContentSize" width="88.5" height="24"/>
-        </designable>
-        <designable name="paN-70-GrB">
-            <size key="intrinsicContentSize" width="66" height="17"/>
-        </designable>
-        <designable name="qIt-LP-q9h">
-            <size key="intrinsicContentSize" width="75" height="19.5"/>
-        </designable>
-        <designable name="zZH-IU-giM">
-            <size key="intrinsicContentSize" width="155" height="17"/>
-        </designable>
-    </designables>
     <resources>
         <image name="PandaPapers" width="300" height="162"/>
-        <image name="arrowOpenRightSolid" width="24" height="24"/>
+        <image name="arrowOpenRightLine" width="24" height="24"/>
         <image name="shadow" width="21" height="21"/>
         <namedColor name="backgroundLightest">
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="textDark">
+            <color red="0.40000000000000002" green="0.44313725490196076" blue="0.48627450980392156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Core/Core/Features/Pages/PageList/PageListViewController.swift
+++ b/Core/Core/Features/Pages/PageList/PageListViewController.swift
@@ -230,6 +230,11 @@ class PageListCell: UITableViewCell {
     @IBOutlet weak var dateLabel: UILabel!
     @IBOutlet weak var titleLabel: UILabel!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(_ page: Page?, indexPath: IndexPath, color: UIColor?) {
         backgroundColor = .backgroundLightest
         titleLabel.accessibilityIdentifier = "PageList.\(indexPath.row)"

--- a/Core/Core/Features/People/PeopleListViewController.swift
+++ b/Core/Core/Features/People/PeopleListViewController.swift
@@ -269,6 +269,11 @@ class PeopleListCell: UITableViewCell {
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var rolesLabel: UILabel!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(user: PeopleListUser?, color: UIColor?, isOffline: Bool) {
         backgroundColor = .backgroundLightest
         selectedBackgroundView = ContextCellBackgroundView.create(color: color)

--- a/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
@@ -228,6 +228,7 @@ class PlannerListCell: UITableViewCell {
     override func awakeFromNib() {
         super.awakeFromNib()
         pointsDivider.setText(pointsDivider.text, style: .textCellSupportingText)
+        setupInstDisclosureIndicator()
     }
 
     func update(_ p: Plannable?) {
@@ -262,8 +263,6 @@ class PlannerListCell: UITableViewCell {
         }
         points.setText(pointsText, style: .textCellSupportingText)
         pointsDivider.isHidden = dueDate.text == nil || pointsText == nil
-
-        accessoryType = .disclosureIndicator
     }
 
     private func contextName(for plannable: Plannable?) -> String? {

--- a/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
@@ -197,7 +197,7 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
             cell.backgroundColor = .backgroundLightest
             cell.textLabel?.text = categoryMap[row.category]?.1
             cell.detailTextLabel?.text = row.frequency.name
-            cell.accessoryType = .disclosureIndicator
+            cell.setupInstDisclosureIndicator()
             return cell
         default:
             let cell: SwitchTableViewCell = tableView.dequeue(for: indexPath)

--- a/Core/Core/Features/Profile/Settings/NotificationChannelsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationChannelsViewController.swift
@@ -90,7 +90,7 @@ extension NotificationChannelsViewController: UITableViewDataSource, UITableView
         let cell: RightDetailTableViewCell = tableView.dequeue(for: indexPath)
         cell.backgroundColor = .backgroundLightest
         cell.textLabel?.text = channel.address
-        cell.accessoryType = .disclosureIndicator
+        cell.setupInstDisclosureIndicator()
         return cell
     }
 

--- a/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
@@ -330,7 +330,11 @@ extension ProfileSettingsViewController: UITableViewDataSource, UITableViewDeleg
             cell.backgroundColor = .backgroundLightest
             cell.textLabel?.text = row.title
             cell.detailTextLabel?.text = row.detail
-            cell.accessoryType = row.hasDisclosure ? .disclosureIndicator : .none
+            if row.hasDisclosure {
+                cell.setupInstDisclosureIndicator()
+            } else {
+                cell.accessoryView = nil
+            }
             let isAvailable = !offlineModeInteractor.isOfflineModeEnabled() || row.isSupportedOffline
             cell.contentView.alpha = isAvailable ? 1 : 0.5
             if let accessibilityTraits = row.accessibilityTraits {

--- a/Core/Core/Features/Quizzes/QuizListViewController.swift
+++ b/Core/Core/Features/Quizzes/QuizListViewController.swift
@@ -153,6 +153,7 @@ class QuizListCell: UITableViewCell {
         super.awakeFromNib()
         statusDot.setText(statusDot.text, style: .textCellSupportingText)
         pointsDot.setText(pointsDot.text, style: .textCellBottomLabel)
+        setupInstDisclosureIndicator()
     }
 
     func update(quiz: Quiz?, isTeacher: Bool, color: UIColor?) {

--- a/Core/Core/Features/Todos/TodoListViewController.swift
+++ b/Core/Core/Features/Todos/TodoListViewController.swift
@@ -194,6 +194,7 @@ class TodoListCell: UITableViewCell {
         needsGradingView.layer.borderColor = Brand.shared.primary.cgColor
         needsGradingView.layer.borderWidth = 1
         needsGradingView.layer.cornerRadius = needsGradingView.frame.height / 2
+        setupInstDisclosureIndicator()
     }
 
     func update(_ todo: Todo?) {

--- a/Parent/Parent/Students/StudentListViewController.swift
+++ b/Parent/Parent/Students/StudentListViewController.swift
@@ -116,6 +116,11 @@ class StudentListCell: UITableViewCell {
     @IBOutlet weak var avatarView: AvatarView!
     @IBOutlet weak var nameLabel: UILabel!
 
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        setupInstDisclosureIndicator()
+    }
+
     func update(_ student: User?, indexPath: IndexPath) {
         backgroundColor = .backgroundLightest
         accessibilityIdentifier = "StudentListCell.\(indexPath.row)"

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -92,7 +92,7 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             buttonConfig.baseForegroundColor = Brand.shared.linkColor
             buttonConfig.imagePlacement = .trailing
             buttonConfig.imagePadding = 4
-            buttonConfig.image = .arrowOpenRightSolid
+            buttonConfig.image = .arrowOpenRightLine
                 .scaleTo(.init(width: 14, height: 14))
                 .withRenderingMode(.alwaysTemplate)
             buttonConfig.contentInsets = {

--- a/Student/Student/Groups/GroupNavigation/GroupNavigationViewController.swift
+++ b/Student/Student/Groups/GroupNavigation/GroupNavigationViewController.swift
@@ -93,7 +93,7 @@ extension GroupNavigationViewController {
         cell.textLabel?.text = tab?.label
         cell.imageView?.image = tab?.icon
         cell.imageView?.tintColor = color
-        cell.accessoryType = .disclosureIndicator
+        cell.setupInstDisclosureIndicator()
         return cell
     }
 

--- a/Teacher/Teacher/Submissions/PostGradesViewController.swift
+++ b/Teacher/Teacher/Submissions/PostGradesViewController.swift
@@ -115,7 +115,7 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
                 cell.textLabel?.text = String(localized: "Post to...", bundle: .teacher)
                 cell.detailTextLabel?.text = postPolicy.title
                 cell.detailTextLabel?.accessibilityIdentifier = "PostPolicy.postToValue"
-                cell.accessoryType = .disclosureIndicator
+                cell.setupInstDisclosureIndicator()
                 cell.selectionStyle = .default
                 cell.accessibilityIdentifier = "PostPolicy.postTo"
             case .section:


### PR DESCRIPTION
This is a follow-up for a [previous PR](https://github.com/instructure/canvas-ios/pull/3220) that unified SwiftUI disclosure indicators but now it's for UIKit.

refs: [MBL-18325](https://instructure.atlassian.net/browse/MBL-18325)
affects: Student, Teacher, Parent
release note: none

test plan:
- UIKit based disclosure indicators should use textDark tint color.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode

[MBL-18325]: https://instructure.atlassian.net/browse/MBL-18325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ