### PR TITLE
Fix test not being torn down correctly

### DIFF
--- a/Core/CoreTests/Features/Inbox/ComposeMessage/Model/ComposeMessageInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/Inbox/ComposeMessage/Model/ComposeMessageInteractorLiveTests.swift
@@ -30,6 +30,11 @@ class ComposeMessageInteractorLiveTests: CoreTestCase {
         testee = ComposeMessageInteractorLive(batchId: "testId", uploadFolderPath: "", uploadManager: uploadManager)
     }
 
+    override func tearDown() {
+        testee = nil
+        super.tearDown()
+    }
+
     func testFailedCreate() {
         let subject = "Test subject"
         let body = "Test body"


### PR DESCRIPTION
Without this, repeating the whole suite failed due to an expectation fulfilled multiple times.

[ignore-commit-lint]