### PR TITLE
[Horizon] Hide Submission Button for Submission Type None

### DIFF
--- a/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/View/AssignmentDetails.swift
+++ b/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/View/AssignmentDetails.swift
@@ -137,15 +137,18 @@ struct AssignmentDetails: View {
         }
     }
 
+    @ViewBuilder
     private var submitButton: some View {
-        HStack {
-            Spacer()
-            HorizonUI.PrimaryButton(viewModel.submitButtonTitle) {
-                dismissKeyboard.toggle()
-                viewModel.submit()
+        if !viewModel.isSubmitButtonHidden {
+            HStack {
+                Spacer()
+                HorizonUI.PrimaryButton(viewModel.submitButtonTitle) {
+                    dismissKeyboard.toggle()
+                    viewModel.submit()
+                }
+                .disableWithOpacity(!viewModel.shouldEnableSubmitButton, disabledOpacity: 0.7)
+                .hidden(!(viewModel.assignment?.showSubmitButton ?? false))
             }
-            .disableWithOpacity(!viewModel.shouldEnableSubmitButton, disabledOpacity: 0.7)
-            .hidden(!(viewModel.assignment?.showSubmitButton ?? false))
         }
     }
 

--- a/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/View/AssignmentDetailsViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/View/AssignmentDetailsViewModel.swift
@@ -52,6 +52,9 @@ final class AssignmentDetailsViewModel {
     private(set) var externalURL: URL?
     var isStartTyping = false
     var assignmentPreference: AssignmentPreferenceKeyType?
+    var isSubmitButtonHidden: Bool {
+        assignment?.submissionTypes.contains(.none) == true && assignment?.submissionTypes.count == 1
+    }
 
     // MARK: - Properties
 


### PR DESCRIPTION
When the submission type is none on an assignment and that's the only submission type, then hide the submit button. I'm guessing quite a bit here on the business rules, so let me know if that's not right.

`    var isSubmitButtonHidden: Bool {
        assignment?.submissionTypes.contains(.none) == true && assignment?.submissionTypes.count == 1
    }
`


https://github.com/user-attachments/assets/d8ae139f-f037-4607-bf50-a862c07de8a9


[ignore-commit-lint]