### PR TITLE
Accessibility - Submission comments

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -107,7 +107,7 @@ extension InstUI {
                 return String.localizedAccessibilityErrorMessage(errorMessage)
             }()
 
-            let value = [dateTimeValue, errorValue].compactMap { $0 }.joined(separator: ", ")
+            let value = [dateTimeValue, errorValue].joined(separator: ", ")
 
             label
                 .textStyle(.cellLabel)

--- a/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
@@ -103,9 +103,7 @@ public struct MultiSelectionView: View {
     }
 
     private func accessibilityIdentifier(for item: OptionItem) -> String {
-        [accessibilityIdentifier ?? "", item.id]
-            .compactMap { $0 }
-            .joined(separator: ".")
+        [accessibilityIdentifier, item.id].joined(separator: ".")
     }
 }
 

--- a/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
@@ -89,9 +89,7 @@ public struct SingleSelectionView: View {
     }
 
     private func accessibilityIdentifier(for item: OptionItem) -> String {
-        [accessibilityIdentifier ?? "", item.id]
-            .compactMap { $0 }
-            .joined(separator: ".")
+        [accessibilityIdentifier, item.id].joined(separator: ".")
     }
 }
 

--- a/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/StringExtensions.swift
@@ -133,6 +133,12 @@ extension String {
     }
 }
 
+public extension Array<String?> {
+    func joined(separator: String = "") -> String {
+        compactMap { $0 }.joined(separator: separator)
+    }
+}
+
 extension ReferenceWritableKeyPath {
     var string: String {
         NSExpression(forKeyPath: self).keyPath

--- a/Core/Core/Features/CourseSync/Common/ViewModel/OfflineListCellViewModel.swift
+++ b/Core/Core/Features/CourseSync/Common/ViewModel/OfflineListCellViewModel.swift
@@ -144,7 +144,6 @@ class OfflineListCellViewModel: ObservableObject {
             collapseText.nilIfEmpty,
             progressText.nilIfEmpty
         ]
-            .compactMap({ $0 })
             .joined(separator: ", ")
     }
 

--- a/Core/Core/Features/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
+++ b/Core/Core/Features/Courses/AllCourses/ViewModel/AllCoursesCellViewModel.swift
@@ -79,11 +79,11 @@ public class AllCoursesCellViewModel: ObservableObject {
             isItemAvailableOffline = false
         }
 
-        setuProperties()
+        setupProperties()
         setupBindings()
     }
 
-    private func setuProperties() {
+    private func setupProperties() {
         isCellDisabled = !item.isDetailsAvailable || !calculateIsCourseEnabled(offlineModeInteractor.isOfflineModeEnabled())
         isOfflineIndicatorVisible = isItemAvailableOffline
         isFavoriteStarDisabled = offlineModeInteractor.isOfflineModeEnabled()
@@ -99,7 +99,7 @@ public class AllCoursesCellViewModel: ObservableObject {
             offlineText,
             publishedText
         ]
-        .compactMap { $0 }.joined(separator: ", ")
+        .joined(separator: ", ")
 
         favoriteButtonAccessibilityText = pending ? String(localized: "Updating", bundle: .core) : String(localized: "Favorite", bundle: .core)
         favoriteButtonTraits = (item.isFavourite && !pending) ? .isSelected : []

--- a/Core/Core/Features/Discussions/DiscussionListViewController.swift
+++ b/Core/Core/Features/Discussions/DiscussionListViewController.swift
@@ -343,7 +343,7 @@ class DiscussionListCell: UITableViewCell {
         unreadDot.backgroundColor = .backgroundInfo
 
         accessibilityIdentifier = "DiscussionListCell.\(topic?.id ?? "")"
-        accessibilityLabel = [titleLabel.text, statusLabel.text, dateLabel.text, pointsLabel.text, repliesLabel.text, unreadLabel.text].compactMap { $0 }.joined(separator: " ")
+        accessibilityLabel = [titleLabel.text, statusLabel.text, dateLabel.text, pointsLabel.text, repliesLabel.text, unreadLabel.text].joined(separator: " ")
     }
 
     override func prepareForReuse() {

--- a/Core/Core/Features/Files/View/FileList/FileListViewController.swift
+++ b/Core/Core/Features/Files/View/FileList/FileListViewController.swift
@@ -563,6 +563,6 @@ class FileListCell: UITableViewCell {
 
     func updateAccessibilityLabel() {
         accessibilityLabel = [ iconView.accessibilityLabel, nameLabel.text, sizeLabel.text ]
-            .compactMap { $0 }.joined(separator: ", ")
+            .joined(separator: ", ")
     }
 }

--- a/Core/Core/Features/Inbox/ViewModel/InboxMessageListItemViewModel.swift
+++ b/Core/Core/Features/Inbox/ViewModel/InboxMessageListItemViewModel.swift
@@ -49,9 +49,9 @@ public struct InboxMessageListItemViewModel: Identifiable, Equatable {
                     message.message,
                     message.participantName,
                     message.date,
-                    message.isStarred ? String(localized: "Starred", bundle: .core) : "",
-                    message.state == .unread ? String(localized: "Unread", bundle: .core) : "",
-                    message.hasAttachment ? String(localized: "Attachments available", bundle: .core) : ""
+                    message.isStarred ? String(localized: "Starred", bundle: .core) : nil,
+                    message.state == .unread ? String(localized: "Unread", bundle: .core) : nil,
+                    message.hasAttachment ? String(localized: "Attachments available", bundle: .core) : nil
                    ].joined(separator: ","))
         }()
     }

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -57,7 +57,6 @@ public struct LoginSession: Codable, Hashable {
             userID,
             originalUserID
         ]
-        .compactMap { $0 }
         .joined(separator: "-")
     }
 

--- a/Core/Core/Features/Modules/ModuleList/ModuleItemCell.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleItemCell.swift
@@ -127,7 +127,7 @@ class ModuleItemCell: UITableViewCell {
             dueLabel.textColor = tintColor
             accessoryView = UIImageView(image: .masteryPathsLine)
         } else {
-            dueLabel.setText([dueAt, points, requirement].compactMap { $0 }.joined(separator: " | "), style: .textCellSupportingText)
+            dueLabel.setText([dueAt, points, requirement].joined(separator: " | "), style: .textCellSupportingText)
             dueLabel.textColor = .textDark
             accessoryView = nil
         }
@@ -162,7 +162,7 @@ class ModuleItemCell: UITableViewCell {
             ])
         }
 
-        accessibilityLabel = a11yLabels.compactMap { $0 }.filter { !$0.isEmpty }.joined(separator: ", ")
+        accessibilityLabel = a11yLabels.map { $0?.nilIfEmpty }.joined(separator: ", ")
     }
 
     // MARK: - Publish

--- a/Core/Core/Features/Modules/ModuleList/ModuleSectionHeaderView.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleSectionHeaderView.swift
@@ -121,7 +121,7 @@ class ModuleSectionHeaderView: UITableViewHeaderFooterView {
             isExpanded
                 ? String(localized: "expanded", bundle: .core)
                 : String(localized: "collapsed", bundle: .core)
-        ].compactMap { $0 }.joined(separator: ", ")
+        ].joined(separator: ", ")
     }
 
     private func updatePublishedState(_ module: Module) {

--- a/Core/Core/Features/Planner/CalendarEvent/Model/Helpers/RecurrenceRule.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/Model/Helpers/RecurrenceRule.swift
@@ -422,7 +422,7 @@ extension RecurrenceRule {
         }()
         subRules.append(endString)
 
-        return "RRULE:" + subRules.compactMap({ $0 }).joined(separator: ";")
+        return "RRULE:" + subRules.joined(separator: ";")
     }
 }
 

--- a/Core/Core/Features/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModel+Entities.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/ViewModel/EditCustomFrequencyViewModel+Entities.swift
@@ -33,7 +33,6 @@ extension EditCustomFrequencyViewModel {
                     "weekday: \(dayOfWeek.weekday.dateComponent)",
                     dayOfWeek.weekNumber.flatMap({ "weekNumber: \($0)" })
                 ]
-                    .compactMap({ $0 })
                     .joined(separator: ", ")
             case .day(let dayNo):
                 info = "day: \(dayNo)"

--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -317,13 +317,13 @@ extension Submission {
         case .basic_lti_launch, .external_tool, .online_quiz:
             return String.localizedAttemptNumber(attempt)
         case .discussion_topic:
-            return discussionEntriesOrdered.first?.message?.htmlToSubtitle(lineBreaks: " ")
+            return discussionEntriesOrdered.first?.message?.htmlToPlainText(lineBreaks: " ")
         case .media_recording:
             return mediaComment?.mediaType == .audio
                 ? String(localized: "Audio", bundle: .core)
                 : String(localized: "Video", bundle: .core)
         case .online_text_entry:
-            return body?.htmlToSubtitle(lineBreaks: " ")
+            return body?.htmlToPlainText(lineBreaks: " ")
         case .online_upload:
             return attachments?.first?.size.humanReadableFileSize
         case .online_url:
@@ -344,12 +344,12 @@ extension Submission {
             nil
         case .discussion_topic:
             discussionEntriesOrdered.first?.message?
-                .htmlToSubtitle(lineBreaks: "\n")
+                .htmlToPlainText(lineBreaks: "\n")
                 .components(separatedBy: "\n")
                 .first
         case .online_text_entry:
             body?
-                .htmlToSubtitle(lineBreaks: "\n")
+                .htmlToPlainText(lineBreaks: "\n")
                 .components(separatedBy: "\n")
                 .first
         case .online_upload:
@@ -364,7 +364,7 @@ extension Submission {
 }
 
 private extension String {
-    func htmlToSubtitle(lineBreaks lineBreakReplacement: String) -> String {
+    func htmlToPlainText(lineBreaks lineBreakReplacement: String) -> String {
         self
             .replacingOccurrences(of: "<div>", with: lineBreakReplacement)
             .replacingOccurrences(of: "<br>", with: lineBreakReplacement)

--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -317,13 +317,13 @@ extension Submission {
         case .basic_lti_launch, .external_tool, .online_quiz:
             return String.localizedAttemptNumber(attempt)
         case .discussion_topic:
-            return discussionEntriesOrdered.first?.message?.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            return discussionEntriesOrdered.first?.message?.htmlToSubtitle(lineBreaks: " ")
         case .media_recording:
             return mediaComment?.mediaType == .audio
                 ? String(localized: "Audio", bundle: .core)
                 : String(localized: "Video", bundle: .core)
         case .online_text_entry:
-            return body?.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            return body?.htmlToSubtitle(lineBreaks: " ")
         case .online_upload:
             return attachments?.first?.size.humanReadableFileSize
         case .online_url:
@@ -331,6 +331,44 @@ extension Submission {
         case .none, .not_graded, .on_paper, .wiki_page, .student_annotation:
             return nil
         }
+    }
+
+    public var attemptAccessibilityDescription: String? {
+        guard let typeWithQuizLTIMapping else { return nil }
+
+        let title = typeWithQuizLTIMapping.localizedString
+
+        let subtitle: String? = switch typeWithQuizLTIMapping {
+        case .basic_lti_launch, .external_tool, .online_quiz:
+            // omitting attempt number, as it is included elsewhere
+            nil
+        case .discussion_topic:
+            discussionEntriesOrdered.first?.message?
+                .htmlToSubtitle(lineBreaks: "\n")
+                .components(separatedBy: "\n")
+                .first
+        case .online_text_entry:
+            body?
+                .htmlToSubtitle(lineBreaks: "\n")
+                .components(separatedBy: "\n")
+                .first
+        case .online_upload:
+            // omitting file size, as it is included elsewhere for each file
+            nil
+        default:
+            attemptSubtitle
+        }
+
+        return [title, subtitle].joined(separator: ", ")
+    }
+}
+
+private extension String {
+    func htmlToSubtitle(lineBreaks lineBreakReplacement: String) -> String {
+        self
+            .replacingOccurrences(of: "<div>", with: lineBreakReplacement)
+            .replacingOccurrences(of: "<br>", with: lineBreakReplacement)
+            .replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
     }
 }
 

--- a/Core/Core/Features/Submissions/SubmissionCommentAccessibility.swift
+++ b/Core/Core/Features/Submissions/SubmissionCommentAccessibility.swift
@@ -1,0 +1,78 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension SubmissionComment {
+    public var accessibilityLabelForHeader: String {
+        if let attempt {
+            let attemptString = String.localizedAttemptNumber(attempt)
+            let submissionInfo = String.localizedStringWithFormat(
+                String(localized: "Submitted by %1$@, on %2$@", bundle: .core, comment: "Submitted by John Doe, on 1948.12.02. at 11:42"),
+                authorName,
+                createdAtLocalizedString
+            )
+            return "\(attemptString), \(submissionInfo)"
+        }
+
+        if let mediaType, mediaURL != nil {
+            let format = switch mediaType {
+            case .audio:
+                String(localized: "%1$@ left an audio comment on %2$@", bundle: .core, comment: "John Doe left an audio comment on 1948.12.02. at 11:42")
+            case .video:
+                String(localized: "%1$@ left a video comment on %2$@", bundle: .core, comment: "John Doe left a video comment on 1948.12.02. at 11:42")
+            }
+            return String.localizedStringWithFormat(
+                format,
+                authorName,
+                createdAtLocalizedString
+            )
+        }
+
+        return String.localizedStringWithFormat(
+            String(localized: "%1$@ commented on %2$@: %3$@", bundle: .core, comment: "John Doe commented on 1948.12.02. at 11:42: This is my comment"),
+            authorName,
+            createdAtLocalizedString,
+            comment
+        )
+    }
+
+    public func accessibilityLabelForAttempt(submission: Submission) -> String {
+        [
+            String.localizedAttemptNumber(submission.attempt),
+            submission.attemptAccessibilityDescription
+        ].joined(separator: ", ")
+    }
+
+    public func accessibilityLabelForCommentAttachment(_ file: File) -> String {
+        [
+            String(localized: "Attached file", bundle: .core, comment: "Describes an attached file, not the act of attaching."),
+            file.displayName,
+            file.size.humanReadableFileSize
+        ].joined(separator: ", ")
+    }
+
+    public func accessibilityLabelForAttemptAttachment(_ file: File, submission: Submission) -> String {
+        [
+            String.localizedAttemptNumber(submission.attempt),
+            submission.attemptAccessibilityDescription,
+            file.displayName,
+            file.size.humanReadableFileSize
+        ].joined(separator: ", ")
+    }
+}

--- a/Core/Core/Features/Todos/TodoListViewController.swift
+++ b/Core/Core/Features/Todos/TodoListViewController.swift
@@ -213,6 +213,6 @@ class TodoListCell: UITableViewCell {
         needsGradingSpacer.isHidden = needsGradingView.isHidden
         needsGradingLabel.text = todo?.needsGradingText
         accessibilityIdentifier = "to-do.list.\(todo?.assignmentOrQuizID ?? "unknown").row"
-        accessibilityLabel = [accessIconView.accessibilityLabel, todo?.contextName, todo?.name, todo?.dueText, todo?.needsGradingText].compactMap { $0 }.joined(separator: ", ")
+        accessibilityLabel = [accessIconView.accessibilityLabel, todo?.contextName, todo?.name, todo?.dueText, todo?.needsGradingText].joined(separator: ", ")
     }
 }

--- a/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/StringExtensionsTests.swift
@@ -88,4 +88,19 @@ class StringExtensionsTests: XCTestCase {
         XCTAssertEqual("Canvas1".deletingPrefix("Canvas"), "1")
         XCTAssertEqual("1Canvas1".deletingPrefix("Canvas"), "1Canvas1")
     }
+
+    func testJoinedForOptionalStrings() {
+        var texts: [String?] = ["one", nil, "three"]
+        XCTAssertEqual(texts.joined(separator: ","), "one,three")
+        XCTAssertEqual(texts.joined(separator: ""), "onethree")
+
+        texts = ["1", "", "3"]
+        XCTAssertEqual(texts.joined(separator: ","), "1,,3")
+
+        texts = ["3"]
+        XCTAssertEqual(texts.joined(separator: ","), "3")
+
+        texts = []
+        XCTAssertEqual(texts.joined(separator: "."), "")
+    }
 }

--- a/Core/CoreTests/Features/Submissions/SubmissionCommentAccessibilityTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionCommentAccessibilityTests.swift
@@ -1,0 +1,195 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import XCTest
+@testable import Core
+
+class SubmissionCommentAccessibilityTests: CoreTestCase {
+
+    private enum TestConstants {
+        static let date = Date.make(year: 2048, month: 05, day: 06)
+        static let fileSize = 589824
+    }
+
+    // MARK: - Label for header
+
+    func test_labelForHeader_whenCommentIsForAttempt() {
+        let comment = makeComment(
+            attempt: 7,
+            authorName: "Some Author",
+            createdAt: TestConstants.date,
+            comment: "This is ignored"
+        )
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForHeader,
+            "Attempt 7, Submitted by Some Author, on \(TestConstants.date.dateTimeString)"
+        )
+    }
+
+    func test_labelForHeader_whenCommentIsAudio() {
+        let comment = makeComment(
+            attempt: nil,
+            authorName: "Some Author",
+            createdAt: TestConstants.date,
+            comment: "Comment text to be ignored",
+            mediaType: .audio,
+            mediaURL: .make()
+        )
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForHeader,
+            "Some Author left an audio comment on \(TestConstants.date.dateTimeString)"
+        )
+    }
+
+    func test_labelForHeader_whenCommentIsVideo() {
+        let comment = makeComment(
+            attempt: nil,
+            authorName: "Some Author",
+            createdAt: TestConstants.date,
+            comment: "Comment text to be ignored",
+            mediaType: .video,
+            mediaURL: .make()
+        )
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForHeader,
+            "Some Author left a video comment on \(TestConstants.date.dateTimeString)"
+        )
+    }
+
+    func test_labelForHeader_whenCommentHasNoMediaURL_shouldBehaveAsTextComment() {
+        let comment = makeComment(
+            attempt: nil,
+            authorName: "Some Author",
+            createdAt: TestConstants.date,
+            comment: "Comment text to be included",
+            mediaType: .video,
+            mediaURL: nil
+        )
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForHeader,
+            "Some Author commented on \(TestConstants.date.dateTimeString): Comment text to be included"
+        )
+    }
+
+    func test_labelForHeader_whenCommentIsText() {
+        let comment = makeComment(
+            attempt: nil,
+            authorName: "Some Author",
+            createdAt: TestConstants.date,
+            comment: "Comment text to be included"
+        )
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForHeader,
+            "Some Author commented on \(TestConstants.date.dateTimeString): Comment text to be included"
+        )
+    }
+
+    // MARK: - Label for Attempt
+
+    func test_labelForAttempt_whenAttemptIsText() {
+        let comment = makeComment(attempt: 42, authorName: "To be ignored", comment: "To be ignored")
+        let submission = makeSubmission(attempt: 7, type: .online_text_entry)
+        submission.body = "Some submission text"
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForAttempt(submission: submission),
+            "Attempt 7, Text Entry, Some submission text"
+        )
+    }
+
+    func test_labelForAttempt_whenAttemptIsExternalTool() {
+        let comment = makeComment()
+        let submission = makeSubmission(attempt: 7, type: .external_tool)
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForAttempt(submission: submission),
+            "Attempt 7, External Tool"
+        )
+    }
+
+    // MARK: - Label for Attachment
+
+    func test_labelForCommentAttachment() {
+        let comment = makeComment(attempt: 42, authorName: "To be ignored", comment: "To be ignored")
+        let file = makeFile(displayName: "Some file name", size: TestConstants.fileSize)
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForCommentAttachment(file),
+            "Attached file, Some file name, \(TestConstants.fileSize.humanReadableFileSize)"
+        )
+    }
+
+    func test_labelForAttemptAttachment() {
+        let comment = makeComment(attempt: 42, authorName: "author", comment: "Comment text")
+        let file = makeFile(displayName: "Some file name", size: TestConstants.fileSize)
+        let submission = makeSubmission(attempt: 7, type: .online_upload)
+
+        XCTAssertEqual(
+            comment.accessibilityLabelForAttemptAttachment(file, submission: submission),
+            "Attempt 7, File Upload, Some file name, \(TestConstants.fileSize.humanReadableFileSize)"
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func makeComment(
+        attempt: Int? = nil,
+        authorName: String = "",
+        createdAt: Date? = nil,
+        comment commentString: String = "",
+        mediaType: MediaCommentType? = nil,
+        mediaURL: URL? = nil
+    ) -> SubmissionComment {
+        let comment = SubmissionComment.save(.make(), for: .make(), in: databaseClient)
+        if let attempt {
+            comment.id = "submission-1-\(attempt)"
+        }
+        comment.authorName = authorName
+        comment.createdAt = createdAt
+        comment.comment = commentString
+        comment.mediaType = mediaType
+        comment.mediaURL = mediaURL
+        return comment
+    }
+
+    private func makeSubmission(
+        attempt: Int = 0,
+        type: SubmissionType? = nil
+    ) -> Submission {
+        let submission = Submission.save(.make(), in: databaseClient)
+        submission.attempt = attempt
+        submission.type = type
+        return submission
+    }
+
+    private func makeFile(
+        displayName: String? = nil,
+        size: Int = 0
+    ) -> File {
+        let file = File.save(.make(), to: nil, in: databaseClient)
+        file.displayName = displayName
+        file.size = size
+        return file
+    }
+}

--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -4481,6 +4481,9 @@
         }
       }
     },
+    "%1$@ commented on %2$@: %3$@" : {
+      "comment" : "John Doe commented on 1948.12.02. at 11:42: This is my comment"
+    },
     "%1$@ is due in %2$@" : {
       "comment" : "local notification countdown alert",
       "extractionState" : "manual",
@@ -4744,6 +4747,12 @@
           }
         }
       }
+    },
+    "%1$@ left a video comment on %2$@" : {
+      "comment" : "John Doe left a video comment on 1948.12.02. at 11:42"
+    },
+    "%1$@ left an audio comment on %2$@" : {
+      "comment" : "John Doe left an audio comment on 1948.12.02. at 11:42"
     },
     "%1$@ out of %2$@" : {
       "comment" : "88 out of 100 points",
@@ -23405,6 +23414,9 @@
           }
         }
       }
+    },
+    "Attached file" : {
+      "comment" : "Describes an attached file, not the act of attaching."
     },
     "Attachment" : {
       "comment" : "An item for attaching to a discussion",
@@ -45134,6 +45146,12 @@
       }
     },
     "Double tap to select attempt" : {
+
+    },
+    "Double tap to view attempt" : {
+
+    },
+    "Double tap to view file" : {
 
     },
     "Download Canceled" : {
@@ -86051,6 +86069,7 @@
       }
     },
     "On %@ %@ commented \"%@\"" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86307,6 +86326,7 @@
       }
     },
     "On %@ %@ left a video comment" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86563,6 +86583,7 @@
       }
     },
     "On %@ %@ left an audio comment" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -86819,6 +86840,7 @@
       }
     },
     "On %@ %@ submitted the following" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -114772,6 +114794,9 @@
         }
       }
     },
+    "Submitted by %1$@, on %2$@" : {
+      "comment" : "Submitted by John Doe, on 1948.12.02. at 11:42"
+    },
     "Submitting..." : {
       "localizations" : {
         "ar" : {
@@ -138882,6 +138907,7 @@
       }
     },
     "View file %@ %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -139395,6 +139421,7 @@
       }
     },
     "View submission attempt %d. %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -4481,9 +4481,6 @@
         }
       }
     },
-    "%1$@ commented on %2$@: %3$@" : {
-      "comment" : "John Doe commented on 1948.12.02. at 11:42: This is my comment"
-    },
     "%1$@ is due in %2$@" : {
       "comment" : "local notification countdown alert",
       "extractionState" : "manual",
@@ -4747,12 +4744,6 @@
           }
         }
       }
-    },
-    "%1$@ left a video comment on %2$@" : {
-      "comment" : "John Doe left a video comment on 1948.12.02. at 11:42"
-    },
-    "%1$@ left an audio comment on %2$@" : {
-      "comment" : "John Doe left an audio comment on 1948.12.02. at 11:42"
     },
     "%1$@ out of %2$@" : {
       "comment" : "88 out of 100 points",
@@ -23414,9 +23405,6 @@
           }
         }
       }
-    },
-    "Attached file" : {
-      "comment" : "Describes an attached file, not the act of attaching."
     },
     "Attachment" : {
       "comment" : "An item for attaching to a discussion",
@@ -114793,9 +114781,6 @@
           }
         }
       }
-    },
-    "Submitted by %1$@, on %2$@" : {
-      "comment" : "Submitted by John Doe, on 1948.12.02. at 11:42"
     },
     "Submitting..." : {
       "localizations" : {

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
@@ -30,25 +30,23 @@ class SubmissionCommentAttemptCell: UITableViewCell {
     }
 
     func update(comment: SubmissionComment, submission: Submission?, onFileTap: @escaping (Submission?, File?) -> Void) {
+        guard let submission else { return } // it will never happen
+
         accessibilityIdentifier = "SubmissionComments.attemptCell.\(comment.id)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "On %@ %@ submitted the following", bundle: .student),
-            comment.createdAtLocalizedString,
-            comment.authorName
-        )
+
         self.onFileTap = onFileTap
 
         for view in stackView?.arrangedSubviews ?? [] { view.removeFromSuperview() }
-        if submission?.type == .online_upload, let files = submission?.attachments?.sorted(by: File.idCompare) {
+        if submission.type == .online_upload, let files = submission.attachments?.sorted(by: File.idCompare) {
             for file in files {
                 let view = SubmissionCommentFileView.loadFromXib()
-                view.update(file: file)
+                view.update(file: file, submission: submission)
                 view.onTap = { [weak self] in
                     self?.onFileTap?(submission, file)
                 }
                 stackView?.addArrangedSubview(view)
             }
-        } else if let submission = submission, submission.submittedAt != nil {
+        } else if submission.submittedAt != nil {
             let view = SubmissionCommentFileView.loadFromXib()
             view.update(submission: submission)
             view.onTap = { [weak self] in

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentAttemptCell.swift
@@ -40,7 +40,7 @@ class SubmissionCommentAttemptCell: UITableViewCell {
         if submission.type == .online_upload, let files = submission.attachments?.sorted(by: File.idCompare) {
             for file in files {
                 let view = SubmissionCommentFileView.loadFromXib()
-                view.update(file: file, submission: submission)
+                view.update(comment: comment, file: file, submission: submission)
                 view.onTap = { [weak self] in
                     self?.onFileTap?(submission, file)
                 }
@@ -48,7 +48,7 @@ class SubmissionCommentAttemptCell: UITableViewCell {
             }
         } else if submission.submittedAt != nil {
             let view = SubmissionCommentFileView.loadFromXib()
-            view.update(submission: submission)
+            view.update(comment: comment, submission: submission)
             view.onTap = { [weak self] in
                 self?.onFileTap?(submission, nil)
             }

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentAudioCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentAudioCell.swift
@@ -32,11 +32,6 @@ class SubmissionCommentAudioCell: UITableViewCell {
 
     func update(comment: SubmissionComment, parent: UIViewController) {
         accessibilityIdentifier = "SubmissionComments.audioCell.\(comment.id)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "On %@ %@ left an audio comment", bundle: .student),
-            comment.createdAtLocalizedString,
-            comment.authorName
-        )
 
         guard let mediaURL = comment.mediaURL else { return } // The cell should always have a valid mediaURL
         player.accessibilityPrefix = "SubmissionComments.audioCell.\(comment.id)."

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
@@ -35,29 +35,33 @@ class SubmissionCommentFileView: UIControl {
         addTarget(self, action: #selector(didTapFile), for: .touchUpInside)
     }
 
-    func update(file: File) {
-        let id = file.id ?? ""
-        accessibilityIdentifier = "SubmissionComments.fileView.\(id)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "View file %@ %@", bundle: .student),
-            file.displayName ?? "",
-            file.size.humanReadableFileSize
-        )
+    // This method (and the whole class) is used only for files in attempts, not for files in simple comments
+    func update(file: File, submission: Submission) {
         iconView?.image = file.icon
         nameLabel?.text = file.displayName
         sizeLabel?.text = file.size.humanReadableFileSize
+
+        accessibilityIdentifier = "SubmissionComments.fileView.\(file.id ?? "")"
+        accessibilityLabel = [
+            String.localizedAttemptNumber(submission.attempt),
+            submission.attemptAccessibilityDescription,
+            file.displayName,
+            file.size.humanReadableFileSize
+        ].joined(separator: ", ")
+        accessibilityHint = String(localized: "Double tap to view file", bundle: .core)
     }
 
     func update(submission: Submission) {
-        accessibilityIdentifier = "SubmissionComments.attemptView.\(submission.attempt)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "View submission attempt %d. %@", bundle: .student),
-            submission.attempt,
-            submission.attemptTitle ?? ""
-        )
         iconView?.image = submission.attemptIcon
         nameLabel?.text = submission.attemptTitle
         sizeLabel?.text = submission.attemptSubtitle
+
+        accessibilityIdentifier = "SubmissionComments.attemptView.\(submission.attempt)"
+        accessibilityLabel = [
+            String.localizedAttemptNumber(submission.attempt),
+            submission.attemptAccessibilityDescription
+        ].joined(separator: ", ")
+        accessibilityHint = String(localized: "Double tap to view attempt", bundle: .core)
     }
 
     @IBAction func didTapFile(_ sender: UIControl) {

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentFileView.swift
@@ -36,31 +36,23 @@ class SubmissionCommentFileView: UIControl {
     }
 
     // This method (and the whole class) is used only for files in attempts, not for files in simple comments
-    func update(file: File, submission: Submission) {
+    func update(comment: SubmissionComment, file: File, submission: Submission) {
         iconView?.image = file.icon
         nameLabel?.text = file.displayName
         sizeLabel?.text = file.size.humanReadableFileSize
 
         accessibilityIdentifier = "SubmissionComments.fileView.\(file.id ?? "")"
-        accessibilityLabel = [
-            String.localizedAttemptNumber(submission.attempt),
-            submission.attemptAccessibilityDescription,
-            file.displayName,
-            file.size.humanReadableFileSize
-        ].joined(separator: ", ")
+        accessibilityLabel = comment.accessibilityLabelForAttemptAttachment(file, submission: submission)
         accessibilityHint = String(localized: "Double tap to view file", bundle: .core)
     }
 
-    func update(submission: Submission) {
+    func update(comment: SubmissionComment, submission: Submission) {
         iconView?.image = submission.attemptIcon
         nameLabel?.text = submission.attemptTitle
         sizeLabel?.text = submission.attemptSubtitle
 
         accessibilityIdentifier = "SubmissionComments.attemptView.\(submission.attempt)"
-        accessibilityLabel = [
-            String.localizedAttemptNumber(submission.attempt),
-            submission.attemptAccessibilityDescription
-        ].joined(separator: ", ")
+        accessibilityLabel = comment.accessibilityLabelForAttempt(submission: submission)
         accessibilityHint = String(localized: "Double tap to view attempt", bundle: .core)
     }
 

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentHeaderCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentHeaderCell.swift
@@ -39,37 +39,6 @@ class SubmissionCommentHeaderCell: UITableViewCell {
         chatBubbleView?.isHidden = comment.attempt != nil || comment.mediaURL != nil
 
         isAccessibilityElement = true
-
-        if let attempt = comment.attempt {
-            let attemptString = String.localizedAttemptNumber(attempt)
-            let submissionInfo = String.localizedStringWithFormat(
-                String(localized: "Submitted by %1$@, on %2$@", bundle: .student, comment: "Submitted by John Doe, on 1948.12.02. at 11:42"),
-                comment.authorName,
-                comment.createdAtLocalizedString
-            )
-            accessibilityLabel = "\(attemptString), \(submissionInfo)"
-        } else if let mediaType = comment.mediaType, comment.mediaURL != nil {
-            switch mediaType {
-            case .audio:
-                accessibilityLabel = String.localizedStringWithFormat(
-                    String(localized: "%1$@ left an audio comment on %2$@", bundle: .student, comment: "John Doe left an audio comment on 1948.12.02. at 11:42"),
-                    comment.authorName,
-                    comment.createdAtLocalizedString
-                )
-            case .video:
-                accessibilityLabel = String.localizedStringWithFormat(
-                    String(localized: "%1$@ left a video comment on %2$@", bundle: .student, comment: "John Doe left a video comment on 1948.12.02. at 11:42"),
-                    comment.authorName,
-                    comment.createdAtLocalizedString
-                )
-            }
-        } else {
-            accessibilityLabel = String.localizedStringWithFormat(
-                String(localized: "%1$@ commented on %2$@: %3$@", bundle: .student, comment: "John Doe commented on 1948.12.02. at 11:42: This is my comment"),
-                comment.authorName,
-                comment.createdAtLocalizedString,
-                comment.comment
-            )
-        }
+        accessibilityLabel = comment.accessibilityLabelForHeader
     }
 }

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentHeaderCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentHeaderCell.swift
@@ -32,12 +32,44 @@ class SubmissionCommentHeaderCell: UITableViewCell {
 
     func update(comment: SubmissionComment) {
         backgroundColor = .backgroundLightest
-        isAccessibilityElement = false
-        accessibilityElementsHidden = true
         authorAvatarView?.name = comment.authorName
         authorAvatarView?.url = comment.authorAvatarURL
         authorNameLabel?.text = User.displayName(comment.authorName, pronouns: comment.authorPronouns)
         createdAtLabel?.text = comment.createdAtLocalizedString
         chatBubbleView?.isHidden = comment.attempt != nil || comment.mediaURL != nil
+
+        isAccessibilityElement = true
+
+        if let attempt = comment.attempt {
+            let attemptString = String.localizedAttemptNumber(attempt)
+            let submissionInfo = String.localizedStringWithFormat(
+                String(localized: "Submitted by %1$@, on %2$@", bundle: .student, comment: "Submitted by John Doe, on 1948.12.02. at 11:42"),
+                comment.authorName,
+                comment.createdAtLocalizedString
+            )
+            accessibilityLabel = "\(attemptString), \(submissionInfo)"
+        } else if let mediaType = comment.mediaType, comment.mediaURL != nil {
+            switch mediaType {
+            case .audio:
+                accessibilityLabel = String.localizedStringWithFormat(
+                    String(localized: "%1$@ left an audio comment on %2$@", bundle: .student, comment: "John Doe left an audio comment on 1948.12.02. at 11:42"),
+                    comment.authorName,
+                    comment.createdAtLocalizedString
+                )
+            case .video:
+                accessibilityLabel = String.localizedStringWithFormat(
+                    String(localized: "%1$@ left a video comment on %2$@", bundle: .student, comment: "John Doe left a video comment on 1948.12.02. at 11:42"),
+                    comment.authorName,
+                    comment.createdAtLocalizedString
+                )
+            }
+        } else {
+            accessibilityLabel = String.localizedStringWithFormat(
+                String(localized: "%1$@ commented on %2$@: %3$@", bundle: .student, comment: "John Doe commented on 1948.12.02. at 11:42: This is my comment"),
+                comment.authorName,
+                comment.createdAtLocalizedString,
+                comment.comment
+            )
+        }
     }
 }

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
@@ -66,10 +66,7 @@ class SubmissionCommentTextCell: UITableViewCell {
             button.imageView?.contentMode = .scaleAspectFit
             button.setTitle(attachment.displayName, for: .normal)
             button.setTitleColor(color, for: .normal)
-            button.accessibilityLabel = [
-                String(localized: "Attached file", bundle: .core, comment: "Describes an attached file, not the act of attaching."),
-                attachment.displayName
-            ].joined(separator: ", ")
+            button.accessibilityLabel = comment.accessibilityLabelForCommentAttachment(attachment)
             button.accessibilityHint = String(localized: "Double tap to view file", bundle: .core)
 
             button.layer.cornerRadius = 4

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentTextCell.swift
@@ -34,15 +34,14 @@ class SubmissionCommentTextCell: UITableViewCell {
 
     func update(comment: SubmissionComment) {
         guard !comment.isFault else { return }
+
         self.comment = comment
-        accessibilityIdentifier = "SubmissionComments.textCell.\(comment.id)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "On %@ %@ commented \"%@\"", bundle: .student),
-            comment.createdAtLocalizedString,
-            comment.authorName,
-            comment.comment
-        )
         commentLabel?.setText(comment.comment, lineHeight: .body)
+
+        accessibilityIdentifier = "SubmissionComments.textCell.\(comment.id)"
+        let hasAttachements = comment.attachments?.isNotEmpty ?? false
+        accessibilityElementsHidden = !hasAttachements
+        commentLabel?.accessibilityElementsHidden = true
 
         attachmentsStackView?.arrangedSubviews.forEach { subview in
             attachmentsStackView?.removeArrangedSubview(subview)
@@ -67,6 +66,11 @@ class SubmissionCommentTextCell: UITableViewCell {
             button.imageView?.contentMode = .scaleAspectFit
             button.setTitle(attachment.displayName, for: .normal)
             button.setTitleColor(color, for: .normal)
+            button.accessibilityLabel = [
+                String(localized: "Attached file", bundle: .core, comment: "Describes an attached file, not the act of attaching."),
+                attachment.displayName
+            ].joined(separator: ", ")
+            button.accessibilityHint = String(localized: "Double tap to view file", bundle: .core)
 
             button.layer.cornerRadius = 4
             button.layer.borderColor = UIColor.borderMedium.ensureContrast(against: .textLightest.variantForLightMode).cgColor

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentVideoCell.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentVideoCell.swift
@@ -40,11 +40,6 @@ class SubmissionCommentVideoCell: UITableViewCell {
 
     func update(comment: SubmissionComment, parent: UIViewController) {
         accessibilityIdentifier = "SubmissionComments.videoCell.\(comment.id)"
-        accessibilityLabel = String.localizedStringWithFormat(
-            String(localized: "On %@ %@ left a video comment", bundle: .student),
-            comment.createdAtLocalizedString,
-            comment.authorName
-        )
 
         playerViewController.player = comment.mediaLocalOrRemoteURL.flatMap { AVPlayer(url: $0) }
         if playerViewController.view?.superview == nil, let view = containerView {

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -259,14 +259,14 @@ extension SubmissionCommentsViewController: UITableViewDataSource, UITableViewDe
             return cell
         }
 
-        if comment.mediaURL != nil, comment.mediaType == .some(.audio) {
+        if comment.mediaURL != nil, comment.mediaType == .audio {
             let cell: SubmissionCommentAudioCell = tableView.dequeue(for: indexPath)
             cell.update(comment: comment, parent: self)
             cell.transform = CGAffineTransform(scaleX: 1, y: -1)
             return cell
         }
 
-        if comment.mediaURL != nil, comment.mediaType == .some(.video) {
+        if comment.mediaURL != nil, comment.mediaType == .video {
             let cell: SubmissionCommentVideoCell = tableView.dequeue(for: indexPath)
             cell.update(comment: comment, parent: self)
             cell.transform = CGAffineTransform(scaleX: 1, y: -1)

--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -1281,6 +1281,9 @@
         }
       }
     },
+    "Add custom grade" : {
+
+    },
     "All grades are currently hidden." : {
       "localizations" : {
         "ar" : {

--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -8963,6 +8963,15 @@
         }
       }
     },
+    "Double tap to view attempt" : {
+
+    },
+    "Double tap to view file" : {
+
+    },
+    "Double tap to view profile" : {
+
+    },
     "Edit" : {
       "localizations" : {
         "ar" : {
@@ -34405,6 +34414,7 @@
       }
     },
     "View file %@ %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -35174,6 +35184,7 @@
       }
     },
     "View submission attempt %lld. %@" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
+++ b/Teacher/Teacher/SpeedGrader/RubricAssessor.swift
@@ -153,7 +153,8 @@ struct RubricAssessor: View {
                 Image.addSolid
             }
         }
-        .accessibility(label: Text("Customize Grade", bundle: .teacher))
+        .accessibilityLabel(Text("Add custom grade", bundle: .teacher))
+        .accessibilityRemoveTraits(.isImage)
         .alignmentGuide(.leading, computeValue: leading)
         .alignmentGuide(.top, computeValue: top)
     }

--- a/Teacher/Teacher/SpeedGrader/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionCommentListCell.swift
@@ -44,10 +44,20 @@ struct SubmissionCommentListCell: View {
                             self.attempt = attempt
                             self.fileID = file.id
                         }
+                        .accessibilityLabel(
+                            Text(comment.accessibilityLabelForAttemptAttachment(file, submission: submission))
+                        )
+                        .accessibilityHint(Text("Double tap to view file", bundle: .core))
                     }
                 } else {
                     Spacer().frame(height: 12)
-                    SubmissionAttempt(submission: submission) { self.attempt = attempt }
+                    SubmissionAttempt(submission: submission) {
+                        self.attempt = attempt
+                    }
+                    .accessibilityLabel(
+                        Text(comment.accessibilityLabelForAttempt(submission: submission))
+                    )
+                    .accessibilityHint(Text("Double tap to view attempt", bundle: .core))
                 }
             } else if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
                 Spacer().frame(height: 12)
@@ -68,6 +78,7 @@ struct SubmissionCommentListCell: View {
                         .fill(isAuthor ? Color.backgroundInfo : Color.backgroundLight)
                         .scaleEffect(x: isAuthor ? -1: 1)
                     )
+                    .accessibilityHidden(true) // already included in header
                     .identifier("SubmissionComments.textCell.\(comment.id)")
                 ForEach(comment.attachments?.sorted(by: File.idCompare) ?? [], id: \.id) { file in
                     Spacer().frame(height: 4)
@@ -79,6 +90,10 @@ struct SubmissionCommentListCell: View {
                             options: .modal(embedInNav: true, addDoneButton: true)
                         )
                     }
+                    .accessibilityLabel(
+                        Text(comment.accessibilityLabelForCommentAttachment(file))
+                    )
+                    .accessibilityHint(Text("Double tap to view file", bundle: .core))
                 }
             }
         }
@@ -99,6 +114,20 @@ struct SubmissionCommentListCell: View {
                 Spacer()
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityRepresentation {
+            if assignment.anonymizeStudents && comment.authorID != currentUserID {
+                Text(comment.accessibilityLabelForHeader)
+            } else if let id = comment.authorID {
+                Button(
+                    action: { avatarButtonAction(authorId: id) },
+                    label: { Text(comment.accessibilityLabelForHeader) }
+                )
+                .accessibilityHint(Text("Double tap to view profile", bundle: .core))
+            } else {
+                Text(comment.accessibilityLabelForHeader)
+            }
+        }
     }
 
     @ViewBuilder var avatar: some View {
@@ -111,20 +140,22 @@ struct SubmissionCommentListCell: View {
                     .stroke(Color.borderMedium, lineWidth: 1)
                 )
         } else if let id = comment.authorID {
-            Button(action: {
-                env.router.route(
-                    to: "/courses/\(assignment.courseID)/users/\(id)",
-                    userInfo: ["navigatorOptions": ["modal": true]], // fix nav style
-                    from: controller,
-                    options: .modal(embedInNav: true, addDoneButton: true)
-                )
-            }, label: {
-                Avatar(name: comment.authorName, url: comment.authorAvatarURL)
-            })
-                .accessibility(label: Text(comment.authorName))
+            Button(
+                action: { avatarButtonAction(authorId: id) },
+                label: { Avatar(name: comment.authorName, url: comment.authorAvatarURL) }
+            )
         } else {
             Avatar(name: comment.authorName, url: comment.authorAvatarURL)
         }
+    }
+
+    private func avatarButtonAction(authorId: String) {
+        env.router.route(
+            to: "/courses/\(assignment.courseID)/users/\(authorId)",
+            userInfo: ["navigatorOptions": ["modal": true]], // fix nav style
+            from: controller,
+            options: .modal(embedInNav: true, addDoneButton: true)
+        )
     }
 
     @ViewBuilder func headerText() -> some View {
@@ -156,7 +187,6 @@ struct SubmissionCommentFile: View {
                 .frame(width: 300)
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
         })
-            .accessibility(label: Text("View file \(file.displayName ?? file.filename) \(file.size.humanReadableFileSize)", bundle: .teacher))
             .identifier("SubmissionComments.fileView.\(file.id ?? "")")
     }
 }
@@ -186,7 +216,6 @@ struct SubmissionAttempt: View {
                 .frame(width: 300)
                 .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
         })
-            .accessibility(label: Text("View submission attempt \(submission.attempt). \(submission.attemptTitle ?? "")", bundle: .teacher))
     }
 }
 


### PR DESCRIPTION
refs: [MBL-18446](https://instructure.atlassian.net/browse/MBL-18446)
affects: Student, Teacher
release note: none

## What's changed
- Aligned and improved Submission Comments a11y in Student app SubmissionDetails and Teacher app SpeedGrader
- Updated SpeedGrader > Rubric > Add grade button a11y

### Chore
- Added `joined(separator:)` method for optional string array, removed now unneeded `compactMap` calls

## What's not changed
- VoiceOver on Audio comments sometimes skips some of the controls
  - Only on iOS17 and Student app Submission Details (UIKit implementation)
- Anonymous Student setting leaves the attempt submitter's name empty (in label and for VoiceOver, too)
  - "Anonymous User" is not returned as the name from backend in these cases, as they do for actual comments
- Left-right swipes in VoiceOver sometimes jump out of the comments instead of scrolling them, but not always

## Test plan
- Verify VoiceOver support in both apps, because one is based on UIKit and the other on SwiftUI
- See ticket comments for general expectations

## Checklist
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Approve from product

[MBL-18446]: https://instructure.atlassian.net/browse/MBL-18446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ