### PR TITLE
Fix translation export

### DIFF
--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -112,11 +112,11 @@ async function pushToS3(toUpload) {
 
 async function exportLocalizations(outputPath) {
   await run('xcodebuild', [
-    '-sdk',
-    'iphonesimulator',
     '-exportLocalizations',
     '-workspace',
     'Canvas.xcworkspace',
+    '-sdk',
+    'iphonesimulator',
     '-localizationPath',
     outputPath,
     '-n'

--- a/scripts/translations/export.js
+++ b/scripts/translations/export.js
@@ -112,12 +112,14 @@ async function pushToS3(toUpload) {
 
 async function exportLocalizations(outputPath) {
   await run('xcodebuild', [
-  	'-exportLocalizations',
-	'-workspace',
-  	'Canvas.xcworkspace',
-  	'-localizationPath',
-  	outputPath,
-  	'-n'
+    '-sdk',
+    'iphonesimulator',
+    '-exportLocalizations',
+    '-workspace',
+    'Canvas.xcworkspace',
+    '-localizationPath',
+    outputPath,
+    '-n'
   ])
 }
 


### PR DESCRIPTION
Use iphone simulator SDK because Pendo has no catalyst support. Fixed export is [here](https://app.bitrise.io/build/38d59307-634d-401c-ab9f-93d4040212a0).

[ignore-commit-lint]