### PR TITLE
Accessibility - Parent - ManageStudents - textDark for placeholder color

### DIFF
--- a/Core/Core/Resources/Assets.xcassets/Colors/text/textPlaceholder.colorset/Contents.json
+++ b/Core/Core/Resources/Assets.xcassets/Colors/text/textPlaceholder.colorset/Contents.json
@@ -5,9 +5,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0xAD",
-          "green" : "0xA6",
-          "red" : "0x9E"
+          "blue" : "0x7C",
+          "green" : "0x71",
+          "red" : "0x66"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0x64",
-          "green" : "0x5D",
-          "red" : "0x56"
+          "blue" : "0x91",
+          "green" : "0x89",
+          "red" : "0x81"
         }
       },
       "idiom" : "universal"

--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -83,7 +83,7 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
             field.accessibilityLabel = type.name
             field.attributedPlaceholder = NSAttributedString(
                 string: field.placeholder ?? "",
-                attributes: [NSAttributedString.Key.foregroundColor: UIColor.textDark]
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.textPlaceholder]
             )
         }
         for toggle in alertSwitches {

--- a/Parent/Parent/Students/StudentDetailsViewController.swift
+++ b/Parent/Parent/Students/StudentDetailsViewController.swift
@@ -81,6 +81,10 @@ class StudentDetailsViewController: ScreenViewTrackableViewController, ErrorView
             let type = AlertThresholdType.allCases[field.tag]
             field.accessibilityIdentifier = "AlertThreshold.\(type.rawValue)"
             field.accessibilityLabel = type.name
+            field.attributedPlaceholder = NSAttributedString(
+                string: field.placeholder ?? "",
+                attributes: [NSAttributedString.Key.foregroundColor: UIColor.textDark]
+            )
         }
         for toggle in alertSwitches {
             let type = AlertThresholdType.allCases[toggle.tag]


### PR DESCRIPTION
## Accessibility - Parent - ManageStudents - textDark for placeholder color

refs: MBL-18391
affects: Parent
release note: None
test plan: See ticket.

## Checklist

- [ ] A11y checked
- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
