### PR TITLE
Stop web media playback when switching to a new module item.

### DIFF
--- a/Core/Core/Common/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -17,6 +17,7 @@
 //
 
 import UIKit
+import WebKit
 
 public protocol ViewControllerLoader {}
 extension UIViewController: ViewControllerLoader {}
@@ -220,6 +221,12 @@ extension UIViewController {
                 return String(localized: "You must allow notifications in Settings to set reminders.", bundle: .core)
             }
         }
+    }
+
+    /// Pauses media playback on all WKWebView instances in the view hierarchy.
+    @objc
+    public func pauseWebViewPlayback() {
+        view.findAllSubviews(ofType: WKWebView.self).forEach { $0.pauseAllMediaPlayback() }
     }
 }
 

--- a/Core/Core/Common/Extensions/UIKit/UIViewExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIViewExtensions.swift
@@ -136,4 +136,19 @@ extension UIView {
     public var isHorizontallyCompact: Bool {
         traitCollection.horizontalSizeClass == .compact
     }
+
+    /// Searches the view tree for all subviews of a given type.
+    public func findAllSubviews<T: UIView>(ofType type: T.Type) -> Set<T> {
+        var result = Set<T>()
+
+        for subview in subviews {
+            if let match = subview as? T {
+                result.insert(match)
+            } else {
+                result.formUnion(subview.findAllSubviews(ofType: type))
+            }
+        }
+
+        return result
+    }
 }

--- a/Core/Core/Features/Modules/ModuleItems/ModuleItemSequenceViewController.swift
+++ b/Core/Core/Features/Modules/ModuleItems/ModuleItemSequenceViewController.swift
@@ -143,7 +143,8 @@ public final class ModuleItemSequenceViewController: UIViewController {
         store.refresh(force: true)
     }
 
-    private func setCurrentPage(_ page: UIViewController, direction: PagesViewController.Direction? = nil) {
+    internal func setCurrentPage(_ page: UIViewController, direction: PagesViewController.Direction? = nil) {
+        pages.currentPage?.pauseWebViewPlayback()
         pages.setCurrentPage(page, direction: direction)
         navigationItem.rightBarButtonItems = rightBarButtonItems
         navigationItem.leftBarButtonItems = leftBarButtonItems

--- a/Core/CoreTests/Common/Extensions/UIKit/UIViewControllerExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UIViewControllerExtensionsTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 import UIKit
 @testable import Core
+import WebKit
 
 class UIViewControllerExtensionsTests: XCTestCase {
     class MockController: UIViewController {
@@ -93,5 +94,34 @@ class UIViewControllerExtensionsTests: XCTestCase {
         let split = UISplitViewController()
         split.viewControllers = [controller]
         XCTAssertNotNil(controller.splitDisplayModeButtonItem)
+    }
+
+    func test_stopWebViewPlayback() {
+        let parentViewController = UIViewController()
+
+        let mockWebView = MockWKWebView()
+        let containerView = UIView()
+        let mockNestedWebView = MockWKWebView()
+
+        parentViewController.view.addSubview(mockWebView)
+        parentViewController.view.addSubview(containerView)
+        containerView.addSubview(mockNestedWebView)
+
+        // WHEN
+        parentViewController.pauseWebViewPlayback()
+
+        // THEN
+        XCTAssertTrue(mockWebView.pauseAllMediaPlaybackCalled)
+        XCTAssertTrue(mockNestedWebView.pauseAllMediaPlaybackCalled)
+    }
+}
+
+private class MockWKWebView: WKWebView {
+    var pauseAllMediaPlaybackCalled = false
+
+    override func pauseAllMediaPlayback(
+        completionHandler: (@MainActor @Sendable () -> Void)? = nil
+    ) {
+        pauseAllMediaPlaybackCalled = true
     }
 }

--- a/Core/CoreTests/Common/Extensions/UIKit/UIViewExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UIViewExtensionsTests.swift
@@ -106,4 +106,25 @@ class UIViewExtensionsTests: XCTestCase {
         testee.restrictFrameInsideSuperview()
         XCTAssertEqual(testee.frame, CGRect(x: 80, y: 80, width: 20, height: 20))
     }
+
+    func test_findAllSubviews() {
+        let label1 = UILabel()
+        let nestedLabel = UILabel()
+        let containerView = UIView()
+        containerView.addSubview(label1)
+        containerView.addSubview(nestedLabel)
+
+        let label2 = UILabel()
+        let button = UIButton()
+        let parentView = UIView()
+        parentView.addSubview(label2)
+        parentView.addSubview(button)
+        parentView.addSubview(containerView)
+
+        // WHEN
+        let foundLabels = parentView.findAllSubviews(ofType: UILabel.self)
+
+        // THEN
+        XCTAssertEqual(foundLabels, Set([label1, label2, nestedLabel]))
+    }
 }

--- a/Core/CoreTests/Features/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
+++ b/Core/CoreTests/Features/Modules/ModuleItems/ModuleItemSequenceViewControllerTests.swift
@@ -172,4 +172,24 @@ class ModuleItemSequenceViewControllerTests: CoreTestCase {
         XCTAssertTrue(controller.previousButton.isHidden)
         XCTAssertFalse(controller.nextButton.isHidden)
     }
+
+    func test_setCurrentPage_stopWebViewPlayback() {
+        let viewController = ModuleItemSequenceViewController()
+        let playerViewController = MockViewController()
+        viewController.pages.setCurrentPage(playerViewController)
+
+        // WHEN
+        viewController.setCurrentPage(UIViewController(), direction: .forward)
+
+        // THEN
+        XCTAssertTrue(playerViewController.stopWebViewPlaybackCalled)
+    }
+}
+
+private class MockViewController: UIViewController {
+    var stopWebViewPlaybackCalled = false
+
+    override func pauseWebViewPlayback() {
+        stopWebViewPlaybackCalled = true
+    }
 }


### PR DESCRIPTION
I also tried to exit PiP mode by calling `closeAllMediaPresentations` but it kept crashing so I left it out.

refs: MBL-18772
affects: Student, Teacher
release note: Fixed embedded media playback not getting stopped when switching to another module item.

test plan:
- Go to a module item that has an embedded studio view.
- Start playing the video with sound on.
- Go to next or previous module item.
- Audio should pause.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet