### PR TITLE
Grade list grading period filter should not be saved (delete)

### DIFF
--- a/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
@@ -23,7 +23,6 @@ public protocol GradeFilterInteractor {
     var selectedGradingId: String? { get }
     var selectedSortById: String? { get }
     var isParentApp: Bool { get }
-    func saveSelectedGradingPeriod(id: String?)
     func saveSortByOption(type: GradeArrangementOptions)
 }
 
@@ -59,15 +58,6 @@ extension GradeFilterInteractorLive: GradeFilterInteractor {
 
     public var selectedSortById: String? {
         appEnvironment.userDefaults?.selectedSortByOptionIDs?[courseId]
-    }
-
-    public func saveSelectedGradingPeriod(id: String?) {
-        let gradingId = id ?? gradingShowAllId
-        if appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs == nil {
-            appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: gradingId]
-        } else {
-            appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId] = gradingId
-        }
     }
 
     public func saveSortByOption(type: GradeArrangementOptions) {

--- a/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
@@ -53,7 +53,7 @@ extension GradeFilterInteractorLive: GradeFilterInteractor {
     }
 
     public var selectedGradingId: String? {
-        return appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId]
+        appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId]
     }
 
     public var selectedSortById: String? {

--- a/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
@@ -53,7 +53,7 @@ extension GradeFilterInteractorLive: GradeFilterInteractor {
     }
 
     public var selectedGradingId: String? {
-        appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId]
+        return appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId]
     }
 
     public var selectedSortById: String? {

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -210,8 +210,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                 }
             }
             .padding([.horizontal, .top], 16)
-            .padding(.bottom, 5)
-            .padding(.bottom, hasBottomPadding ? 10 : 0)
+            .padding(.bottom, hasBottomPadding ? 15 : 5)
 
             if totalGrade != nil {
                 if toggleViewIsVisible {
@@ -292,7 +291,8 @@ public struct GradeListView: View, ScreenViewTrackable {
             .padding(.horizontal, 16)
             .accessibilityIdentifier("BasedOnGradedToggle")
 
-            if viewModel.isWhatIfScoreFlagEnabled {
+            // MARK: DO NOT LEAVE LIKE THIS
+//            if viewModel.isWhatIfScoreFlagEnabled {
                 Divider()
 
                 InstUI.Toggle(isOn: $viewModel.isWhatIfScoreModeOn) {
@@ -303,7 +303,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                 }
                 .frame(minHeight: 51)
                 .padding(.horizontal, 16)
-            }
+//            }
         }
     }
 

--- a/Core/Core/Features/Grades/View/GradeListView.swift
+++ b/Core/Core/Features/Grades/View/GradeListView.swift
@@ -210,7 +210,8 @@ public struct GradeListView: View, ScreenViewTrackable {
                 }
             }
             .padding([.horizontal, .top], 16)
-            .padding(.bottom, hasBottomPadding ? 15 : 5)
+            .padding(.bottom, 5)
+            .padding(.bottom, hasBottomPadding ? 10 : 0)
 
             if totalGrade != nil {
                 if toggleViewIsVisible {
@@ -291,8 +292,7 @@ public struct GradeListView: View, ScreenViewTrackable {
             .padding(.horizontal, 16)
             .accessibilityIdentifier("BasedOnGradedToggle")
 
-            // MARK: DO NOT LEAVE LIKE THIS
-//            if viewModel.isWhatIfScoreFlagEnabled {
+            if viewModel.isWhatIfScoreFlagEnabled {
                 Divider()
 
                 InstUI.Toggle(isOn: $viewModel.isWhatIfScoreModeOn) {
@@ -303,7 +303,7 @@ public struct GradeListView: View, ScreenViewTrackable {
                 }
                 .frame(minHeight: 51)
                 .padding(.horizontal, 16)
-//            }
+            }
         }
     }
 

--- a/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
@@ -101,7 +101,6 @@ public final class GradeFilterViewModel: ObservableObject {
         let optionId = gradingPeriodOptions.selected.value?.id
         let selectedGradingPeriodId = optionId == OptionItem.allId ? nil : optionId
         dependency.selectedGradingPeriodPublisher.accept(selectedGradingPeriodId)
-        gradeFilterInteractor.saveSelectedGradingPeriod(id: selectedGradingPeriodId)
 
         dependency.router.dismiss(viewController) {
             UIAccessibility.announce(String(localized: "Filter applied successfully", bundle: .core))

--- a/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
@@ -62,6 +62,8 @@ public final class GradeFilterViewModel: ObservableObject {
             return
         }
 
+        gradingPeriods.forEach { print( "all: \($0.title ?? "") - \($0.id ?? "")") }
+        print("selected: \(gradeFilterInteractor.selectedGradingId ?? "no selectedGradeId")")
         let initialGradingPeriod = gradingPeriods.first { $0.id == gradeFilterInteractor.selectedGradingId }
         gradingPeriodOptions = .init(
             all: [GradingPeriod.optionItemAll] + gradingPeriods.map { $0.optionItem },

--- a/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
@@ -62,8 +62,6 @@ public final class GradeFilterViewModel: ObservableObject {
             return
         }
 
-        gradingPeriods.forEach { print( "all: \($0.title ?? "") - \($0.id ?? "")") }
-        print("selected: \(gradeFilterInteractor.selectedGradingId ?? "no selectedGradeId")")
         let initialGradingPeriod = gradingPeriods.first { $0.id == gradeFilterInteractor.selectedGradingId }
         gradingPeriodOptions = .init(
             all: [GradingPeriod.optionItemAll] + gradingPeriods.map { $0.optionItem },

--- a/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
@@ -219,10 +219,10 @@ public final class GradeListViewModel: ObservableObject {
         gradingPeriods: [GradingPeriod]
     ) -> String? {
         let currentId = gradeFilterInteractor.selectedGradingId
-        guard !gradingPeriods.isEmpty else {
-            gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
-            return currentGradingPeriodID
-        }
+//        guard !gradingPeriods.isEmpty else {
+//            gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
+//            return currentGradingPeriodID
+//        }
 
         if let currentId {
             if currentId == gradeFilterInteractor.gradingShowAllId {
@@ -230,12 +230,12 @@ public final class GradeListViewModel: ObservableObject {
             } else if gradingPeriods.contains(where: { $0.id == currentId }) {
                 return currentId
             } else {
-                gradeFilterInteractor.saveSelectedGradingPeriod(id: gradingPeriods.first?.id)
+//                gradeFilterInteractor.saveSelectedGradingPeriod(id: gradingPeriods.first?.id)
                 gradeFilterInteractor.saveSortByOption(type: .dueDate)
                 return gradingPeriods.first?.id
             }
         }
-        gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
+//        gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
         return currentGradingPeriodID
     }
 

--- a/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
@@ -219,10 +219,6 @@ public final class GradeListViewModel: ObservableObject {
         gradingPeriods: [GradingPeriod]
     ) -> String? {
         let currentId = gradeFilterInteractor.selectedGradingId
-//        guard !gradingPeriods.isEmpty else {
-//            gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
-//            return currentGradingPeriodID
-//        }
 
         if let currentId {
             if currentId == gradeFilterInteractor.gradingShowAllId {
@@ -230,12 +226,10 @@ public final class GradeListViewModel: ObservableObject {
             } else if gradingPeriods.contains(where: { $0.id == currentId }) {
                 return currentId
             } else {
-//                gradeFilterInteractor.saveSelectedGradingPeriod(id: gradingPeriods.first?.id)
                 gradeFilterInteractor.saveSortByOption(type: .dueDate)
                 return gradingPeriods.first?.id
             }
         }
-//        gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
         return currentGradingPeriodID
     }
 

--- a/Core/CoreTests/Features/Grades/Model/GradeFilterInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/GradeFilterInteractorLiveTests.swift
@@ -43,38 +43,6 @@ final class GradeFilterInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(testee.gradingShowAllId, "-1")
     }
 
-    func test_saveGradingForFistTime() {
-        // Given
-        let id = "10"
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = nil
-        // When
-        testee.saveSelectedGradingPeriod(id: id)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, id)
-    }
-
-    func test_saveGradingChangeValue() {
-        // Given
-        let oldValue = "10"
-        let newValue = "20"
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: oldValue]
-        // When
-        testee.saveSelectedGradingPeriod(id: newValue)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, newValue)
-    }
-
-    func test_saveGrading_whenSaveShowAll() {
-        // Given
-        let oldValue = "10"
-        let newValue: String? = nil
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: oldValue]
-        // When
-        testee.saveSelectedGradingPeriod(id: newValue)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, "-1")
-    }
-
     func test_saveSortByOptionForFirstTime() {
         // Given
         environment.userDefaults?.selectedSortByOptionIDs = nil


### PR DESCRIPTION
### What's new?
- Grade Period filter on the Grade List screen now defaults back to the current period.

refs: MBL-18768
affects: Student, Parent
release note: Grade Period filter now auto-selects the current period on the Grade List screen.

test plan:
- Check if Grading Period filter resets to the current period. Previously, the selected option was saved and reloaded.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
