### PR TITLE
Student - AssignmentList - Use GradeFormatter for displaying grades

### DIFF
--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentCellView.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentCellView.swift
@@ -126,7 +126,7 @@ public struct AssignmentCellView: View {
     }
 
     private var score: some View {
-        Text(viewModel.scoreLabel ?? "")
+        Text(GradeFormatter.string(from: viewModel.assignment, style: .medium) ?? "")
             .style(.textCellSupportingText)
             .foregroundColor(viewModel.courseColor)
     }

--- a/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentCellViewModel.swift
@@ -46,7 +46,7 @@ public class AssignmentCellViewModel: ObservableObject {
     public var needsGradingCount: Int { assignment.needsGradingCount }
 
     public var scoreLabel: String? {
-        guard !assignment.hideQuantitativeData, let pointsPossible = assignment.pointsPossible else { return nil }
+        guard let pointsPossible = assignment.pointsPossible else { return nil }
         var scoreString = "-"
         if let viewableScore = assignment.viewableScore {
             scoreString = String(Int(viewableScore))


### PR DESCRIPTION
## Student - AssignmentList - Use GradeFormatter for displaying grades

- Same grade formatter is used as in Grade List screen, so the displayed grade should be in the same format as there.
- In case of LGO courses, now the letter grades are displayed properly.

refs: MBL-18732
affects: Student
release note: Fixed an issue that caused all types of grades to be displayed as points on the Assignment List.
test plan: Check if all grades are displayed correctly on Assignment List screen. Also check the displayed grades with a LGO course.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/f277f261-486a-484f-a4c7-bd551058ae3c" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/72fee7a1-8b73-4ce4-ac6c-b4e608134112" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product
