### PR TITLE
Fix the issue where empty view is shown on reload (PTR) an assignment detail after appearance switch

### DIFF
--- a/Core/Core/Common/CommonModels/Router/DefaultViewProvider.swift
+++ b/Core/Core/Common/CommonModels/Router/DefaultViewProvider.swift
@@ -25,7 +25,7 @@ import UIKit
  */
 public protocol DefaultViewProvider: UIViewController {
     var defaultViewRoute: DefaultViewRouteParameters? { get }
-    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool)
+    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?)
 }
 
 public struct DefaultViewRouteParameters: ExpressibleByStringLiteral {
@@ -40,12 +40,6 @@ public struct DefaultViewRouteParameters: ExpressibleByStringLiteral {
     public init(stringLiteral value: StringLiteralType) {
         self.url = value
         self.userInfo = nil
-    }
-}
-
-public extension DefaultViewProvider {
-    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?) {
-        setDefaultViewRoute(route, updating: true)
     }
 }
 

--- a/Core/Core/Common/CommonModels/Router/DefaultViewProvider.swift
+++ b/Core/Core/Common/CommonModels/Router/DefaultViewProvider.swift
@@ -24,16 +24,28 @@ import UIKit
  View controllers implementing this protocol can provide a default view for such situations.
  */
 public protocol DefaultViewProvider: UIViewController {
-    var defaultViewRoute: DefaultViewRouteParameters? { get set }
+    var defaultViewRoute: DefaultViewRouteParameters? { get }
+    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool)
 }
 
-public struct DefaultViewRouteParameters {
+public struct DefaultViewRouteParameters: ExpressibleByStringLiteral {
     let url: String
     let userInfo: [String: Any]?
 
     public init(url: String, userInfo: [String: Any]? = nil) {
         self.url = url
         self.userInfo = userInfo
+    }
+
+    public init(stringLiteral value: StringLiteralType) {
+        self.url = value
+        self.userInfo = nil
+    }
+}
+
+public extension DefaultViewProvider {
+    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?) {
+        setDefaultViewRoute(route, updating: true)
     }
 }
 

--- a/Core/Core/Common/CommonUI/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
@@ -52,11 +52,7 @@ public class CoreHostingController<Content: View>: UIHostingController<CoreHosti
 
     // MARK: - Public Properties
     public var navigationBarStyle = NavigationBarStyle.color(nil) // not applied until changed
-    public var defaultViewRoute: DefaultViewRouteParameters? {
-        didSet {
-            showDefaultDetailViewIfNeeded()
-        }
-    }
+    public private(set) var defaultViewRoute: DefaultViewRouteParameters?
 
     // MARK: - Private Variables
     var testTree: TestTree?
@@ -104,6 +100,11 @@ public class CoreHostingController<Content: View>: UIHostingController<CoreHosti
 
     public var didAppearPublisher: AnyPublisher<Void, Never> {
         didAppearSubject.eraseToAnyPublisher()
+    }
+
+    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {
+        defaultViewRoute = route
+        if updating { showDefaultDetailViewIfNeeded() }
     }
 }
 

--- a/Core/Core/Common/CommonUI/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/UIKitSwiftUIBridging/CoreHostingController.swift
@@ -102,9 +102,10 @@ public class CoreHostingController<Content: View>: UIHostingController<CoreHosti
         didAppearSubject.eraseToAnyPublisher()
     }
 
-    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {
+    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?) {
+        let prevRoute = defaultViewRoute
         defaultViewRoute = route
-        if updating { showDefaultDetailViewIfNeeded() }
+        if prevRoute == nil { showDefaultDetailViewIfNeeded() }
     }
 }
 

--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
@@ -137,10 +137,7 @@ public struct AssignmentListScreen: View, ScreenViewTrackable {
         guard let defaultViewProvider = controller.value as? DefaultViewProvider,
               defaultViewProvider.defaultViewRoute?.url != routeUrl
         else { return }
-
-        // Update only on first load
-        let updating = defaultViewProvider.defaultViewRoute == nil
-        defaultViewProvider.setDefaultViewRoute(.init(url: routeUrl), updating: updating)
+        defaultViewProvider.setDefaultViewRoute(.init(url: routeUrl))
     }
 }
 

--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListScreen.swift
@@ -138,7 +138,9 @@ public struct AssignmentListScreen: View, ScreenViewTrackable {
               defaultViewProvider.defaultViewRoute?.url != routeUrl
         else { return }
 
-        defaultViewProvider.defaultViewRoute = .init(url: routeUrl)
+        // Update only on first load
+        let updating = defaultViewProvider.defaultViewRoute == nil
+        defaultViewProvider.setDefaultViewRoute(.init(url: routeUrl), updating: updating)
     }
 }
 

--- a/Core/Core/Features/Courses/CourseDetails/View/CourseDetailsView.swift
+++ b/Core/Core/Features/Courses/CourseDetails/View/CourseDetailsView.swift
@@ -191,12 +191,15 @@ public struct CourseDetailsView: View, ScreenViewTrackable {
               defaultViewProvider.defaultViewRoute?.url != routeUrl
         else { return }
 
-        defaultViewProvider.defaultViewRoute = routeUrl.map {
-            .init(
-                url: $0,
-                userInfo: [CourseTabUrlInteractor.blockDisabledTabUserInfoKey: false]
+        defaultViewProvider
+            .setDefaultViewRoute(
+                routeUrl.map {
+                    .init(
+                        url: $0,
+                        userInfo: [CourseTabUrlInteractor.blockDisabledTabUserInfoKey: false]
+                    )
+                }
             )
-        }
     }
 }
 

--- a/Core/Core/Features/Grades/GradeListAssembly.swift
+++ b/Core/Core/Features/Grades/GradeListAssembly.swift
@@ -57,7 +57,7 @@ public enum GradeListAssembly {
             router: env.router
         )
         let viewController = CoreHostingController(GradeListView(viewModel: viewModel))
-        viewController.defaultViewRoute = .init(url: "/empty")
+        viewController.setDefaultViewRoute("/empty")
         return viewController
     }
 

--- a/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
@@ -352,10 +352,6 @@ extension ModuleListViewController: MasteryPathDelegate {
 }
 
 extension ModuleListViewController: DefaultViewProvider {
-
-    public var defaultViewRoute: DefaultViewRouteParameters? {
-        get { .init(url: "/empty") }
-        // swiftlint:disable:next unused_setter_value
-        set {}
-    }
+    public var defaultViewRoute: DefaultViewRouteParameters? { "/empty" }
+    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {}
 }

--- a/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
@@ -353,5 +353,5 @@ extension ModuleListViewController: MasteryPathDelegate {
 
 extension ModuleListViewController: DefaultViewProvider {
     public var defaultViewRoute: DefaultViewRouteParameters? { "/empty" }
-    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {}
+    public func setDefaultViewRoute(_ route: DefaultViewRouteParameters?) {}
 }

--- a/Core/CoreTests/Common/CommonModels/Router/DefaultViewProviderTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/DefaultViewProviderTests.swift
@@ -48,8 +48,6 @@ class DefaultViewProviderTests: CoreTestCase {
 }
 
 class MockDefaultViewProviderViewController: UIViewController, DefaultViewProvider {
-    var defaultViewRoute: DefaultViewRouteParameters? {
-        get { .init(url: "/empty") }
-        set {}
-    }
+    var defaultViewRoute: DefaultViewRouteParameters? { "/empty" }
+    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {}
 }

--- a/Core/CoreTests/Common/CommonModels/Router/DefaultViewProviderTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Router/DefaultViewProviderTests.swift
@@ -49,5 +49,5 @@ class DefaultViewProviderTests: CoreTestCase {
 
 class MockDefaultViewProviderViewController: UIViewController, DefaultViewProvider {
     var defaultViewRoute: DefaultViewRouteParameters? { "/empty" }
-    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?, updating: Bool) {}
+    func setDefaultViewRoute(_ route: DefaultViewRouteParameters?) {}
 }


### PR DESCRIPTION
refs: MBL-18783
affects: Student
release note: Fixes the issue where empty view is shown on reload (PTR) an assignment detail after appearance switch.

## What Changed

The main cause of the issue is actually due to resetting of `defaultDetailViewRoute` upon Course object update callback on `AssignmentListViewModel`. This triggered by (Pull-to-refresh) on assignment detail page.

This line in particular:
https://github.com/instructure/canvas-ios/blob/3771e0a48ba3e8a1981fe6cd0b4a413626fef813/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentListViewModel.swift#L302

Upon appearance mode switch this would generate different values for route between dark and light mode, as the color is resolved to different hex decimal values between those mode. 
For example: `/empty?contextColor=#C47832` in dark to `/empty?contextColor=#C23874`  in light

Setting this value would trigger the callback on `AssignmentListScreen` for this published property, which is `setupDefaultSplitDetailView()`, which end up calling `showDefaultDetailViewIfNeeded()` on the containing `CoreHostingController`, and that's what would show up the empty page.

The resolution was to control the call of `CoreHostingController.showDefaultDetailViewIfNeeded()` only to when needed, which is upon the first appearance of the list.

## Test Plan

See ticket's description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
