### PR TITLE
[Horizon] PKCE Login

### DIFF
--- a/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0ad268b08401283782af7df64dff9e2df1a4d73a50e3d7d3161d25cd005214c9",
+  "originHash" : "5dc4489962906251dd3b9a07c7adeccfe65a0937a7c2e4bdefab3ded66ee239b",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",

--- a/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironmentOverride.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironmentOverride.swift
@@ -92,8 +92,7 @@ public final class AppEnvironmentOverride: AppEnvironment {
                 userID: cSession.userID,
                 userName: cSession.userName,
                 userEmail: cSession.userEmail,
-                clientID: cSession.clientID,
-                clientSecret: cSession.clientSecret,
+                oauthType: cSession.oauthType,
                 isFakeStudent: cSession.isFakeStudent
             )
         }

--- a/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
@@ -41,7 +41,7 @@ public enum Secret {
 
     /// The value used for testing that Secret is working properly
     case testSecret
-    
+
     /// The clientID required for OAuth. Currently only Horizon uses it with PKCE login, regular Canvas apps use the Mobile Verify endpoint to obtain clientID (and other required properties).
     case appClientID
 

--- a/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
@@ -41,6 +41,8 @@ public enum Secret {
 
     /// The value used for testing that Secret is working properly
     case testSecret
+    
+    case appClientID
 
     public var string: String? {
         guard let data = NSDataAsset(name: String(describing: self), bundle: .core)?.data else { return nil }

--- a/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/Secret.swift
@@ -42,6 +42,7 @@ public enum Secret {
     /// The value used for testing that Secret is working properly
     case testSecret
     
+    /// The clientID required for OAuth. Currently only Horizon uses it with PKCE login, regular Canvas apps use the Mobile Verify endpoint to obtain clientID (and other required properties).
     case appClientID
 
     public var string: String? {

--- a/Core/Core/Features/ActAsUser/ActAsUserViewController.swift
+++ b/Core/Core/Features/ActAsUser/ActAsUserViewController.swift
@@ -141,8 +141,7 @@ public class ActAsUserViewController: UIViewController {
                 userID: user.id.value,
                 userName: user.short_name,
                 userEmail: user.email,
-                clientID: session.clientID,
-                clientSecret: session.clientSecret
+                oauthType: session.oauthType
             ))
         } }
     }

--- a/Core/Core/Features/Dashboard/K5/View/K5Preview.swift
+++ b/Core/Core/Features/Dashboard/K5/View/K5Preview.swift
@@ -44,8 +44,7 @@ struct K5Preview {
             userID: "1",
             userName: "Eve",
             userEmail: nil,
-            clientID: nil,
-            clientSecret: nil
+            oauthType: nil
         )
         AppEnvironment.shared.userDidLogin(session: session)
         AppEnvironment.shared.k5.userDidLogin(isK5Account: true)

--- a/Core/Core/Features/Login/APILoginWeb.swift
+++ b/Core/Core/Features/Login/APILoginWeb.swift
@@ -56,3 +56,29 @@ struct LoginWebRequest: APIRequestable {
         return headers
     }
 }
+
+struct LoginWebRequestPKCE: APIRequestable {
+    typealias Response = String
+    let clientID: String
+    let host: URL
+    let challenge: PKCEChallenge.ChallengePair
+    let shouldAddNoVerifierQuery = false
+
+    var path: String {
+        return "https://\(host)/login/oauth2/auth"
+    }
+
+    var query: [APIQueryItem] { [
+        .value("client_id", clientID),
+        .value("redirect_uri", "https://canvas/login"),
+        .value("response_type", "code"),
+        .value("code_challenge", challenge.codeChallenge),
+        .value("code_challenge_method", "S256"),
+        .value("mobile", "1")
+    ]
+    }
+
+    let headers: [String: String?] = [
+        HttpHeader.userAgent: UserAgent.safari.description
+    ]
+}

--- a/Core/Core/Features/Login/APILoginWeb.swift
+++ b/Core/Core/Features/Login/APILoginWeb.swift
@@ -63,6 +63,7 @@ struct LoginWebRequestPKCE: APIRequestable {
     let host: URL
     let challenge: PKCEChallenge.ChallengePair
     let shouldAddNoVerifierQuery = false
+    let isSiteAdminLogin: Bool
 
     var path: String {
         return "https://\(host)/login/oauth2/auth"
@@ -78,7 +79,13 @@ struct LoginWebRequestPKCE: APIRequestable {
     ]
     }
 
-    let headers: [String: String?] = [
-        HttpHeader.userAgent: UserAgent.safari.description
-    ]
+    var headers: [String: String?] {
+        var headers = [
+            HttpHeader.userAgent: UserAgent.safari.description
+        ]
+        if isSiteAdminLogin {
+            headers[HttpHeader.cookie] = "canvas_sa_delegated=1"
+        }
+        return headers
+    }
 }

--- a/Core/Core/Features/Login/APIOAuth.swift
+++ b/Core/Core/Features/Login/APIOAuth.swift
@@ -179,7 +179,6 @@ struct PostLoginOAuthRequest: APIRequestable {
     }
 
     let oauthType: OAuthType
-//    let client: APIVerifyClient
 
     init(oauthType: OAuthType, code: String) {
         self.oauthType = oauthType
@@ -200,45 +199,6 @@ struct PostLoginOAuthRequest: APIRequestable {
     let headers: [String: String?] = [
         HttpHeader.authorization: nil
     ]
-}
-
-public struct ManualOAuthAttributes: Codable {
-    let baseURL: URL?
-    let clientID: String?
-    let clientSecret: String?
-    
-    init(baseURL: URL?, clientID: String?, clientSecret: String?) {
-        self.baseURL = baseURL
-        self.clientID = clientID
-        self.clientSecret = clientSecret
-    }
-    
-    init(client: APIVerifyClient) {
-        self.baseURL = client.base_url
-        self.clientID = client.client_id
-        self.clientSecret = client.client_secret
-    }
-}
-
-
-public struct PKCEOAuthAttributes: Codable {
-    let baseURL: URL
-    let clientID: String
-    let codeVerifier: String
-}
-
-public enum OAuthType: Codable {
-    case manual(ManualOAuthAttributes)
-    case pkce(PKCEOAuthAttributes)
-
-    var baseURL: URL? {
-        switch self {
-        case let .manual(attributes):
-            return attributes.baseURL
-        case let .pkce(attributes):
-            return attributes.baseURL
-        }
-    }
 }
 
 // https://canvas.instructure.com/doc/api/file.oauth_endpoints.html#delete-login-oauth2-token

--- a/Core/Core/Features/Login/APIOAuth.swift
+++ b/Core/Core/Features/Login/APIOAuth.swift
@@ -19,7 +19,7 @@
 import Foundation
 
 // Not documented in canvas rest api
-struct APIVerifyClient: Codable, Equatable {
+public struct APIVerifyClient: Codable, Equatable {
     let authorized: Bool
     let base_url: URL?
     let client_id: String?

--- a/Core/Core/Features/Login/GetSSOLogin.swift
+++ b/Core/Core/Features/Login/GetSSOLogin.swift
@@ -57,7 +57,7 @@ public class GetSSOLogin {
         }
         api.makeRequest(GetMobileVerifyRequest(domain: domain)) { (response, _, error) in
             guard let client = response, let baseURL = client.base_url, error == nil else { return done(nil, error) }
-            api.makeRequest(PostLoginOAuthRequest(client: client, code: code)) { (response, _, error) in
+            api.makeRequest(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: code)) { (response, _, error) in
                 guard let model = response, error == nil else { return done(nil, error) }
                 done(LoginSession(
                     accessToken: model.access_token,
@@ -73,8 +73,7 @@ public class GetSSOLogin {
                     userID: model.user.id.value,
                     userName: model.user.name,
                     userEmail: model.user.email,
-                    clientID: client.client_id,
-                    clientSecret: client.client_secret
+                    oauthType: .manual(.init(client: client))
                 ), nil)
             }
         }

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -30,7 +30,7 @@ public struct LoginSession: Codable, Hashable {
     public let userID: String
     public let userName: String
     public let userEmail: String?
-
+    
     public let oauthType: OAuthType?
     
     /** Returns the acted user's ID. If the session isn't masquaraded this property returns nil. */

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -30,9 +30,9 @@ public struct LoginSession: Codable, Hashable {
     public let userID: String
     public let userName: String
     public let userEmail: String?
-    
+
     public let oauthType: OAuthType?
-    
+
     /** Returns the acted user's ID. If the session isn't masquaraded this property returns nil. */
     public var actAsUserID: String? {
         return masquerader == nil ? nil : userID

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -30,9 +30,9 @@ public struct LoginSession: Codable, Hashable {
     public let userID: String
     public let userName: String
     public let userEmail: String?
-    public let clientID: String?
-    public let clientSecret: String?
 
+    public let oauthType: OAuthType?
+    
     /** Returns the acted user's ID. If the session isn't masquaraded this property returns nil. */
     public var actAsUserID: String? {
         return masquerader == nil ? nil : userID
@@ -72,8 +72,7 @@ public struct LoginSession: Codable, Hashable {
         userID: String,
         userName: String,
         userEmail: String? = nil,
-        clientID: String? = nil,
-        clientSecret: String? = nil,
+        oauthType: OAuthType? = nil,
         isFakeStudent: Bool = false
     ) {
         self.accessToken = accessToken
@@ -90,8 +89,7 @@ public struct LoginSession: Codable, Hashable {
         self.userID = userID
         self.userName = userName
         self.userEmail = userEmail
-        self.clientID = clientID
-        self.clientSecret = clientSecret
+        self.oauthType = oauthType
     }
 
     // Only keep 1 entry per account user
@@ -122,8 +120,7 @@ public struct LoginSession: Codable, Hashable {
             userID: userID,
             userName: userName,
             userEmail: userEmail,
-            clientID: clientID,
-            clientSecret: clientSecret
+            oauthType: oauthType
         )
     }
 
@@ -146,8 +143,7 @@ public struct LoginSession: Codable, Hashable {
             userID: userID,
             userName: userName,
             userEmail: userEmail,
-            clientID: clientID,
-            clientSecret: clientSecret
+            oauthType: oauthType
         )
     }
 

--- a/Core/Core/Features/Login/LoginStartViewController.swift
+++ b/Core/Core/Features/Login/LoginStartViewController.swift
@@ -173,8 +173,7 @@ class LoginStartViewController: UIViewController {
                     userID: session.userID,
                     userName: response.short_name,
                     userEmail: response.email,
-                    clientID: session.clientID,
-                    clientSecret: session.clientSecret
+                    oauthType: session.oauthType
                 )
                 if LoginSession.sessions.contains(entry) {
                     LoginSession.add(entry)

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -115,10 +115,6 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         setupProgressView()
         setupIndeterminateLoadingIndicator()
 
-        guard clientID != nil else {
-            fatalError("App Client ID not set")
-        }
-        
         // If ManualOAuth was selected, we provide the client_id and client_secret to the oauth request.
         if let mobileVerifyModel {
             // Modify the title to include the url scheme to easily catch http/https errors.
@@ -126,6 +122,9 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
             loadManualOAuthLoginWebRequest()
         // For PKCE OAuth login, we provide a client_id and generate a code challenge pair.
         } else {
+            guard clientID != nil else {
+                fatalError("App Client ID not set")
+            }
             loadPKCEOauthLoginWebRequest()
         }
     }

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -44,7 +44,7 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
 
     var mobileVerifyModel: APIVerifyClient?
     var mdmLogin: MDMLogin?
-    
+
     /// Passed as a string parameter e.g.: institution.instructure.com
     var host = ""
     /// Returns host in URL format e.g.: institution.instructure.com
@@ -119,7 +119,7 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
             loadPKCEOauthLoginWebRequest()
         }
     }
-    
+
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: true)

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -204,7 +204,11 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
             showFailedPanda(reason: .invalidDomain)
             return
         }
-        let requestable = LoginWebRequest(authMethod: method, clientID: clientID, provider: authenticationProvider)
+        let requestable = LoginWebRequest(
+            authMethod: method,
+            clientID: clientID,
+            provider: authenticationProvider
+        )
         if var request = try? requestable.urlRequest(relativeTo: url, accessToken: nil, actAsUserID: nil) {
             request.timeoutInterval = 30
             webView.load(request)
@@ -217,7 +221,12 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         }
         self.challenge = challenge
 
-        let requestable = LoginWebRequestPKCE(clientID: Secret.appClientID.string!, host: hostURL, challenge: challenge)
+        let requestable = LoginWebRequestPKCE(
+            clientID: Secret.appClientID.string!,
+            host: hostURL,
+            challenge: challenge,
+            isSiteAdminLogin: method == .siteAdminLogin
+        )
         if var request = try? requestable.urlRequest(relativeTo: hostURL, accessToken: nil, actAsUserID: nil) {
             request.timeoutInterval = 30
             webView.load(request)

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -115,6 +115,10 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         setupProgressView()
         setupIndeterminateLoadingIndicator()
 
+        guard clientID != nil else {
+            fatalError("App Client ID not set")
+        }
+        
         // If ManualOAuth was selected, we provide the client_id and client_secret to the oauth request.
         if let mobileVerifyModel {
             // Modify the title to include the url scheme to easily catch http/https errors.

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -44,7 +44,16 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
 
     var mobileVerifyModel: APIVerifyClient?
     var mdmLogin: MDMLogin?
+    
+    /// Passed as a string parameter e.g.: institution.instructure.com
     var host = ""
+    /// Returns host in URL format e.g.: institution.instructure.com
+    var hostURL: URL?
+    /// Returns host with https prefix in URL format e.g.: https://institution.instructure.com
+    var hostURLWithHttpsPrefix: URL?
+    /// Challenge pair used for PKCE OAuth login
+    var challenge: PKCEChallenge.ChallengePair?
+
     var authenticationProvider: String?
     var method = AuthenticationMethod.normalLogin
     var pairingCode: String?
@@ -81,6 +90,8 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         controller.title = host
         controller.authenticationProvider = authenticationProvider
         controller.host = host
+        controller.hostURL = URL(string: host)
+        controller.hostURLWithHttpsPrefix = URL(string: "https://" + host)
         controller.mdmLogin = mdmLogin
         controller.loginDelegate = loginDelegate
         controller.method = method
@@ -98,22 +109,17 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         setupProgressView()
         setupIndeterminateLoadingIndicator()
 
-        // Manual OAuth provided mobileVerifyModel
+        // If ManualOAuth was selected, we provide the client_id and client_secret to the oauth request.
         if let mobileVerifyModel {
             // Modify the title to include the url scheme to easily catch http/https errors.
             title = mobileVerifyModel.base_url?.absoluteString
-            return loadLoginWebRequest()
+            loadManualOAuthLoginWebRequest()
+        // For PKCE OAuth login, we provide a client_id and generate a code challenge pair.
+        } else {
+            loadPKCEOauthLoginWebRequest()
         }
-
-        // Lookup OAuth from mobile verify
-        task?.cancel()
-        task = API().makeRequest(GetMobileVerifyRequest(domain: host)) { [weak self] (response, _, _) in performUIUpdate {
-            self?.mobileVerifyModel = response
-            self?.task = nil
-            self?.loadLoginWebRequest()
-        } }
     }
-
+    
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         navigationController?.setNavigationBarHidden(false, animated: true)
@@ -193,14 +199,26 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
         }
     }
 
-    private func loadLoginWebRequest() {
+    private func loadManualOAuthLoginWebRequest() {
         guard let verify = mobileVerifyModel, let url = verify.base_url, let clientID = verify.client_id else {
             showFailedPanda(reason: .invalidDomain)
             return
         }
-
         let requestable = LoginWebRequest(authMethod: method, clientID: clientID, provider: authenticationProvider)
         if var request = try? requestable.urlRequest(relativeTo: url, accessToken: nil, actAsUserID: nil) {
+            request.timeoutInterval = 30
+            webView.load(request)
+        }
+    }
+
+    private func loadPKCEOauthLoginWebRequest() {
+        guard let challenge = PKCEChallenge().generateChallenge(), let hostURL else {
+            return
+        }
+        self.challenge = challenge
+
+        let requestable = LoginWebRequestPKCE(clientID: Secret.appClientID.string!, host: hostURL, challenge: challenge)
+        if var request = try? requestable.urlRequest(relativeTo: hostURL, accessToken: nil, actAsUserID: nil) {
             request.timeoutInterval = 30
             webView.load(request)
         }
@@ -262,43 +280,57 @@ extension LoginWebViewController: WKNavigationDelegate {
             return decisionHandler(.allow)
         }
 
-        if components.scheme == "about" && components.path == "blank" {
+        if components.scheme == "about", components.path == "blank" {
             return decisionHandler(.cancel)
         }
 
+        weak var weakSelf = self
+
         let queryItems = components.queryItems
-        if // wait for "https://canvas/login?code="
-            url.absoluteString.hasPrefix("https://canvas/login"),
-            let code = queryItems?.first(where: { $0.name == "code" })?.value, !code.isEmpty,
-            let mobileVerify = mobileVerifyModel, let baseURL = mobileVerify.base_url {
+
+        // wait for "https://canvas/login?code="
+        if url.absoluteString.hasPrefix("https://canvas/login"),
+           let code = queryItems?.first(where: { $0.name == "code" })?.value, !code.isEmpty {
             task?.cancel()
-            task = API().makeRequest(PostLoginOAuthRequest(client: mobileVerify, code: code)) { [weak self] (response, _, error) in performUIUpdate {
-                guard let self = self else { return }
-                guard let token = response, error == nil else {
-                    self.showError(error ?? NSError.internalError())
-                    return
-                }
-                let session = LoginSession(
-                    accessToken: token.access_token,
-                    baseURL: baseURL,
-                    expiresAt: token.expires_in.flatMap { Clock.now + $0 },
-                    locale: token.user.effective_locale,
-                    refreshToken: token.refresh_token,
-                    userID: token.user.id.value,
-                    userName: token.user.name,
-                    clientID: mobileVerify.client_id,
-                    clientSecret: mobileVerify.client_secret
+            if let mobileVerify = mobileVerifyModel {
+                let oauthType = OAuthType.manual(
+                    .init(
+                        baseURL: mobileVerify.base_url,
+                        clientID: mobileVerify.client_id,
+                        clientSecret: mobileVerify.client_secret
+                    )
                 )
-                if let completion = self.loginCompletion {
-                    completion(session)
-                } else if AppEnvironment.shared.app == .horizon {
-                    self.loginDelegate?.userDidLogin(session: session)
-                    self.env.router.route(to: "/splash", from: self)
-                } else {
-                    self.env.router.show(LoadingViewController.create(), from: self)
-                    self.loginDelegate?.userDidLogin(session: session)
+                task = API().makeRequest(
+                    PostLoginOAuthRequest(
+                        oauthType: oauthType,
+                        code: code
+                    )
+                ) { response, _, error in
+                    performUIUpdate {
+                        weakSelf?.handleLoginResult(oauthType: oauthType, response: response, error: error)
+                    }
                 }
-            } }
+
+            } else if let challenge = challenge, let hostURLWithHttpsPrefix {
+                let oauthType = OAuthType.pkce(
+                    .init(
+                        baseURL: hostURLWithHttpsPrefix,
+                        clientID: Secret.appClientID.string!,
+                        codeVerifier: challenge.codeVerifier
+                    )
+                )
+                task = API().makeRequest(
+                    PostLoginOAuthRequest(
+                        oauthType: oauthType,
+                        code: code
+                    )
+                ) { response, _, error in
+                    performUIUpdate {
+                        weakSelf?.handleLoginResult(oauthType: oauthType, response: response, error: error)
+                    }
+                }
+            }
+
             return decisionHandler(.cancel)
         } else if queryItems?.first(where: { $0.name == "error" })?.value == "access_denied" {
             // access_denied is the only currently implemented error code
@@ -310,7 +342,34 @@ extension LoginWebViewController: WKNavigationDelegate {
         decisionHandler(.allow)
     }
 
-    public func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+    private func handleLoginResult(oauthType: OAuthType, response: APIOAuthToken?, error: Error?) {
+        guard let token = response, error == nil, let hostURLWithHttpsPrefix else {
+            self.showError(error ?? NSError.internalError())
+            return
+        }
+        let session = LoginSession(
+            accessToken: token.access_token,
+            baseURL: hostURLWithHttpsPrefix,
+            expiresAt: token.expires_in.flatMap { Clock.now + $0 },
+            locale: token.user.effective_locale,
+            refreshToken: token.refresh_token,
+            userID: token.user.id.value,
+            userName: token.user.name,
+            oauthType: oauthType
+        )
+
+        if let completion = self.loginCompletion {
+            completion(session)
+        } else if AppEnvironment.shared.app == .horizon {
+            self.loginDelegate?.userDidLogin(session: session)
+            self.env.router.route(to: "/splash", from: self)
+        } else {
+            self.env.router.show(LoadingViewController.create(), from: self)
+            self.loginDelegate?.userDidLogin(session: session)
+        }
+    }
+
+    public func webView(_: WKWebView, didStartProvisionalNavigation _: WKNavigation!) {
         progressView.alpha = 1
         progressView.isHidden = false
     }

--- a/Core/Core/Features/Login/OAuthType.swift
+++ b/Core/Core/Features/Login/OAuthType.swift
@@ -1,0 +1,57 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public enum OAuthType: Codable {
+    case manual(ManualOAuthAttributes)
+    case pkce(PKCEOAuthAttributes)
+
+    var baseURL: URL? {
+        switch self {
+        case let .manual(attributes):
+            return attributes.baseURL
+        case let .pkce(attributes):
+            return attributes.baseURL
+        }
+    }
+}
+
+public struct ManualOAuthAttributes: Codable {
+    let baseURL: URL?
+    let clientID: String?
+    let clientSecret: String?
+
+    init(baseURL: URL?, clientID: String?, clientSecret: String?) {
+        self.baseURL = baseURL
+        self.clientID = clientID
+        self.clientSecret = clientSecret
+    }
+
+    init(client: APIVerifyClient) {
+        self.baseURL = client.base_url
+        self.clientID = client.client_id
+        self.clientSecret = client.client_secret
+    }
+}
+
+public struct PKCEOAuthAttributes: Codable {
+    let baseURL: URL
+    let clientID: String
+    let codeVerifier: String
+}

--- a/Core/Core/Features/Login/OAuthType.swift
+++ b/Core/Core/Features/Login/OAuthType.swift
@@ -37,13 +37,13 @@ public struct ManualOAuthAttributes: Codable {
     let clientID: String?
     let clientSecret: String?
 
-    init(baseURL: URL?, clientID: String?, clientSecret: String?) {
+    public init(baseURL: URL?, clientID: String?, clientSecret: String?) {
         self.baseURL = baseURL
         self.clientID = clientID
         self.clientSecret = clientSecret
     }
 
-    init(client: APIVerifyClient) {
+    public init(client: APIVerifyClient) {
         self.baseURL = client.base_url
         self.clientID = client.client_id
         self.clientSecret = client.client_secret

--- a/Core/Core/Features/Login/OAuthType.swift
+++ b/Core/Core/Features/Login/OAuthType.swift
@@ -30,6 +30,33 @@ public enum OAuthType: Codable {
             return attributes.baseURL
         }
     }
+
+    var clientID: String {
+        switch self {
+        case let .manual(attributes):
+            return attributes.clientID ?? ""
+        case let .pkce(attributes):
+            return attributes.clientID
+        }
+    }
+
+    var clientSecret: String {
+        switch self {
+        case let .manual(attributes):
+            return attributes.clientSecret ?? ""
+        case .pkce:
+            fatalError("Client secret not available for PKCE")
+        }
+    }
+
+    var codeVerifier: String {
+        switch self {
+        case .manual:
+            fatalError("Code Verifier not available for ManualOAuth")
+        case let .pkce(attributes):
+            return attributes.codeVerifier
+        }
+    }
 }
 
 public struct ManualOAuthAttributes: Codable {

--- a/Core/Core/Features/Login/PKCE.swift
+++ b/Core/Core/Features/Login/PKCE.swift
@@ -1,0 +1,59 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import CommonCrypto
+import Foundation
+
+class PKCEChallenge {
+    struct ChallengePair {
+        let codeVerifier: String
+        let codeChallenge: String
+    }
+
+    // Allowed characters as per RFC7636 https://datatracker.ietf.org/doc/html/rfc7636
+    static let allowedChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~"
+
+    /// Generates a code verifier for the given length from the allowed char set.
+    /// - Parameter length: The length of the verifier between (43 and 128). Defaults to 43.
+    /// - Returns: A code verifier
+    private func generateCodeVerifier(length: Int) -> String {
+        String((0 ..< length).map { _ in Self.allowedChars.randomElement()! })
+    }
+
+    /// Generates a PKCE challenge pair
+    /// - Parameter length: The length of the verifier between (43 and 128). Defaults to 43.
+    /// - Returns: PKCE challenge pair
+    func generateChallenge(length: Int = 43) -> PKCEChallenge.ChallengePair? {
+        let verifier = generateCodeVerifier(length: length)
+        guard let data = verifier.data(using: .utf8) else { return nil }
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        data.withUnsafeBytes {
+            _ = CC_SHA256($0.baseAddress, CC_LONG(data.count), &hash)
+        }
+
+        let challenge = Data(hash).base64EncodedString()
+            .replacingOccurrences(of: "=", with: "")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+
+        return ChallengePair(
+            codeVerifier: verifier,
+            codeChallenge: challenge
+        )
+    }
+}

--- a/Core/Core/Features/Profile/UploadAvatar.swift
+++ b/Core/Core/Features/Profile/UploadAvatar.swift
@@ -94,8 +94,7 @@ public class UploadAvatar {
                     userID: session.userID,
                     userName: session.userName,
                     userEmail: session.userEmail,
-                    clientID: session.clientID,
-                    clientSecret: session.clientSecret
+                    oauthType: session.oauthType
                 )
                 self.env.currentSession = updated
                 if LoginSession.sessions.contains(updated) {

--- a/Core/Core/Features/TokenRefresh/Model/AccessTokenRefreshInteractor.swift
+++ b/Core/Core/Features/TokenRefresh/Model/AccessTokenRefreshInteractor.swift
@@ -29,8 +29,7 @@ class AccessTokenRefreshInteractor {
         guard
             let oldLoginSession = api.loginSession,
             let refreshToken = oldLoginSession.refreshToken,
-            let clientID = oldLoginSession.clientID,
-            let clientSecret = oldLoginSession.clientSecret
+            let oauthType = oldLoginSession.oauthType
         else {
             return Fail(
                 outputType: LoginSession.self,
@@ -39,13 +38,7 @@ class AccessTokenRefreshInteractor {
             .eraseToAnyPublisher()
         }
 
-        let client = APIVerifyClient(
-            authorized: true,
-            base_url: api.baseURL,
-            client_id: clientID,
-            client_secret: clientSecret
-        )
-        let request = PostLoginOAuthRequest(client: client, refreshToken: refreshToken)
+        let request = PostLoginOAuthRequest(oauthType: oauthType, refreshToken: refreshToken)
 
         return api.makeRequest(request, refreshToken: false)
             .map {

--- a/Core/Core/Features/TokenRefresh/Model/AccessTokenRefreshInteractor.swift
+++ b/Core/Core/Features/TokenRefresh/Model/AccessTokenRefreshInteractor.swift
@@ -44,7 +44,8 @@ class AccessTokenRefreshInteractor {
             .map {
                 oldLoginSession.refresh(
                     accessToken: $0.body.access_token,
-                    expiresAt: $0.body.expires_in.flatMap { Clock.now + $0 }
+                    expiresAt: $0.body.expires_in.flatMap { Clock.now + $0 },
+                    refreshToken: $0.body.refresh_token
                 )
             }
             .mapError { error in

--- a/Core/CoreTests/Common/CommonModels/API/APITests.swift
+++ b/Core/CoreTests/Common/CommonModels/API/APITests.swift
@@ -205,108 +205,108 @@ class APITests: XCTestCase {
         wait(for: [expectation], timeout: 1.0)
     }
 
-    func testRefreshToken() {
-        API.resetMocks()
-        Clock.mockNow(Date())
-        let session = LoginSession.make(
-            accessToken: "expired-token",
-            refreshToken: "refresh-token",
-            clientID: "client-id",
-            clientSecret: "client-secret"
-        )
-        AppEnvironment.shared.currentSession = session
-        api.loginSession = session
-        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
-        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
-        api.mock(url: url, response: response)
-        let refresh = api.mock(
-            PostLoginOAuthRequest(
-                client: APIVerifyClient(
-                    authorized: true,
-                    base_url: api.baseURL,
-                    client_id: "client-id",
-                    client_secret: "client-secret"
-                ),
-                refreshToken: "refresh-token"
-            ),
-            value: .make(accessToken: "new-token", expiresIn: 3600)
-        )
-        refresh.suspend()
-        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
-        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
-        refresh.resume()
-        waitUntil(5) { api.loginSession?.accessToken == "new-token" }
-        XCTAssertEqual(api.loginSession?.expiresAt, Clock.now.addingTimeInterval(3600))
-        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, "new-token")
-        XCTAssertTrue(LoginSession.sessions.contains(where: { $0.accessToken == "new-token" }))
-        Clock.reset()
-    }
+//    func testRefreshToken() {
+//        API.resetMocks()
+//        Clock.mockNow(Date())
+//        let session = LoginSession.make(
+//            accessToken: "expired-token",
+//            refreshToken: "refresh-token",
+//            clientID: "client-id",
+//            clientSecret: "client-secret"
+//        )
+//        AppEnvironment.shared.currentSession = session
+//        api.loginSession = session
+//        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
+//        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+//        api.mock(url: url, response: response)
+//        let refresh = api.mock(
+//            PostLoginOAuthRequest(
+//                client: APIVerifyClient(
+//                    authorized: true,
+//                    base_url: api.baseURL,
+//                    client_id: "client-id",
+//                    client_secret: "client-secret"
+//                ),
+//                refreshToken: "refresh-token"
+//            ),
+//            value: .make(accessToken: "new-token", expiresIn: 3600)
+//        )
+//        refresh.suspend()
+//        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
+//        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
+//        refresh.resume()
+//        waitUntil(5) { api.loginSession?.accessToken == "new-token" }
+//        XCTAssertEqual(api.loginSession?.expiresAt, Clock.now.addingTimeInterval(3600))
+//        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, "new-token")
+//        XCTAssertTrue(LoginSession.sessions.contains(where: { $0.accessToken == "new-token" }))
+//        Clock.reset()
+//    }
 
-    func testRefreshTokenNotCurrentSession() {
-        API.resetMocks()
-        AppEnvironment.shared.currentSession = LoginSession.make(
-            accessToken: "expired-token",
-            baseURL: URL(string: "https://other.instructure.com")!,
-            refreshToken: "refresh-token",
-            clientID: "client-id",
-            clientSecret: "client-secret"
-        )
-        let session = LoginSession.make(
-            accessToken: "expired-token",
-            baseURL: URL(string: "https://canvas.instructure.com")!,
-            refreshToken: "refresh-token",
-            clientID: "client-id",
-            clientSecret: "client-secret"
-        )
-        api.loginSession = session
-        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
-        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
-        api.mock(url: url, response: response)
-        api.mock(
-            PostLoginOAuthRequest(
-                client: APIVerifyClient(
-                    authorized: true,
-                    base_url: api.baseURL,
-                    client_id: "client-id",
-                    client_secret: "client-secret"
-                ),
-                refreshToken: "refresh-token"
-            ),
-            value: .make(accessToken: "new-token")
-        )
-        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
-        waitUntil(5) { api.loginSession?.accessToken == "new-token" }
-        XCTAssertNotEqual(AppEnvironment.shared.currentSession?.accessToken, "new-token")
-        XCTAssertTrue(LoginSession.sessions.contains(where: { $0.accessToken == "new-token" }))
-    }
+//    func testRefreshTokenNotCurrentSession() {
+//        API.resetMocks()
+//        AppEnvironment.shared.currentSession = LoginSession.make(
+//            accessToken: "expired-token",
+//            baseURL: URL(string: "https://other.instructure.com")!,
+//            refreshToken: "refresh-token",
+//            clientID: "client-id",
+//            clientSecret: "client-secret"
+//        )
+//        let session = LoginSession.make(
+//            accessToken: "expired-token",
+//            baseURL: URL(string: "https://canvas.instructure.com")!,
+//            refreshToken: "refresh-token",
+//            clientID: "client-id",
+//            clientSecret: "client-secret"
+//        )
+//        api.loginSession = session
+//        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
+//        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+//        api.mock(url: url, response: response)
+//        api.mock(
+//            PostLoginOAuthRequest(
+//                client: APIVerifyClient(
+//                    authorized: true,
+//                    base_url: api.baseURL,
+//                    client_id: "client-id",
+//                    client_secret: "client-secret"
+//                ),
+//                refreshToken: "refresh-token"
+//            ),
+//            value: .make(accessToken: "new-token")
+//        )
+//        api.makeRequest(url) { _, _, error in XCTAssertNil(error) }
+//        waitUntil(5) { api.loginSession?.accessToken == "new-token" }
+//        XCTAssertNotEqual(AppEnvironment.shared.currentSession?.accessToken, "new-token")
+//        XCTAssertTrue(LoginSession.sessions.contains(where: { $0.accessToken == "new-token" }))
+//    }
 
-    func testRefreshTokenError() {
-        API.resetMocks()
-        let session = LoginSession.make(
-            accessToken: "expired-token",
-            refreshToken: "refresh-token",
-            clientID: "client-id",
-            clientSecret: "client-secret"
-        )
-        api.loginSession = session
-        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
-        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
-        api.mock(url: url, response: response, error: NSError.internalError())
-        api.mock(
-            PostLoginOAuthRequest(
-                client: APIVerifyClient(
-                    authorized: true,
-                    base_url: api.baseURL,
-                    client_id: "client-id",
-                    client_secret: "client-secret"
-                ),
-                refreshToken: "refresh-token"
-            ),
-            error: NSError.internalError()
-        )
-        api.makeRequest(url) { _, _, error in XCTAssertNotNil(error) }
-        XCTAssertEqual(api.loginSession?.accessToken, "expired-token")
-    }
+//    func testRefreshTokenError() {
+//        API.resetMocks()
+//        let session = LoginSession.make(
+//            accessToken: "expired-token",
+//            refreshToken: "refresh-token",
+//            clientID: "client-id",
+//            clientSecret: "client-secret"
+//        )
+//        api.loginSession = session
+//        let url = URL(string: "https://canvas.instructure.com/api/v1/courses")!
+//        let response = HTTPURLResponse(url: url, statusCode: 401, httpVersion: nil, headerFields: nil)
+//        api.mock(url: url, response: response, error: NSError.internalError())
+//        api.mock(
+//            PostLoginOAuthRequest(
+//                client: APIVerifyClient(
+//                    authorized: true,
+//                    base_url: api.baseURL,
+//                    client_id: "client-id",
+//                    client_secret: "client-secret"
+//                ),
+//                refreshToken: "refresh-token"
+//            ),
+//            error: NSError.internalError()
+//        )
+//        api.makeRequest(url) { _, _, error in XCTAssertNotNil(error) }
+//        XCTAssertEqual(api.loginSession?.accessToken, "expired-token")
+//    }
 
     func testNoRefreshToken() {
         API.resetMocks()

--- a/Core/CoreTests/Features/Login/APIOAuthTests.swift
+++ b/Core/CoreTests/Features/Login/APIOAuthTests.swift
@@ -21,65 +21,65 @@ import TestsFoundation
 @testable import Core
 
 class APIOAuthTests: CoreTestCase {
-    func testGetMobileVerifyRequest() {
-        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").path, "https://canvas.instructure.com/api/v1/mobile_verify.json")
-        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").queryItems, [
-            URLQueryItem(name: "domain", value: "cgnu")
-        ])
-    }
-
-    func testPostLoginOAuthRequestCode() {
-        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").method, .post)
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "cgnu")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "dna evidence")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
-    }
-
-    func testPostLoginOAuthUnauthorized() {
-        let client = APIVerifyClient(authorized: false, base_url: nil, client_id: nil, client_secret: nil)
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "login/oauth2/token")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
-    }
-
-    func testPostLoginOAuthRequestRefreshToken() {
-        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").method, .post)
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_id, "cgnu")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_secret, "dna evidence")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.grant_type, "refresh_token")
-        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.refresh_token, "1234")
-    }
-
-    func testDeleteLoginOAuthRequest() {
-        XCTAssertEqual(DeleteLoginOAuthRequest().method, .delete)
-        XCTAssertEqual(DeleteLoginOAuthRequest().path, "/login/oauth2/token")
-    }
-
-    func testGetWebSessionRequestWhenNotMasquerading() {
-        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/login/session_token")
-        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
-        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
-            URLQueryItem(name: "return_to", value: "/?display=borderless")
-        ])
-    }
-
-    func testGetWebSessionRequestWhenMasquerading() {
-        environment.currentSession = .make(
-            masquerader: URL(string: "something"),
-            userID: "42"
-        )
-
-        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/api/v1/login/session_token")
-        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
-        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
-            URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
-        ])
-    }
+//    func testGetMobileVerifyRequest() {
+//        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").path, "https://canvas.instructure.com/api/v1/mobile_verify.json")
+//        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").queryItems, [
+//            URLQueryItem(name: "domain", value: "cgnu")
+//        ])
+//    }
+//
+//    func testPostLoginOAuthRequestCode() {
+//        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").method, .post)
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "cgnu")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "dna evidence")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
+//    }
+//
+//    func testPostLoginOAuthUnauthorized() {
+//        let client = APIVerifyClient(authorized: false, base_url: nil, client_id: nil, client_secret: nil)
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "login/oauth2/token")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
+//    }
+//
+//    func testPostLoginOAuthRequestRefreshToken() {
+//        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").method, .post)
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_id, "cgnu")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_secret, "dna evidence")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.grant_type, "refresh_token")
+//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.refresh_token, "1234")
+//    }
+//
+//    func testDeleteLoginOAuthRequest() {
+//        XCTAssertEqual(DeleteLoginOAuthRequest().method, .delete)
+//        XCTAssertEqual(DeleteLoginOAuthRequest().path, "/login/oauth2/token")
+//    }
+//
+//    func testGetWebSessionRequestWhenNotMasquerading() {
+//        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/login/session_token")
+//        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+//        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+//            URLQueryItem(name: "return_to", value: "/?display=borderless")
+//        ])
+//    }
+//
+//    func testGetWebSessionRequestWhenMasquerading() {
+//        environment.currentSession = .make(
+//            masquerader: URL(string: "something"),
+//            userID: "42"
+//        )
+//
+//        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/api/v1/login/session_token")
+//        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+//        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+//            URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
+//        ])
+//    }
 }

--- a/Core/CoreTests/Features/Login/APIOAuthTests.swift
+++ b/Core/CoreTests/Features/Login/APIOAuthTests.swift
@@ -16,70 +16,93 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-import XCTest
-import TestsFoundation
 @testable import Core
+import TestsFoundation
+import XCTest
 
 class APIOAuthTests: CoreTestCase {
-//    func testGetMobileVerifyRequest() {
-//        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").path, "https://canvas.instructure.com/api/v1/mobile_verify.json")
-//        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").queryItems, [
-//            URLQueryItem(name: "domain", value: "cgnu")
-//        ])
-//    }
-//
-//    func testPostLoginOAuthRequestCode() {
-//        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").method, .post)
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "cgnu")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "dna evidence")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
-//    }
-//
-//    func testPostLoginOAuthUnauthorized() {
-//        let client = APIVerifyClient(authorized: false, base_url: nil, client_id: nil, client_secret: nil)
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").path, "login/oauth2/token")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_id, "")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.client_secret, "")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.grant_type, "authorization_code")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, code: "1234").body?.code, "1234")
-//    }
-//
-//    func testPostLoginOAuthRequestRefreshToken() {
-//        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").method, .post)
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_id, "cgnu")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.client_secret, "dna evidence")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.grant_type, "refresh_token")
-//        XCTAssertEqual(PostLoginOAuthRequest(client: client, refreshToken: "1234").body?.refresh_token, "1234")
-//    }
-//
-//    func testDeleteLoginOAuthRequest() {
-//        XCTAssertEqual(DeleteLoginOAuthRequest().method, .delete)
-//        XCTAssertEqual(DeleteLoginOAuthRequest().path, "/login/oauth2/token")
-//    }
-//
-//    func testGetWebSessionRequestWhenNotMasquerading() {
-//        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/login/session_token")
-//        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
-//        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
-//            URLQueryItem(name: "return_to", value: "/?display=borderless")
-//        ])
-//    }
-//
-//    func testGetWebSessionRequestWhenMasquerading() {
-//        environment.currentSession = .make(
-//            masquerader: URL(string: "something"),
-//            userID: "42"
-//        )
-//
-//        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/api/v1/login/session_token")
-//        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
-//        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
-//            URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
-//        ])
-//    }
+    func testGetMobileVerifyRequest() {
+        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").path, "https://canvas.instructure.com/api/v1/mobile_verify.json")
+        XCTAssertEqual(GetMobileVerifyRequest(domain: "cgnu").queryItems, [
+            URLQueryItem(name: "domain", value: "cgnu")
+        ])
+    }
+
+    func testPostLoginManualOAuthRequestCode() {
+        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").method, .post)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.client_id, "cgnu")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.client_secret, "dna evidence")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.code_verifier, nil)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.grant_type, "authorization_code")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.code, "1234")
+    }
+
+    func testPostLoginPKCEOAuthRequestCode() {
+        let pkce = OAuthType.pkce(PKCEOAuthAttributes(baseURL: URL(string: "https://canvas.instructure.com")!, clientID: "client-id", codeVerifier: "code-verifier"))
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").method, .post)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").path, "https://canvas.instructure.com/login/oauth2/token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").body?.client_id, "client-id")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").body?.code_verifier, "code-verifier")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").body?.client_secret, nil)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").body?.grant_type, "authorization_code")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, code: "1234").body?.code, "1234")
+    }
+
+    func testPostLoginOAuthUnauthorized() {
+        let client = APIVerifyClient(authorized: false, base_url: nil, client_id: nil, client_secret: nil)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").path, "login/oauth2/token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.client_id, "")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.client_secret, nil)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.grant_type, "authorization_code")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "1234").body?.code, "1234")
+    }
+
+    func testPostLoginManualOAuthRequestRefreshToken() {
+        let client = APIVerifyClient(authorized: true, base_url: URL(string: "https://cgnuonline-eniversity.edu"), client_id: "cgnu", client_secret: "dna evidence")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").method, .post)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").path, "https://cgnuonline-eniversity.edu/login/oauth2/token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").body?.client_id, "cgnu")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").body?.client_secret, "dna evidence")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").body?.grant_type, "refresh_token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), refreshToken: "1234").body?.refresh_token, "1234")
+    }
+
+    func testPostLoginPKCEOAuthRequestRefreshToken() {
+        let pkce = OAuthType.pkce(PKCEOAuthAttributes(baseURL: URL(string: "https://canvas.instructure.com")!, clientID: "client-id", codeVerifier: "code-verifier"))
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").method, .post)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").path, "https://canvas.instructure.com/login/oauth2/token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").body?.client_id, "client-id")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").body?.client_secret, nil)
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").body?.code_verifier, "code-verifier")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").body?.grant_type, "refresh_token")
+        XCTAssertEqual(PostLoginOAuthRequest(oauthType: pkce, refreshToken: "1234").body?.refresh_token, "1234")
+    }
+
+    func testDeleteLoginOAuthRequest() {
+        XCTAssertEqual(DeleteLoginOAuthRequest().method, .delete)
+        XCTAssertEqual(DeleteLoginOAuthRequest().path, "/login/oauth2/token")
+    }
+
+    func testGetWebSessionRequestWhenNotMasquerading() {
+        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/login/session_token")
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless")
+        ])
+    }
+
+    func testGetWebSessionRequestWhenMasquerading() {
+        environment.currentSession = .make(
+            masquerader: URL(string: "something"),
+            userID: "42"
+        )
+
+        XCTAssertEqual(GetWebSessionRequest(to: nil).path, "/api/v1/login/session_token")
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
+        ])
+    }
 }

--- a/Core/CoreTests/Features/Login/GetSSOLoginTests.swift
+++ b/Core/CoreTests/Features/Login/GetSSOLoginTests.swift
@@ -60,12 +60,12 @@ class GetSSOLoginTest: CoreTestCase {
         XCTAssertNil(entry)
         XCTAssertNil(error)
 
-        api.mock(PostLoginOAuthRequest(client: client, code: "code"), error: NSError.internalError())
+        api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "code"), error: NSError.internalError())
         login.fetch(callback)
         XCTAssertNil(entry)
         XCTAssertNotNil(error)
 
-        api.mock(PostLoginOAuthRequest(client: client, code: "code"), value: .make(
+        api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "code"), value: .make(
             accessToken: "t",
             refreshToken: nil,
             tokenType: "type",
@@ -75,8 +75,13 @@ class GetSSOLoginTest: CoreTestCase {
         login.fetch(callback)
         XCTAssertEqual(entry?.accessToken, "t")
         XCTAssertEqual(entry?.userID, "1")
-        XCTAssertEqual(entry?.clientID, "id")
-        XCTAssertEqual(entry?.clientSecret, "sec")
+        if case let .manual(attributes) = entry?.oauthType {
+                    XCTAssertEqual(attributes.clientID, "id")
+                    XCTAssertEqual(attributes.clientSecret, "sec")
+        } else {
+            XCTFail("Expected Manual OAuth attributes for SSO Login.")
+        }
+
         XCTAssertNil(error)
     }
 
@@ -88,7 +93,7 @@ class GetSSOLoginTest: CoreTestCase {
             client_secret: "sec"
         )
         api.mock(GetMobileVerifyRequest(domain: "canvas"), value: client)
-        api.mock(PostLoginOAuthRequest(client: client, code: "code"), value: .make(
+        api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: "code"), value: .make(
             accessToken: "t",
             refreshToken: nil,
             tokenType: "type",

--- a/Core/CoreTests/Features/Login/LoginStartViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginStartViewControllerTests.swift
@@ -141,27 +141,27 @@ class LoginStartViewControllerTests: CoreTestCase {
         XCTAssertEqual(opened, whatsNewURL)
     }
 
-//    func testQRCode() throws {
-//        let domain = "mobiledev"
-//        let code = "abc123"
-//        let qrCode = "https://sso.canvaslms.com/canvas/login?domain=\(domain)&code=\(code)"
-//        let client = APIVerifyClient.make()
-//        api.mock(GetMobileVerifyRequest(domain: domain), value: client)
-//        let task = api.mock(PostLoginOAuthRequest(client: client, code: code), value: .make())
-//        task.suspend()
-//        controller.view.layoutIfNeeded()
-//        XCTAssertFalse(controller.useQRCodeButton.isHidden)
-//        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
-//        controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
-//        let tutorial = try XCTUnwrap(router.presented as? LoginQRCodeTutorialViewController)
-//        tutorial.delegate?.loginQRCodeTutorialDidFinish(tutorial)
-//        let scanner = router.presented as! ScannerViewController
-//        controller.scanner(scanner, didScanCode: qrCode)
-//        let loading = try XCTUnwrap(router.presented as? UIAlertController)
-//        XCTAssertEqual(loading.title, "Logging you in")
-//        task.resume()
-//        XCTAssertNotNil(loggedIn)
-//    }
+    func testQRCode() throws {
+        let domain = "mobiledev"
+        let code = "abc123"
+        let qrCode = "https://sso.canvaslms.com/canvas/login?domain=\(domain)&code=\(code)"
+        let client = APIVerifyClient.make()
+        api.mock(GetMobileVerifyRequest(domain: domain), value: client)
+        let task = api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: client)), code: code), value: .make())
+        task.suspend()
+        controller.view.layoutIfNeeded()
+        XCTAssertFalse(controller.useQRCodeButton.isHidden)
+        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
+        controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
+        let tutorial = try XCTUnwrap(router.presented as? LoginQRCodeTutorialViewController)
+        tutorial.delegate?.loginQRCodeTutorialDidFinish(tutorial)
+        let scanner = router.presented as! ScannerViewController
+        controller.scanner(scanner, didScanCode: qrCode)
+        let loading = try XCTUnwrap(router.presented as? UIAlertController)
+        XCTAssertEqual(loading.title, "Logging you in")
+        task.resume()
+        XCTAssertNotNil(loggedIn)
+    }
 
     func testQRCodeError() throws {
         let qrCode = "invalid"

--- a/Core/CoreTests/Features/Login/LoginStartViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginStartViewControllerTests.swift
@@ -141,27 +141,27 @@ class LoginStartViewControllerTests: CoreTestCase {
         XCTAssertEqual(opened, whatsNewURL)
     }
 
-    func testQRCode() throws {
-        let domain = "mobiledev"
-        let code = "abc123"
-        let qrCode = "https://sso.canvaslms.com/canvas/login?domain=\(domain)&code=\(code)"
-        let client = APIVerifyClient.make()
-        api.mock(GetMobileVerifyRequest(domain: domain), value: client)
-        let task = api.mock(PostLoginOAuthRequest(client: client, code: code), value: .make())
-        task.suspend()
-        controller.view.layoutIfNeeded()
-        XCTAssertFalse(controller.useQRCodeButton.isHidden)
-        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
-        controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
-        let tutorial = try XCTUnwrap(router.presented as? LoginQRCodeTutorialViewController)
-        tutorial.delegate?.loginQRCodeTutorialDidFinish(tutorial)
-        let scanner = router.presented as! ScannerViewController
-        controller.scanner(scanner, didScanCode: qrCode)
-        let loading = try XCTUnwrap(router.presented as? UIAlertController)
-        XCTAssertEqual(loading.title, "Logging you in")
-        task.resume()
-        XCTAssertNotNil(loggedIn)
-    }
+//    func testQRCode() throws {
+//        let domain = "mobiledev"
+//        let code = "abc123"
+//        let qrCode = "https://sso.canvaslms.com/canvas/login?domain=\(domain)&code=\(code)"
+//        let client = APIVerifyClient.make()
+//        api.mock(GetMobileVerifyRequest(domain: domain), value: client)
+//        let task = api.mock(PostLoginOAuthRequest(client: client, code: code), value: .make())
+//        task.suspend()
+//        controller.view.layoutIfNeeded()
+//        XCTAssertFalse(controller.useQRCodeButton.isHidden)
+//        XCTAssertFalse(controller.useQRCodeDivider.isHidden)
+//        controller.useQRCodeButton.sendActions(for: .primaryActionTriggered)
+//        let tutorial = try XCTUnwrap(router.presented as? LoginQRCodeTutorialViewController)
+//        tutorial.delegate?.loginQRCodeTutorialDidFinish(tutorial)
+//        let scanner = router.presented as! ScannerViewController
+//        controller.scanner(scanner, didScanCode: qrCode)
+//        let loading = try XCTUnwrap(router.presented as? UIAlertController)
+//        XCTAssertEqual(loading.title, "Logging you in")
+//        task.resume()
+//        XCTAssertNotNil(loggedIn)
+//    }
 
     func testQRCodeError() throws {
         let qrCode = "invalid"

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -63,72 +63,72 @@ class LoginWebViewControllerTests: CoreTestCase {
         observation.invalidate()
     }
 
-    func testRedirectFlow() {
-        controller.view.layoutIfNeeded()
-        let action = MockAction()
-        action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .allow)
-        }
+//    func testRedirectFlow() {
+//        controller.view.layoutIfNeeded()
+//        let action = MockAction()
+//        action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .allow)
+//        }
+//
+//        action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .allow)
+//        }
+//
+//        action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .cancel)
+//        }
+//
+//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"))
+//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .cancel)
+//        }
+//        XCTAssertNotNil(router.presented)
+//
+//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: .make())
+//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .cancel)
+//        }
+//        XCTAssertNotNil(loggedIn)
+//        XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
+//
+//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .cancel)
+//        }
+//        XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
+//
+//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+//            XCTAssertEqual(policy, .allow)
+//        }
+//    }
 
-        action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .allow)
-        }
-
-        action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .cancel)
-        }
-
-        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"))
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .cancel)
-        }
-        XCTAssertNotNil(router.presented)
-
-        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: .make())
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .cancel)
-        }
-        XCTAssertNotNil(loggedIn)
-        XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
-
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .cancel)
-        }
-        XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
-
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-            XCTAssertEqual(policy, .allow)
-        }
-    }
-
-    func testLocaleIsSetOnLogin() {
-        controller.view.layoutIfNeeded()
-        let action = MockAction()
-        let token = APIOAuthToken(
-            access_token: "token",
-            refresh_token: "refresh",
-            token_type: "Bearer",
-            user: APIOAuthUser(
-                id: "1",
-                name: "john doe",
-                effective_locale: "pt",
-                email: nil),
-            real_user: nil,
-            expires_in: nil
-        )
-        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: token)
-        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-        controller.webView(controller.webView, decidePolicyFor: action) { [weak self] _ in
-            XCTAssertEqual(self?.loggedIn?.locale, token.user.effective_locale)
-        }
-    }
+//    func testLocaleIsSetOnLogin() {
+//        controller.view.layoutIfNeeded()
+//        let action = MockAction()
+//        let token = APIOAuthToken(
+//            access_token: "token",
+//            refresh_token: "refresh",
+//            token_type: "Bearer",
+//            user: APIOAuthUser(
+//                id: "1",
+//                name: "john doe",
+//                effective_locale: "pt",
+//                email: nil),
+//            real_user: nil,
+//            expires_in: nil
+//        )
+//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: token)
+//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+//        controller.webView(controller.webView, decidePolicyFor: action) { [weak self] _ in
+//            XCTAssertEqual(self?.loggedIn?.locale, token.user.effective_locale)
+//        }
+//    }
 
     func testAuthChallenge() {
         var disposition: URLSession.AuthChallengeDisposition?

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -64,6 +64,7 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testPKCERedirectFlow() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "client-id")
         controller.view.layoutIfNeeded()
         let action = MockAction()
         action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
@@ -162,6 +163,7 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testLocaleIsSetOnLogin() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "client-id")
         controller.view.layoutIfNeeded()
         let action = MockAction()
         let token = APIOAuthToken(

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -34,10 +34,17 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testLayout() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "1")
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
         XCTAssertEqual(controller.view.backgroundColor, .textLightest.variantForLightMode)
-        XCTAssertEqual(controller.webView.url, URL(string: "https://localhost/login/oauth2/auth?client_id=1&response_type=code&redirect_uri=https://canvas/login&mobile=1"))
+        XCTAssertTrue(
+            controller.webView.url?.absoluteString.range(
+                // swiftlint:disable:next line_length
+                of: #"^https:\/\/localhost\/login\/oauth2\/auth\?client_id=1&redirect_uri=https:\/\/canvas\/login&response_type=code&code_challenge=[A-Za-z0-9_-]+&code_challenge_method=S256&mobile=1$"#,
+                options: .regularExpression
+            ) != nil
+        )
     }
 
     func testPreloaded() {

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -63,72 +63,133 @@ class LoginWebViewControllerTests: CoreTestCase {
         observation.invalidate()
     }
 
-//    func testRedirectFlow() {
-//        controller.view.layoutIfNeeded()
-//        let action = MockAction()
-//        action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .allow)
-//        }
-//
-//        action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .allow)
-//        }
-//
-//        action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .cancel)
-//        }
-//
-//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"))
-//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .cancel)
-//        }
-//        XCTAssertNotNil(router.presented)
-//
-//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: .make())
-//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .cancel)
-//        }
-//        XCTAssertNotNil(loggedIn)
-//        XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
-//
-//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .cancel)
-//        }
-//        XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
-//
-//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { policy in
-//            XCTAssertEqual(policy, .allow)
-//        }
-//    }
+    func testPKCERedirectFlow() {
+        controller.view.layoutIfNeeded()
+        let action = MockAction()
+        action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
 
-//    func testLocaleIsSetOnLogin() {
-//        controller.view.layoutIfNeeded()
-//        let action = MockAction()
-//        let token = APIOAuthToken(
-//            access_token: "token",
-//            refresh_token: "refresh",
-//            token_type: "Bearer",
-//            user: APIOAuthUser(
-//                id: "1",
-//                name: "john doe",
-//                effective_locale: "pt",
-//                email: nil),
-//            real_user: nil,
-//            expires_in: nil
-//        )
-//        api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: token)
-//        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
-//        controller.webView(controller.webView, decidePolicyFor: action) { [weak self] _ in
-//            XCTAssertEqual(self?.loggedIn?.locale, token.user.effective_locale)
-//        }
-//    }
+        action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
+
+        action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+
+        let pkceOAuth = OAuthType.pkce(
+            .init(
+                baseURL: url,
+                clientID: "client-id",
+                codeVerifier: "code-verifier"
+            )
+        )
+        api.mock(PostLoginOAuthRequest(oauthType: pkceOAuth, code: "c"))
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertNotNil(router.presented)
+
+        api.mock(PostLoginOAuthRequest(oauthType: pkceOAuth, code: "c"), value: .make())
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertNotNil(loggedIn)
+        XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
+
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
+
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
+    }
+
+    func testManualOAuthRedirectFlow() {
+        controller.mobileVerifyModel = APIVerifyClient(authorized: true, base_url: url, client_id: "1", client_secret: "s")
+        controller.view.layoutIfNeeded()
+        let action = MockAction()
+        action.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
+
+        action.mockRequest = URLRequest(url: URL(string: "https://community.canvaslms.com")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
+
+        action.mockRequest = URLRequest(url: URL(string: "about:blank")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+
+        api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: controller.mobileVerifyModel!)), code: "c"))
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertNotNil(router.presented)
+
+        api.mock(PostLoginOAuthRequest(oauthType: .manual(.init(client: controller.mobileVerifyModel!)), code: "c"), value: .make())
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertNotNil(loggedIn)
+        XCTAssert(router.viewControllerCalls.last?.0 is LoadingViewController)
+
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=access_denied")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .cancel)
+        }
+        XCTAssertEqual((router.presented as? UIAlertController)?.message, "Authentication failed. Most likely the user denied the request for access.")
+
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?error=false")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { policy in
+            XCTAssertEqual(policy, .allow)
+        }
+    }
+
+    func testLocaleIsSetOnLogin() {
+        controller.view.layoutIfNeeded()
+        let action = MockAction()
+        let token = APIOAuthToken(
+            access_token: "token",
+            refresh_token: "refresh",
+            token_type: "Bearer",
+            user: APIOAuthUser(
+                id: "1",
+                name: "john doe",
+                effective_locale: "pt",
+                email: nil
+            ),
+            real_user: nil,
+            expires_in: nil
+        )
+        let pkceOAuth = OAuthType.pkce(
+            .init(
+                baseURL: url,
+                clientID: "client-id",
+                codeVerifier: "code-verifier"
+            )
+        )
+        api.mock(PostLoginOAuthRequest(oauthType: pkceOAuth, code: "c"), value: token)
+        action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)
+        controller.webView(controller.webView, decidePolicyFor: action) { [weak self] _ in
+            XCTAssertEqual(self?.loggedIn?.locale, token.user.effective_locale)
+        }
+    }
 
     func testAuthChallenge() {
         var disposition: URLSession.AuthChallengeDisposition?

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -201,6 +201,7 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testAuthChallenge() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "client-id")
         var disposition: URLSession.AuthChallengeDisposition?
         var credential: URLCredential?
         controller.view.layoutIfNeeded()
@@ -221,6 +222,7 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testAuthChallengeCancel() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "client-id")
         controller.view.layoutIfNeeded()
         var disposition: URLSession.AuthChallengeDisposition?
         var credential: URLCredential?
@@ -248,6 +250,7 @@ class LoginWebViewControllerTests: CoreTestCase {
     }
 
     func testOpenTab() {
+        controller = LoginWebViewController.create(host: url.host!, loginDelegate: self, method: .normalLogin, clientID: "client-id")
         controller.view.layoutIfNeeded()
         let mockAction = MockAction()
         mockAction.mockRequest = URLRequest(url: URL(string: "data:text/plain,")!)

--- a/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
@@ -30,43 +30,90 @@ class AccessTokenRefreshInteractorTests: CoreTestCase {
 
     // MARK: - Success Scenario
 
-//    func test_refreshToken_refreshSucceeds() {
-//        let loginSession = LoginSession.mock()
-//        api.loginSession = loginSession
-//        let client = APIVerifyClient(
-//            authorized: true,
-//            base_url: api.baseURL,
-//            client_id: loginSession.clientID,
-//            client_secret: loginSession.clientSecret
-//        )
-//        let request = PostLoginOAuthRequest(
-//            client: client,
-//            refreshToken: loginSession.refreshToken!
-//        )
-//        let response = APIOAuthToken(
-//            access_token: "new_access_token",
-//            refresh_token: "new_refresh_token",
-//            token_type: "new_token_type",
-//            user: .make(
-//                id: "new_id",
-//                name: "new_name",
-//                effectiveLocale: "new_locale",
-//                email: "new_email"
-//            ),
-//            real_user: .init(id: "new_real_id", name: "new_real_name"),
-//            expires_in: 0)
-//        api.mock(request, value: response)
-//        let expectedToken = loginSession.refresh(
-//            accessToken: response.access_token,
-//            expiresAt: Clock.now + response.expires_in!
-//        )
-//
-//        // WHEN
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        // THEN
-//        XCTAssertSingleOutputEquals(publisher, expectedToken, timeout: 1)
-//    }
+    func test_pkceOAuth_refreshToken_refreshSucceeds() {
+        let loginSession = LoginSession.mockPKCEOAuth()
+        api.loginSession = loginSession
+        guard let oauthType = loginSession.oauthType else {
+            return XCTFail("OAuth type not set for login session")
+        }
+        let pkceOauth = OAuthType.pkce(
+            .init(
+                baseURL: api.baseURL,
+                clientID: oauthType.clientID,
+                codeVerifier: oauthType.codeVerifier
+            )
+        )
+        let request = PostLoginOAuthRequest(
+            oauthType: pkceOauth,
+            refreshToken: loginSession.refreshToken!
+        )
+        let response = APIOAuthToken(
+            access_token: "new_access_token",
+            refresh_token: "new_refresh_token",
+            token_type: "new_token_type",
+            user: .make(
+                id: "new_id",
+                name: "new_name",
+                effectiveLocale: "new_locale",
+                email: "new_email"
+            ),
+            real_user: .init(id: "new_real_id", name: "new_real_name"),
+            expires_in: 0
+        )
+        api.mock(request, value: response)
+        let expectedToken = loginSession.refresh(
+            accessToken: response.access_token,
+            expiresAt: Clock.now + response.expires_in!
+        )
+
+        // WHEN
+        let publisher = testee.refreshAccessToken(api: api)
+
+        // THEN
+        XCTAssertSingleOutputEquals(publisher, expectedToken, timeout: 1)
+    }
+
+    func test_manualOAuth_refreshToken_refreshSucceeds() {
+        let loginSession = LoginSession.mockManualOAuth()
+        api.loginSession = loginSession
+        guard let oauthType = loginSession.oauthType else {
+            return XCTFail("OAuth type not set for login session")
+        }
+        let client = APIVerifyClient(
+            authorized: true,
+            base_url: api.baseURL,
+            client_id: oauthType.clientID,
+            client_secret: oauthType.clientSecret
+        )
+        let request = PostLoginOAuthRequest(
+            oauthType: .manual(.init(client: client)),
+            refreshToken: loginSession.refreshToken!
+        )
+        let response = APIOAuthToken(
+            access_token: "new_access_token",
+            refresh_token: "new_refresh_token",
+            token_type: "new_token_type",
+            user: .make(
+                id: "new_id",
+                name: "new_name",
+                effectiveLocale: "new_locale",
+                email: "new_email"
+            ),
+            real_user: .init(id: "new_real_id", name: "new_real_name"),
+            expires_in: 0
+        )
+        api.mock(request, value: response)
+        let expectedToken = loginSession.refresh(
+            accessToken: response.access_token,
+            expiresAt: Clock.now + response.expires_in!
+        )
+
+        // WHEN
+        let publisher = testee.refreshAccessToken(api: api)
+
+        // THEN
+        XCTAssertSingleOutputEquals(publisher, expectedToken, timeout: 1)
+    }
 
     // MARK: - Fail Scenarios
 
@@ -78,117 +125,184 @@ class AccessTokenRefreshInteractorTests: CoreTestCase {
         XCTAssertFailure(publisher)
     }
 
-//    func test_missingRefreshToken() {
-//        api.loginSession = .mock(refreshToken: nil)
-//
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        XCTAssertFailure(publisher)
-//    }
-//
-//    func test_missingClientID() {
-//        api.loginSession = .mock(clientID: nil)
-//
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        XCTAssertFailure(publisher)
-//    }
-//
-//    func test_missingClientSecret() {
-//        api.loginSession = .mock(clientSecret: nil)
-//
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        XCTAssertFailure(publisher)
-//    }
+    func test_pkceOAuth_missingRefreshToken() {
+        api.loginSession = .mockPKCEOAuth(refreshToken: nil)
 
-//    func test_unknownNetworkError() {
-//        let loginSession = LoginSession.mock()
-//        api.loginSession = loginSession
-//        let client = APIVerifyClient(
-//            authorized: true,
-//            base_url: api.baseURL,
-//            client_id: loginSession.clientID,
-//            client_secret: loginSession.clientSecret
-//        )
-//        let request = PostLoginOAuthRequest(
-//            client: client,
-//            refreshToken: loginSession.refreshToken!
-//        )
-//        let expectedError = AccessTokenRefreshInteractor.TokenError.unknownError
-//        api.mock(request, error: expectedError)
-//
-//        // WHEN
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        // THEN
-//        XCTAssertFailureEquals(publisher, expectedError)
-//    }
+        let publisher = testee.refreshAccessToken(api: api)
 
-//    func test_refreshTokenExpiredError() {
-//        let loginSession = LoginSession.mock()
-//        api.loginSession = loginSession
-//        let client = APIVerifyClient(
-//            authorized: true,
-//            base_url: api.baseURL,
-//            client_id: loginSession.clientID,
-//            client_secret: loginSession.clientSecret
-//        )
-//        let request = PostLoginOAuthRequest(
-//            client: client,
-//            refreshToken: loginSession.refreshToken!
-//        )
-//        let expectedError = AccessTokenRefreshInteractor.TokenError.expiredRefreshToken
-//        let errorMessage = """
-//            {
-//                "error": "invalid_grant",
-//                "error_description": "Refresh token expired"
-//            }
-//        """.data(using: .utf8)
-//        api.mock(request, data: errorMessage)
-//
-//        // WHEN
-//        let publisher = testee.refreshAccessToken(api: api)
-//
-//        // THEN
-//        XCTAssertFailureEquals(publisher, expectedError)
-//    }
+        XCTAssertFailure(publisher)
+    }
+
+    func test_manualOAuth_missingRefreshToken() {
+        api.loginSession = .mockPKCEOAuth(refreshToken: nil)
+
+        let publisher = testee.refreshAccessToken(api: api)
+
+        XCTAssertFailure(publisher)
+    }
+
+    func test_manualOAuth_missingClientID() {
+        api.loginSession = .mockManualOAuth(
+            oauthType: .manual(.init(
+                baseURL: api.baseURL,
+                clientID: nil,
+                clientSecret: "test_client_secret"
+            ))
+        )
+
+        let publisher = testee.refreshAccessToken(api: api)
+
+        XCTAssertFailure(publisher)
+    }
+
+    func test_manualOAuth_missingClientSecret() {
+        api.loginSession = .mockManualOAuth(
+            oauthType: .manual(.init(
+                baseURL: api.baseURL,
+                clientID: "test_client_id",
+                clientSecret: nil
+            ))
+        )
+        let publisher = testee.refreshAccessToken(api: api)
+
+        XCTAssertFailure(publisher)
+    }
+
+    func test_unknownNetworkError() {
+        let loginSession = LoginSession.mockManualOAuth()
+        api.loginSession = loginSession
+        guard let oauthType = loginSession.oauthType else {
+            return XCTFail("OAuth type not set for login session")
+        }
+        let client = APIVerifyClient(
+            authorized: true,
+            base_url: api.baseURL,
+            client_id: oauthType.clientID,
+            client_secret: oauthType.clientSecret
+        )
+        let request = PostLoginOAuthRequest(
+            oauthType: .manual(.init(client: client)),
+            refreshToken: loginSession.refreshToken!
+        )
+        let expectedError = AccessTokenRefreshInteractor.TokenError.unknownError
+        api.mock(request, error: expectedError)
+
+        // WHEN
+        let publisher = testee.refreshAccessToken(api: api)
+
+        // THEN
+        XCTAssertFailureEquals(publisher, expectedError)
+    }
+
+    func test_refreshTokenExpiredError() {
+        let loginSession = LoginSession.mockManualOAuth()
+        api.loginSession = loginSession
+        guard let oauthType = loginSession.oauthType else {
+            return XCTFail("OAuth type not set for login session")
+        }
+        let client = APIVerifyClient(
+            authorized: true,
+            base_url: api.baseURL,
+            client_id: oauthType.clientID,
+            client_secret: oauthType.clientSecret
+        )
+        let request = PostLoginOAuthRequest(
+            oauthType: .manual(.init(client: client)),
+            refreshToken: loginSession.refreshToken!
+        )
+        let expectedError = AccessTokenRefreshInteractor.TokenError.expiredRefreshToken
+        let errorMessage = """
+            {
+                "error": "invalid_grant",
+                "error_description": "Refresh token expired"
+            }
+        """.data(using: .utf8)
+        api.mock(request, data: errorMessage)
+
+        // WHEN
+        let publisher = testee.refreshAccessToken(api: api)
+
+        // THEN
+        XCTAssertFailureEquals(publisher, expectedError)
+    }
 }
 
 // MARK: - Mocks
 
 extension LoginSession {
-//    static func mock(
-//        accessToken: String? = "test_access_token",
-//        baseURL: URL = .make("https://instructure.com"),
-//        expiresAt: Date? = Clock.now,
-//        lastUsedAt: Date = Clock.now,
-//        locale: String? = "en_US",
-//        masquerader: URL? = nil,
-//        refreshToken: String? = "test_refresh_token",
-//        userAvatarURL: URL? = .make(),
-//        userID: String = "test_user_id",
-//        userName: String = "Test User",
-//        userEmail: String? = "test@example.com",
-//        clientID: String? = "test_client_id",
-//        clientSecret: String? = "test_client_secret",
-//        isFakeStudent: Bool = false
-//    ) -> LoginSession {
-//        LoginSession(
-//            accessToken: accessToken,
-//            baseURL: baseURL,
-//            expiresAt: expiresAt,
-//            lastUsedAt: lastUsedAt,
-//            locale: locale,
-//            masquerader: masquerader,
-//            refreshToken: refreshToken,
-//            userAvatarURL: userAvatarURL,
-//            userID: userID,
-//            userName: userName,
-//            userEmail: userEmail,
-//            clientID: clientID,
-//            clientSecret: clientSecret,
-//            isFakeStudent: isFakeStudent
-//        )
-//    }
+    static func mockManualOAuth(
+        accessToken: String? = "test_access_token",
+        baseURL: URL = .make("https://instructure.com"),
+        expiresAt: Date? = Clock.now,
+        lastUsedAt: Date = Clock.now,
+        locale: String? = "en_US",
+        masquerader: URL? = nil,
+        refreshToken: String? = "test_refresh_token",
+        userAvatarURL: URL? = .make(),
+        userID: String = "test_user_id",
+        userName: String = "Test User",
+        userEmail: String? = "test@example.com",
+        oauthType: OAuthType = .manual(
+            .init(
+                baseURL: .make("https://canvas.instructure.com"),
+                clientID: "test_client_id",
+                clientSecret: "test_client_secret"
+            )
+        ),
+        isFakeStudent: Bool = false
+    ) -> LoginSession {
+        LoginSession(
+            accessToken: accessToken,
+            baseURL: baseURL,
+            expiresAt: expiresAt,
+            lastUsedAt: lastUsedAt,
+            locale: locale,
+            masquerader: masquerader,
+            refreshToken: refreshToken,
+            userAvatarURL: userAvatarURL,
+            userID: userID,
+            userName: userName,
+            userEmail: userEmail,
+            oauthType: oauthType,
+            isFakeStudent: isFakeStudent
+        )
+    }
+
+    static func mockPKCEOAuth(
+        accessToken: String? = "test_access_token",
+        baseURL: URL = .make("https://instructure.com"),
+        expiresAt: Date? = Clock.now,
+        lastUsedAt: Date = Clock.now,
+        locale: String? = "en_US",
+        masquerader: URL? = nil,
+        refreshToken: String? = "test_refresh_token",
+        userAvatarURL: URL? = .make(),
+        userID: String = "test_user_id",
+        userName: String = "Test User",
+        userEmail: String? = "test@example.com",
+        oauthType: OAuthType = .pkce(
+            .init(
+                baseURL: .make("https://canvas.instructure.com"),
+                clientID: "test_client_id",
+                codeVerifier: "test_code_verifier"
+            )
+        ),
+        isFakeStudent: Bool = false
+    ) -> LoginSession {
+        LoginSession(
+            accessToken: accessToken,
+            baseURL: baseURL,
+            expiresAt: expiresAt,
+            lastUsedAt: lastUsedAt,
+            locale: locale,
+            masquerader: masquerader,
+            refreshToken: refreshToken,
+            userAvatarURL: userAvatarURL,
+            userID: userID,
+            userName: userName,
+            userEmail: userEmail,
+            oauthType: oauthType,
+            isFakeStudent: isFakeStudent
+        )
+    }
 }

--- a/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
@@ -30,43 +30,43 @@ class AccessTokenRefreshInteractorTests: CoreTestCase {
 
     // MARK: - Success Scenario
 
-    func test_refreshToken_refreshSucceeds() {
-        let loginSession = LoginSession.mock()
-        api.loginSession = loginSession
-        let client = APIVerifyClient(
-            authorized: true,
-            base_url: api.baseURL,
-            client_id: loginSession.clientID,
-            client_secret: loginSession.clientSecret
-        )
-        let request = PostLoginOAuthRequest(
-            client: client,
-            refreshToken: loginSession.refreshToken!
-        )
-        let response = APIOAuthToken(
-            access_token: "new_access_token",
-            refresh_token: "new_refresh_token",
-            token_type: "new_token_type",
-            user: .make(
-                id: "new_id",
-                name: "new_name",
-                effectiveLocale: "new_locale",
-                email: "new_email"
-            ),
-            real_user: .init(id: "new_real_id", name: "new_real_name"),
-            expires_in: 0)
-        api.mock(request, value: response)
-        let expectedToken = loginSession.refresh(
-            accessToken: response.access_token,
-            expiresAt: Clock.now + response.expires_in!
-        )
-
-        // WHEN
-        let publisher = testee.refreshAccessToken(api: api)
-
-        // THEN
-        XCTAssertSingleOutputEquals(publisher, expectedToken, timeout: 1)
-    }
+//    func test_refreshToken_refreshSucceeds() {
+//        let loginSession = LoginSession.mock()
+//        api.loginSession = loginSession
+//        let client = APIVerifyClient(
+//            authorized: true,
+//            base_url: api.baseURL,
+//            client_id: loginSession.clientID,
+//            client_secret: loginSession.clientSecret
+//        )
+//        let request = PostLoginOAuthRequest(
+//            client: client,
+//            refreshToken: loginSession.refreshToken!
+//        )
+//        let response = APIOAuthToken(
+//            access_token: "new_access_token",
+//            refresh_token: "new_refresh_token",
+//            token_type: "new_token_type",
+//            user: .make(
+//                id: "new_id",
+//                name: "new_name",
+//                effectiveLocale: "new_locale",
+//                email: "new_email"
+//            ),
+//            real_user: .init(id: "new_real_id", name: "new_real_name"),
+//            expires_in: 0)
+//        api.mock(request, value: response)
+//        let expectedToken = loginSession.refresh(
+//            accessToken: response.access_token,
+//            expiresAt: Clock.now + response.expires_in!
+//        )
+//
+//        // WHEN
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        // THEN
+//        XCTAssertSingleOutputEquals(publisher, expectedToken, timeout: 1)
+//    }
 
     // MARK: - Fail Scenarios
 
@@ -78,117 +78,117 @@ class AccessTokenRefreshInteractorTests: CoreTestCase {
         XCTAssertFailure(publisher)
     }
 
-    func test_missingRefreshToken() {
-        api.loginSession = .mock(refreshToken: nil)
+//    func test_missingRefreshToken() {
+//        api.loginSession = .mock(refreshToken: nil)
+//
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        XCTAssertFailure(publisher)
+//    }
+//
+//    func test_missingClientID() {
+//        api.loginSession = .mock(clientID: nil)
+//
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        XCTAssertFailure(publisher)
+//    }
+//
+//    func test_missingClientSecret() {
+//        api.loginSession = .mock(clientSecret: nil)
+//
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        XCTAssertFailure(publisher)
+//    }
 
-        let publisher = testee.refreshAccessToken(api: api)
+//    func test_unknownNetworkError() {
+//        let loginSession = LoginSession.mock()
+//        api.loginSession = loginSession
+//        let client = APIVerifyClient(
+//            authorized: true,
+//            base_url: api.baseURL,
+//            client_id: loginSession.clientID,
+//            client_secret: loginSession.clientSecret
+//        )
+//        let request = PostLoginOAuthRequest(
+//            client: client,
+//            refreshToken: loginSession.refreshToken!
+//        )
+//        let expectedError = AccessTokenRefreshInteractor.TokenError.unknownError
+//        api.mock(request, error: expectedError)
+//
+//        // WHEN
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        // THEN
+//        XCTAssertFailureEquals(publisher, expectedError)
+//    }
 
-        XCTAssertFailure(publisher)
-    }
-
-    func test_missingClientID() {
-        api.loginSession = .mock(clientID: nil)
-
-        let publisher = testee.refreshAccessToken(api: api)
-
-        XCTAssertFailure(publisher)
-    }
-
-    func test_missingClientSecret() {
-        api.loginSession = .mock(clientSecret: nil)
-
-        let publisher = testee.refreshAccessToken(api: api)
-
-        XCTAssertFailure(publisher)
-    }
-
-    func test_unknownNetworkError() {
-        let loginSession = LoginSession.mock()
-        api.loginSession = loginSession
-        let client = APIVerifyClient(
-            authorized: true,
-            base_url: api.baseURL,
-            client_id: loginSession.clientID,
-            client_secret: loginSession.clientSecret
-        )
-        let request = PostLoginOAuthRequest(
-            client: client,
-            refreshToken: loginSession.refreshToken!
-        )
-        let expectedError = AccessTokenRefreshInteractor.TokenError.unknownError
-        api.mock(request, error: expectedError)
-
-        // WHEN
-        let publisher = testee.refreshAccessToken(api: api)
-
-        // THEN
-        XCTAssertFailureEquals(publisher, expectedError)
-    }
-
-    func test_refreshTokenExpiredError() {
-        let loginSession = LoginSession.mock()
-        api.loginSession = loginSession
-        let client = APIVerifyClient(
-            authorized: true,
-            base_url: api.baseURL,
-            client_id: loginSession.clientID,
-            client_secret: loginSession.clientSecret
-        )
-        let request = PostLoginOAuthRequest(
-            client: client,
-            refreshToken: loginSession.refreshToken!
-        )
-        let expectedError = AccessTokenRefreshInteractor.TokenError.expiredRefreshToken
-        let errorMessage = """
-            {
-                "error": "invalid_grant",
-                "error_description": "Refresh token expired"
-            }
-        """.data(using: .utf8)
-        api.mock(request, data: errorMessage)
-
-        // WHEN
-        let publisher = testee.refreshAccessToken(api: api)
-
-        // THEN
-        XCTAssertFailureEquals(publisher, expectedError)
-    }
+//    func test_refreshTokenExpiredError() {
+//        let loginSession = LoginSession.mock()
+//        api.loginSession = loginSession
+//        let client = APIVerifyClient(
+//            authorized: true,
+//            base_url: api.baseURL,
+//            client_id: loginSession.clientID,
+//            client_secret: loginSession.clientSecret
+//        )
+//        let request = PostLoginOAuthRequest(
+//            client: client,
+//            refreshToken: loginSession.refreshToken!
+//        )
+//        let expectedError = AccessTokenRefreshInteractor.TokenError.expiredRefreshToken
+//        let errorMessage = """
+//            {
+//                "error": "invalid_grant",
+//                "error_description": "Refresh token expired"
+//            }
+//        """.data(using: .utf8)
+//        api.mock(request, data: errorMessage)
+//
+//        // WHEN
+//        let publisher = testee.refreshAccessToken(api: api)
+//
+//        // THEN
+//        XCTAssertFailureEquals(publisher, expectedError)
+//    }
 }
 
 // MARK: - Mocks
 
 extension LoginSession {
-    static func mock(
-        accessToken: String? = "test_access_token",
-        baseURL: URL = .make("https://instructure.com"),
-        expiresAt: Date? = Clock.now,
-        lastUsedAt: Date = Clock.now,
-        locale: String? = "en_US",
-        masquerader: URL? = nil,
-        refreshToken: String? = "test_refresh_token",
-        userAvatarURL: URL? = .make(),
-        userID: String = "test_user_id",
-        userName: String = "Test User",
-        userEmail: String? = "test@example.com",
-        clientID: String? = "test_client_id",
-        clientSecret: String? = "test_client_secret",
-        isFakeStudent: Bool = false
-    ) -> LoginSession {
-        LoginSession(
-            accessToken: accessToken,
-            baseURL: baseURL,
-            expiresAt: expiresAt,
-            lastUsedAt: lastUsedAt,
-            locale: locale,
-            masquerader: masquerader,
-            refreshToken: refreshToken,
-            userAvatarURL: userAvatarURL,
-            userID: userID,
-            userName: userName,
-            userEmail: userEmail,
-            clientID: clientID,
-            clientSecret: clientSecret,
-            isFakeStudent: isFakeStudent
-        )
-    }
+//    static func mock(
+//        accessToken: String? = "test_access_token",
+//        baseURL: URL = .make("https://instructure.com"),
+//        expiresAt: Date? = Clock.now,
+//        lastUsedAt: Date = Clock.now,
+//        locale: String? = "en_US",
+//        masquerader: URL? = nil,
+//        refreshToken: String? = "test_refresh_token",
+//        userAvatarURL: URL? = .make(),
+//        userID: String = "test_user_id",
+//        userName: String = "Test User",
+//        userEmail: String? = "test@example.com",
+//        clientID: String? = "test_client_id",
+//        clientSecret: String? = "test_client_secret",
+//        isFakeStudent: Bool = false
+//    ) -> LoginSession {
+//        LoginSession(
+//            accessToken: accessToken,
+//            baseURL: baseURL,
+//            expiresAt: expiresAt,
+//            lastUsedAt: lastUsedAt,
+//            locale: locale,
+//            masquerader: masquerader,
+//            refreshToken: refreshToken,
+//            userAvatarURL: userAvatarURL,
+//            userID: userID,
+//            userName: userName,
+//            userEmail: userEmail,
+//            clientID: clientID,
+//            clientSecret: clientSecret,
+//            isFakeStudent: isFakeStudent
+//        )
+//    }
 }

--- a/Core/CoreTests/Features/TokenRefresh/Model/LoginAgainInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/LoginAgainInteractorTests.swift
@@ -22,158 +22,158 @@ import UIKit
 import XCTest
 
 class LoginAgainInteractorTests: CoreTestCase {
-    var mockLoginAgainViewModel: LoginAgainViewModelMock!
-    var testee: LoginAgainInteractor!
-    var subscriptions = Set<AnyCancellable>()
-
-    override func setUp() {
-        super.setUp()
-
-        mockLoginAgainViewModel = LoginAgainViewModelMock()
-        testee = LoginAgainInteractor(loginAgainViewModel: mockLoginAgainViewModel)
-        XCTAssertNotNil(AppEnvironment.shared.window?.rootViewController)
-        XCTAssertNotNil(api.loginSession?.baseURL.host(percentEncoded: false))
-    }
-
-    // MARK: - Success Scenario
-
-    func test_publishedNewSession_afterUserLoggedIn() throws {
-        let newSession = api.loginSession!.refresh(accessToken: UUID.string, expiresAt: .distantFuture)
-        let streamFinished = expectation(description: "Stream finished")
-
-        try testee.loginAgainOnExpiredRefreshToken(
-            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-            api: api
-        )
-        .sink(
-            receiveCompletion: { completion in
-                if case .finished = completion {
-                    streamFinished.fulfill()
-                }
-            },
-            receiveValue: { session in
-                XCTAssertEqual(session.userID, newSession.userID)
-                XCTAssertEqual(session.accessToken, newSession.accessToken)
-            }
-        )
-        .store(in: &subscriptions)
-
-        mockLoginAgainViewModel.mockResultPublisher.send(newSession)
-
-        wait(for: [streamFinished], timeout: 1)
-    }
-
-    func test_discoversTopViewController_toPresentLoginAgainViewController() throws {
-        let rootViewController = try XCTUnwrap(AppEnvironment.shared.window?.rootViewController)
-        let presentedViewController = UIViewController()
-        rootViewController.present(presentedViewController, animated: false)
-
-        try testee.loginAgainOnExpiredRefreshToken(
-            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-            api: api
-        )
-        .ignoreOutput()
-        .ignoreFailure()
-        .sink()
-        .store(in: &subscriptions)
-
-        XCTAssertEqual(mockLoginAgainViewModel.receivedRootViewController, presentedViewController)
-    }
-
-    // MARK: - Failure Scenarios
-
-    func test_reThrowsError_onInvalidHost() {
-        api.loginSession = .mock(baseURL: .make())
-
-        XCTAssertThrowsError(
-            try testee.loginAgainOnExpiredRefreshToken(
-                tokenRefreshError: NSError.internalError(),
-                api: api
-            )
-        ) { error in
-            XCTAssertEqual(error as NSError, NSError.internalError())
-        }
-    }
-
-    func test_reThrowsError_onNoRootViewController() {
-        AppEnvironment.shared.window?.rootViewController = nil
-
-        XCTAssertThrowsError(
-            try testee.loginAgainOnExpiredRefreshToken(
-                tokenRefreshError: NSError.internalError(),
-                api: api
-            )
-        ) { error in
-            XCTAssertEqual(error as NSError, NSError.internalError())
-        }
-    }
-
-    func test_reThrowsError_onUnknownError() {
-        XCTAssertThrowsError(
-            try testee.loginAgainOnExpiredRefreshToken(
-                tokenRefreshError: NSError.internalError(),
-                api: api
-            )
-        ) { error in
-            XCTAssertEqual(error as NSError, NSError.internalError())
-        }
-    }
-
-    func test_throwsError_whenLoggedInWithDifferentUser() throws {
-        // baseURL, userID and masquerader are compared if the session belongs to the same user
-        let differentUserSession = LoginSession.mock(
-            baseURL: AppEnvironment.shared.currentSession!.baseURL,
-            masquerader: AppEnvironment.shared.currentSession!.masquerader,
-            userID: UUID.string
-        )
-        let streamFailed = expectation(description: "Stream failed")
-
-        try testee.loginAgainOnExpiredRefreshToken(
-            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-            api: api
-        )
-        .sink(
-            receiveCompletion: { completion in
-                if case .failure(let failure) = completion {
-                    XCTAssertEqual(failure, .loggedInWithDifferentUser)
-                    streamFailed.fulfill()
-                }
-            },
-            receiveValue: { _ in
-                XCTFail("There should be no new session")
-            }
-        )
-        .store(in: &subscriptions)
-
-        mockLoginAgainViewModel.mockResultPublisher.send(differentUserSession)
-
-        wait(for: [streamFailed], timeout: 1)
-    }
-
-    func test_reThrowsCancelError_whenUserCancelsLogin() throws {
-        let streamFailed = expectation(description: "Stream failed")
-
-        try testee.loginAgainOnExpiredRefreshToken(
-            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-            api: api
-        )
-        .sink(
-            receiveCompletion: { completion in
-                if case .failure(let failure) = completion {
-                    XCTAssertEqual(failure, .canceledByUser)
-                    streamFailed.fulfill()
-                }
-            },
-            receiveValue: { _ in
-                XCTFail("There should be no new session")
-            }
-        )
-        .store(in: &subscriptions)
-
-        mockLoginAgainViewModel.mockResultPublisher.send(completion: .failure(.canceledByUser))
-
-        wait(for: [streamFailed], timeout: 1)
-    }
+//    var mockLoginAgainViewModel: LoginAgainViewModelMock!
+//    var testee: LoginAgainInteractor!
+//    var subscriptions = Set<AnyCancellable>()
+//
+//    override func setUp() {
+//        super.setUp()
+//
+//        mockLoginAgainViewModel = LoginAgainViewModelMock()
+//        testee = LoginAgainInteractor(loginAgainViewModel: mockLoginAgainViewModel)
+//        XCTAssertNotNil(AppEnvironment.shared.window?.rootViewController)
+//        XCTAssertNotNil(api.loginSession?.baseURL.host(percentEncoded: false))
+//    }
+//
+//    // MARK: - Success Scenario
+//
+//    func test_publishedNewSession_afterUserLoggedIn() throws {
+//        let newSession = api.loginSession!.refresh(accessToken: UUID.string, expiresAt: .distantFuture)
+//        let streamFinished = expectation(description: "Stream finished")
+//
+//        try testee.loginAgainOnExpiredRefreshToken(
+//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+//            api: api
+//        )
+//        .sink(
+//            receiveCompletion: { completion in
+//                if case .finished = completion {
+//                    streamFinished.fulfill()
+//                }
+//            },
+//            receiveValue: { session in
+//                XCTAssertEqual(session.userID, newSession.userID)
+//                XCTAssertEqual(session.accessToken, newSession.accessToken)
+//            }
+//        )
+//        .store(in: &subscriptions)
+//
+//        mockLoginAgainViewModel.mockResultPublisher.send(newSession)
+//
+//        wait(for: [streamFinished], timeout: 1)
+//    }
+//
+//    func test_discoversTopViewController_toPresentLoginAgainViewController() throws {
+//        let rootViewController = try XCTUnwrap(AppEnvironment.shared.window?.rootViewController)
+//        let presentedViewController = UIViewController()
+//        rootViewController.present(presentedViewController, animated: false)
+//
+//        try testee.loginAgainOnExpiredRefreshToken(
+//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+//            api: api
+//        )
+//        .ignoreOutput()
+//        .ignoreFailure()
+//        .sink()
+//        .store(in: &subscriptions)
+//
+//        XCTAssertEqual(mockLoginAgainViewModel.receivedRootViewController, presentedViewController)
+//    }
+//
+//    // MARK: - Failure Scenarios
+//
+//    func test_reThrowsError_onInvalidHost() {
+//        api.loginSession = .mock(baseURL: .make())
+//
+//        XCTAssertThrowsError(
+//            try testee.loginAgainOnExpiredRefreshToken(
+//                tokenRefreshError: NSError.internalError(),
+//                api: api
+//            )
+//        ) { error in
+//            XCTAssertEqual(error as NSError, NSError.internalError())
+//        }
+//    }
+//
+//    func test_reThrowsError_onNoRootViewController() {
+//        AppEnvironment.shared.window?.rootViewController = nil
+//
+//        XCTAssertThrowsError(
+//            try testee.loginAgainOnExpiredRefreshToken(
+//                tokenRefreshError: NSError.internalError(),
+//                api: api
+//            )
+//        ) { error in
+//            XCTAssertEqual(error as NSError, NSError.internalError())
+//        }
+//    }
+//
+//    func test_reThrowsError_onUnknownError() {
+//        XCTAssertThrowsError(
+//            try testee.loginAgainOnExpiredRefreshToken(
+//                tokenRefreshError: NSError.internalError(),
+//                api: api
+//            )
+//        ) { error in
+//            XCTAssertEqual(error as NSError, NSError.internalError())
+//        }
+//    }
+//
+//    func test_throwsError_whenLoggedInWithDifferentUser() throws {
+//        // baseURL, userID and masquerader are compared if the session belongs to the same user
+//        let differentUserSession = LoginSession.mock(
+//            baseURL: AppEnvironment.shared.currentSession!.baseURL,
+//            masquerader: AppEnvironment.shared.currentSession!.masquerader,
+//            userID: UUID.string
+//        )
+//        let streamFailed = expectation(description: "Stream failed")
+//
+//        try testee.loginAgainOnExpiredRefreshToken(
+//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+//            api: api
+//        )
+//        .sink(
+//            receiveCompletion: { completion in
+//                if case .failure(let failure) = completion {
+//                    XCTAssertEqual(failure, .loggedInWithDifferentUser)
+//                    streamFailed.fulfill()
+//                }
+//            },
+//            receiveValue: { _ in
+//                XCTFail("There should be no new session")
+//            }
+//        )
+//        .store(in: &subscriptions)
+//
+//        mockLoginAgainViewModel.mockResultPublisher.send(differentUserSession)
+//
+//        wait(for: [streamFailed], timeout: 1)
+//    }
+//
+//    func test_reThrowsCancelError_whenUserCancelsLogin() throws {
+//        let streamFailed = expectation(description: "Stream failed")
+//
+//        try testee.loginAgainOnExpiredRefreshToken(
+//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+//            api: api
+//        )
+//        .sink(
+//            receiveCompletion: { completion in
+//                if case .failure(let failure) = completion {
+//                    XCTAssertEqual(failure, .canceledByUser)
+//                    streamFailed.fulfill()
+//                }
+//            },
+//            receiveValue: { _ in
+//                XCTFail("There should be no new session")
+//            }
+//        )
+//        .store(in: &subscriptions)
+//
+//        mockLoginAgainViewModel.mockResultPublisher.send(completion: .failure(.canceledByUser))
+//
+//        wait(for: [streamFailed], timeout: 1)
+//    }
 }
 
 class LoginAgainViewModelMock: LoginAgainViewModel {

--- a/Core/CoreTests/Features/TokenRefresh/Model/LoginAgainInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/LoginAgainInteractorTests.swift
@@ -16,164 +16,208 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-@testable import Core
 import Combine
+@testable import Core
 import UIKit
 import XCTest
 
 class LoginAgainInteractorTests: CoreTestCase {
-//    var mockLoginAgainViewModel: LoginAgainViewModelMock!
-//    var testee: LoginAgainInteractor!
-//    var subscriptions = Set<AnyCancellable>()
-//
-//    override func setUp() {
-//        super.setUp()
-//
-//        mockLoginAgainViewModel = LoginAgainViewModelMock()
-//        testee = LoginAgainInteractor(loginAgainViewModel: mockLoginAgainViewModel)
-//        XCTAssertNotNil(AppEnvironment.shared.window?.rootViewController)
-//        XCTAssertNotNil(api.loginSession?.baseURL.host(percentEncoded: false))
-//    }
-//
-//    // MARK: - Success Scenario
-//
-//    func test_publishedNewSession_afterUserLoggedIn() throws {
-//        let newSession = api.loginSession!.refresh(accessToken: UUID.string, expiresAt: .distantFuture)
-//        let streamFinished = expectation(description: "Stream finished")
-//
-//        try testee.loginAgainOnExpiredRefreshToken(
-//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-//            api: api
-//        )
-//        .sink(
-//            receiveCompletion: { completion in
-//                if case .finished = completion {
-//                    streamFinished.fulfill()
-//                }
-//            },
-//            receiveValue: { session in
-//                XCTAssertEqual(session.userID, newSession.userID)
-//                XCTAssertEqual(session.accessToken, newSession.accessToken)
-//            }
-//        )
-//        .store(in: &subscriptions)
-//
-//        mockLoginAgainViewModel.mockResultPublisher.send(newSession)
-//
-//        wait(for: [streamFinished], timeout: 1)
-//    }
-//
-//    func test_discoversTopViewController_toPresentLoginAgainViewController() throws {
-//        let rootViewController = try XCTUnwrap(AppEnvironment.shared.window?.rootViewController)
-//        let presentedViewController = UIViewController()
-//        rootViewController.present(presentedViewController, animated: false)
-//
-//        try testee.loginAgainOnExpiredRefreshToken(
-//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-//            api: api
-//        )
-//        .ignoreOutput()
-//        .ignoreFailure()
-//        .sink()
-//        .store(in: &subscriptions)
-//
-//        XCTAssertEqual(mockLoginAgainViewModel.receivedRootViewController, presentedViewController)
-//    }
-//
-//    // MARK: - Failure Scenarios
-//
-//    func test_reThrowsError_onInvalidHost() {
-//        api.loginSession = .mock(baseURL: .make())
-//
-//        XCTAssertThrowsError(
-//            try testee.loginAgainOnExpiredRefreshToken(
-//                tokenRefreshError: NSError.internalError(),
-//                api: api
-//            )
-//        ) { error in
-//            XCTAssertEqual(error as NSError, NSError.internalError())
-//        }
-//    }
-//
-//    func test_reThrowsError_onNoRootViewController() {
-//        AppEnvironment.shared.window?.rootViewController = nil
-//
-//        XCTAssertThrowsError(
-//            try testee.loginAgainOnExpiredRefreshToken(
-//                tokenRefreshError: NSError.internalError(),
-//                api: api
-//            )
-//        ) { error in
-//            XCTAssertEqual(error as NSError, NSError.internalError())
-//        }
-//    }
-//
-//    func test_reThrowsError_onUnknownError() {
-//        XCTAssertThrowsError(
-//            try testee.loginAgainOnExpiredRefreshToken(
-//                tokenRefreshError: NSError.internalError(),
-//                api: api
-//            )
-//        ) { error in
-//            XCTAssertEqual(error as NSError, NSError.internalError())
-//        }
-//    }
-//
-//    func test_throwsError_whenLoggedInWithDifferentUser() throws {
-//        // baseURL, userID and masquerader are compared if the session belongs to the same user
-//        let differentUserSession = LoginSession.mock(
-//            baseURL: AppEnvironment.shared.currentSession!.baseURL,
-//            masquerader: AppEnvironment.shared.currentSession!.masquerader,
-//            userID: UUID.string
-//        )
-//        let streamFailed = expectation(description: "Stream failed")
-//
-//        try testee.loginAgainOnExpiredRefreshToken(
-//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-//            api: api
-//        )
-//        .sink(
-//            receiveCompletion: { completion in
-//                if case .failure(let failure) = completion {
-//                    XCTAssertEqual(failure, .loggedInWithDifferentUser)
-//                    streamFailed.fulfill()
-//                }
-//            },
-//            receiveValue: { _ in
-//                XCTFail("There should be no new session")
-//            }
-//        )
-//        .store(in: &subscriptions)
-//
-//        mockLoginAgainViewModel.mockResultPublisher.send(differentUserSession)
-//
-//        wait(for: [streamFailed], timeout: 1)
-//    }
-//
-//    func test_reThrowsCancelError_whenUserCancelsLogin() throws {
-//        let streamFailed = expectation(description: "Stream failed")
-//
-//        try testee.loginAgainOnExpiredRefreshToken(
-//            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
-//            api: api
-//        )
-//        .sink(
-//            receiveCompletion: { completion in
-//                if case .failure(let failure) = completion {
-//                    XCTAssertEqual(failure, .canceledByUser)
-//                    streamFailed.fulfill()
-//                }
-//            },
-//            receiveValue: { _ in
-//                XCTFail("There should be no new session")
-//            }
-//        )
-//        .store(in: &subscriptions)
-//
-//        mockLoginAgainViewModel.mockResultPublisher.send(completion: .failure(.canceledByUser))
-//
-//        wait(for: [streamFailed], timeout: 1)
-//    }
+    var mockLoginAgainViewModel: LoginAgainViewModelMock!
+    var testee: LoginAgainInteractor!
+    var subscriptions = Set<AnyCancellable>()
+
+    override func setUp() {
+        super.setUp()
+
+        mockLoginAgainViewModel = LoginAgainViewModelMock()
+        testee = LoginAgainInteractor(loginAgainViewModel: mockLoginAgainViewModel)
+        XCTAssertNotNil(AppEnvironment.shared.window?.rootViewController)
+        XCTAssertNotNil(api.loginSession?.baseURL.host(percentEncoded: false))
+    }
+
+    // MARK: - Success Scenario
+
+    func test_publishedNewSession_afterUserLoggedIn() throws {
+        let newSession = api.loginSession!.refresh(accessToken: UUID.string, expiresAt: .distantFuture)
+        let streamFinished = expectation(description: "Stream finished")
+
+        try testee.loginAgainOnExpiredRefreshToken(
+            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+            api: api
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case .finished = completion {
+                    streamFinished.fulfill()
+                }
+            },
+            receiveValue: { session in
+                XCTAssertEqual(session.userID, newSession.userID)
+                XCTAssertEqual(session.accessToken, newSession.accessToken)
+            }
+        )
+        .store(in: &subscriptions)
+
+        mockLoginAgainViewModel.mockResultPublisher.send(newSession)
+
+        wait(for: [streamFinished], timeout: 1)
+    }
+
+    func test_discoversTopViewController_toPresentLoginAgainViewController() throws {
+        let rootViewController = try XCTUnwrap(AppEnvironment.shared.window?.rootViewController)
+        let presentedViewController = UIViewController()
+        rootViewController.present(presentedViewController, animated: false)
+
+        try testee.loginAgainOnExpiredRefreshToken(
+            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+            api: api
+        )
+        .ignoreOutput()
+        .ignoreFailure()
+        .sink()
+        .store(in: &subscriptions)
+
+        XCTAssertEqual(mockLoginAgainViewModel.receivedRootViewController, presentedViewController)
+    }
+
+    // MARK: - Failure Scenarios
+
+    func test_manualOAuth_reThrowsError_onInvalidHost() {
+        api.loginSession = .mockManualOAuth(baseURL: .make())
+
+        XCTAssertThrowsError(
+            try testee.loginAgainOnExpiredRefreshToken(
+                tokenRefreshError: NSError.internalError(),
+                api: api
+            )
+        ) { error in
+            XCTAssertEqual(error as NSError, NSError.internalError())
+        }
+    }
+
+    func test_pkceOAuth_reThrowsError_onInvalidHost() {
+        api.loginSession = .mockPKCEOAuth(baseURL: .make())
+
+        XCTAssertThrowsError(
+            try testee.loginAgainOnExpiredRefreshToken(
+                tokenRefreshError: NSError.internalError(),
+                api: api
+            )
+        ) { error in
+            XCTAssertEqual(error as NSError, NSError.internalError())
+        }
+    }
+
+    func test_reThrowsError_onNoRootViewController() {
+        AppEnvironment.shared.window?.rootViewController = nil
+
+        XCTAssertThrowsError(
+            try testee.loginAgainOnExpiredRefreshToken(
+                tokenRefreshError: NSError.internalError(),
+                api: api
+            )
+        ) { error in
+            XCTAssertEqual(error as NSError, NSError.internalError())
+        }
+    }
+
+    func test_reThrowsError_onUnknownError() {
+        XCTAssertThrowsError(
+            try testee.loginAgainOnExpiredRefreshToken(
+                tokenRefreshError: NSError.internalError(),
+                api: api
+            )
+        ) { error in
+            XCTAssertEqual(error as NSError, NSError.internalError())
+        }
+    }
+
+    func test_pkceOAuth_throwsError_whenLoggedInWithDifferentUser() throws {
+        // baseURL, userID and masquerader are compared if the session belongs to the same user
+        let differentUserSession = LoginSession.mockPKCEOAuth(
+            baseURL: AppEnvironment.shared.currentSession!.baseURL,
+            masquerader: AppEnvironment.shared.currentSession!.masquerader,
+            userID: UUID.string
+        )
+        let streamFailed = expectation(description: "Stream failed")
+
+        try testee.loginAgainOnExpiredRefreshToken(
+            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+            api: api
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case let .failure(failure) = completion {
+                    XCTAssertEqual(failure, .loggedInWithDifferentUser)
+                    streamFailed.fulfill()
+                }
+            },
+            receiveValue: { _ in
+                XCTFail("There should be no new session")
+            }
+        )
+        .store(in: &subscriptions)
+
+        mockLoginAgainViewModel.mockResultPublisher.send(differentUserSession)
+
+        wait(for: [streamFailed], timeout: 1)
+    }
+
+    func test_manualOAuth_throwsError_whenLoggedInWithDifferentUser() throws {
+        // baseURL, userID and masquerader are compared if the session belongs to the same user
+        let differentUserSession = LoginSession.mockManualOAuth(
+            baseURL: AppEnvironment.shared.currentSession!.baseURL,
+            masquerader: AppEnvironment.shared.currentSession!.masquerader,
+            userID: UUID.string
+        )
+        let streamFailed = expectation(description: "Stream failed")
+
+        try testee.loginAgainOnExpiredRefreshToken(
+            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+            api: api
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case let .failure(failure) = completion {
+                    XCTAssertEqual(failure, .loggedInWithDifferentUser)
+                    streamFailed.fulfill()
+                }
+            },
+            receiveValue: { _ in
+                XCTFail("There should be no new session")
+            }
+        )
+        .store(in: &subscriptions)
+
+        mockLoginAgainViewModel.mockResultPublisher.send(differentUserSession)
+
+        wait(for: [streamFailed], timeout: 1)
+    }
+
+    func test_reThrowsCancelError_whenUserCancelsLogin() throws {
+        let streamFailed = expectation(description: "Stream failed")
+
+        try testee.loginAgainOnExpiredRefreshToken(
+            tokenRefreshError: AccessTokenRefreshInteractor.TokenError.expiredRefreshToken,
+            api: api
+        )
+        .sink(
+            receiveCompletion: { completion in
+                if case let .failure(failure) = completion {
+                    XCTAssertEqual(failure, .canceledByUser)
+                    streamFailed.fulfill()
+                }
+            },
+            receiveValue: { _ in
+                XCTFail("There should be no new session")
+            }
+        )
+        .store(in: &subscriptions)
+
+        mockLoginAgainViewModel.mockResultPublisher.send(completion: .failure(.canceledByUser))
+
+        wait(for: [streamFailed], timeout: 1)
+    }
 }
 
 class LoginAgainViewModelMock: LoginAgainViewModel {
@@ -181,9 +225,9 @@ class LoginAgainViewModelMock: LoginAgainViewModel {
     var receivedRootViewController: UIViewController?
 
     override func askUserToLogin(
-        host: String,
+        host _: String,
         rootViewController: UIViewController,
-        router: Router
+        router _: Router
     ) -> AnyPublisher<LoginSession, LoginAgainInteractor.LoginError> {
         receivedRootViewController = rootViewController
         return mockResultPublisher.first().eraseToAnyPublisher()

--- a/Core/CoreTests/Features/TokenRefresh/Model/TokenRefreshInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/TokenRefreshInteractorTests.swift
@@ -18,145 +18,301 @@
 
 import Combine
 @testable import Core
-import XCTest
 import TestsFoundation
+import XCTest
 
 class TokenRefreshInteractorTests: CoreTestCase {
-//    var mockAccessTokenRefreshInteractor: MockAccessTokenRefreshInteractor!
-//    var mockLoginAgainInteractor: MockLoginAgainInteractor!
-//    var testee: TokenRefreshInteractor!
-//
-//    let refreshedSession = LoginSession.mock(accessToken: "newAccessToken", refreshToken: "newRefreshToken")
-//    let expiredSession = LoginSession.mock(accessToken: "oldAccessToken", refreshToken: "oldRefreshToken")
-//
-//    override func setUp() {
-//        super.setUp()
-//        mockAccessTokenRefreshInteractor = MockAccessTokenRefreshInteractor()
-//        mockLoginAgainInteractor = MockLoginAgainInteractor()
-//        testee = TokenRefreshInteractor(
-//            api: api,
-//            accessTokenRefreshInteractor: mockAccessTokenRefreshInteractor,
-//            loginAgainInteractor: mockLoginAgainInteractor,
-//            mainThread: DispatchQueue.immediate.eraseToAnyScheduler()
-//        )
-//        api.loginSession = expiredSession
-//        AppEnvironment.shared.currentSession = expiredSession
-//    }
-//
-//    // MARK: - Success Scenarios
-//
-//    func test_accessTokenRenewalSucceeds() {
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
-//
-//        // THEN
-//        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
-//        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
-//        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
-//    }
-//
-//    func test_refreshesRefreshToken_whenItExpired() {
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-//        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
-//
-//        // THEN
-//        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
-//        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
-//        XCTAssertEqual(api.loginSession?.refreshToken, refreshedSession.refreshToken)
-//        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
-//        XCTAssertEqual(AppEnvironment.shared.currentSession?.refreshToken, refreshedSession.refreshToken)
-//    }
-//
-//    func test_executesQueuedRequests_whenAccessTokenRefreshSucceeds() {
-//        let queuedRequest = expectation(description: "Request should be canceled")
-//        testee.addRequestWaitingForToken {
-//            queuedRequest.fulfill()
-//        }
-//
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
-//
-//        // THEN
-//        waitForExpectations(timeout: 1)
-//    }
-//
-//    func test_executesQueuedRequests_whenRefreshTokenRefreshSucceeds() {
-//        let queuedRequest = expectation(description: "Request should be canceled")
-//        testee.addRequestWaitingForToken {
-//            queuedRequest.fulfill()
-//        }
-//
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-//        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
-//
-//        // THEN
-//        waitForExpectations(timeout: 1)
-//    }
-//
-//    // MARK: - Failure Scenarios
-//
-//    func test_logout_whenUserCancelsReLogin() {
-//        let queuedRequest = expectation(description: "Request should be canceled")
-//        queuedRequest.isInverted = true
-//        testee.addRequestWaitingForToken {
-//            queuedRequest.fulfill()
-//        }
-//        login.session = expiredSession
-//
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-//        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.canceledByUser))
-//
-//        // THEN
-//        waitForExpectations(timeout: 1)
-//        XCTAssertNil(login.session)
-//    }
-//
-//    func test_logout_whenUserLogsInWithDifferentUser() {
-//        let queuedRequest = expectation(description: "Request should be canceled")
-//        queuedRequest.isInverted = true
-//        testee.addRequestWaitingForToken {
-//            queuedRequest.fulfill()
-//        }
-//        login.session = expiredSession
-//
-//        // WHEN
-//        testee.refreshToken()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-//        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.loggedInWithDifferentUser))
-//
-//        // THEN
-//        waitForExpectations(timeout: 1)
-//        XCTAssertNil(login.session)
-//    }
-//
-//    func test_releasesQueuedRequests_onNetworkFailure() {
-//        let queuedRequest = expectation(description: "Request should be canceled")
-//        testee.addRequestWaitingForToken {
-//            queuedRequest.fulfill()
-//        }
-//
-//        // WHEN
-//        testee.refreshToken()
-//        mockLoginAgainInteractor.mockedThrownError = NSError.internalError()
-//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.unknownError))
-//
-//        // THEN
-//        waitForExpectations(timeout: 1)
-//    }
+    var mockAccessTokenRefreshInteractor: MockAccessTokenRefreshInteractor!
+    var mockLoginAgainInteractor: MockLoginAgainInteractor!
+    var testee: TokenRefreshInteractor!
+
+    let refreshedManualOAuthSession = LoginSession.mockManualOAuth(accessToken: "newAccessToken", refreshToken: "newRefreshToken")
+    let expiredManualOAuthSession = LoginSession.mockManualOAuth(accessToken: "oldAccessToken", refreshToken: "oldRefreshToken")
+
+    let refreshedPKCEOAuthSession = LoginSession.mockPKCEOAuth(accessToken: "newAccessToken", refreshToken: "newRefreshToken")
+    let expiredPKCEOAuthSession = LoginSession.mockPKCEOAuth(accessToken: "oldAccessToken", refreshToken: "oldRefreshToken")
+
+    override func setUp() {
+        super.setUp()
+        mockAccessTokenRefreshInteractor = MockAccessTokenRefreshInteractor()
+        mockLoginAgainInteractor = MockLoginAgainInteractor()
+        testee = TokenRefreshInteractor(
+            api: api,
+            accessTokenRefreshInteractor: mockAccessTokenRefreshInteractor,
+            loginAgainInteractor: mockLoginAgainInteractor,
+            mainThread: DispatchQueue.immediate.eraseToAnyScheduler()
+        )
+    }
+
+    private func setManualOAuthSessions() {
+        api.loginSession = expiredManualOAuthSession
+        AppEnvironment.shared.currentSession = refreshedManualOAuthSession
+    }
+
+    private func setPKCEOAuthSessions() {
+        api.loginSession = expiredPKCEOAuthSession
+        AppEnvironment.shared.currentSession = refreshedPKCEOAuthSession
+    }
+
+    // MARK: - Success Scenarios
+
+    func test_pkceOAuth_accessTokenRenewalSucceeds() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedPKCEOAuthSession)
+
+        // THEN
+        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+        XCTAssertEqual(api.loginSession?.accessToken, refreshedPKCEOAuthSession.accessToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedPKCEOAuthSession.accessToken)
+    }
+
+    func test_manualOAuth_accessTokenRenewalSucceeds() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedManualOAuthSession)
+
+        // THEN
+        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+        XCTAssertEqual(api.loginSession?.accessToken, refreshedManualOAuthSession.accessToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedManualOAuthSession.accessToken)
+    }
+
+    func test_pkceOAuth_refreshesRefreshToken_whenItExpired() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(refreshedPKCEOAuthSession)
+
+        // THEN
+        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+        XCTAssertEqual(api.loginSession?.accessToken, refreshedPKCEOAuthSession.accessToken)
+        XCTAssertEqual(api.loginSession?.refreshToken, refreshedPKCEOAuthSession.refreshToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedPKCEOAuthSession.accessToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.refreshToken, refreshedPKCEOAuthSession.refreshToken)
+    }
+
+    func test_manualOAuth_refreshesRefreshToken_whenItExpired() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(refreshedManualOAuthSession)
+
+        // THEN
+        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+        XCTAssertEqual(api.loginSession?.accessToken, refreshedManualOAuthSession.accessToken)
+        XCTAssertEqual(api.loginSession?.refreshToken, refreshedManualOAuthSession.refreshToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedManualOAuthSession.accessToken)
+        XCTAssertEqual(AppEnvironment.shared.currentSession?.refreshToken, refreshedManualOAuthSession.refreshToken)
+    }
+
+    func test_pkceOAuth_executesQueuedRequests_whenAccessTokenRefreshSucceeds() {
+        setPKCEOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedPKCEOAuthSession)
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_manualOAuth_executesQueuedRequests_whenAccessTokenRefreshSucceeds() {
+        setManualOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedManualOAuthSession)
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_pkceOAuth_executesQueuedRequests_whenRefreshTokenRefreshSucceeds() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(refreshedPKCEOAuthSession)
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_manualOAuth_executesQueuedRequests_whenRefreshTokenRefreshSucceeds() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(refreshedManualOAuthSession)
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    // MARK: - Failure Scenarios
+
+    func test_pkceOAuth_logout_whenUserCancelsReLogin() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        queuedRequest.isInverted = true
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+        login.session = expiredPKCEOAuthSession
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.canceledByUser))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+        XCTAssertNil(login.session)
+    }
+
+    func test_manualOAuth_logout_whenUserCancelsReLogin() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        queuedRequest.isInverted = true
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+        login.session = expiredManualOAuthSession
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.canceledByUser))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+        XCTAssertNil(login.session)
+    }
+
+    func test_pkceOAuth_logout_whenUserLogsInWithDifferentUser() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        queuedRequest.isInverted = true
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+        login.session = expiredPKCEOAuthSession
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.loggedInWithDifferentUser))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+        XCTAssertNil(login.session)
+    }
+
+    func test_manualOAuth_logout_whenUserLogsInWithDifferentUser() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        queuedRequest.isInverted = true
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+        login.session = expiredManualOAuthSession
+
+        // WHEN
+        testee.refreshToken()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.loggedInWithDifferentUser))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+        XCTAssertNil(login.session)
+    }
+
+    func test_pkceOAuth_releasesQueuedRequests_onNetworkFailure() {
+        // GIVEN
+        setPKCEOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockLoginAgainInteractor.mockedThrownError = NSError.internalError()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.unknownError))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
+
+    func test_manualOAuth_releasesQueuedRequests_onNetworkFailure() {
+        // GIVEN
+        setManualOAuthSessions()
+
+        let queuedRequest = expectation(description: "Request should be canceled")
+        testee.addRequestWaitingForToken {
+            queuedRequest.fulfill()
+        }
+
+        // WHEN
+        testee.refreshToken()
+        mockLoginAgainInteractor.mockedThrownError = NSError.internalError()
+        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.unknownError))
+
+        // THEN
+        waitForExpectations(timeout: 1)
+    }
 }
 
 class MockAccessTokenRefreshInteractor: AccessTokenRefreshInteractor {
     var mockResultPublisher = PassthroughSubject<LoginSession, TokenError>()
 
-    override func refreshAccessToken(api: API) -> AnyPublisher<LoginSession, TokenError> {
+    override func refreshAccessToken(api _: API) -> AnyPublisher<LoginSession, TokenError> {
         mockResultPublisher
             .first()
             .eraseToAnyPublisher()
@@ -168,8 +324,8 @@ class MockLoginAgainInteractor: LoginAgainInteractor {
     var mockedThrownError: Error?
 
     override func loginAgainOnExpiredRefreshToken(
-        tokenRefreshError: Error,
-        api: API
+        tokenRefreshError _: Error,
+        api _: API
     ) throws -> AnyPublisher<LoginSession, LoginAgainInteractor.LoginError> {
         if let mockedThrownError {
             throw mockedThrownError

--- a/Core/CoreTests/Features/TokenRefresh/Model/TokenRefreshInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/TokenRefreshInteractorTests.swift
@@ -22,135 +22,135 @@ import XCTest
 import TestsFoundation
 
 class TokenRefreshInteractorTests: CoreTestCase {
-    var mockAccessTokenRefreshInteractor: MockAccessTokenRefreshInteractor!
-    var mockLoginAgainInteractor: MockLoginAgainInteractor!
-    var testee: TokenRefreshInteractor!
-
-    let refreshedSession = LoginSession.mock(accessToken: "newAccessToken", refreshToken: "newRefreshToken")
-    let expiredSession = LoginSession.mock(accessToken: "oldAccessToken", refreshToken: "oldRefreshToken")
-
-    override func setUp() {
-        super.setUp()
-        mockAccessTokenRefreshInteractor = MockAccessTokenRefreshInteractor()
-        mockLoginAgainInteractor = MockLoginAgainInteractor()
-        testee = TokenRefreshInteractor(
-            api: api,
-            accessTokenRefreshInteractor: mockAccessTokenRefreshInteractor,
-            loginAgainInteractor: mockLoginAgainInteractor,
-            mainThread: DispatchQueue.immediate.eraseToAnyScheduler()
-        )
-        api.loginSession = expiredSession
-        AppEnvironment.shared.currentSession = expiredSession
-    }
-
-    // MARK: - Success Scenarios
-
-    func test_accessTokenRenewalSucceeds() {
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
-
-        // THEN
-        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
-        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
-        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
-    }
-
-    func test_refreshesRefreshToken_whenItExpired() {
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
-
-        // THEN
-        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
-        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
-        XCTAssertEqual(api.loginSession?.refreshToken, refreshedSession.refreshToken)
-        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
-        XCTAssertEqual(AppEnvironment.shared.currentSession?.refreshToken, refreshedSession.refreshToken)
-    }
-
-    func test_executesQueuedRequests_whenAccessTokenRefreshSucceeds() {
-        let queuedRequest = expectation(description: "Request should be canceled")
-        testee.addRequestWaitingForToken {
-            queuedRequest.fulfill()
-        }
-
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
-
-        // THEN
-        waitForExpectations(timeout: 1)
-    }
-
-    func test_executesQueuedRequests_whenRefreshTokenRefreshSucceeds() {
-        let queuedRequest = expectation(description: "Request should be canceled")
-        testee.addRequestWaitingForToken {
-            queuedRequest.fulfill()
-        }
-
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
-
-        // THEN
-        waitForExpectations(timeout: 1)
-    }
-
-    // MARK: - Failure Scenarios
-
-    func test_logout_whenUserCancelsReLogin() {
-        let queuedRequest = expectation(description: "Request should be canceled")
-        queuedRequest.isInverted = true
-        testee.addRequestWaitingForToken {
-            queuedRequest.fulfill()
-        }
-        login.session = expiredSession
-
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.canceledByUser))
-
-        // THEN
-        waitForExpectations(timeout: 1)
-        XCTAssertNil(login.session)
-    }
-
-    func test_logout_whenUserLogsInWithDifferentUser() {
-        let queuedRequest = expectation(description: "Request should be canceled")
-        queuedRequest.isInverted = true
-        testee.addRequestWaitingForToken {
-            queuedRequest.fulfill()
-        }
-        login.session = expiredSession
-
-        // WHEN
-        testee.refreshToken()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
-        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.loggedInWithDifferentUser))
-
-        // THEN
-        waitForExpectations(timeout: 1)
-        XCTAssertNil(login.session)
-    }
-
-    func test_releasesQueuedRequests_onNetworkFailure() {
-        let queuedRequest = expectation(description: "Request should be canceled")
-        testee.addRequestWaitingForToken {
-            queuedRequest.fulfill()
-        }
-
-        // WHEN
-        testee.refreshToken()
-        mockLoginAgainInteractor.mockedThrownError = NSError.internalError()
-        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.unknownError))
-
-        // THEN
-        waitForExpectations(timeout: 1)
-    }
+//    var mockAccessTokenRefreshInteractor: MockAccessTokenRefreshInteractor!
+//    var mockLoginAgainInteractor: MockLoginAgainInteractor!
+//    var testee: TokenRefreshInteractor!
+//
+//    let refreshedSession = LoginSession.mock(accessToken: "newAccessToken", refreshToken: "newRefreshToken")
+//    let expiredSession = LoginSession.mock(accessToken: "oldAccessToken", refreshToken: "oldRefreshToken")
+//
+//    override func setUp() {
+//        super.setUp()
+//        mockAccessTokenRefreshInteractor = MockAccessTokenRefreshInteractor()
+//        mockLoginAgainInteractor = MockLoginAgainInteractor()
+//        testee = TokenRefreshInteractor(
+//            api: api,
+//            accessTokenRefreshInteractor: mockAccessTokenRefreshInteractor,
+//            loginAgainInteractor: mockLoginAgainInteractor,
+//            mainThread: DispatchQueue.immediate.eraseToAnyScheduler()
+//        )
+//        api.loginSession = expiredSession
+//        AppEnvironment.shared.currentSession = expiredSession
+//    }
+//
+//    // MARK: - Success Scenarios
+//
+//    func test_accessTokenRenewalSucceeds() {
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
+//
+//        // THEN
+//        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+//        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
+//        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
+//    }
+//
+//    func test_refreshesRefreshToken_whenItExpired() {
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+//        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
+//
+//        // THEN
+//        waitUntil(1, shouldFail: true) { !testee.isTokenRefreshInProgress() }
+//        XCTAssertEqual(api.loginSession?.accessToken, refreshedSession.accessToken)
+//        XCTAssertEqual(api.loginSession?.refreshToken, refreshedSession.refreshToken)
+//        XCTAssertEqual(AppEnvironment.shared.currentSession?.accessToken, refreshedSession.accessToken)
+//        XCTAssertEqual(AppEnvironment.shared.currentSession?.refreshToken, refreshedSession.refreshToken)
+//    }
+//
+//    func test_executesQueuedRequests_whenAccessTokenRefreshSucceeds() {
+//        let queuedRequest = expectation(description: "Request should be canceled")
+//        testee.addRequestWaitingForToken {
+//            queuedRequest.fulfill()
+//        }
+//
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(refreshedSession)
+//
+//        // THEN
+//        waitForExpectations(timeout: 1)
+//    }
+//
+//    func test_executesQueuedRequests_whenRefreshTokenRefreshSucceeds() {
+//        let queuedRequest = expectation(description: "Request should be canceled")
+//        testee.addRequestWaitingForToken {
+//            queuedRequest.fulfill()
+//        }
+//
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+//        mockLoginAgainInteractor.mockResultPublisher.send(refreshedSession)
+//
+//        // THEN
+//        waitForExpectations(timeout: 1)
+//    }
+//
+//    // MARK: - Failure Scenarios
+//
+//    func test_logout_whenUserCancelsReLogin() {
+//        let queuedRequest = expectation(description: "Request should be canceled")
+//        queuedRequest.isInverted = true
+//        testee.addRequestWaitingForToken {
+//            queuedRequest.fulfill()
+//        }
+//        login.session = expiredSession
+//
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+//        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.canceledByUser))
+//
+//        // THEN
+//        waitForExpectations(timeout: 1)
+//        XCTAssertNil(login.session)
+//    }
+//
+//    func test_logout_whenUserLogsInWithDifferentUser() {
+//        let queuedRequest = expectation(description: "Request should be canceled")
+//        queuedRequest.isInverted = true
+//        testee.addRequestWaitingForToken {
+//            queuedRequest.fulfill()
+//        }
+//        login.session = expiredSession
+//
+//        // WHEN
+//        testee.refreshToken()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.expiredRefreshToken))
+//        mockLoginAgainInteractor.mockResultPublisher.send(completion: .failure(.loggedInWithDifferentUser))
+//
+//        // THEN
+//        waitForExpectations(timeout: 1)
+//        XCTAssertNil(login.session)
+//    }
+//
+//    func test_releasesQueuedRequests_onNetworkFailure() {
+//        let queuedRequest = expectation(description: "Request should be canceled")
+//        testee.addRequestWaitingForToken {
+//            queuedRequest.fulfill()
+//        }
+//
+//        // WHEN
+//        testee.refreshToken()
+//        mockLoginAgainInteractor.mockedThrownError = NSError.internalError()
+//        mockAccessTokenRefreshInteractor.mockResultPublisher.send(completion: .failure(.unknownError))
+//
+//        // THEN
+//        waitForExpectations(timeout: 1)
+//    }
 }
 
 class MockAccessTokenRefreshInteractor: AccessTokenRefreshInteractor {

--- a/Core/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
+++ b/Core/TestsFoundation/Fixtures/Keychain/KeychainEntryFixture.swift
@@ -32,8 +32,7 @@ extension LoginSession {
         userID: String = "1",
         userName: String = "Eve",
         userEmail: String? = nil,
-        clientID: String? = nil,
-        clientSecret: String? = nil
+        oauthType: OAuthType? = nil
     ) -> LoginSession {
         return LoginSession(
             accessToken: accessToken,
@@ -47,8 +46,7 @@ extension LoginSession {
             userID: userID,
             userName: userName,
             userEmail: userEmail,
-            clientID: clientID,
-            clientSecret: clientSecret
+            oauthType: oauthType
         )
     }
 }

--- a/Core/TestsFoundation/MiniCanvas/MiniCanvasEndpoints.swift
+++ b/Core/TestsFoundation/MiniCanvas/MiniCanvasEndpoints.swift
@@ -419,7 +419,7 @@ enum MiniCanvasEndpoints {
             // login always works
             return .movedTemporarily("\(redirectUri)?code=t")
         },
-        .apiRequest(PostLoginOAuthRequest(client: .make(), code: "")) { request in
+        .apiRequest(PostLoginOAuthRequest(oauthType: .manual(.init(client: .make())), code: "")) { request in
             APIOAuthToken.make(user: .from(user: request.state.selfUser))
         },
         .apiRequest(DeleteLoginOAuthRequest()) { _ in .init() },

--- a/Teacher/Teacher/TeacherAppDelegate.swift
+++ b/Teacher/Teacher/TeacherAppDelegate.swift
@@ -366,8 +366,7 @@ extension TeacherAppDelegate: LoginDelegate {
             userID: fakeStudentID,
             userName: String(localized: "Test Student", bundle: .teacher),
             userEmail: session.userEmail,
-            clientID: session.clientID,
-            clientSecret: session.clientSecret
+            oauthType: session.oauthType
         )
         LoginSession.add(entry, to: .shared, forKey: .fakeStudents)
         var deepLink = "canvas-student:student_view"


### PR DESCRIPTION
## Why PKCE login is needed

Mobile apps are public clients, which means they cannot securely store a shared secret. [RFC 8252](https://datatracker.ietf.org/doc/html/rfc8252) recommends PKCE, which entirely eliminates the need for a client secret by using a dynamic code verifier and code challenge. This prevents authorization code interception attacks, ensuring only the original client can exchange the code for a token. A couple of relevant excerpts from RFC 8252:

[RFC8252  Section 6] Public native app clients MUST implement the Proof Key for Code Exchange (PKCE [RFC7636]) extension to OAuth, and authorization servers MUST support PKCE for such clients, for the reasons detailed in Section 8.1.

[RFC8252  Section 8.1] Authorization servers SHOULD reject authorization requests from native apps that don't use PKCE by returning an error message.

Canvas recently updated the OAuth provider to support the PKCE extension (for the CLX web SPA, which is also a public client). The use of PKCE significantly improves our security posture.

## How it works
- Instead of making a request to the mobile verify endpoint to obtain the `clientID` and `clientSecret` the apps now generate a PKCE Challenge pair that is, a code challenge and a code verifier. 
- App specific ClientID is stored in the secret repo.
- ManualOAuth is still available. 
- LoginSession stores the OAuth type that was used for login. 
- Requests to the OAuth endpoint now require a `clientID` and the `codeVerifier` that was generated from the PKCE Challenge. 

## What's not included
The secret repo only contains the Horizon iOS ClientID so Student, Teacher and Parent PKCE Login won't work unless clientIDs are added.  

Affects: Student, Teacher, Parent, Horizon

