### PR TITLE
Make SubmissionDetails content always focusable

### DIFF
--- a/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
+++ b/Student/Student/Submissions/SubmissionDetails/SubmissionDetailsViewController.swift
@@ -67,6 +67,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
         emptyView?.submitCallback = { [weak self] button in
             self?.presenter?.submit(button: button)
         }
+        emptyView?.shouldGroupAccessibilityChildren = true
         attemptPicker?.hideDivider()
 
         NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow(_:)), name: UIResponder.keyboardWillShowNotification, object: nil)
@@ -77,8 +78,7 @@ class SubmissionDetailsViewController: ScreenViewTrackableViewController, Submis
     override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         _ = setDrawerPositionOnce
-        drawerContentViewController?.view.accessibilityElementsHidden = drawer?.height == 0
-        contentView?.accessibilityElementsHidden = drawer?.height != 0
+        drawerContentViewController?.view.accessibilityElementsHidden = drawer?.height == 2
     }
 
     func reload() {


### PR DESCRIPTION
refs: [MBL-18793](https://instructure.atlassian.net/browse/MBL-18793)
affects: Student
release note: Improved accessibility of submission screen.

Made submission content always focusable, regardless of drawer state (as discussed with UX).

## Checklist
- [x] Tested on phone
- [x] Tested on tablet

[MBL-18793]: https://instructure.atlassian.net/browse/MBL-18793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ