### PR TITLE
Fix Studio videos not getting downloaded 

### DIFF
--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractor.swift
@@ -124,7 +124,7 @@ public class CourseSyncStudioMediaInteractorLive: CourseSyncStudioMediaInteracto
             .offlineStudioDirectory(for: courseSyncID)
 
         let studioApiPublisher = studioAuthInteractor
-            .makeStudioAPI(env: envResolver.targetEnvironment(for: courseSyncID))
+            .makeStudioAPI(env: envResolver.targetEnvironment(for: courseSyncID), courseId: courseSyncID.value)
             .mapError { $0 as Error }
 
         let iframesDiscoveryPublisher = studioIFrameDiscoveryInteractor
@@ -136,7 +136,7 @@ public class CourseSyncStudioMediaInteractorLive: CourseSyncStudioMediaInteracto
             .flatMap { [metadataDownloadInteractor] (api, iframes) in
 
                 return metadataDownloadInteractor
-                    .fetchStudioMediaItems(api: api, courseID: courseSyncID.value)
+                    .fetchStudioMediaItems(api: api, courseID: courseSyncID.localID)
                     .map { mediaItems in
                         return CourseMediaData(
                             studioDirectory: studioDirectory,

--- a/Core/Core/Features/LTI/ExternalTool.swift
+++ b/Core/Core/Features/LTI/ExternalTool.swift
@@ -22,6 +22,7 @@ public final class ExternalTool: NSManagedObject {
     @NSManaged public var id: String
     @NSManaged public var arc: Bool
     @NSManaged public var courseID: String?
+    @NSManaged public var url: URL?
 
     @discardableResult
     public static func save(_ item: APIExternalTool, courseID: String?, in context: NSManagedObjectContext) -> ExternalTool {
@@ -30,6 +31,7 @@ public final class ExternalTool: NSManagedObject {
         tool.id = item.id.value
         tool.arc = item.arc
         tool.courseID = courseID
+        tool.url = item.url
         return tool
     }
 }

--- a/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E263" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AccountNotification" representedClassName="Core.AccountNotification" syncable="YES">
         <attribute name="endAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="iconRaw" attributeType="String"/>
@@ -507,6 +507,7 @@
         <attribute name="arc" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="courseID" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="URI"/>
     </entity>
     <entity name="ExternalToolLaunchPlacement" representedClassName="Core.ExternalToolLaunchPlacement" syncable="YES">
         <attribute name="definitionID" attributeType="String"/>

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractorLiveTests.swift
@@ -168,7 +168,7 @@ private class MockStudioAPIAuthInteractor: StudioAPIAuthInteractor {
     var mockedErrorResponse: StudioAPIAuthError?
     private(set) var makeAPICalled = false
 
-    func makeStudioAPI(env: AppEnvironment) -> AnyPublisher<API, StudioAPIAuthError> {
+    func makeStudioAPI(env: AppEnvironment, courseId: String) -> AnyPublisher<API, StudioAPIAuthError> {
         makeAPICalled = true
 
         if let mockedErrorResponse {

--- a/Core/CoreTests/Features/Studio/Model/StudioAPIAuthInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/Studio/Model/StudioAPIAuthInteractorLiveTests.swift
@@ -42,7 +42,7 @@ class StudioAPIAuthInteractorLiveTests: CoreTestCase {
                 userName: ""
             )
         )
-        let publisher = StudioAPIAuthInteractorLive(webViewFactory: { mockWebView }).makeStudioAPI(env: environment)
+        let publisher = StudioAPIAuthInteractorLive(webViewFactory: { mockWebView }).makeStudioAPI(env: environment, courseId: "1")
 
         XCTAssertFirstValueAndCompletion(publisher, timeout: 14) { api in
             XCTAssertEqual(api.loginSession, expectedAPIResult.loginSession)
@@ -60,16 +60,8 @@ class StudioAPIAuthInteractorLiveTests: CoreTestCase {
 
     private func mockStudioLTIData() {
         api.mock(
-            GetGlobalNavExternalToolsPlacements(
-                enrollment: .student
-            ),
-            value: [.make(
-                domain: LTIDomains.studio.rawValue,
-                placements: [ExternalToolLaunchPlacementLocation.global_navigation.rawValue: .init(
-                    title: "",
-                    url: TestData.studioLaunchURL
-                )]
-            )]
+            GetArc(courseID: "1"),
+            value: [.make(domain: LTIDomains.studio.rawValue, url: TestData.studioLaunchURL)]
         )
     }
 


### PR DESCRIPTION
The `accounts/self/lti_apps/launch_definitions` API call failed with 403 for cross shard users so I changed to a different API that seems to work for everyone.

refs: [MBL-18812](https://instructure.atlassian.net/browse/MBL-18812)
affects: Student
release note: Fixed Studio videos not getting downloaded for cross shard users for offline mode.

test plan:
- See ticket for test account.
- Studio offline sync should work when logged in via the root or the 01 instance as well.
- Test a non-shard instance if Studio sync still works on those.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet


[MBL-18812]: https://instructure.atlassian.net/browse/MBL-18812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ