### PR TITLE
Student - NewQuizzes submission detail screen has balloon image messing up the layout

### DIFF
--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -79,6 +78,8 @@
                     <connections>
                         <outlet property="attemptPicker" destination="gAY-Hn-Rdg" id="Vce-Uf-bGQ"/>
                         <outlet property="contentView" destination="OAc-d9-7i7" id="xfM-xF-980"/>
+                        <outlet property="contentViewSafeAreaConstraint" destination="KYL-Ok-7ua" id="Hf5-hF-NCB"/>
+                        <outlet property="dividerView" destination="ZGl-0o-0RI" id="n3g-bP-TCa"/>
                         <outlet property="drawer" destination="ac8-45-rao" id="r8P-vQ-czH"/>
                         <outlet property="emptyView" destination="pNE-3D-zl2" id="WQS-H9-pBe"/>
                         <outlet property="lockedEmptyView" destination="EAM-Lb-Jft" id="wV7-dY-BB3"/>

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -46,6 +46,8 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
     @IBOutlet weak var emptyView: SubmissionDetailsEmptyView?
     @IBOutlet weak var lockedEmptyView: SubmissionDetailsLockedEmptyView?
     @IBOutlet weak var attemptPicker: SubmissionAttemptPickerView?
+    @IBOutlet weak var dividerView: DividerView?
+    @IBOutlet weak var contentViewSafeAreaConstraint: NSLayoutConstraint?
 
     static func create(env: AppEnvironment, context: Context, assignmentID: String, userID: String, selectedAttempt: Int? = nil) -> SubmissionDetailsViewController {
         let controller = loadFromStoryboard()
@@ -117,7 +119,13 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         guard let attemptPicker,
               let currentSubmission,
               let currentAttemptDate = currentSubmission.submittedAt
-        else { return }
+        else {
+
+            contentViewSafeAreaConstraint?.isActive = false
+            dividerView?.isHidden = true
+            contentView?.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0).isActive = true
+            return
+        }
 
         let isActive = submissions.count > 1 && !assignment.isExternalToolAssignment
 

--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -119,13 +119,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         guard let attemptPicker,
               let currentSubmission,
               let currentAttemptDate = currentSubmission.submittedAt
-        else {
-
-            contentViewSafeAreaConstraint?.isActive = false
-            dividerView?.isHidden = true
-            contentView?.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0).isActive = true
-            return
-        }
+        else { return setConstraintsForNoSubmission() }
 
         let isActive = submissions.count > 1 && !assignment.isExternalToolAssignment
 
@@ -150,6 +144,12 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         attemptPicker.updateLabel(text: currentAttemptNumber)
         attemptPicker.updatePickerButton(isActive: isActive, attemptDate: currentAttemptDate.dateTimeString, items: items)
 
+    }
+
+    private func setConstraintsForNoSubmission() {
+        contentViewSafeAreaConstraint?.isActive = false
+        dividerView?.isHidden = true
+        contentView?.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 0).isActive = true
     }
 
     func reloadNavBar() {


### PR DESCRIPTION
## NewQuizzes submission detail screen has balloon image messing up the layout

refs: MBL-18735
affects: Student
release note: None
test plan: See ticket.

The issue was cause by the space for the attempt picker. When there's no attempt (no submission) then the attempt picker is hidden, so when the submission detail screen is opened and the accessibility font size is set to the largest then the top of the balloon panda from the empty view appears in that "window" where the attempt picker should be (if there were any submission). So the solution was to set the constraints of the view depending on the attempt picker (which depends on the submission). So when there is no attempt picker (no submission) then the top constraint of the content view is set to match the top constraint of the safe area (by default it's set to the bottom constraint of the attempt picker).

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
