### PR TITLE
Accessibility - Teacher - ComposeMessageView - Placeholder text of "Add" input field

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -304,7 +304,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         .opacity(model.isRecipientsDisabled ? 0.6 : 1)
     }
 
-    private var promptText: Text {
+    private var toPromptText: Text {
         Text(String(localized: "Type to search", bundle: .core))
             .foregroundColor(.textPlaceholder)
     }

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -306,7 +306,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
     private var promptText: Text {
         Text(String(localized: "Type to search", bundle: .core))
-            .foregroundColor(.textDark)
+            .foregroundColor(.textPlaceholder)
     }
 
     private var toRecipientText: some View {

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -278,7 +278,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                         .accessibilitySortPriority(1)
                 }
 
-                TextField("", text: $model.textRecipientSearch, prompt: promptText)
+                TextField("", text: $model.textRecipientSearch, prompt: toPromptText)
                     .font(.regular16)
                     .focused($focusedInput, equals: .search)
                     .foregroundColor(.textDark)

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -278,7 +278,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                         .accessibilitySortPriority(1)
                 }
 
-                TextField(String(localized: "Search", bundle: .core), text: $model.textRecipientSearch)
+                TextField("", text: $model.textRecipientSearch, prompt: promptText)
                     .font(.regular16)
                     .focused($focusedInput, equals: .search)
                     .foregroundColor(.textDark)
@@ -302,6 +302,11 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
         .padding(.horizontal, defaultHorizontalPaddingValue)
         .disabled(model.isRecipientsDisabled)
         .opacity(model.isRecipientsDisabled ? 0.6 : 1)
+    }
+
+    private var promptText: Text {
+        Text(String(localized: "Type to search", bundle: .core))
+            .foregroundColor(.textDark)
     }
 
     private var toRecipientText: some View {


### PR DESCRIPTION
## Accessibility - Teacher - ComposeMessageView - Placeholder text of "Add" input field

refs: MBL-18362
affects: Student, Teacher, Parent
release note: None
test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/ad7f04f8-0c4c-4cdb-88a6-c013e34cdc2d" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/26972c16-f04c-4265-88df-10de0c3bbd97" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
