### PR TITLE
Update dark modeCSS for discussions

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
@@ -29,8 +29,17 @@ private class DarkModeForWebDiscussions: CoreWebViewFeature {
                 background: \(backgroundDarkest);
             }
             div[data-testid="discussion-topic-container"],
-            div[data-testid="discussion-root-entry-container"]{
+            div[data-testid="discussion-root-entry-container"] {
                 color: \(textLightest);
+            }
+
+            /* Thread Dialog */
+            div[data-testid="drawer-layout-tray"] {
+                background: \(backgroundDarkest);
+                color: \(textLightest);
+            }
+            .css-1eaecfq-baseButton__content {
+                color: \(textLightest) !important;
             }
 
             span[data-testid="mobile-Designer"],
@@ -121,6 +130,8 @@ private class DarkModeForWebDiscussions: CoreWebViewFeature {
             .css-z3sx20-textInput__facade,
             .css-7naoe-textInput__facade,
             .css-1dn3ise-textInput__facade,
+            .css-1n8dxlp-view,
+            .css-1n1ez2a-textInput__facade,
             button[data-testid="manage-assign-to"] span {
                 color: \(textLightest) !important;
                 background: \(backgroundDarkest) !important;


### PR DESCRIPTION
refs: MBL-18678
affects: Student, Teacher
release note: none

test plan:
- When you tap on a threaded reply, the dialog popping up should have dark theme.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode