### PR TITLE
[Horizon] File Upload Loading Indicator is Duplicated

### DIFF
--- a/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
@@ -119,6 +119,8 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         view.backgroundColor = .backgroundLightest
         contentView.backgroundColor = .backgroundLightest
 
+        spinnerView.isHidden = true
+        
         arButton.setTitle(String(localized: "Augment Reality", bundle: .core), for: .normal)
         arButton.isHidden = true
         arImageView.isHidden = true

--- a/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
@@ -119,8 +119,10 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
         view.backgroundColor = .backgroundLightest
         contentView.backgroundColor = .backgroundLightest
 
-        spinnerView.isHidden = true
-        
+        if env.app == .horizon {
+            spinnerView.isHidden = true
+        }
+
         arButton.setTitle(String(localized: "Augment Reality", bundle: .core), for: .normal)
         arButton.isHidden = true
         arImageView.isHidden = true

--- a/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/Domain/HUploadFileManager.swift
+++ b/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetails/Domain/HUploadFileManager.swift
@@ -87,7 +87,7 @@ final class HUploadFileManagerLive: HUploadFileManager {
 
     func uploadFiles() {
         let context = FileUploadContext.submission(courseID: courseID, assignmentID: assignmentID, comment: nil)
-        UploadManager.shared.upload(batch: batchId, to: context)
+        uploadManager.upload(batch: batchId, to: context)
     }
 
     func cancelAllFiles() {

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
@@ -48,6 +48,7 @@ final class ModuleItemSequenceViewModel {
         var buttons: [ModuleNavBarUtilityButtons] = [.chatBot(navigateToTutor)]
         if isAssignmentOptionsButtonVisible, moduleItem?.isQuizLTI == false {
           buttons.append(.assignmentMoreOptions(assignmentOptionsTapped))
+          assignmentAttemptCount = moduleItem?.isQuizLTI == true ? nil : assignmentAttemptCount
         } else if moduleItem?.type?.assetType == .page && isNotebookDisabled == false {
           buttons.append(.notebook(navigateToNotebook))
         }
@@ -113,7 +114,7 @@ final class ModuleItemSequenceViewModel {
             .store(in: &subscriptions)
 
         didLoadAssignment = { [weak self] count, moduleItem in
-            self?.assignmentAttemptCount = moduleItem.isQuizLTI == true ? nil : count
+            self?.assignmentAttemptCount = count
             if self?.isAssignmentAvailableInItemSequence == false {
                 self?.moduleItem = moduleItem
             }

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
@@ -48,7 +48,6 @@ final class ModuleItemSequenceViewModel {
         var buttons: [ModuleNavBarUtilityButtons] = [.chatBot(navigateToTutor)]
         if isAssignmentOptionsButtonVisible, moduleItem?.isQuizLTI == false {
           buttons.append(.assignmentMoreOptions(assignmentOptionsTapped))
-          assignmentAttemptCount = moduleItem?.isQuizLTI == true ? nil : assignmentAttemptCount
         } else if moduleItem?.type?.assetType == .page && isNotebookDisabled == false {
           buttons.append(.notebook(navigateToNotebook))
         }
@@ -114,7 +113,7 @@ final class ModuleItemSequenceViewModel {
             .store(in: &subscriptions)
 
         didLoadAssignment = { [weak self] count, moduleItem in
-            self?.assignmentAttemptCount = count
+            self?.assignmentAttemptCount = moduleItem.isQuizLTI == true ? nil : count
             if self?.isAssignmentAvailableInItemSequence == false {
                 self?.moduleItem = moduleItem
             }


### PR DESCRIPTION
I'm unsure this one should be changed. You can see the before and after. I can hide the spinner in the view controller, but then why have it? It would be better to just remove it altogether. But I'm not sure I should do that since it's part of Core. I could also extend the FileDetailsViewController and hide it just for Horizon. But that seems like a lot just to hide a spinner. I personally, would probably just close this defect and not change anything. But I thought I'd let you weigh in @szabinst 

Before and After:

https://github.com/user-attachments/assets/7a0e6f2b-734e-4c56-944a-bf68bbf85a20


https://github.com/user-attachments/assets/c2e137eb-39e7-4d1c-9445-c134acc3ef02




[ignore-commit-lint]