### PR TITLE
[Horizon] Hide Previous/Next Page Buttons in Notebook

### DIFF
--- a/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookView.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookView.swift
@@ -65,27 +65,29 @@ struct NotebookView: View {
         .padding(.bottom, .huiSpaces.space16)
     }
 
+    @ViewBuilder
     private var forwardBackButtons: some View {
-        HStack {
-            HorizonUI.IconButton(
-                .huiIcons.chevronLeft,
-                type: .black,
-                isSmall: true
-            ) {
-                viewModel.previousPage()
+        if viewModel.isPaginationButtonsVisible {
+            HStack {
+                HorizonUI.IconButton(
+                    .huiIcons.chevronLeft,
+                    type: .black,
+                    isSmall: true
+                ) {
+                    viewModel.previousPage()
+                }
+                .disabled(viewModel.isPreviousDisabled)
+                HorizonUI.IconButton(
+                    .huiIcons.chevronRight,
+                    type: .black,
+                    isSmall: true
+                ) {
+                    viewModel.nextPage()
+                }
+                .disabled(viewModel.isNextDisabled)
             }
-            .disabled(viewModel.isPreviousDisabled)
-
-            HorizonUI.IconButton(
-                .huiIcons.chevronRight,
-                type: .black,
-                isSmall: true
-            ) {
-                viewModel.nextPage()
-            }
-            .disabled(viewModel.isNextDisabled)
+            .padding(.top, .huiSpaces.space24)
         }
-        .padding(.top, .huiSpaces.space24)
     }
 
     private var navigationBar: some View {

--- a/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Notebook/View/NotebookViewModel.swift
@@ -51,6 +51,9 @@ final class NotebookViewModel {
     var isFiltersVisible: Bool { courseId == nil }
     var isNavigationBarVisible: Bool { courseId == nil || pageUrl != nil }
     private(set) var isNextDisabled: Bool = true
+    var isPaginationButtonsVisible: Bool {
+        !(isNextDisabled && isPreviousDisabled)
+    }
     private(set) var isPreviousDisabled: Bool = true
     var navigationBarTopPadding: CGFloat { courseId == nil ? .zero : .huiSpaces.space24 }
     private(set) var notes: [NotebookNote] = []


### PR DESCRIPTION
If there are no other pages, hide the previous and next page buttons in the notebook.


https://github.com/user-attachments/assets/66444ac4-2658-4d93-9d00-8175898dabf8


[ignore-commit-lint]