### PR TITLE
Fix Calendar Event start & end time calculation

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/DateExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/DateExtensions.swift
@@ -297,8 +297,8 @@ extension DateFormatter {
 
 #if DEBUG
 public extension Date {
-    static func make(calendar: Calendar = .current, year: Int, month: Int? = nil, day: Int? = nil, hour: Int? = nil, minute: Int? = nil, second: Int? = nil) -> Date {
-        DateComponents(calendar: calendar, year: year, month: month, day: day, hour: hour, minute: minute, second: second).date!
+    static func make(calendar: Calendar = Cal.currentCalendar, year: Int, month: Int? = nil, day: Int? = nil, hour: Int? = nil, minute: Int? = nil, second: Int? = nil) -> Date {
+        return DateComponents(calendar: calendar, year: year, month: month, day: day, hour: hour, minute: minute, second: second).date!
     }
 }
 #endif

--- a/Core/CoreTests/Common/Extensions/Foundation/DateExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/DateExtensionsTests.swift
@@ -115,7 +115,7 @@ class DateExtensionsTests: XCTestCase {
     }
 
     func testTimeOnlyString() {
-        XCTAssertEqual(Date.make(year: 2000, month: 12, day: 25, hour: 11, minute: 45).timeOnlyString, "11:45 AM")
+        XCTAssertEqual(Date.make(calendar: .current, year: 2000, month: 12, day: 25, hour: 11, minute: 45).timeOnlyString, "11:45 AM")
     }
 
     func testRelativeDateOnlyString() {

--- a/Core/CoreTests/Features/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -49,6 +49,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
     override func setUp() {
         super.setUp()
+        Cal.mockCalendar(.current, timeZone: .gmt)
         Clock.mockNow(TestConstants.dateNow)
         eventInteractor = .init()
         calendarListProviderInteractor = .init()
@@ -56,6 +57,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     }
 
     override func tearDown() {
+        Cal.reset()
         Clock.reset()
         eventInteractor = nil
         calendarListProviderInteractor = nil
@@ -66,7 +68,7 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
     // MARK: - Initial values
 
     func testAddModeInitialValues() {
-        let testee = makeAddViewModel()
+        testee = makeAddViewModel()
 
         XCTAssertEqual(testee.state, .data)
         XCTAssertEqual(testee.endTimeErrorMessage, nil)
@@ -90,6 +92,24 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
         testee = makeAddViewModel(selectedDate: TestConstants.dateStart)
         XCTAssertEqual(testee.date, TestConstants.dateStart.startOfDay())
+    }
+
+    func testDefaultTimesAfter22() {
+        Clock.mockNow(Date.make(year: 2024, month: 1, day: 1, hour: 22, minute: 7))
+
+        testee = makeAddViewModel()
+
+        XCTAssertEqual(testee.startTime, Date.make(year: 2024, month: 1, day: 1, hour: 23, minute: 0))
+        XCTAssertEqual(testee.endTime, Date.make(year: 2024, month: 1, day: 1, hour: 23, minute: 59, second: 59))
+    }
+
+    func testDefaultTimesAfter23() {
+        Clock.mockNow(Date.make(year: 2024, month: 1, day: 1, hour: 23, minute: 7))
+
+        testee = makeAddViewModel()
+
+        XCTAssertEqual(testee.startTime, Date.make(year: 2024, month: 1, day: 1, hour: 0, minute: 0))
+        XCTAssertEqual(testee.endTime, Date.make(year: 2024, month: 1, day: 1, hour: 1, minute: 0))
     }
 
     func testEditModeInitialValues() {
@@ -120,8 +140,8 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
 
         XCTAssertEqual(testee.isAllDay, true)
         XCTAssertEqual(testee.date, TestConstants.dateStart)
-        XCTAssertEqual(testee.startTime, Date.make(year: 2024, month: 1, day: 1, hour: 15))
-        XCTAssertEqual(testee.endTime, Date.make(year: 2024, month: 1, day: 1, hour: 16))
+        XCTAssertEqual(testee.startTime, Date.make(year: 2023, month: 8, day: 8, hour: 15))
+        XCTAssertEqual(testee.endTime, Date.make(year: 2023, month: 8, day: 8, hour: 16))
 
         testee = makeEditViewModel(makeEvent(
             isAllDay: false,


### PR DESCRIPTION
refs: [MBL-18646](https://instructure.atlassian.net/browse/MBL-18646)
affects: Student, Teacher
release note: Fixed new calendar events having incorrect end time in some cases.

## Test plan
See ticket for details.
You may need to test in a specific timeframe or mock this on your test device

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18646]: https://instructure.atlassian.net/browse/MBL-18646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ