### PR TITLE
LTIViewController - Rearrange views to make Open Button easily reachable

### DIFF
--- a/Core/Core/Features/LTI/View/LTIViewController.storyboard
+++ b/Core/Core/Features/LTI/View/LTIViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -18,38 +18,6 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LTI Tool" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dW-v6-GRg" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="64" width="382" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="bold20"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gdo-sp-Qqp" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="16" y="117" width="382" height="20.5"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium16"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
-                                </userDefinedRuntimeAttributes>
-                            </label>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FEg-ym-aNw" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="808" width="414" height="54"/>
-                                <inset key="contentEdgeInsets" minX="0.0" minY="18" maxX="0.0" maxY="18"/>
-                                <userDefinedRuntimeAttributes>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="buttonPrimaryBackground"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
-                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="buttonPrimaryText"/>
-                                </userDefinedRuntimeAttributes>
-                                <connections>
-                                    <action selector="openButtonPressed:" destination="Oq6-za-864" eventType="primaryActionTriggered" id="mmG-rB-Izc"/>
-                                </connections>
-                            </button>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="37k-c3-ELz" customClass="CircleProgressView" customModule="Core" customModuleProvider="target">
                                 <rect key="frame" x="187" y="435" width="40" height="40"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
@@ -58,31 +26,90 @@
                                     <constraint firstAttribute="width" constant="40" id="hgV-AZ-Cqe"/>
                                 </constraints>
                             </view>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZiZ-T9-6yO">
-                                <rect key="frame" x="16" y="100.5" width="382" height="0.5"/>
-                                <color key="backgroundColor" name="borderMedium"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="83F-H3-eHy">
+                                <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                                <subviews>
+                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UeY-1V-yl8" userLabel="ContentView">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="815"/>
+                                        <subviews>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="LTI Tool" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2dW-v6-GRg" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="16" width="382" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="bold20"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </label>
+                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZiZ-T9-6yO" userLabel="Divider">
+                                                <rect key="frame" x="16" y="52.5" width="382" height="0.5"/>
+                                                <color key="backgroundColor" name="borderMedium"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="0.5" id="5YL-eH-HJ0"/>
+                                                </constraints>
+                                            </view>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Description" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gdo-sp-Qqp" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                <rect key="frame" x="16" y="69" width="382" height="20.5"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                <nil key="textColor"/>
+                                                <nil key="highlightedColor"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="medium16"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
+                                                </userDefinedRuntimeAttributes>
+                                            </label>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="FEg-ym-aNw" customClass="DynamicButton" customModule="Core" customModuleProvider="target">
+                                                <rect key="frame" x="0.0" y="105.5" width="414" height="54"/>
+                                                <inset key="contentEdgeInsets" minX="0.0" minY="18" maxX="0.0" maxY="18"/>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="buttonPrimaryBackground"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
+                                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="buttonPrimaryText"/>
+                                                </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="openButtonPressed:" destination="Oq6-za-864" eventType="primaryActionTriggered" id="mmG-rB-Izc"/>
+                                                </connections>
+                                            </button>
+                                        </subviews>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                        <constraints>
+                                            <constraint firstItem="FEg-ym-aNw" firstAttribute="leading" secondItem="UeY-1V-yl8" secondAttribute="leading" id="4CV-OU-hOl"/>
+                                            <constraint firstItem="gdo-sp-Qqp" firstAttribute="top" secondItem="ZiZ-T9-6yO" secondAttribute="bottom" constant="16" id="9SI-Ay-ick"/>
+                                            <constraint firstItem="ZiZ-T9-6yO" firstAttribute="top" secondItem="2dW-v6-GRg" secondAttribute="bottom" constant="16" id="IsG-mI-3ZK"/>
+                                            <constraint firstItem="FEg-ym-aNw" firstAttribute="trailing" secondItem="UeY-1V-yl8" secondAttribute="trailing" id="YDD-mK-hY2"/>
+                                            <constraint firstItem="gdo-sp-Qqp" firstAttribute="leading" secondItem="UeY-1V-yl8" secondAttribute="leading" constant="16" id="ZZs-ye-TdU"/>
+                                            <constraint firstItem="FEg-ym-aNw" firstAttribute="bottom" relation="lessThanOrEqual" secondItem="UeY-1V-yl8" secondAttribute="bottom" constant="-64" id="egz-qe-58J"/>
+                                            <constraint firstItem="2dW-v6-GRg" firstAttribute="top" secondItem="UeY-1V-yl8" secondAttribute="top" constant="16" id="hzn-43-Quc"/>
+                                            <constraint firstItem="gdo-sp-Qqp" firstAttribute="trailing" secondItem="UeY-1V-yl8" secondAttribute="trailing" constant="-16" id="iHw-c1-O0V"/>
+                                            <constraint firstItem="ZiZ-T9-6yO" firstAttribute="leading" secondItem="UeY-1V-yl8" secondAttribute="leading" constant="16" id="keQ-Qt-KKm"/>
+                                            <constraint firstItem="2dW-v6-GRg" firstAttribute="leading" secondItem="UeY-1V-yl8" secondAttribute="leading" constant="16" id="ld6-Tl-cU9"/>
+                                            <constraint firstItem="ZiZ-T9-6yO" firstAttribute="trailing" secondItem="UeY-1V-yl8" secondAttribute="trailing" constant="-16" id="mjY-Gg-8q1"/>
+                                            <constraint firstItem="2dW-v6-GRg" firstAttribute="trailing" secondItem="UeY-1V-yl8" secondAttribute="trailing" constant="-16" id="tlA-Og-MZC"/>
+                                            <constraint firstItem="FEg-ym-aNw" firstAttribute="top" secondItem="gdo-sp-Qqp" secondAttribute="bottom" constant="16" id="wx4-pN-5bj"/>
+                                        </constraints>
+                                    </view>
+                                </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="0.5" id="5YL-eH-HJ0"/>
+                                    <constraint firstItem="hpA-cb-mlS" firstAttribute="leading" secondItem="UeY-1V-yl8" secondAttribute="leading" id="6jF-92-AOs"/>
+                                    <constraint firstItem="hpA-cb-mlS" firstAttribute="trailing" secondItem="UeY-1V-yl8" secondAttribute="trailing" id="FQQ-uU-SUa"/>
+                                    <constraint firstItem="UeY-1V-yl8" firstAttribute="height" secondItem="83F-H3-eHy" secondAttribute="height" priority="250" constant="1" id="T6h-zG-ghm"/>
+                                    <constraint firstItem="g1k-Vi-dLr" firstAttribute="top" secondItem="UeY-1V-yl8" secondAttribute="top" id="VCF-7o-a9s"/>
+                                    <constraint firstItem="UeY-1V-yl8" firstAttribute="bottom" secondItem="g1k-Vi-dLr" secondAttribute="bottom" id="pXT-tE-PJn"/>
                                 </constraints>
-                            </view>
+                                <viewLayoutGuide key="contentLayoutGuide" id="g1k-Vi-dLr"/>
+                                <viewLayoutGuide key="frameLayoutGuide" id="hpA-cb-mlS"/>
+                            </scrollView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6vh-22-FCW"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="FEg-ym-aNw" firstAttribute="leading" secondItem="6vh-22-FCW" secondAttribute="leading" id="15s-cG-55S"/>
-                            <constraint firstItem="ZiZ-T9-6yO" firstAttribute="top" secondItem="2dW-v6-GRg" secondAttribute="bottom" constant="16" id="6qS-YN-mLp"/>
-                            <constraint firstItem="gdo-sp-Qqp" firstAttribute="leading" secondItem="6vh-22-FCW" secondAttribute="leading" constant="16" id="AzB-Fa-hVw"/>
-                            <constraint firstItem="gdo-sp-Qqp" firstAttribute="top" secondItem="ZiZ-T9-6yO" secondAttribute="bottom" constant="16" id="FEz-nR-x1a"/>
-                            <constraint firstItem="6vh-22-FCW" firstAttribute="trailing" secondItem="FEg-ym-aNw" secondAttribute="trailing" id="KU1-iH-yyB"/>
-                            <constraint firstItem="2dW-v6-GRg" firstAttribute="leading" secondItem="6vh-22-FCW" secondAttribute="leading" constant="16" id="UAi-vg-1nn"/>
-                            <constraint firstItem="6vh-22-FCW" firstAttribute="trailing" secondItem="gdo-sp-Qqp" secondAttribute="trailing" constant="16" id="aeW-gQ-0L1"/>
-                            <constraint firstItem="ZiZ-T9-6yO" firstAttribute="leading" secondItem="6vh-22-FCW" secondAttribute="leading" constant="16" id="arm-g4-7ze"/>
-                            <constraint firstItem="37k-c3-ELz" firstAttribute="centerX" secondItem="6vh-22-FCW" secondAttribute="centerX" id="f6A-ZM-ltI"/>
-                            <constraint firstItem="6vh-22-FCW" firstAttribute="bottom" secondItem="FEg-ym-aNw" secondAttribute="bottom" id="gqN-0k-9ty"/>
-                            <constraint firstItem="6vh-22-FCW" firstAttribute="trailing" secondItem="2dW-v6-GRg" secondAttribute="trailing" constant="16" id="hH0-BK-Jq2"/>
-                            <constraint firstItem="2dW-v6-GRg" firstAttribute="top" secondItem="6vh-22-FCW" secondAttribute="top" constant="16" id="mp6-GE-Rtx"/>
-                            <constraint firstItem="6vh-22-FCW" firstAttribute="trailing" secondItem="ZiZ-T9-6yO" secondAttribute="trailing" constant="16" id="pjA-kN-asM"/>
-                            <constraint firstItem="37k-c3-ELz" firstAttribute="centerY" secondItem="6vh-22-FCW" secondAttribute="centerY" id="zUN-5q-efF"/>
+                            <constraint firstItem="6vh-22-FCW" firstAttribute="leading" secondItem="83F-H3-eHy" secondAttribute="leading" id="6Et-sF-fhg"/>
+                            <constraint firstItem="6vh-22-FCW" firstAttribute="top" secondItem="83F-H3-eHy" secondAttribute="top" id="PEg-Vs-HuO"/>
+                            <constraint firstItem="6vh-22-FCW" firstAttribute="bottom" secondItem="83F-H3-eHy" secondAttribute="bottom" id="Q6l-KH-pnY"/>
+                            <constraint firstItem="83F-H3-eHy" firstAttribute="trailing" secondItem="6vh-22-FCW" secondAttribute="trailing" id="YRc-0W-DtM"/>
+                            <constraint firstItem="37k-c3-ELz" firstAttribute="centerY" secondItem="6vh-22-FCW" secondAttribute="centerY" id="pHL-Q4-w6q"/>
+                            <constraint firstItem="37k-c3-ELz" firstAttribute="centerX" secondItem="6vh-22-FCW" secondAttribute="centerX" id="s0P-7A-bxi"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Core/Core/Features/LTI/View/LTIViewController.storyboard
+++ b/Core/Core/Features/LTI/View/LTIViewController.storyboard
@@ -113,9 +113,11 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="contentView" destination="UeY-1V-yl8" id="NLq-d6-P7g"/>
                         <outlet property="descriptionLabel" destination="gdo-sp-Qqp" id="SJx-RO-PTP"/>
                         <outlet property="nameLabel" destination="2dW-v6-GRg" id="dFI-r3-Uuv"/>
                         <outlet property="openButton" destination="FEg-ym-aNw" id="Aok-f3-jIU"/>
+                        <outlet property="scrollView" destination="83F-H3-eHy" id="ird-4Q-xBk"/>
                         <outlet property="spinnerView" destination="37k-c3-ELz" id="Y0P-OK-dVi"/>
                     </connections>
                 </viewController>

--- a/Core/Core/Features/LTI/View/LTIViewController.swift
+++ b/Core/Core/Features/LTI/View/LTIViewController.swift
@@ -23,6 +23,8 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
     @IBOutlet weak var nameLabel: UILabel!
     @IBOutlet weak var descriptionLabel: UILabel!
     @IBOutlet weak var openButton: UIButton!
+    @IBOutlet weak var contentView: UIView!
+    @IBOutlet weak var scrollView: UIScrollView!
 
     private var env: AppEnvironment = .defaultValue
     public var tools: LTITools!
@@ -54,6 +56,8 @@ public class LTIViewController: UIViewController, ErrorViewController, ColoredNa
     public override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
+        contentView.backgroundColor = .backgroundLightest
+        scrollView.backgroundColor = .backgroundLightest
         spinnerView.isHidden = true
         nameLabel.text = name ?? String(localized: "LTI Tool", bundle: .core)
         setupTitleViewInNavbar(title: String(localized: "External Tool", bundle: .core))


### PR DESCRIPTION
## LTIViewController - Rearrange views to make Open Button easily reachable

refs: MBL-18679
affects: Student
release note: Fixed a bug that caused Open the Quiz button to be covered out by Comments drawer.

## Test Plan

The original problem was that the "Open Button" was covered out by the "Comments Drawer". So it has been moved closer to the top for better reachability for the users.

However, upon testing the solution another issue was found:
When the font size was increased to the maximum accessibility value then the button went out of the screen and was completely unreachable. To solve this, a scroll view has been added, so even when the button goes out of the screen because of the insanely large fonts, it stays reachable by scrolling. Please test this on different devices.

Known issue: On iPhone SE 3, the "Open Button" is still covered out by the "Comments Drawer".

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/c463a084-2671-460a-8d13-f8f8be5e79ef" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ac748c8f-8072-4d68-b37f-54eb420ce170" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
