### PR TITLE
[Horizon] iOS Course List Discrepancy with Web

### DIFF
--- a/Core/Core/Features/Courses/CourseProgression/GetCoursesProgressionRequest.swift
+++ b/Core/Core/Features/Courses/CourseProgression/GetCoursesProgressionRequest.swift
@@ -25,19 +25,20 @@ public struct GetCoursesProgressionRequest: APIGraphQLRequestable {
 
     public struct Input: Codable, Equatable {
         var id: String
+        var horizonCourses: Bool
     }
 
-    public init(userId: String) {
-        variables = Input(id: userId)
+    public init(userId: String, horizonCourses: Bool = true) {
+        variables = Input(id: userId, horizonCourses: horizonCourses)
     }
 
     public static let operationName = "GetUserCourses"
 
     public static let query = """
-            query \(operationName)($id: ID!) {
+            query \(operationName)($id: ID!, $horizonCourses: Boolean!) {
                 legacyNode(_id: $id, type: User) {
                     ... on User {
-                        enrollments(currentOnly: false, horizonCourses: true) {
+                        enrollments(currentOnly: false, horizonCourses: $horizonCourses) {
                             course {
                                 id: _id
                                 name

--- a/Core/Core/Features/Courses/CourseProgression/GetCoursesProgressionRequest.swift
+++ b/Core/Core/Features/Courses/CourseProgression/GetCoursesProgressionRequest.swift
@@ -37,7 +37,7 @@ public struct GetCoursesProgressionRequest: APIGraphQLRequestable {
             query \(operationName)($id: ID!) {
                 legacyNode(_id: $id, type: User) {
                     ... on User {
-                        enrollments(currentOnly: true) {
+                        enrollments(currentOnly: false, horizonCourses: true) {
                             course {
                                 id: _id
                                 name

--- a/Core/Core/Features/Courses/CourseProgression/GetDashboardCoursesWithProgressionsUseCase.swift
+++ b/Core/Core/Features/Courses/CourseProgression/GetDashboardCoursesWithProgressionsUseCase.swift
@@ -33,16 +33,18 @@ public class GetDashboardCoursesWithProgressionsUseCase: APIUseCase {
     }
     private let courseId: String?
     private let userId: String
+    private let horizonCourses: Bool
 
     public var request: GetCoursesProgressionRequest {
-        .init(userId: userId)
+        .init(userId: userId, horizonCourses: horizonCourses)
     }
 
     // MARK: - Init
 
-    public init(userId: String, courseId: String? = nil) {
+    public init(userId: String, courseId: String? = nil, horizonCourses: Bool = false) {
         self.userId = userId
         self.courseId = courseId
+        self.horizonCourses = horizonCourses
     }
 
     // MARK: - Functions

--- a/Horizon/Horizon/Sources/Common/Domain/GetCoursesInteractor.swift
+++ b/Horizon/Horizon/Sources/Common/Domain/GetCoursesInteractor.swift
@@ -63,7 +63,7 @@ final class GetCoursesInteractorLive: GetCoursesInteractor {
     }
 
     func getInstitutionName() -> AnyPublisher<String, Never> {
-        ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: userId))
+        ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: userId, horizonCourses: true))
             .getEntities()
             .replaceError(with: [])
             .compactMap { $0.first?.institutionName }
@@ -98,7 +98,7 @@ final class GetCoursesInteractorLive: GetCoursesInteractor {
             .delay(for: .milliseconds(500), scheduler: scheduler)
             .map { _ in () }
             .flatMapLatest {
-                ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: unownedSelf.userId))
+                ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: unownedSelf.userId, horizonCourses: true))
                     .getEntities(ignoreCache: true)
                     .replaceError(with: [])
                     .flatMap {
@@ -121,7 +121,7 @@ final class GetCoursesInteractorLive: GetCoursesInteractor {
     private func fetchCourses(courseId: String? = nil, ignoreCache: Bool) -> AnyPublisher<[HCourse], Never> {
         unowned let unownedSelf = self
 
-        return ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: unownedSelf.userId, courseId: courseId))
+        return ReactiveStore(useCase: GetDashboardCoursesWithProgressionsUseCase(userId: unownedSelf.userId, courseId: courseId, horizonCourses: true))
             .getEntities(ignoreCache: ignoreCache)
             .replaceError(with: [])
             .flatMap { unownedSelf.fetchModules(dashboardCourses: $0, ignoreCache: ignoreCache) }


### PR DESCRIPTION
iOS and web were not showing the same list of courses. The GraphQL call to `GetUserCourses` on the web includes the parameter `horizonCourses: true`, which we were not.

[ignore-commit-lint]