### PR TITLE
Fix the issue of submission files not showing  in New Quizzes

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DisableLinkPreviews.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DisableLinkPreviews.swift
@@ -1,0 +1,51 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+private class DisableLinkPreviews: CoreWebViewFeature {
+
+    private let script: String = {
+        return """
+        function disableLinksPreviews() {
+            const links = document.querySelectorAll('a.inline_disabled.preview_in_overlay')
+            links.forEach(elm => {
+                const d_rel = elm.getAttributeNode("class");
+                d_rel.value = "inline_disabled no_preview"
+            })
+        }
+        window.addEventListener("DOMSubtreeModified", disableLinksPreviews)
+        """
+    }()
+
+    public override init() {}
+
+    override func apply(on webView: CoreWebView) {
+        webView.addScript(script)
+    }
+}
+
+public extension CoreWebViewFeature {
+
+    /**
+     This feature is to disable preview on all links of the loaded page.
+     */
+    static var disableLinkPreviews: CoreWebViewFeature {
+        DisableLinkPreviews()
+    }
+}

--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DisableLinksOverlayPreviews.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/DisableLinksOverlayPreviews.swift
@@ -18,18 +18,28 @@
 
 import UIKit
 
-private class DisableLinkPreviews: CoreWebViewFeature {
+private class DisableLinksOverlayPreviews: CoreWebViewFeature {
 
     private let script: String = {
         return """
-        function disableLinksPreviews() {
-            const links = document.querySelectorAll('a.inline_disabled.preview_in_overlay')
-            links.forEach(elm => {
-                const d_rel = elm.getAttributeNode("class");
-                d_rel.value = "inline_disabled no_preview"
+        function disableLinksOverlayPreviews() {
+            const spans = document.querySelectorAll('span.instructure_file_link_holder');
+
+            spans.forEach(elm => {
+                const a1 = elm.querySelector("a.preview_in_overlay");
+                const a2 = elm.querySelector("a.file_download_btn");
+
+                if(a1 && a2) {
+                    const d_href1 = a1.getAttributeNode("href");
+                    const d_href2 = a2.getAttributeNode("href");
+                    d_href1.value = d_href2.value;
+
+                    const d_class1 = a1.getAttributeNode("class");
+                    d_class1.value = d_class1.value.replace("preview_in_overlay", "no_preview");
+                }
             })
         }
-        window.addEventListener("DOMSubtreeModified", disableLinksPreviews)
+        window.addEventListener("DOMSubtreeModified", disableLinksOverlayPreviews)
         """
     }()
 
@@ -45,7 +55,7 @@ public extension CoreWebViewFeature {
     /**
      This feature is to disable preview on all links of the loaded page.
      */
-    static var disableLinkPreviews: CoreWebViewFeature {
-        DisableLinkPreviews()
+    static var disableLinksOverlayPreviews: CoreWebViewFeature {
+        DisableLinksOverlayPreviews()
     }
 }

--- a/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
+++ b/Core/Core/Features/Files/View/FileDetails/FileDetailsViewController.swift
@@ -130,7 +130,9 @@ public class FileDetailsViewController: ScreenViewTrackableViewController, CoreW
 
         lockView.isHidden = true
 
-        if presentingViewController != nil, navigationItem.leftBarButtonItem == nil {
+        if presentingViewController != nil,
+           navigationItem.leftBarButtonItem == nil,
+           navigationController?.viewControllers.count == 1 {
             addDoneButton(side: .left)
         }
         navigationItem.rightBarButtonItem = canEdit ? editButton : shareButton

--- a/Core/Core/Features/LTI/LTITools.swift
+++ b/Core/Core/Features/LTI/LTITools.swift
@@ -182,7 +182,8 @@ public class LTITools: NSObject {
             if isQuizLTI == true {
                 let controller = CoreWebViewController(features: [
                     .invertColorsInDarkMode,
-                    .hideReturnButtonInQuizLTI
+                    .hideReturnButtonInQuizLTI,
+                    .disableLinksOverlayPreviews
                 ])
                 controller.webView.load(URLRequest(url: url))
                 controller.title = String(localized: "Quiz", bundle: .core)

--- a/Core/Core/Features/Quizzes/QuizDetails/Student/StudentQuizWebViewController.swift
+++ b/Core/Core/Features/Quizzes/QuizDetails/Student/StudentQuizWebViewController.swift
@@ -24,7 +24,11 @@ public class StudentQuizWebViewController: UIViewController {
     var quizID = ""
 
     let env = AppEnvironment.shared
-    let webView = CoreWebView(features: [.invertColorsInDarkMode, .skipJSInjection(CoreWebView.mathJaxJS)])
+    let webView = CoreWebView(features: [
+        .invertColorsInDarkMode,
+        .skipJSInjection(CoreWebView.mathJaxJS),
+        .disableLinksOverlayPreviews
+    ])
 
     public static func create(courseID: String, quizID: String) -> StudentQuizWebViewController {
         let controller = StudentQuizWebViewController()

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/Model/Features/DisableLinksOverlayPreviewsTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/Model/Features/DisableLinksOverlayPreviewsTests.swift
@@ -1,0 +1,140 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import XCTest
+
+class DisableLinksOverlayPreviewsTests: XCTestCase {
+
+    func test_links_with_previews_tweaking() {
+        let mockLinkDelegate = MockCoreWebViewLinkDelegate()
+        let webView = CoreWebView(features: [.disableLinksOverlayPreviews])
+        webView.linkDelegate = mockLinkDelegate
+        webView.loadHTMLString(TestConstants.htmlString)
+        wait(for: [mockLinkDelegate.navigationFinishedExpectation], timeout: 10)
+
+        let jsEvaluated = expectation(description: "JS evaluated")
+        let jsScript = """
+        function listLinks() {
+            const spans = Array.from(document.querySelectorAll('span.instructure_file_link_holder'));
+            const objects = spans.map(elm => {
+                const links = Array.from(elm.querySelectorAll("a"));
+                return links.map(lin => {
+                    let d_href = lin.getAttributeNode("href").value;
+                    let d_class = lin.getAttributeNode("class").value;
+
+                    return {href: d_href, a_class: d_class};
+                });
+            });
+
+            return JSON.stringify(objects);
+        }
+
+        listLinks();
+        """
+
+        var jsonResult: String?
+        webView.evaluateJavaScript(jsScript) { result, _ in
+            jsonResult = result as? String
+            jsEvaluated.fulfill()
+        }
+
+        waitForExpectations(timeout: 1)
+
+        guard
+            let jsonData = jsonResult?.data(using: .utf8),
+            let spansList = try? JSONDecoder().decode([[HtmlLink]].self, from: jsonData) else {
+            XCTFail("Failed to parse JSON result")
+            return
+        }
+
+        XCTAssertEqual(spansList.count, 2)
+
+        spansList.forEach { span in
+            guard span.count == 2 else {
+                XCTFail("Expecting 2 links per span")
+                return
+            }
+
+            let link1 = span[0], link2 = span[1]
+
+            XCTAssertFalse(link1.a_class.contains("preview_in_overlay"))
+            XCTAssertTrue(link1.a_class.contains("no_preview"))
+
+            XCTAssertEqual(link2.a_class, "file_download_btn")
+            XCTAssertTrue(link1.href.contains("/download?"))
+            XCTAssertEqual(link1.href, link2.href)
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private struct HtmlLink: Decodable {
+    let href: String
+    let a_class: String
+}
+
+// MARK: - Test Constants
+
+// swiftlint:disable line_length
+
+private extension DisableLinksOverlayPreviewsTests {
+
+    enum TestConstants {
+        static let htmlString =  """
+            <div>
+               <span class="instructure_file_holder link_holder instructure_file_link_holder">
+                   <a class="inline_disabled preview_in_overlay"
+                       title="example.pdf"
+                       href="https://suhaibalabsi.instructure.com/courses/59827/files/571574?wrap=1&amp;instfs_id=48ffea&amp;access_token=eyJ0eXAi"
+                       target="canvas" rel="noopener noreferrer"
+                       data-old-link="/courses/59827/files/571574?wrap=1">example.pdf</a>
+
+                       <a class="file_download_btn" role="button" download="" href="https://suhaibalabsi.instructure.com/courses/59827/files/571574/download?instfs_id=48ffea&amp;access_token=eyJ0eXAi&amp;download_frd=1">
+                       <span role="presentation">
+                           <svg viewBox="0 0 1920 1920" xmlns="http://www.w3.org/2000/svg">
+                               <path d="" fill-rule="evenodd"></path>
+                           </svg>
+                       </span>
+                       <span class="screenreader-only">Download example.pdf</span>
+                       </a>
+               </span>
+
+               <span class="instructure_file_holder link_holder instructure_file_link_holder">
+                   <a class="inline_disabled preview_in_overlay"
+                       title="demo.docx"
+                       href="https://suhaibalabsi.instructure.com/courses/59827/files/576703?wrap=1&amp;instfs_id=48ffea&amp;access_token=eyJ0eXAi"
+                       target="canvas" rel="noopener noreferrer"
+                       data-old-link="/courses/59827/files/576703?wrap=1">demo.docx</a>
+
+                       <a class="file_download_btn" role="button" download="" href="https://suhaibalabsi.instructure.com/courses/59827/files/576703/download?instfs_id=48ffea&amp;access_token=eyJ0eXAi&amp;download_frd=1">
+                       <span role="presentation">
+                           <svg viewBox="0 0 1920 1920" xmlns="http://www.w3.org/2000/svg">
+                               <path d="" fill-rule="evenodd"></path>
+                           </svg>
+                       </span>
+                       <span class="screenreader-only">Download demo.docx</span>
+                       </a>
+               </span>
+            </div>
+        """
+    }
+}
+
+// swiftlint:enable line_length

--- a/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
@@ -44,7 +44,8 @@ struct SubmissionViewer: View {
                 WebView(url: url,
                         features: [
                             .userAgent(UserAgent.safariLTI.description),
-                            .invertColorsInDarkMode
+                            .invertColorsInDarkMode,
+                            .disableLinkPreviews
                         ]
                 )
                 .onLink(openInSafari)
@@ -69,7 +70,10 @@ struct SubmissionViewer: View {
             } else {
                 WebSession(url: submission.previewUrl) { url in
                     WebView(url: url,
-                            features: [.invertColorsInDarkMode])
+                            features: [
+                                .invertColorsInDarkMode,
+                                .disableLinkPreviews
+                            ])
                     .onLink(handleLink)
                     .onNavigationFinished(handleRefresh)
                 }

--- a/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
@@ -45,7 +45,7 @@ struct SubmissionViewer: View {
                         features: [
                             .userAgent(UserAgent.safariLTI.description),
                             .invertColorsInDarkMode,
-                            .disableLinkPreviews
+                            .disableLinksOverlayPreviews
                         ]
                 )
                 .onLink(openInSafari)
@@ -72,7 +72,7 @@ struct SubmissionViewer: View {
                     WebView(url: url,
                             features: [
                                 .invertColorsInDarkMode,
-                                .disableLinkPreviews
+                                .disableLinksOverlayPreviews
                             ])
                     .onLink(handleLink)
                     .onNavigationFinished(handleRefresh)


### PR DESCRIPTION
refs: MBL-18800
affects: Student, Teacher
release note: Fixes the issue of submission files not showing  in New Quizzes

## Root Cause Analysis

The issue originally caused by a web script that interrupts clicks/taps to links with "preview_in_overlay" class. 

![Screenshot 2025-04-29 at 8 40 35 PM](https://github.com/user-attachments/assets/9fd0eec4-ac21-47e3-aadb-cbc015cbe314)

![Screenshot 2025-04-29 at 8 42 21 PM](https://github.com/user-attachments/assets/58d6e22a-6e47-4fb8-8dc7-cbf57e415d3f)

This class is added to files links when link's **_Display Options_** is set to "Preview in overlay"

![Screenshot 2025-04-29 at 8 30 02 PM](https://github.com/user-attachments/assets/839324bc-6302-4630-8e78-47fbc8ef29c9)

## Resolution

It was noticed that this issue doesn't show up for links with Display Options set to "Disable Preview".
Therefore, a possible resolution to it would be to activate a script to tweak HTML content of those failing links to match that generated for working ones. Which is basically: 

1. Replacing "preview_in_overlay" in `class` attribute with "no_preview"
2. Replacing `href` attribute value with that associated for direct file download.

This script was encapsulated in a `CoreWebViewFeature` sub-type named `DisableLinksOverlayPreviews` to give the option of controlling this behavior on webViews, considering that this is a Javascript issue that might not exist on other web pages.

## Test Plan

See ticket's description.
Also, as a precaution, we need to test that for old quizzes as well.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product
