### PR TITLE
[Horizon] Notebook not navigating the module item correctly

### DIFF
--- a/Horizon/Horizon/Sources/Features/LearningObjects/ExternalURL/ExternalURLViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/LearningObjects/ExternalURL/ExternalURLViewModel.swift
@@ -53,7 +53,7 @@ final class ExternalURLViewModel {
     // MARK: - Actions
 
     func openURL() {
-        guard let viewController = viewController?.value else { return }
+        guard let viewController = viewController?.value, UIApplication.shared.canOpenURL(url) else { return }
         router.show(
             SFSafariViewController(url: url),
             from: viewController,

--- a/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookViewModel.swift
@@ -100,7 +100,7 @@ final class NotebookViewModel {
             return
         }
         router.route(
-            to: "/courses/\(note.courseNotebookNote.courseId)/modules/items/\(note.courseNotebookNote.objectId)?notebook_disabled=true",
+            to: "/courses/\(note.courseNotebookNote.courseId)/modules/items/\(note.courseNotebookNote.objectId)?asset_type=Page&notebook_disabled=true",
             from: viewController
         )
     }

--- a/Horizon/Horizon/Sources/Routing/HorizonRoutes.swift
+++ b/Horizon/Horizon/Sources/Routing/HorizonRoutes.swift
@@ -74,11 +74,18 @@ enum HorizonRoutes {
                 )
             },
             RouteHandler("/courses/:courseID/modules/items/:itemID") { url, params, _, env in
-                guard let courseID = params["courseID"], let itemID = params["itemID"] else { return nil }
+                guard let courseID = params["courseID"],
+                      let itemID = params["itemID"] else { return nil }
+
+                var assetType: GetModuleItemSequenceRequest.AssetType?
+                if let assetTypeRaw = url.queryItems?.first(where: { $0.name == "asset_type" })?.value {
+                    assetType = GetModuleItemSequenceRequest.AssetType(rawValue: assetTypeRaw)
+                }
+
                 return ModuleItemSequenceAssembly.makeItemSequenceView(
                     environment: env,
                     courseID: courseID,
-                    assetType: .moduleItem,
+                    assetType: assetType ?? .moduleItem,
                     assetID: itemID,
                     url: url
                 )


### PR DESCRIPTION
The object ID we store for notes changed from being a module item ID to a page ID. Because of this we now need to pass the `Page` asset type when navigating to the module item sequence.


https://github.com/user-attachments/assets/a3051178-2987-406f-979a-6155c2a54081


[ignore-commit-lint]