### PR TITLE
Fix letter grade conversion

### DIFF
--- a/Core/Core/Features/Enrollments/Enrollment.swift
+++ b/Core/Core/Features/Enrollments/Enrollment.swift
@@ -150,7 +150,8 @@ extension Enrollment {
             return notAvailable
         }
         if let score = currentScore(gradingPeriodID: gradingPeriodID) {
-            return gradingScheme.convertScoreToLetterGrade(score: score) ?? notAvailable
+            let normalizedScore = score / 100.0
+            return gradingScheme.convertNormalizedScoreToLetterGrade(normalizedScore) ?? notAvailable
         }
         return notAvailable
     }
@@ -162,14 +163,16 @@ extension Enrollment {
             return notAvailable
         }
         if let score = finalScore(gradingPeriodID: gradingPeriodID) {
-            return gradingScheme.convertScoreToLetterGrade(score: score) ?? notAvailable
+            let normalizedScore = score / 100.0
+            return gradingScheme.convertNormalizedScoreToLetterGrade(normalizedScore) ?? notAvailable
         }
         return notAvailable
     }
 
     public func convertedLetterGrade(scorePercentage: Double, gradingScheme: GradingScheme) -> String {
         let notAvailable = String(localized: "N/A", bundle: .core)
-        return gradingScheme.convertScoreToLetterGrade(score: scorePercentage) ?? notAvailable
+        let normalizedScore = scorePercentage / 100.0
+        return gradingScheme.convertNormalizedScoreToLetterGrade(normalizedScore) ?? notAvailable
     }
 }
 

--- a/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
@@ -21,14 +21,13 @@ import Foundation
 public protocol GradingScheme {
     var entries: [GradingSchemeEntry] { get }
 
-    func convertScoreToLetterGrade(score: Double) -> String?
+    func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String?
     func formattedScore(from value: Double) -> String?
 }
 
 public extension GradingScheme {
 
-    func convertScoreToLetterGrade(score: Double) -> String? {
-        let normalizedScore = score / 100.0
-        return entries.first { normalizedScore >= $0.value }?.name
+    func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String? {
+        entries.first { normalizedScore >= $0.value }?.name
     }
 }

--- a/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
@@ -28,6 +28,9 @@ public protocol GradingScheme {
 public extension GradingScheme {
 
     func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String? {
-        entries.first { normalizedScore >= $0.value }?.name
+        // Teachers can add extra points so the "normalized" score can be higher than 1.0. But 10 would be very suspicious.
+        assert(abs(normalizedScore) < 10)
+
+        return entries.first { normalizedScore >= $0.value }?.name
     }
 }

--- a/Core/Core/Features/Grades/Model/GradeFormatter.swift
+++ b/Core/Core/Features/Grades/Model/GradeFormatter.swift
@@ -125,8 +125,9 @@ public class GradeFormatter {
         case .points:
             if hideScores {
                 if let normalizedScore = submission.normalizedScore,
-                   let converterLetterGrade =  submission.assignment?.gradingScheme?.convertScoreToLetterGrade(score: normalizedScore) {
-                    return converterLetterGrade
+                   let gradingScheme = submission.assignment?.gradingScheme,
+                   let letterGrade = gradingScheme.convertNormalizedScoreToLetterGrade(normalizedScore) {
+                    return letterGrade
                 } else {
                     return placeholder
                 }
@@ -152,8 +153,9 @@ public class GradeFormatter {
         case .percent:
             if hideScores {
                 if let normalizedScore = submission.normalizedScore,
-                   let converterLetterGrade =  submission.assignment?.gradingScheme?.convertScoreToLetterGrade(score: normalizedScore) {
-                    return converterLetterGrade
+                   let gradingScheme = submission.assignment?.gradingScheme,
+                   let letterGrade = gradingScheme.convertNormalizedScoreToLetterGrade(normalizedScore) {
+                    return letterGrade
                 } else {
                     return placeholder
                 }

--- a/Core/CoreTests/Features/Grades/Model/Entities/PercentageBasedGradingSchemeTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/PercentageBasedGradingSchemeTests.swift
@@ -24,25 +24,25 @@ class PercentageBasedGradingSchemeTests: GradingSchemeTestCase {
     func testScoreConversion() {
         let testee = PercentageBasedGradingScheme(entries: scoreConversionEntries())
 
-        var result = testee.convertScoreToLetterGrade(score: 90)
+        var result = testee.convertNormalizedScoreToLetterGrade(0.90)
         XCTAssertEqual(result, "A")
 
-        result = testee.convertScoreToLetterGrade(score: 89)
+        result = testee.convertNormalizedScoreToLetterGrade(0.89)
         XCTAssertEqual(result, "B")
 
-        result = testee.convertScoreToLetterGrade(score: 0)
+        result = testee.convertNormalizedScoreToLetterGrade(0)
         XCTAssertEqual(result, "F")
     }
 
     func testScoreConversionWithEmptyScheme() {
         let testee = PercentageBasedGradingScheme.default
-        let result = testee.convertScoreToLetterGrade(score: 30)
+        let result = testee.convertNormalizedScoreToLetterGrade(0.30)
         XCTAssertNil(result)
     }
 
     func testScoreConversionWithInvalidScheme() {
         let testee = PercentageBasedGradingScheme(entries: invalidConversionEntries())
-        let result = testee.convertScoreToLetterGrade(score: 30)
+        let result = testee.convertNormalizedScoreToLetterGrade(0.30)
 
         XCTAssertNil(result)
     }

--- a/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
@@ -25,25 +25,25 @@ class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
     func testScoreConversion() {
         let testee = PointsBasedGradingScheme(scaleFactor: 5, entries: scoreConversionEntries())
 
-        var result = testee.convertScoreToLetterGrade(score: 90)
+        var result = testee.convertNormalizedScoreToLetterGrade(0.90)
         XCTAssertEqual(result, "A")
 
-        result = testee.convertScoreToLetterGrade(score: 89)
+        result = testee.convertNormalizedScoreToLetterGrade(0.89)
         XCTAssertEqual(result, "B")
 
-        result = testee.convertScoreToLetterGrade(score: 0)
+        result = testee.convertNormalizedScoreToLetterGrade(0)
         XCTAssertEqual(result, "F")
     }
 
     func testScoreConversionWithEmptyScheme() {
         let testee = PointsBasedGradingScheme.default
-        let result = testee.convertScoreToLetterGrade(score: 30)
+        let result = testee.convertNormalizedScoreToLetterGrade(0.30)
         XCTAssertNil(result)
     }
 
     func testScoreConversionWithInvalidScheme() {
         let testee = PointsBasedGradingScheme(scaleFactor: 4, entries: invalidConversionEntries())
-        let result = testee.convertScoreToLetterGrade(score: 30)
+        let result = testee.convertNormalizedScoreToLetterGrade(0.30)
         XCTAssertNil(result)
     }
 


### PR DESCRIPTION
refs: [MBL-18785](https://instructure.atlassian.net/browse/MBL-18785)
affects: Student, Teacher, Parent
release note: Fixed letter grades being displayed incorrectly in some cases.

The problem was that scores ended up being normalized twice after a recent bugfix.
It is now fixed, and the method got a more explicit name.

#### NOTE
The `Enrollment` class has multiple unused members, but I didn't remove any of them for now. It may require a deeper look to make it consistent.

## Test plan
- Verify the issue in the ticket is fixed, see details there
- Smoke test letter grades

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18785]: https://instructure.atlassian.net/browse/MBL-18785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ