### PR TITLE
Add snackbar to parent app

### DIFF
--- a/Core/Core/Common/CommonUI/SnackBar/View/UIKit/SnackBarProvider.swift
+++ b/Core/Core/Common/CommonUI/SnackBar/View/UIKit/SnackBarProvider.swift
@@ -22,20 +22,37 @@ public protocol SnackBarProvider {
     var snackBarViewModel: SnackBarViewModel { get }
 }
 
+public extension WeakViewController {
+
+    func findSnackBarViewModel() -> SnackBarViewModel? {
+        value.findSnackBarViewModel()
+    }
+}
+
 public extension UIViewController {
 
     func findSnackBarViewModel() -> SnackBarViewModel? {
-        let possibleProviders = [
-            self,
-            tabBarController,
-            presentingViewController,
-            presentingViewController?.tabBarController
-        ]
+        if let provider = self as? SnackBarProvider {
+            return provider.snackBarViewModel
+        }
 
-        let provider = possibleProviders
-            .compactMap { $0 as? SnackBarProvider }
-            .first
-        return provider?.snackBarViewModel
+        if let parent {
+            return parent.findSnackBarViewModel()
+        } else if let presentingViewController {
+            return presentingViewController.findSnackBarViewModel()
+        }
+
+        return nil
+    }
+}
+
+public extension SnackBarProvider where Self: UIViewController {
+
+    func addSnackBar() {
+        let snackBarController = SnackBarViewController(viewModel: snackBarViewModel)
+        let snackView = snackBarController.view!
+        view.addSubview(snackView)
+        snackView.pin(inside: view)
     }
 }
 

--- a/Core/Core/Common/CommonUI/UIViews/CoreNavigationController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/CoreNavigationController.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-public class CoreNavigationController: UINavigationController {
+open class CoreNavigationController: UINavigationController {
     public var remoteLogger = RemoteLogger.shared
     public override var prefersStatusBarHidden: Bool {
         topViewController?.prefersStatusBarHidden ?? super.prefersStatusBarHidden
@@ -51,7 +51,7 @@ public class CoreNavigationController: UINavigationController {
 
     // MARK: - Lifecycle Methods
 
-    public override func viewDidLoad() {
+    open override func viewDidLoad() {
         super.viewDidLoad()
         self.interactivePopGestureRecognizer?.delegate = self
     }

--- a/Core/Core/Features/Inbox/ComposeMessage/ComposeMessageAssembly.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ComposeMessageAssembly.swift
@@ -24,8 +24,7 @@ public enum ComposeMessageAssembly {
 
     public static func makeComposeMessageViewController(
         env: AppEnvironment = .shared,
-        options: ComposeMessageOptions = ComposeMessageOptions(),
-        sentMailEvent: PassthroughSubject<Void, Never>? = nil
+        options: ComposeMessageOptions = ComposeMessageOptions()
     ) -> UIViewController {
 
         let batchId = UUID.string
@@ -45,7 +44,6 @@ public enum ComposeMessageAssembly {
             options: options,
             interactor: interactor,
             recipientInteractor: recipientInteractor,
-            sentMailEvent: sentMailEvent,
             audioSession: audioSession,
             cameraPermissionService: cameraPermissionService
         )
@@ -73,7 +71,6 @@ public enum ComposeMessageAssembly {
             options: options,
             interactor: interactor,
             recipientInteractor: RecipientInteractorLive(),
-            sentMailEvent: nil,
             audioSession: AVAudioSession.sharedInstance(),
             cameraPermissionService: AVCaptureDevice.self
         )

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -91,7 +91,6 @@ final class ComposeMessageViewModel: ObservableObject {
     // MARK: - Private
     private var initialMessageProperties = ComposeMessageProperties()
     private var changedMessageProperties = ComposeMessageProperties()
-    private var didSentMailSuccessfully: PassthroughSubject<Void, Never>?
     public let didTapRetry = PassthroughRelay<WeakViewController>()
     private var viewController  = WeakViewController()
     private var subscriptions = Set<AnyCancellable>()
@@ -115,7 +114,6 @@ final class ComposeMessageViewModel: ObservableObject {
         interactor: ComposeMessageInteractor,
         scheduler: AnySchedulerOf<DispatchQueue> = .main,
         recipientInteractor: RecipientInteractor,
-        sentMailEvent: PassthroughSubject<Void, Never>? = nil,
         audioSession: AudioSessionProtocol,
         cameraPermissionService: CameraPermissionService.Type
     ) {
@@ -124,7 +122,6 @@ final class ComposeMessageViewModel: ObservableObject {
         self.scheduler = scheduler
         self.messageType = options.messageType
         self.recipientInteractor = recipientInteractor
-        self.didSentMailSuccessfully = sentMailEvent
         self.audioSession = audioSession
         self.cameraPermissionService = cameraPermissionService
         setIncludedMessages(messageType: options.messageType)
@@ -543,7 +540,7 @@ final class ComposeMessageViewModel: ObservableObject {
     }
 
     private func didSendMessage(viewController: WeakViewController) {
-        didSentMailSuccessfully?.send()
+        viewController.findSnackBarViewModel()?.showSnack(InboxMessageScope.sent.localizedName)
         router.dismiss(viewController)
     }
 

--- a/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -48,7 +48,6 @@ class MessageDetailsViewModel: ObservableObject {
     public let updateState = PassthroughSubject<ConversationWorkflowState, Never>()
 
     // MARK: - Private
-    private var didSendMailSuccessfully = PassthroughSubject<Void, Never>()
     private var subscriptions = Set<AnyCancellable>()
     private let interactor: MessageDetailsInteractor
     private let router: Router
@@ -191,8 +190,7 @@ class MessageDetailsViewModel: ObservableObject {
             router.show(
                 ComposeMessageAssembly.makeComposeMessageViewController(
                     options: .init(
-                        fromType: .forward(conversation: conversation, message: message)),
-                    sentMailEvent: didSendMailSuccessfully
+                        fromType: .forward(conversation: conversation, message: message))
                 ),
                 from: viewController,
                 options: .modal(
@@ -208,7 +206,7 @@ class MessageDetailsViewModel: ObservableObject {
     public func replyTapped(message: ConversationMessage?, viewController: WeakViewController) {
         if let conversation = conversations.first {
             router.show(
-                ComposeMessageAssembly.makeComposeMessageViewController(options: .init(fromType: .reply(conversation: conversation, message: message)), sentMailEvent: didSendMailSuccessfully),
+                ComposeMessageAssembly.makeComposeMessageViewController(options: .init(fromType: .reply(conversation: conversation, message: message))),
                 from: viewController,
                 options: .modal(.automatic, isDismissable: false, embedInNav: true, addDoneButton: false, animated: true)
             )
@@ -218,7 +216,7 @@ class MessageDetailsViewModel: ObservableObject {
     public func replyAllTapped(message: ConversationMessage?, viewController: WeakViewController) {
         if let conversation = conversations.first {
             router.show(
-                ComposeMessageAssembly.makeComposeMessageViewController(options: .init(fromType: .replyAll(conversation: conversation, message: message)), sentMailEvent: didSendMailSuccessfully),
+                ComposeMessageAssembly.makeComposeMessageViewController(options: .init(fromType: .replyAll(conversation: conversation, message: message))),
                 from: viewController,
                 options: .modal(.automatic, isDismissable: false, embedInNav: true, addDoneButton: false, animated: true)
             )
@@ -313,12 +311,6 @@ class MessageDetailsViewModel: ObservableObject {
                     self?.router.dismiss(viewController)
                 }
                 self?.refreshDidTrigger.send({ })
-            }
-            .store(in: &subscriptions)
-
-        didSendMailSuccessfully
-            .sink { [weak self] in
-                self?.snackBarViewModel.showSnack(InboxMessageScope.sent.localizedName)
             }
             .store(in: &subscriptions)
     }

--- a/Core/Core/Features/Inbox/View/InboxView.swift
+++ b/Core/Core/Features/Inbox/View/InboxView.swift
@@ -69,7 +69,6 @@ public struct InboxView: View, ScreenViewTrackable {
                 }
             }
         }
-        .snackBar(viewModel: model.snackBarViewModel)
         .background(Color.backgroundLightest)
         .navigationBarItems(leading: model.isShowMenuButton ? menuButton : nil, trailing: newMessageButton)
         .navigationBarStyle(.global)

--- a/Core/Core/Features/Inbox/ViewModel/InboxViewModel.swift
+++ b/Core/Core/Features/Inbox/ViewModel/InboxViewModel.swift
@@ -57,7 +57,6 @@ public class InboxViewModel: ObservableObject {
     private let favouriteInteractor: InboxMessageFavouriteInteractor
     private var subscriptions = Set<AnyCancellable>()
     private var isLoadingNextPage = CurrentValueSubject<Bool, Never>(false)
-    private var didSendMailSuccessfully = PassthroughSubject<Void, Never>()
 
     // MARK: - Init
     public init(
@@ -162,12 +161,6 @@ public class InboxViewModel: ObservableObject {
             }
             .sink()
             .store(in: &subscriptions)
-
-        didSendMailSuccessfully
-            .sink { [weak self] in
-                self?.snackBarViewModel.showSnack(InboxMessageScope.sent.localizedName)
-            }
-            .store(in: &subscriptions)
     }
 
     private func subscribeToTapEvents(router: Router) {
@@ -177,7 +170,7 @@ public class InboxViewModel: ObservableObject {
             }
             .store(in: &subscriptions)
         newMessageDidTap
-            .sink { [router, didSendMailSuccessfully, messageInteractor] source in
+            .sink { [router, messageInteractor] source in
                 // In the parent app we need a different logic for student context picker
                 if messageInteractor.isParentApp {
                     if let bottomSheet = router.match("/conversations/new_message") {
@@ -185,7 +178,7 @@ public class InboxViewModel: ObservableObject {
                     }
                 } else {
                     router.show(
-                        ComposeMessageAssembly.makeComposeMessageViewController(sentMailEvent: didSendMailSuccessfully),
+                        ComposeMessageAssembly.makeComposeMessageViewController(),
                         from: source,
                         options: .modal(.automatic, isDismissable: false, embedInNav: true, addDoneButton: false, animated: true)
                     )

--- a/Parent/Parent.xcodeproj/project.pbxproj
+++ b/Parent/Parent.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		CFEE68D82B1A24ED00A04E43 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */; };
 		CFEE68DB2B1A251C00A04E43 /* LaunchScreen.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */; };
 		CFEE68DC2B1A251C00A04E43 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = CFEE68DA2B1A251C00A04E43 /* Localizable.xcstrings */; };
+		CFEF720A2D8D88D6009606C7 /* ParentContainerNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFEF72092D8D88D4009606C7 /* ParentContainerNavigationController.swift */; };
 		CFFE286A27B3B8A90029A408 /* CourseListCellGradesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CFFE286927B3B8A90029A408 /* CourseListCellGradesTests.swift */; };
 		D3DFD59F2D6E0FD800C278C2 /* ParentInboxCoursePickerAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DFD59C2D6E0FD800C278C2 /* ParentInboxCoursePickerAssembly.swift */; };
 		D3DFD5A02D6E0FD800C278C2 /* ParentInboxCoursePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3DFD5982D6E0FD800C278C2 /* ParentInboxCoursePickerView.swift */; };
@@ -282,6 +283,7 @@
 		CFEE68D72B1A24ED00A04E43 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
 		CFEE68D92B1A251C00A04E43 /* LaunchScreen.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = LaunchScreen.xcstrings; sourceTree = "<group>"; };
 		CFEE68DA2B1A251C00A04E43 /* Localizable.xcstrings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
+		CFEF72092D8D88D4009606C7 /* ParentContainerNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentContainerNavigationController.swift; sourceTree = "<group>"; };
 		CFFE286927B3B8A90029A408 /* CourseListCellGradesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CourseListCellGradesTests.swift; sourceTree = "<group>"; };
 		D3DFD5912D6E0FD800C278C2 /* GetObservedEnrollments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetObservedEnrollments.swift; sourceTree = "<group>"; };
 		D3DFD5922D6E0FD800C278C2 /* ParentInboxCoursePickerInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParentInboxCoursePickerInteractor.swift; sourceTree = "<group>"; };
@@ -433,6 +435,7 @@
 		5E0F9A4E1C739E6A00BB7707 /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				CFEF72092D8D88D4009606C7 /* ParentContainerNavigationController.swift */,
 				CF4DA8EA2D64D01500F3D120 /* ViewModel */,
 				CF4DA8E92D64D00C00F3D120 /* View */,
 				7893BDCE20D1A74700231DF7 /* Admin */,
@@ -1321,6 +1324,7 @@
 				D3DFD59F2D6E0FD800C278C2 /* ParentInboxCoursePickerAssembly.swift in Sources */,
 				D3DFD5A02D6E0FD800C278C2 /* ParentInboxCoursePickerView.swift in Sources */,
 				D3DFD5A12D6E0FD800C278C2 /* ParentInboxCoursePickerInteractorLive.swift in Sources */,
+				CFEF720A2D8D88D6009606C7 /* ParentContainerNavigationController.swift in Sources */,
 				D3DFD5A22D6E0FD800C278C2 /* ParentInboxCoursePickerViewModel.swift in Sources */,
 				D3DFD5A32D6E0FD800C278C2 /* StudentContextItem.swift in Sources */,
 				D3DFD5A42D6E0FD800C278C2 /* ParentInboxCoursePickerBottomSheetViewController.swift in Sources */,

--- a/Parent/Parent/Dashboard/ParentContainerNavigationController.swift
+++ b/Parent/Parent/Dashboard/ParentContainerNavigationController.swift
@@ -1,0 +1,28 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+
+class ParentContainerNavigationController: CoreNavigationController, SnackBarProvider {
+    var snackBarViewModel = SnackBarViewModel()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        addSnackBar()
+    }
+}

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -123,7 +123,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 
     func showRootView() {
         guard let window = self.window else { return }
-        let controller = CoreNavigationController(rootViewController: DashboardViewController.create())
+        let controller = ParentContainerNavigationController(rootViewController: DashboardViewController.create())
         controller.view.layoutIfNeeded()
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
             window.rootViewController = controller


### PR DESCRIPTION
### What's new?
- I simplified the snack presentation logic in inbox. As a side effect this also made snacks to appear when you compose a message from a people detail page in Student and Teacher apps.
- Made the root navigation controller a snack provider in the parent app since that app was missing a root container providing snack bars. The confirmation snack after a successful message send now appears in this app as well.

refs: MBL-18675
affects: Student, Teacher, Parent
release note: none

test plan:
- Check if snack notifications appear in Parent app when sending a message from a course or from the inbox.
- Test if snack notification appears when sending a message from the people details page in Student and Teacher apps.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet