### PR TITLE
RCE Dark mode issue

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DarkModeForWebDiscussions.swift
@@ -20,9 +20,9 @@ import UIKit
 
 private class DarkModeForWebDiscussions: CoreWebViewFeature {
     private let script: String = {
-        let textLight = UIColor.textDark.hexString(userInterfaceStyle: .dark)
-        let textLightest = UIColor.textDarkest.hexString(userInterfaceStyle: .dark)
-        let backgroundDarkest = UIColor.backgroundLightest.hexString(userInterfaceStyle: .dark)
+        let textLight = UIColor.textDark.hexString(for: .dark)
+        let textLightest = UIColor.textDarkest.hexString(for: .dark)
+        let backgroundDarkest = UIColor.backgroundLightest.hexString(for: .dark)
         let darkCss = """
         @media (prefers-color-scheme: dark) {
             body {

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -210,10 +210,10 @@ open class CoreWebView: WKWebView {
 
         let light: UIUserInterfaceStyle = isThemeInverted ? .dark : .light
         let dark: UIUserInterfaceStyle = isThemeInverted ? .light : .dark
-        let background = UIColor.backgroundLightest.hexString(userInterfaceStyle: light)
-        let backgroundDark = UIColor.backgroundLightest.hexString(userInterfaceStyle: dark)
-        let foreground = UIColor.textDarkest.hexString(userInterfaceStyle: light)
-        let foregroundDark = UIColor.textDarkest.hexString(userInterfaceStyle: dark)
+        let background = UIColor.backgroundLightest.hexString(for: light)
+        let backgroundDark = UIColor.backgroundLightest.hexString(for: dark)
+        let foreground = UIColor.textDarkest.hexString(for: light)
+        let foregroundDark = UIColor.textDarkest.hexString(for: dark)
 
            return """
                 body.dark-theme {

--- a/Core/Core/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManager.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManager.swift
@@ -1,0 +1,65 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+/// When `overrideUserInterfaceStyle` is not `.unspecified` the builtin `UserInterfaceStyle` tracking is disabled.
+/// Neither `traitCollectionDidChange()` is called nor callbacks via `registerForTraitChanges()`.
+/// This class manages an observation for cases when the override needs to be changed.
+public final class OverrideUserInterfaceStyleManager {
+    public typealias StyleChangeHandler = (UIUserInterfaceStyle) -> Void
+
+    private weak var host: UIView?
+    private var additionalAction: StyleChangeHandler?
+    private var observer: NSObjectProtocol?
+
+    public init(host: UIView) {
+        self.host = host
+    }
+
+    public convenience init(host: UIViewController) {
+        self.init(host: host.view)
+    }
+
+    /// Starts the style change observation and sets the override style.
+    /// Observation is started regardless of the current override style.
+    public func setup(currentStyle: UIUserInterfaceStyle, additionalAction: StyleChangeHandler? = nil) {
+        self.additionalAction = additionalAction
+        startStyleChangeObservation()
+        setOverrideStyle(currentStyle)
+    }
+
+    public func setOverrideStyle(_ style: UIUserInterfaceStyle) {
+        host?.overrideUserInterfaceStyle = style
+    }
+
+    private func startStyleChangeObservation() {
+        guard observer == nil else { return }
+
+        observer = NotificationCenter.default.addObserver(
+            forName: .windowUserInterfaceStyleDidChange,
+            object: nil,
+            queue: .main,
+            using: { [weak self] notification in
+                let style = notification.userInfo?["style"] as? UIUserInterfaceStyle ?? .unspecified
+                self?.setOverrideStyle(style)
+                self?.additionalAction?(style)
+            }
+        )
+    }
+}

--- a/Core/Core/Common/CommonUI/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/RichContentEditorViewController.swift
@@ -56,6 +56,7 @@ public class RichContentEditorViewController: UIViewController {
     public var context = Context.currentUser
     public var uploadContext = FileUploadContext.myFiles
     private var focusObserver: AnyCancellable?
+    private var styleManager: OverrideUserInterfaceStyleManager?
 
     private var env: AppEnvironment = .defaultValue
 
@@ -87,6 +88,8 @@ public class RichContentEditorViewController: UIViewController {
         webView.contentInputAccessoryView = toolbar
         webView.scrollView.keyboardDismissMode = .interactive
         webView.accessibilityIdentifier = "RichContentEditor.webView"
+        styleManager = OverrideUserInterfaceStyleManager(host: self)
+        styleManager?.setup(currentStyle: .current)
 
         featureFlags.refresh { [weak self] _ in
             self?.loadHTML()

--- a/Core/Core/Common/CommonUI/RichContentEditor/RichContentEditorViewController.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/RichContentEditorViewController.swift
@@ -109,20 +109,38 @@ public class RichContentEditorViewController: UIViewController {
         webView.loadHTMLString("""
             <style>
             :root {
-                --brand-linkColor: \(Brand.shared.linkColor.hexString);
-                --brand-primary: \(Brand.shared.primary.hexString);
-                --color-backgroundDanger: \(UIColor.backgroundDanger.hexString);
-                --color-backgroundDarkest: \(UIColor.backgroundDarkest.hexString);
-                --color-backgroundLightest: \(UIColor.backgroundLightest.hexString);
-                --color-textDark: \(UIColor.textDark.hexString);
-                --color-textDarkest: \(UIColor.textDarkest.hexString);
+                \(colorsCss(for: .light))
+                \(fontCss())
+            }
 
-                font-size: \(Typography.Style.body.uiFont.pointSize)px;
-                font-family: \(AppEnvironment.shared.k5.isK5Enabled ? "BalsamiqSans-Regular" : "Lato-Regular");
+            @media (prefers-color-scheme: dark) {
+                :root {
+                    \(colorsCss(for: .dark))
+                    \(fontCss())
+                }
             }
             </style>
             <div id="content" contenteditable=\"true\" placeholder=\"\(placeholder)\" aria-label=\"\(a11yLabel)\"></div>
         """)
+    }
+
+    private func colorsCss(for theme: UIUserInterfaceStyle) -> String {
+        """
+            --brand-linkColor: \(Brand.shared.linkColor.hexString(for: theme));
+            --brand-primary: \(Brand.shared.primary.hexString(for: theme));
+            --color-backgroundDanger: \(UIColor.backgroundDanger.hexString(for: theme));
+            --color-backgroundDarkest: \(UIColor.backgroundDarkest.hexString(for: theme));
+            --color-backgroundLightest: \(UIColor.backgroundLightest.hexString(for: theme));
+            --color-textDark: \(UIColor.textDark.hexString(for: theme));
+            --color-textDarkest: \(UIColor.textDarkest.hexString(for: theme));
+        """
+    }
+
+    private func fontCss() -> String {
+        """
+            font-size: \(Typography.Style.body.uiFont.pointSize)px;
+            font-family: \(AppEnvironment.shared.k5.isK5Enabled ? "BalsamiqSans-Regular" : "Lato-Regular");
+        """
     }
 
     func undo() {

--- a/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
@@ -88,10 +88,26 @@ public class RichContentToolbarView: UIView {
         textColorButton.addSubview(textColorView)
         self.textColorView = textColorView
 
+        setupColors()
         setupAccessibility()
 
         updateState(nil)
         updateBorderColors()
+    }
+
+    private func setupColors() {
+        let colors = colorPickerStack.arrangedSubviews
+        if colors.count == 9 {
+            colors[0].tintColor = .textLightest.variantForLightMode
+            colors[1].tintColor = .textDarkest.variantForLightMode
+            colors[2].tintColor = .init(hexString: "#8B969E") // gray
+            colors[3].tintColor = .init(hexString: "#EE0612") // red
+            colors[4].tintColor = .init(hexString: "#FC5E13") // orange
+            colors[5].tintColor = .init(hexString: "#FFC100") // yellow
+            colors[6].tintColor = .init(hexString: "#89C540") // green
+            colors[7].tintColor = .init(hexString: "#1485C8") // blue
+            colors[8].tintColor = .init(hexString: "#65469F") // purple
+        }
     }
 
     private func setupAccessibility() {

--- a/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
@@ -75,9 +75,9 @@ public class RichContentToolbarView: UIView {
         colorPickerView.alpha = 0
         colorPickerView.transform = CGAffineTransform(translationX: 0, y: 45)
 
-        let whiteColorBorder = UIView(frame: CGRect(x: 7, y: 7, width: 30, height: 30))
+        let whiteColorBorder = UIView(frame: CGRect(x: 9, y: 9, width: 26, height: 26))
         whiteColorBorder.layer.borderWidth = 1
-        whiteColorBorder.layer.cornerRadius = 15
+        whiteColorBorder.layer.cornerRadius = 13
         whiteColorBorder.isUserInteractionEnabled = false
         whiteColorButton.addSubview(whiteColorBorder)
         self.whiteColorBorder = whiteColorBorder
@@ -141,10 +141,22 @@ public class RichContentToolbarView: UIView {
     }
 
     private func updateBorderColors() {
-        whiteColorBorder?.layer.borderColor = UIColor.borderMedium.cgColor
+        let clearColor = UIColor.clear.cgColor
 
-        let isWhiteSelected = foreColor.hexString == UIColor.textLightest.variantForLightMode.hexString
-        textColorView?.layer.borderColor = isWhiteSelected ? UIColor.borderMedium.cgColor : foreColor.cgColor
+        let currentTheme = overrideUserInterfaceStyle.nilIfUnspecified ?? traitCollection.userInterfaceStyle
+        if currentTheme.defaultToLight == .light {
+            // border white color
+            let borderColor = UIColor.borderMedium.variantForLightMode.cgColor
+            whiteColorBorder?.layer.borderColor = borderColor
+
+            // border selected color if it's white
+            let isWhiteSelected = foreColor.hexString == UIColor.textLightest.variantForLightMode.hexString
+            textColorView?.layer.borderColor = isWhiteSelected ? borderColor : clearColor
+        } else {
+            // remove borders
+            whiteColorBorder?.layer.borderColor = clearColor
+            textColorView?.layer.borderColor = clearColor
+        }
     }
 
     func updateState(_ state: [String: Any?]?) {
@@ -243,4 +255,9 @@ public class RichContentToolbarView: UIView {
     @IBAction func libraryAction(_ sender: UIButton) {
         controller?.insertFrom(.photoLibrary)
     }
+}
+
+private extension UIUserInterfaceStyle {
+    var nilIfUnspecified: Self? { self == .unspecified ? nil : self }
+    var defaultToLight: Self? { self == .unspecified ? .light : self }
 }

--- a/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
+++ b/Core/Core/Common/CommonUI/RichContentEditor/RichContentToolbarView.swift
@@ -93,6 +93,7 @@ public class RichContentToolbarView: UIView {
 
         updateState(nil)
         updateBorderColors()
+        registerForTraitChanges()
     }
 
     private func setupColors() {
@@ -254,6 +255,13 @@ public class RichContentToolbarView: UIView {
 
     @IBAction func libraryAction(_ sender: UIButton) {
         controller?.insertFrom(.photoLibrary)
+    }
+
+    private func registerForTraitChanges() {
+        let traits = [UITraitUserInterfaceStyle.self]
+        registerForTraitChanges(traits) { (self: RichContentToolbarView, _) in
+            self.updateBorderColors()
+        }
     }
 }
 

--- a/Core/Core/Common/Extensions/UIKit/UIColorExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIColorExtensions.swift
@@ -45,7 +45,7 @@ extension UIColor {
         self.init(red: CGFloat(r) / 255, green: CGFloat(g) / 255, blue: CGFloat(b) / 255, alpha: CGFloat(a) / 255)
     }
 
-    public var hexString: String { hexString(userInterfaceStyle: .current) }
+    public var hexString: String { hexString(for: .current) }
     public var variantForLightMode: UIColor { resolvedColor(with: .light) }
     public var variantForDarkMode: UIColor { resolvedColor(with: .dark) }
 
@@ -63,7 +63,7 @@ extension UIColor {
 
     /** Returns the given color for the current interface style. */
     public static func getColor(dark: UIColor, light: UIColor) -> UIColor {
-        return UIColor { traitCollection  in
+        return UIColor { traitCollection in
             return traitCollection.isDarkInterface ? dark : light
         }
     }
@@ -76,12 +76,12 @@ extension UIColor {
         return abs(ared - bred) + abs(agreen - bgreen) + abs(ablue - bblue) + abs(aalpha - balpha)
     }
 
-    public func hexString(userInterfaceStyle: UIUserInterfaceStyle) -> String {
-        let intValue = intValue(userInterfaceStyle: userInterfaceStyle)
+    public func hexString(for userInterfaceStyle: UIUserInterfaceStyle) -> String {
+        let intValue = intValue(for: userInterfaceStyle)
         return "#\(String(intValue, radix: 16))".replacingOccurrences(of: "#ff", with: "#")
     }
 
-    public func intValue(userInterfaceStyle: UIUserInterfaceStyle) -> UInt32 {
+    private func intValue(for userInterfaceStyle: UIUserInterfaceStyle) -> UInt32 {
         var red: CGFloat = 0, green: CGFloat = 0, blue: CGFloat = 0, alpha: CGFloat = 1
         resolvedColor(with: UITraitCollection(userInterfaceStyle: userInterfaceStyle)).getRed(&red, green: &green, blue: &blue, alpha: &alpha) // assume success
         let toInt = { (n: CGFloat) in return UInt32(max(0.0, min(1.0, n)) * 255) }

--- a/Core/Core/Features/Discussions/DiscussionHTML.swift
+++ b/Core/Core/Features/Discussions/DiscussionHTML.swift
@@ -466,10 +466,10 @@ public enum DiscussionHTML {
         var description: String { "-i\(String(rawValue, radix: 36))" }
 
         static func color(_ path: KeyPath<Brand, UIColor>, style: UIUserInterfaceStyle = .light) -> String {
-            Brand.shared[keyPath: path].hexString(userInterfaceStyle: style)
+            Brand.shared[keyPath: path].hexString(for: style)
         }
         static func color(_ color: UIColor, style: UIUserInterfaceStyle = .light) -> String {
-            color.hexString(userInterfaceStyle: style)
+            color.hexString(for: style)
         }
 
         enum Weight: String {

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewThemeSwitcherTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewThemeSwitcherTests.swift
@@ -150,20 +150,20 @@ final class CoreWebViewThemeSwitcherTests: CoreTestCase {
     // MARK: - Observation
 
     func testObservationShouldBeDisabledInitially() {
-        triggerStyleDidChangeNotificiation(to: .light)
+        triggerStyleDidChangeNotification(to: .light)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .unspecified)
 
-        triggerStyleDidChangeNotificiation(to: .dark)
+        triggerStyleDidChangeNotification(to: .dark)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .unspecified)
     }
 
     func testObservationShouldBeEnabledAfterUpdateStyle() {
         testee.updateUserInterfaceStyle(with: .dark)
 
-        triggerStyleDidChangeNotificiation(to: .light)
+        triggerStyleDidChangeNotification(to: .light)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .light)
 
-        triggerStyleDidChangeNotificiation(to: .dark)
+        triggerStyleDidChangeNotification(to: .dark)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .dark)
     }
 }
@@ -185,7 +185,7 @@ private extension CoreWebViewThemeSwitcherTests {
         button.updateConfiguration()
     }
 
-    func triggerStyleDidChangeNotificiation(to style: UIUserInterfaceStyle) {
+    func triggerStyleDidChangeNotification(to style: UIUserInterfaceStyle) {
         NotificationCenter.default.post(
             name: .windowUserInterfaceStyleDidChange,
             object: nil,

--- a/Core/CoreTests/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManagerTests.swift
+++ b/Core/CoreTests/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManagerTests.swift
@@ -1,0 +1,102 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+final class OverrideUserInterfaceStyleManagerTests: CoreTestCase {
+
+    private var testee: OverrideUserInterfaceStyleManager!
+    private var host: UIView!
+
+    override func setUp() {
+        super.setUp()
+        host = .init()
+        testee = .init(host: host)
+    }
+
+    override func tearDown() {
+        host = nil
+        testee = nil
+        super.tearDown()
+    }
+
+    func test_init_whenHostIsViewController_shouldSetViewAsHost() {
+        let host = UIViewController()
+        testee = .init(host: host)
+        XCTAssertEqual(host.overrideUserInterfaceStyle, .unspecified)
+
+        testee.setOverrideStyle(.dark)
+        XCTAssertEqual(host.view.overrideUserInterfaceStyle, .dark)
+    }
+
+    func test_setOverrideStyle() {
+        // initial state
+        XCTAssertEqual(host.overrideUserInterfaceStyle, .unspecified)
+
+        testee.setOverrideStyle(.dark)
+        XCTAssertEqual(host.overrideUserInterfaceStyle, .dark)
+    }
+
+    // MARK: - Observation
+
+    func test_setup_shouldStartObservation() {
+        var actionInput: UIUserInterfaceStyle?
+        let action: (UIUserInterfaceStyle) -> Void = { actionInput = $0 }
+        testee.setup(currentStyle: .unspecified, additionalAction: action)
+
+        triggerStyleDidChangeNotificiation(to: .light)
+        XCTAssertEqual(host.overrideUserInterfaceStyle, .light)
+        XCTAssertEqual(actionInput, .light)
+
+        triggerStyleDidChangeNotificiation(to: .dark)
+        XCTAssertEqual(host.overrideUserInterfaceStyle, .dark)
+        XCTAssertEqual(actionInput, .dark)
+    }
+
+    func test_setup_whenCalledTwice_shouldStartObservationOnlyOnce() {
+        var action1CallsCount = 0
+        let action1: (UIUserInterfaceStyle) -> Void = { _ in action1CallsCount += 1 }
+        var action2CallsCount = 0
+        let action2: (UIUserInterfaceStyle) -> Void = { _ in action2CallsCount += 1 }
+
+        // setup with action1 -> obbserver should call action1
+        testee.setup(currentStyle: .unspecified, additionalAction: action1)
+        triggerStyleDidChangeNotificiation(to: .light)
+        XCTAssertEqual(action1CallsCount, 1)
+        XCTAssertEqual(action2CallsCount, 0)
+
+        // setup with action2 -> obbserver should no longer call action1
+        testee.setup(currentStyle: .unspecified, additionalAction: action2)
+        triggerStyleDidChangeNotificiation(to: .dark)
+        XCTAssertEqual(action1CallsCount, 1)
+        XCTAssertEqual(action2CallsCount, 1)
+    }
+}
+
+// MARK: - Helpers
+
+private extension OverrideUserInterfaceStyleManagerTests {
+    func triggerStyleDidChangeNotificiation(to style: UIUserInterfaceStyle) {
+        NotificationCenter.default.post(
+            name: .windowUserInterfaceStyleDidChange,
+            object: nil,
+            userInfo: ["style": style]
+        )
+    }
+}

--- a/Core/CoreTests/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManagerTests.swift
+++ b/Core/CoreTests/Common/CommonUI/RichContentEditor/OverrideUserInterfaceStyleManagerTests.swift
@@ -60,11 +60,11 @@ final class OverrideUserInterfaceStyleManagerTests: CoreTestCase {
         let action: (UIUserInterfaceStyle) -> Void = { actionInput = $0 }
         testee.setup(currentStyle: .unspecified, additionalAction: action)
 
-        triggerStyleDidChangeNotificiation(to: .light)
+        triggerStyleDidChangeNotification(to: .light)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .light)
         XCTAssertEqual(actionInput, .light)
 
-        triggerStyleDidChangeNotificiation(to: .dark)
+        triggerStyleDidChangeNotification(to: .dark)
         XCTAssertEqual(host.overrideUserInterfaceStyle, .dark)
         XCTAssertEqual(actionInput, .dark)
     }
@@ -77,13 +77,13 @@ final class OverrideUserInterfaceStyleManagerTests: CoreTestCase {
 
         // setup with action1 -> obbserver should call action1
         testee.setup(currentStyle: .unspecified, additionalAction: action1)
-        triggerStyleDidChangeNotificiation(to: .light)
+        triggerStyleDidChangeNotification(to: .light)
         XCTAssertEqual(action1CallsCount, 1)
         XCTAssertEqual(action2CallsCount, 0)
 
         // setup with action2 -> obbserver should no longer call action1
         testee.setup(currentStyle: .unspecified, additionalAction: action2)
-        triggerStyleDidChangeNotificiation(to: .dark)
+        triggerStyleDidChangeNotification(to: .dark)
         XCTAssertEqual(action1CallsCount, 1)
         XCTAssertEqual(action2CallsCount, 1)
     }
@@ -92,7 +92,7 @@ final class OverrideUserInterfaceStyleManagerTests: CoreTestCase {
 // MARK: - Helpers
 
 private extension OverrideUserInterfaceStyleManagerTests {
-    func triggerStyleDidChangeNotificiation(to style: UIUserInterfaceStyle) {
+    func triggerStyleDidChangeNotification(to style: UIUserInterfaceStyle) {
         NotificationCenter.default.post(
             name: .windowUserInterfaceStyleDidChange,
             object: nil,


### PR DESCRIPTION
refs: [MBL-18743](https://instructure.atlassian.net/browse/MBL-18743)
affects: Student, Teacher
release note: Fixed a dark mode issue on various screens.

## What's changed
- Fixed RCE CSS color handling
- Fixed RCE toolbar borders
- Extracted `OverrideUserInterfaceStyleManager` from `CoreWebViewThemeSwitcher`
  - Couldn't find a proper better name, so I gave up and it stayed Manager

## What's not changed
- Didn't update CoreWebView and/or it's theme switcher to use the new helper, to reduce code/QA scope
- Didn't try to resolve the whole problem of using white/black colors in light/dark mode
  - We've already shown these RCEs in dark mode, now we also show them when the theme is changed on the fly

## Test plan
- See ticket for details and affected screens
- Things should also work properly in forced dark/light modes

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/c69b06bd-9894-4c7a-a3bf-4b2a61d84275" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/350fcc3c-7a83-443f-924a-8b1ea2071d14" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode

[MBL-18743]: https://instructure.atlassian.net/browse/MBL-18743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ