### PR TITLE
Grade list grading period filter auto selects the current period instead of reloading the last selection

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/SessionDefaults.swift
@@ -230,11 +230,6 @@ public struct SessionDefaults: Equatable {
     }
 
     // MARK: - Grades
-    public var selectedGradingPeriodIdsByCourseIDs: [String: String]? {
-        get { self["selectedGradingPeriodIdsByCourseIDs"] as? [String: String] }
-        set { self["selectedGradingPeriodIdsByCourseIDs"] = newValue }
-    }
-
     public var selectedSortByOptionIDs: [String: String]? {
         get { self["selectedSortByOptionIDs"] as? [String: String] }
         set { self["selectedSortByOptionIDs"] = newValue }

--- a/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeFilterInteractor.swift
@@ -20,10 +20,8 @@ import Foundation
 
 public protocol GradeFilterInteractor {
     var gradingShowAllId: String { get }
-    var selectedGradingId: String? { get }
     var selectedSortById: String? { get }
     var isParentApp: Bool { get }
-    func saveSelectedGradingPeriod(id: String?)
     func saveSortByOption(type: GradeArrangementOptions)
 }
 
@@ -53,21 +51,8 @@ extension GradeFilterInteractorLive: GradeFilterInteractor {
         appEnvironment.app == .parent
     }
 
-    public var selectedGradingId: String? {
-        appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId]
-    }
-
     public var selectedSortById: String? {
         appEnvironment.userDefaults?.selectedSortByOptionIDs?[courseId]
-    }
-
-    public func saveSelectedGradingPeriod(id: String?) {
-        let gradingId = id ?? gradingShowAllId
-        if appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs == nil {
-            appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: gradingId]
-        } else {
-            appEnvironment.userDefaults?.selectedGradingPeriodIdsByCourseIDs?[courseId] = gradingId
-        }
     }
 
     public func saveSortByOption(type: GradeArrangementOptions) {

--- a/Core/Core/Features/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeListInteractor.swift
@@ -130,7 +130,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
                 loadAllPages: true
             ),
             enrollmentListStore.getEntities(
-                ignoreCache: ignoreCache,
+                ignoreCache: true,
                 loadAllPages: true
             )
         )

--- a/Core/Core/Features/Grades/View/GradeFilterView.swift
+++ b/Core/Core/Features/Grades/View/GradeFilterView.swift
@@ -96,6 +96,7 @@ public struct GradeFilterView: View {
             dependency: .init(
                 router: AppEnvironment.shared.router,
                 isShowGradingPeriod: false,
+                initialGradingPeriodID: nil,
                 sortByOptions: GradeArrangementOptions.allCases
             ),
             gradeFilterInteractor: GradeFilterInteractorLive(

--- a/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeFilterViewModel.swift
@@ -62,7 +62,7 @@ public final class GradeFilterViewModel: ObservableObject {
             return
         }
 
-        let initialGradingPeriod = gradingPeriods.first { $0.id == gradeFilterInteractor.selectedGradingId }
+        let initialGradingPeriod = gradingPeriods.first { $0.id == dependency.initialGradingPeriodID }
         gradingPeriodOptions = .init(
             all: [GradingPeriod.optionItemAll] + gradingPeriods.map { $0.optionItem },
             initial: initialGradingPeriod?.optionItem ?? GradingPeriod.optionItemAll
@@ -101,7 +101,6 @@ public final class GradeFilterViewModel: ObservableObject {
         let optionId = gradingPeriodOptions.selected.value?.id
         let selectedGradingPeriodId = optionId == OptionItem.allId ? nil : optionId
         dependency.selectedGradingPeriodPublisher.accept(selectedGradingPeriodId)
-        gradeFilterInteractor.saveSelectedGradingPeriod(id: selectedGradingPeriodId)
 
         dependency.router.dismiss(viewController) {
             UIAccessibility.announce(String(localized: "Filter applied successfully", bundle: .core))
@@ -118,6 +117,7 @@ extension GradeFilterViewModel {
     public struct Dependency {
         let router: Router
         let isShowGradingPeriod: Bool
+        let initialGradingPeriodID: String?
         var courseName: String?
         var selectedGradingPeriodPublisher = PassthroughRelay<String?>()
         var selectedSortByPublisher = CurrentValueRelay<GradeArrangementOptions>(.dueDate)

--- a/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
@@ -142,7 +142,7 @@ public final class GradeListViewModel: ObservableObject {
             .store(in: &subscriptions)
 
         loadSortPreferences()
-        loadBaseDataAndGrades(ignoreCache: true, isInitialLoad: true)
+        loadBaseDataAndGrades(ignoreCache: false, isInitialLoad: true)
     }
 
     private func loadBaseDataAndGrades(ignoreCache: Bool, isInitialLoad: Bool = false, completionBlock: (() -> Void)? = nil) {

--- a/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
+++ b/Core/Core/Features/Grades/ViewModel/GradeListViewModel.swift
@@ -142,55 +142,29 @@ public final class GradeListViewModel: ObservableObject {
             .store(in: &subscriptions)
 
         loadSortPreferences()
-        initialLoadBaseDataAndGrades()
+        loadBaseDataAndGrades(ignoreCache: true, isInitialLoad: true)
     }
 
-    private func initialLoadBaseDataAndGrades() {
-        interactor
-            .loadBaseData(ignoreCache: false)
-            .map { [weak self] gradingPeriodData in
-                self?.gradeFilterInteractor.saveSelectedGradingPeriod(id: gradingPeriodData.currentlyActiveGradingPeriodID)
-                self?.selectedGradingPeriod = gradingPeriodData.currentlyActiveGradingPeriodID
-            }
-            .mapToVoid()
-            .receive(on: scheduler)
-            .sink(receiveCompletion: { [weak self] completion in
-                if case .failure = completion {
-                    self?.state = .error
-                }
-            }, receiveValue: { [triggerGradeRefresh] in
-                triggerGradeRefresh.accept((false, nil))
-            })
-            .store(in: &subscriptions)
-    }
-
-    private func loadBaseDataAndGrades(ignoreCache: Bool, completionBlock: (() -> Void)? = nil) {
+    private func loadBaseDataAndGrades(ignoreCache: Bool, isInitialLoad: Bool = false, completionBlock: (() -> Void)? = nil) {
         interactor
             .loadBaseData(ignoreCache: ignoreCache)
             .map { [weak self] gradingPeriodData in
-                self?.calculateGradingPeriodToShow(gradingPeriodData)
+                // Initial loading selects the currently active grading period
+                if isInitialLoad {
+                    self?.selectedGradingPeriod = gradingPeriodData.currentlyActiveGradingPeriodID
+                }
             }
             .mapToVoid()
             .receive(on: scheduler)
-            .sink(receiveCompletion: { [weak self] completion in
+            .sink { [weak self] completion in
                 if case .failure = completion {
                     self?.state = .error
                     completionBlock?()
                 }
-            }, receiveValue: { [triggerGradeRefresh] in
+            } receiveValue: { [triggerGradeRefresh] in
                 triggerGradeRefresh.accept((ignoreCache, completionBlock))
-            })
+            }
             .store(in: &subscriptions)
-    }
-
-    private func calculateGradingPeriodToShow(_ gradingPeriodData: GradeListGradingPeriodData) {
-        let id = Self.getSelectedGradingPeriodId(
-            gradeFilterInteractor: gradeFilterInteractor,
-            currentGradingPeriodID: gradingPeriodData.currentlyActiveGradingPeriodID,
-            gradingPeriods: gradingPeriodData.gradingPeriods
-        )
-
-        selectedGradingPeriod = id
     }
 
     private func refreshGrades(ignoreCache: Bool) -> AnyPublisher<Void, Never> {
@@ -232,32 +206,6 @@ public final class GradeListViewModel: ObservableObject {
         selectedGroupByOption.accept(option)
     }
 
-    private static func getSelectedGradingPeriodId(
-        gradeFilterInteractor: GradeFilterInteractor,
-        currentGradingPeriodID: String?,
-        gradingPeriods: [GradingPeriod]
-    ) -> String? {
-        let currentId = gradeFilterInteractor.selectedGradingId
-        guard !gradingPeriods.isEmpty else {
-            gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
-            return currentGradingPeriodID
-        }
-
-        if let currentId {
-            if currentId == gradeFilterInteractor.gradingShowAllId {
-                return nil
-            } else if gradingPeriods.contains(where: { $0.id == currentId }) {
-                return currentId
-            } else {
-                gradeFilterInteractor.saveSelectedGradingPeriod(id: gradingPeriods.first?.id)
-                gradeFilterInteractor.saveSortByOption(type: .dueDate)
-                return gradingPeriods.first?.id
-            }
-        }
-        gradeFilterInteractor.saveSelectedGradingPeriod(id: currentGradingPeriodID)
-        return currentGradingPeriodID
-    }
-
     func navigateToFilter(viewController: WeakViewController) {
         let gradeData: GradeListData? = {
             switch state {
@@ -273,6 +221,7 @@ public final class GradeListViewModel: ObservableObject {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: isShowGradingPeriod,
+            initialGradingPeriodID: selectedGradingPeriod,
             courseName: courseName,
             selectedGradingPeriodPublisher: didSelectGradingPeriod,
             selectedSortByPublisher: selectedGroupByOption,

--- a/Core/CoreTests/Features/Grades/Model/GradeFilterInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/GradeFilterInteractorLiveTests.swift
@@ -43,38 +43,6 @@ final class GradeFilterInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(testee.gradingShowAllId, "-1")
     }
 
-    func test_saveGradingForFistTime() {
-        // Given
-        let id = "10"
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = nil
-        // When
-        testee.saveSelectedGradingPeriod(id: id)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, id)
-    }
-
-    func test_saveGradingChangeValue() {
-        // Given
-        let oldValue = "10"
-        let newValue = "20"
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: oldValue]
-        // When
-        testee.saveSelectedGradingPeriod(id: newValue)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, newValue)
-    }
-
-    func test_saveGrading_whenSaveShowAll() {
-        // Given
-        let oldValue = "10"
-        let newValue: String? = nil
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = [courseId: oldValue]
-        // When
-        testee.saveSelectedGradingPeriod(id: newValue)
-        // Then
-        XCTAssertEqual(testee.selectedGradingId, "-1")
-    }
-
     func test_saveSortByOptionForFirstTime() {
         // Given
         environment.userDefaults?.selectedSortByOptionIDs = nil

--- a/Core/CoreTests/Features/Grades/ViewModel/GradeFilterViewModelTests.swift
+++ b/Core/CoreTests/Features/Grades/ViewModel/GradeFilterViewModelTests.swift
@@ -36,6 +36,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: nil,
             sortByOptions: GradeArrangementOptions.allCases
         )
         testee = GradeFilterViewModel(
@@ -55,11 +56,11 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: nil,
             gradingPeriods: listGradingPeriods,
             sortByOptions: GradeArrangementOptions.allCases
         )
         // When
-        environment.userDefaults?.selectedGradingPeriodIdsByCourseIDs = nil
         let testee = GradeFilterViewModel(
             dependency: dependency,
             gradeFilterInteractor: gradeFilterInteractor
@@ -72,13 +73,14 @@ final class GradeFilterViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.isShowGradingPeriodsView, true)
     }
 
-    func test_mapGradingPeriod_hasSelectedGradingPeriods() {
+    func test_mapGradingPeriod_selectsInitialGradingPeriod() {
         // Given
         let listGradingPeriods = getListGradingPeriods()
         gradeFilterInteractor.currentGradingId = "4"
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: "1",
             gradingPeriods: listGradingPeriods,
             sortByOptions: GradeArrangementOptions.allCases
         )
@@ -90,7 +92,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         // Then
         XCTAssertEqual(testee.gradingPeriodOptions.all.count, 5)
         XCTAssertEqual(testee.isShowGradingPeriodsView, true)
-        XCTAssertEqual(testee.gradingPeriodOptions.selected.value?.id, "4")
+        XCTAssertEqual(testee.gradingPeriodOptions.selected.value?.id, "1")
     }
 
     func test_mapGradingPeriod_notHasGradingPeriods_hideGradingPeriodSection() {
@@ -98,6 +100,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: false,
+            initialGradingPeriodID: nil,
             gradingPeriods: nil,
             sortByOptions: GradeArrangementOptions.allCases
         )
@@ -119,6 +122,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: false,
+            initialGradingPeriodID: nil,
             gradingPeriods: nil,
             sortByOptions: sortByOptions
         )
@@ -137,6 +141,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: nil,
             gradingPeriods: listGradingPeriods,
             sortByOptions: GradeArrangementOptions.allCases
         )
@@ -156,6 +161,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: nil,
             gradingPeriods: listGradingPeriods,
             sortByOptions: GradeArrangementOptions.allCases
         )
@@ -181,6 +187,7 @@ final class GradeFilterViewModelTests: CoreTestCase {
         let dependency = GradeFilterViewModel.Dependency(
             router: router,
             isShowGradingPeriod: true,
+            initialGradingPeriodID: nil,
             selectedGradingPeriodPublisher: selectedGradingPeriodPublisher,
             selectedSortByPublisher: selectedSortByPublisher,
             gradingPeriods: listGradingPeriods,


### PR DESCRIPTION
### What's new?
- Grade Period filter on the Grade List screen now defaults back to the current period.

refs: MBL-18768
affects: Student, Parent
release note: Grade Period filter now auto-selects the current period on the Grade List screen.

Test plan:
- Check if Grading Period filter resets to the current period. Previously, the selected option was saved and reloaded.
- Check carefully everything as last time serious bugs went unnoticed. Closing the app, pull-to-refresh, all grading periods, combinations of these.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
