### PR TITLE
Fix grades list showing assignments of all observed users

### DIFF
--- a/Core/Core/Features/Grades/GradeListAssembly.swift
+++ b/Core/Core/Features/Grades/GradeListAssembly.swift
@@ -18,7 +18,7 @@
 
 import UIKit
 
-public enum GradListAssembly {
+public enum GradeListAssembly {
     public static func makeInteractor(
         courseID: String,
         userID: String?

--- a/Core/Core/Features/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeListInteractor.swift
@@ -119,7 +119,8 @@ public final class GradeListInteractorLive: GradeListInteractor {
             useCase: GetAssignmentsByGroup(
                 courseID: courseID,
                 gradingPeriodID: gradingPeriodID,
-                gradedOnly: true
+                gradedOnly: true,
+                userID: userID
             )
         )
 

--- a/Core/Core/Features/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeListInteractor.swift
@@ -50,6 +50,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
 
     public let courseID: String
     private let userID: String?
+    private let filterAssignmentsToUserID: Bool
 
     // MARK: - Private properties
     private let colorListStore: ReactiveStore<GetCustomColors>
@@ -58,12 +59,16 @@ public final class GradeListInteractorLive: GradeListInteractor {
 
     // MARK: - Init
 
+    /// - parameters:
+    ///   - filterAssignmentsToUserID: If true, the assignments will be filtered to the userID. This is used for parent accounts where the assignments API call returns all students' assignments.
     public init(
         courseID: String,
-        userID: String?
+        userID: String?,
+        filterAssignmentsToUserID: Bool = (AppEnvironment.shared.app == .parent)
     ) {
         self.courseID = courseID
         self.userID = userID
+        self.filterAssignmentsToUserID = filterAssignmentsToUserID
 
         colorListStore = ReactiveStore(
             useCase: GetCustomColors()
@@ -120,7 +125,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
                 courseID: courseID,
                 gradingPeriodID: gradingPeriodID,
                 gradedOnly: true,
-                userID: userID
+                userID: filterAssignmentsToUserID ? userID : nil
             )
         )
 

--- a/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
@@ -261,7 +261,7 @@ public final class GradeListViewModel: ObservableObject {
             sortByOptions: GradeArrangementOptions.allCases
         )
 
-        let filterView = GradListAssembly.makeGradeFilterViewController(
+        let filterView = GradeListAssembly.makeGradeFilterViewController(
             dependency: dependency,
             gradeFilterInteractor: gradeFilterInteractor
         )

--- a/Core/CoreTests/Features/Grades/Model/UseCase/GetAssignmentsByGroupTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/UseCase/GetAssignmentsByGroupTests.swift
@@ -211,4 +211,28 @@ class GetAssignmentsByGroupTests: CoreTestCase {
         results = environment.subscribe(useCaseGradedOnly)
         XCTAssertEqual(results.all.count, 1)
     }
+
+    func testFetchFiltersAssignmentsByUserID() {
+        let assignment1 = APIAssignment.make(
+            id: "assignment1",
+            name: "Assignment 1",
+            submission: APISubmission.make(user_id: "user1")
+        )
+        let assignment2 = APIAssignment.make(
+            id: "assignment2",
+            name: "Assignment 2",
+            submission: APISubmission.make(user_id: "user2")
+        )
+        let assignmentGroup = APIAssignmentGroup.make(assignments: [assignment1, assignment2])
+        let response = [GetAssignmentsByGroup.AssignmentGroupsByGradingPeriod(gradingPeriod: nil, assignmentGroups: [assignmentGroup])]
+        let testee = GetAssignmentsByGroup(courseID: "", userID: "user1")
+        testee.write(response: response, urlResponse: nil, to: databaseClient)
+
+        // WHEN
+        let assignments: [Assignment] = databaseClient.fetch(scope: testee.scope)
+
+        // THEN
+        XCTAssertEqual(assignments.count, 1)
+        XCTAssertEqual(assignments.first?.id, "assignment1")
+    }
 }

--- a/Parent/Parent/Courses/CourseDetailsViewController.swift
+++ b/Parent/Parent/Courses/CourseDetailsViewController.swift
@@ -98,7 +98,7 @@ class CourseDetailsViewController: HorizontalMenuViewController {
     }
 
     func configureGrades() {
-        gradesViewController = GradListAssembly.makeGradeListViewController(
+        gradesViewController = GradeListAssembly.makeGradeListViewController(
             env: AppEnvironment.shared,
             courseID: courseID,
             userID: studentID

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -286,7 +286,7 @@ let router = Router(routes: [
 
     RouteHandler("/courses/:courseID/grades") { _, params, _ in
         guard let courseID = params["courseID"] else { return nil }
-        return GradListAssembly.makeGradeListViewController(
+        return GradeListAssembly.makeGradeListViewController(
             env: AppEnvironment.shared,
             courseID: courseID,
             userID: AppEnvironment.shared.currentSession?.userID


### PR DESCRIPTION
refs: MBL-18758
affects: Parent, Student
release note: Fixed grades page showing all observed users' assignments not just the selected observee's.

test plan:
- See ticket for test account.
- Check if assignments are still properly displayed in the student app on the grades page.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet