### PR TITLE
[Horizon] Preserve authentication cookies for user's session

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
@@ -91,13 +91,15 @@ open class AppEnvironment {
         refreshWidgets()
         saveAccount(for: session)
 
-        Just(())
-            .receive(on: RunLoop.main)
-            .flatMap { CoreWebView.deleteAllCookies() }
-            .sink {
-                CoreWebView.refreshKeepAliveCookies()
-            }
-            .store(in: &subscriptions)
+        if AppEnvironment.shared.app != .horizon {
+            Just(())
+                .receive(on: RunLoop.main)
+                .flatMap { CoreWebView.deleteAllCookies() }
+                .sink {
+                    CoreWebView.refreshKeepAliveCookies()
+                }
+                .store(in: &subscriptions)
+        }
     }
 
     public func userDidLogout(session: LoginSession) {

--- a/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
@@ -302,3 +302,14 @@ public extension Array where Element == URL {
         }
     }
 }
+
+public extension URL {
+    func replaceHostWithCanvasForCareer() -> URL? {
+        guard let components = URLComponents(url: self, resolvingAgainstBaseURL: false) else {
+            return nil
+        }
+        var newComponents = components
+        newComponents.host?.replace("instructure.com", with: "canvasforcareer.com")
+        return newComponents.url
+    }
+}

--- a/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
@@ -309,7 +309,8 @@ public extension URL {
             return nil
         }
         var newComponents = components
-        newComponents.host?.replace("instructure.com", with: "canvasforcareer.com")
+        newComponents.host?.replace("pd.instructure.com", with: "pd.canvasforcareer.com")
+        newComponents.host?.replace("horizon.cd.instructure.com", with: "dev.cd.canvashorizon.com")
         return newComponents.url
     }
 }

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -66,7 +66,11 @@ public class LoginWebViewController: UIViewController, ErrorViewController {
     var loginCompletion: ((LoginSession) -> Void)?
     lazy var webView: WKWebView = {
         let configuration = WKWebViewConfiguration()
-        configuration.websiteDataStore = .nonPersistent()
+        if AppEnvironment.shared.app != .horizon {
+            // Horizon has web views that rely on the authentication server cookies
+            // to reauthenticate the user.
+            configuration.websiteDataStore = .nonPersistent()
+        }
         return WKWebView(frame: UIScreen.main.bounds, configuration: configuration)
     }()
 

--- a/Horizon/Horizon/Sources/Common/View/EmbeddedWebPage/HEmbeddedWebPageContainerViewModel.swift
+++ b/Horizon/Horizon/Sources/Common/View/EmbeddedWebPage/HEmbeddedWebPageContainerViewModel.swift
@@ -48,7 +48,8 @@ final class HEmbeddedWebPageContainerViewModel {
     // MARK: - Private Functions
 
     private func constructURL(from webPage: EmbeddedWebPageViewModel) -> URL? {
-        var baseURL = URL(string: "https://dev.cd.canvashorizon.com")
+        var baseURL = AppEnvironment.shared.currentSession?.baseURL
+        baseURL = baseURL?.replaceHostWithCanvasForCareer()
         baseURL?.appendPathComponent(webPage.urlPathComponent)
         baseURL?.append(queryItems: webPage.queryItems)
         baseURL?.append(queryItems: [


### PR DESCRIPTION
This is a fix for the web views not being able to display canvasforcareer.com webviews without reauthentication.

https://github.com/user-attachments/assets/495e6002-157d-4996-85fc-71f90b5cdfd6

[ignore-commit-lint]