### PR TITLE
Student - K5 courses shows hidden tabs

### DIFF
--- a/Core/Core/Common/CommonModels/Contexts/GetContextTabs.swift
+++ b/Core/Core/Common/CommonModels/Contexts/GetContextTabs.swift
@@ -32,6 +32,8 @@ public class GetContextTabs: CollectionUseCase {
     }
 
     public var request: GetTabsRequest {
+        // For mixed accounts (users enrolled in both k5 and regular courses) the API returns the k5 tabs only.
+        // Once it gets fixed, we should not only check the feature enablement but the k5 status of the course too.
         if AppEnvironment.shared.k5.isK5Enabled {
             return GetTabsRequest(context: context, include: [.course_subject_tabs])
         }

--- a/Core/Core/Features/Courses/APICourse.swift
+++ b/Core/Core/Features/Courses/APICourse.swift
@@ -263,11 +263,11 @@ public struct GetCoursesRequest: APIRequestable {
         case sections
         case syllabus_body
         case tabs
+        case course_subject_tabs  // for k5 tabs
         case term
         case total_scores
         case settings
         case grading_scheme
-        case course_subject_tabs  // for k5 tabs
     }
 
     let enrollmentState: EnrollmentState?
@@ -299,8 +299,10 @@ public struct GetCoursesRequest: APIRequestable {
     }
 
     public var query: [APIQueryItem] {
-        let isK5 = AppEnvironment.shared.k5.isK5Enabled
-        let includes = isK5 ? Include.allCases : Include.allCases.filter { $0 != .course_subject_tabs }
+        var includes = Include.allCases
+        if AppEnvironment.shared.k5.isK5Enabled {
+            includes.removeAll { $0 == .course_subject_tabs }
+        }
         return [
             .include(includes.map { $0.rawValue }),
             .perPage(perPage),

--- a/Core/Core/Features/Courses/APICourse.swift
+++ b/Core/Core/Features/Courses/APICourse.swift
@@ -267,6 +267,7 @@ public struct GetCoursesRequest: APIRequestable {
         case total_scores
         case settings
         case grading_scheme
+        case course_subject_tabs  // for k5 tabs
     }
 
     let enrollmentState: EnrollmentState?
@@ -298,8 +299,10 @@ public struct GetCoursesRequest: APIRequestable {
     }
 
     public var query: [APIQueryItem] {
-        [
-            .include(Include.allCases.map { $0.rawValue }),
+        let isK5 = AppEnvironment.shared.k5.isK5Enabled
+        let includes = isK5 ? Include.allCases : Include.allCases.filter { $0 != .course_subject_tabs }
+        return [
+            .include(includes.map { $0.rawValue }),
             .perPage(perPage),
             .optionalValue("enrollment_state", enrollmentState?.rawValue),
             .array("state", (state ?? []).map { $0.rawValue }),

--- a/Core/Core/Features/Courses/APICourse.swift
+++ b/Core/Core/Features/Courses/APICourse.swift
@@ -300,7 +300,7 @@ public struct GetCoursesRequest: APIRequestable {
 
     public var query: [APIQueryItem] {
         var includes = Include.allCases
-        if AppEnvironment.shared.k5.isK5Enabled {
+        if !AppEnvironment.shared.k5.isK5Enabled {
             includes.removeAll { $0 == .course_subject_tabs }
         }
         return [

--- a/Core/Core/Features/Courses/K5/ViewModel/K5SubjectViewModel.swift
+++ b/Core/Core/Features/Courses/K5/ViewModel/K5SubjectViewModel.swift
@@ -63,10 +63,15 @@ public class K5SubjectViewModel: ObservableObject {
 
     private func tabsUpdated() {
         guard topBarViewModel == nil, !tabs.isEmpty else { return }
+
         var tabItems: [TopBarItemViewModel] = []
-        tabs.filter({ $0.type == .internal && !($0.hidden ?? false)}).forEach { tab in
+
+        tabs.filter({ tab in
+            tab.type == .internal && !(tab.hidden ?? false) && tab.id != "search"
+        }).forEach { tab in
             tabItems.append(TopBarItemViewModel(tab: tab, iconImage: tabIconImage(for: tab.id)))
         }
+
         if !tabs.filter({$0.id.contains("context_external_tool_") && !($0.hidden ?? false) }).isEmpty {
             let resurceTabItem = TopBarItemViewModel(id: "resources", icon: .k5resources, label: Text("Resources", bundle: .core))
             tabItems.append(resurceTabItem)


### PR DESCRIPTION
## K5 courses shows hidden tabs

To get the correct tabs for a K5 course `course_subject_tabs` must be included with the request to the tabs endpoint.
When we tap on the course then the K5SubjectViewModel retrieves the tabs and it uses the correct request with this `course_subject_tabs` included. However, when we arrive to the course screen we already have the tabs in CoreData because we already sent a request to the courses endpoint at app start with tabs included but without this `course_subject_tabs`, so when the course opens then we will see all tabs and not only the ones for K5 because the correct request with the include is not being sent.

The fix is to include `course_subject_tabs` also in the courses request at app start.

_Note: With mixed accounts (for users enrolled in both k5 and normal courses) it will only display k5 tabs. Same is true for web app. The cause is that in these cases the API returns with only the k5 tabs no matter the course._

refs: MBL-18707
affects: Student
release note: Fixed a bug that caused hidden tabs being shown in elementary type courses.
test plan: Check if tabs are shown correctly. See ticket for details.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product
