### PR TITLE
SpeedGrader comments

### DIFF
--- a/Core/Core/Common/Extensions/Combine/PublisherExtensions.swift
+++ b/Core/Core/Common/Extensions/Combine/PublisherExtensions.swift
@@ -28,6 +28,20 @@ extension Publisher {
         sink { _ in } receiveValue: { _ in }
     }
 
+    public func sinkFailureOrValue(
+        receiveFailure: @escaping (Self.Failure) -> Void,
+        receiveValue: @escaping (Self.Output) -> Void
+    ) -> AnyCancellable {
+        sink(
+            receiveCompletion: { completion in
+                if case .failure(let error) = completion {
+                    receiveFailure(error)
+                }
+            },
+            receiveValue: receiveValue
+        )
+    }
+
     public func bindProgress(_ isLoading: PassthroughRelay<Bool>) -> AnyPublisher<Output, Failure> {
         handleEvents(
             receiveSubscription: { _ in

--- a/Core/Core/Common/Extensions/InstIconExtensions.swift
+++ b/Core/Core/Common/Extensions/InstIconExtensions.swift
@@ -240,6 +240,8 @@ public extension UIImage {
     static var checkbox: UIImage { UIImage(named: "checkbox", in: .core, compatibleWith: nil)! }
     static var checkboxSelected: UIImage { UIImage(named: "checkboxSelected", in: .core, compatibleWith: nil)! }
     static var chevronDown: UIImage { UIImage(named: "chevronDown", in: .core, compatibleWith: nil)! }
+    static var chevronUpLine: UIImage { UIImage(named: "chevronUpLine", in: .core, compatibleWith: nil)! }
+    static var chevronUpSolid: UIImage { UIImage(named: "chevronUpSolid", in: .core, compatibleWith: nil)! }
     static var collaborations: UIImage { UIImage(named: "collaborations", in: .core, compatibleWith: nil)! }
     static var conferences: UIImage { UIImage(named: "conferences", in: .core, compatibleWith: nil)! }
     static var coursesTab: UIImage { UIImage(named: "coursesTab", in: .core, compatibleWith: nil)! }
@@ -494,6 +496,8 @@ public extension Image {
     static var checkbox: Image { Image("checkbox", bundle: .core) }
     static var checkboxSelected: Image { Image("checkboxSelected", bundle: .core) }
     static var chevronDown: Image { Image("chevronDown", bundle: .core) }
+    static var chevronUpLine: Image { Image("chevronUpLine", bundle: .core) }
+    static var chevronUpSolid: Image { Image("chevronUpSolid", bundle: .core) }
     static var collaborations: Image { Image("collaborations", bundle: .core) }
     static var conferences: Image { Image("conferences", bundle: .core) }
     static var coursesTab: Image { Image("coursesTab", bundle: .core) }

--- a/Core/Core/Common/Extensions/SwiftUI/ImageExtensions.swift
+++ b/Core/Core/Common/Extensions/SwiftUI/ImageExtensions.swift
@@ -22,4 +22,12 @@ extension Image {
     public func size(_ size: CGFloat?) -> some View {
         resizable().scaledToFill().frame(width: size, height: size)
     }
+
+    public func size(_ size: CGFloat, paddedTo boundingSize: CGFloat) -> some View {
+        let padding = min((boundingSize - size) / 2, 0)
+        return resizable()
+            .scaledToFill()
+            .frame(width: size, height: size)
+            .padding(padding)
+    }
 }

--- a/Core/Core/Common/Extensions/SwiftUI/View+Typography.swift
+++ b/Core/Core/Common/Extensions/SwiftUI/View+Typography.swift
@@ -20,11 +20,11 @@ import SwiftUI
 
 extension View {
 
-    func style(_ style: Typography.Style) -> some View {
+    public func style(_ style: Typography.Style) -> some View {
         self.font(style.fontName, lineHeight: style.lineHeight)
     }
 
-    func font(_ fontName: UIFont.Name, lineHeight: Typography.LineHeight) -> some View {
+    public func font(_ fontName: UIFont.Name, lineHeight: Typography.LineHeight) -> some View {
         let font = UIFont.scaledNamedFont(fontName)
         let spacing = lineHeight.lineSpacing(for: font)
         let styledSelf = self

--- a/Core/Core/Features/Submissions/GetSubmissions.swift
+++ b/Core/Core/Features/Submissions/GetSubmissions.swift
@@ -194,6 +194,20 @@ public class GetSubmissionsForStudent: CollectionUseCase {
     }
 }
 
+public class GetSubmissionAttemptsLocal: LocalUseCase<Submission> {
+    public init(assignmentId: String, userId: String) {
+        let scope = Scope(
+            predicate: NSCompoundPredicate(andPredicateWithSubpredicates: [
+                NSPredicate(key: #keyPath(Submission.assignmentID), equals: assignmentId),
+                NSPredicate(key: #keyPath(Submission.userID), equals: userId),
+                NSPredicate(format: "%K != nil", #keyPath(Submission.submittedAt))
+            ]),
+            orderBy: #keyPath(Submission.attempt)
+        )
+        super.init(scope: scope)
+    }
+}
+
 public class GetSubmissions: CollectionUseCase {
     public typealias Model = Submission
     public typealias Response = Request.Response

--- a/Core/Core/Resources/Assets.xcassets/icons/chevronUpLine.imageset/Contents.json
+++ b/Core/Core/Resources/Assets.xcassets/icons/chevronUpLine.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "chevron-up_line.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Core/Core/Resources/Assets.xcassets/icons/chevronUpLine.imageset/chevron-up_line.svg
+++ b/Core/Core/Resources/Assets.xcassets/icons/chevronUpLine.imageset/chevron-up_line.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5.18518 15.1852L4 14L12 6L20 14L18.8148 15.1852L12 8.37037L5.18518 15.1852Z" fill="#273540"/>
+</svg>

--- a/Core/Core/Resources/Assets.xcassets/icons/chevronUpSolid.imageset/Contents.json
+++ b/Core/Core/Resources/Assets.xcassets/icons/chevronUpSolid.imageset/Contents.json
@@ -1,0 +1,16 @@
+{
+  "images" : [
+    {
+      "filename" : "chevron-up_solid.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
+  }
+}

--- a/Core/Core/Resources/Assets.xcassets/icons/chevronUpSolid.imageset/chevron-up_solid.svg
+++ b/Core/Core/Resources/Assets.xcassets/icons/chevronUpSolid.imageset/chevron-up_solid.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M2 16.0013L3.8347 17.836L12.0013 9.67069L20.1653 17.836L22 16.0013L12.0013 6L2 16.0013Z" fill="#273540"/>
+</svg>

--- a/Core/CoreTests/Common/CommonModels/Analytics/PendoAnalyticsTrackerTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/PendoAnalyticsTrackerTests.swift
@@ -109,7 +109,7 @@ class PendoAnalyticsTrackerTests: XCTestCase {
             visitorData: .init(id: "some visitor id", locale: "some visitor locale"),
             accountData: .init(id: "some account id", surveyOptOut: true)
         )
-        interactor.getMedatataResult = metadata
+        interactor.getMetadataResult = metadata
 
         try await testee.startSessionAsync()
 
@@ -234,8 +234,8 @@ private final class PendoManagerMock: PendoManagerWrapper {
 
 private class AnalyticsMetadataInteractorMock: AnalyticsMetadataInteractor {
 
-    var getMedatataResult: AnalyticsMetadata = .make()
+    var getMetadataResult: AnalyticsMetadata = .make()
     func getMetadata() async throws -> AnalyticsMetadata {
-        getMedatataResult
+        getMetadataResult
     }
 }

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewAttachmentDownloadTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewAttachmentDownloadTests.swift
@@ -19,6 +19,7 @@
 import XCTest
 import WebKit
 @testable import Core
+import TestsFoundation
 
 class CoreWebViewAttachmentDownloadTests: CoreTestCase {
 
@@ -154,8 +155,4 @@ class CoreWebViewAttachmentDownloadTests: CoreTestCase {
         XCTAssertEqual(failedAttachment.contentType, "video/mp4")
         XCTAssertEqual(failure, error)
     }
-}
-
-private struct MockError: Equatable, Error {
-    let code: Int
 }

--- a/Core/CoreTests/Common/Extensions/InstIconExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/InstIconExtensionsTests.swift
@@ -241,6 +241,8 @@ class InstIconExtensionTests: XCTestCase {
         XCTAssertEqual(UIImage.checkbox, UIImage(named: "checkbox", in: .core, compatibleWith: nil))
         XCTAssertEqual(UIImage.checkboxSelected, UIImage(named: "checkboxSelected", in: .core, compatibleWith: nil))
         XCTAssertEqual(UIImage.chevronDown, UIImage(named: "chevronDown", in: .core, compatibleWith: nil))
+        XCTAssertEqual(UIImage.chevronUpLine, UIImage(named: "chevronUpLine", in: .core, compatibleWith: nil))
+        XCTAssertEqual(UIImage.chevronUpSolid, UIImage(named: "chevronUpSolid", in: .core, compatibleWith: nil))
         XCTAssertEqual(UIImage.collaborations, UIImage(named: "collaborations", in: .core, compatibleWith: nil))
         XCTAssertEqual(UIImage.conferences, UIImage(named: "conferences", in: .core, compatibleWith: nil))
         XCTAssertEqual(UIImage.coursesTab, UIImage(named: "coursesTab", in: .core, compatibleWith: nil))

--- a/Core/CoreTests/Common/Extensions/InstIconTests.swift
+++ b/Core/CoreTests/Common/Extensions/InstIconTests.swift
@@ -43,6 +43,8 @@ class InstIconTests: XCTestCase {
         XCTAssertEqual(Image.checkbox, Image("checkbox", bundle: .core))
         XCTAssertEqual(Image.checkboxSelected, Image("checkboxSelected", bundle: .core))
         XCTAssertEqual(Image.chevronDown, Image("chevronDown", bundle: .core))
+        XCTAssertEqual(Image.chevronUpLine, Image("chevronUpLine", bundle: .core))
+        XCTAssertEqual(Image.chevronUpSolid, Image("chevronUpSolid", bundle: .core))
         XCTAssertEqual(Image.collaborations, Image("collaborations", bundle: .core))
         XCTAssertEqual(Image.conferences, Image("conferences", bundle: .core))
         XCTAssertEqual(Image.coursesTab, Image("coursesTab", bundle: .core))

--- a/Core/CoreTests/Features/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarEvent/ViewModel/EditCalendarEventViewModelTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 @testable import Core
+import TestsFoundation
 
 final class EditCalendarEventViewModelTests: CoreTestCase {
 
@@ -769,5 +770,3 @@ final class EditCalendarEventViewModelTests: CoreTestCase {
         return selectedCalendar
     }
 }
-
-private struct MockError: Error { }

--- a/Core/CoreTests/Features/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModelTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarToDo/ViewModel/EditCalendarToDoViewModelTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 @testable import Core
+import TestsFoundation
 
 final class EditCalendarToDoViewModelTests: CoreTestCase {
 
@@ -452,5 +453,3 @@ final class EditCalendarToDoViewModelTests: CoreTestCase {
         return plannable
     }
 }
-
-private struct MockError: Error { }

--- a/Core/TestsFoundation/Mocks/Errors.swift
+++ b/Core/TestsFoundation/Mocks/Errors.swift
@@ -1,0 +1,33 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public struct MockError: Error, Equatable, LocalizedError {
+    public let code: Int
+    public var errorDescription: String?
+
+    public init(code: Int = 0, message: String = "") {
+        self.code = code
+        self.errorDescription = message
+    }
+}
+
+public struct InvalidCountError: Error {
+    public init() {}
+}

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3B55FED522FDE70F00FCB7B2 /* HideGradesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B55FED322FDE70F00FCB7B2 /* HideGradesViewController.swift */; };
 		494AE0B91F843CB5001A8F31 /* TeacherTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */; };
 		494AE0BA1F843CB5001A8F31 /* Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B61F843CB4001A8F31 /* Routes.swift */; };
+		5B9C5C072DB9B04000103E21 /* SubmissionCommentsAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */; };
 		5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */; };
 		61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */; };
 		78AD913121C8180C0075FBCF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 78AD913021C8180C0075FBCF /* GoogleService-Info.plist */; };
@@ -239,6 +240,7 @@
 		494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherTabBarController.swift; sourceTree = "<group>"; };
 		494AE0B61F843CB4001A8F31 /* Routes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routes.swift; sourceTree = "<group>"; };
 		497CA7321F82ACF400501613 /* CanvasCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CanvasCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsAssembly.swift; sourceTree = "<group>"; };
 		5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractor.swift; sourceTree = "<group>"; };
 		61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeacherAppDelegate.swift; sourceTree = "<group>"; };
 		78AD913021C8180C0075FBCF /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -802,6 +804,7 @@
 		CF0605CD2D95A56C0014C2EC /* Comments */ = {
 			isa = PBXGroup;
 			children = (
+				5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */,
 				5BB37BC42DB90F410096821B /* Model */,
 				CF0605D12D95A60C0014C2EC /* ViewModel */,
 				CF0605CE2D95A5790014C2EC /* View */,
@@ -1503,6 +1506,7 @@
 				3B55FED522FDE70F00FCB7B2 /* HideGradesViewController.swift in Sources */,
 				7D0A28E2251A8284004FB3B6 /* SubmissionHeaderView.swift in Sources */,
 				7DCA321A25423CDF00458651 /* SpeedGraderViewController.swift in Sources */,
+				5B9C5C072DB9B04000103E21 /* SubmissionCommentsAssembly.swift in Sources */,
 				CF0605E32D95C5A50014C2EC /* RubricCircle.swift in Sources */,
 				CFCADAF42D9D871D003796E7 /* RubricRatingView.swift in Sources */,
 				7D742F452556566F00FD6CF1 /* CommentEditorView.swift in Sources */,

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -26,7 +26,9 @@
 		3B55FED522FDE70F00FCB7B2 /* HideGradesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B55FED322FDE70F00FCB7B2 /* HideGradesViewController.swift */; };
 		494AE0B91F843CB5001A8F31 /* TeacherTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */; };
 		494AE0BA1F843CB5001A8F31 /* Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B61F843CB4001A8F31 /* Routes.swift */; };
+		5B05E47E2DC3B16F00919212 /* SubmissionCommentsInteractorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B05E47D2DC3B16F00919212 /* SubmissionCommentsInteractorTests.swift */; };
 		5B1E28662DC0C47000540B3D /* SubmissionCommentListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */; };
+		5B4F3E602DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F3E5F2DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift */; };
 		5B9C5C072DB9B04000103E21 /* SubmissionCommentsAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */; };
 		5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */; };
 		61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */; };
@@ -241,7 +243,9 @@
 		494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherTabBarController.swift; sourceTree = "<group>"; };
 		494AE0B61F843CB4001A8F31 /* Routes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routes.swift; sourceTree = "<group>"; };
 		497CA7321F82ACF400501613 /* CanvasCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CanvasCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B05E47D2DC3B16F00919212 /* SubmissionCommentsInteractorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractorTests.swift; sourceTree = "<group>"; };
 		5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListCellViewModel.swift; sourceTree = "<group>"; };
+		5B4F3E5F2DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListCellViewModelTests.swift; sourceTree = "<group>"; };
 		5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsAssembly.swift; sourceTree = "<group>"; };
 		5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractor.swift; sourceTree = "<group>"; };
 		61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeacherAppDelegate.swift; sourceTree = "<group>"; };
@@ -490,6 +494,14 @@
 				7D0D7AE1251E6E6C00550AEC /* SubmissionListViewController.swift */,
 			);
 			path = Submissions;
+			sourceTree = "<group>";
+		};
+		5B05E47C2DC3B16000919212 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				5B05E47D2DC3B16F00919212 /* SubmissionCommentsInteractorTests.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		5BB37BC42DB90F410096821B /* Model */ = {
@@ -1034,6 +1046,7 @@
 		CF0606052D96E4C20014C2EC /* Comments */ = {
 			isa = PBXGroup;
 			children = (
+				5B05E47C2DC3B16000919212 /* Model */,
 				CF0606062D96E4C90014C2EC /* ViewModel */,
 			);
 			path = Comments;
@@ -1043,6 +1056,7 @@
 			isa = PBXGroup;
 			children = (
 				B417C2E52B1F169000CD6FA4 /* SubmissionCommentListViewModelTests.swift */,
+				5B4F3E5F2DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1577,6 +1591,7 @@
 			files = (
 				7D3DC0C7252432DD00B0EBC1 /* SubmissionFilterPickerViewControllerTests.swift in Sources */,
 				7D64A98123676E36004EAEDF /* RollCallSessionTests.swift in Sources */,
+				5B4F3E602DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift in Sources */,
 				7D64A96D23626C22004EAEDF /* StatusCellTests.swift in Sources */,
 				CF56B71525F68CD3000DD32F /* SubmissionHeaderViewTests.swift in Sources */,
 				D9624A7E29C4AEF000F5303F /* QuizSubmissionListItemTests.swift in Sources */,
@@ -1585,6 +1600,7 @@
 				EB35BC5427BA4DF500166F0D /* SubmissionCommentLibraryViewModelTests.swift in Sources */,
 				D9B484FE29CC91A70004EBB5 /* QuizSubmissionViewModelTests.swift in Sources */,
 				D9B4851E29CDED990004EBB5 /* QuizSubmissionListFilterTests.swift in Sources */,
+				5B05E47E2DC3B16F00919212 /* SubmissionCommentsInteractorTests.swift in Sources */,
 				7D64A96F23626F52004EAEDF /* StatusTests.swift in Sources */,
 				7D64A98523689DD5004EAEDF /* DatePickerViewControllerTests.swift in Sources */,
 				3B1D37C9231085830017CCA2 /* PostGradesPresenterTests.swift in Sources */,

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3B55FED522FDE70F00FCB7B2 /* HideGradesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B55FED322FDE70F00FCB7B2 /* HideGradesViewController.swift */; };
 		494AE0B91F843CB5001A8F31 /* TeacherTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */; };
 		494AE0BA1F843CB5001A8F31 /* Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B61F843CB4001A8F31 /* Routes.swift */; };
+		5B1E28662DC0C47000540B3D /* SubmissionCommentListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */; };
 		5B9C5C072DB9B04000103E21 /* SubmissionCommentsAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */; };
 		5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */; };
 		61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */; };
@@ -240,6 +241,7 @@
 		494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherTabBarController.swift; sourceTree = "<group>"; };
 		494AE0B61F843CB4001A8F31 /* Routes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routes.swift; sourceTree = "<group>"; };
 		497CA7321F82ACF400501613 /* CanvasCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CanvasCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListCellViewModel.swift; sourceTree = "<group>"; };
 		5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsAssembly.swift; sourceTree = "<group>"; };
 		5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractor.swift; sourceTree = "<group>"; };
 		61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeacherAppDelegate.swift; sourceTree = "<group>"; };
@@ -845,6 +847,7 @@
 			isa = PBXGroup;
 			children = (
 				B4707B042B1DDF7900F67CA8 /* SubmissionCommentListViewModel.swift */,
+				5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1532,6 +1535,7 @@
 				CFCADAF22D9D6FE4003796E7 /* RubricCustomRatingViewModel.swift in Sources */,
 				CF0E06942DA8FFC6007AC131 /* SubmissionGraderViewModel.swift in Sources */,
 				D9624A5229B0E90800F5303F /* QuizSubmissionListFilter.swift in Sources */,
+				5B1E28662DC0C47000540B3D /* SubmissionCommentListCellViewModel.swift in Sources */,
 				D9624A5029AF94D000F5303F /* QuizSubmissionListInteractorPreview.swift in Sources */,
 				CF13E54C299D090500F57F69 /* QuizSubmissionListViewModel.swift in Sources */,
 				CFCADAF62D9D89D0003796E7 /* RubricCustomRatingView.swift in Sources */,

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		3B55FED522FDE70F00FCB7B2 /* HideGradesViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B55FED322FDE70F00FCB7B2 /* HideGradesViewController.swift */; };
 		494AE0B91F843CB5001A8F31 /* TeacherTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */; };
 		494AE0BA1F843CB5001A8F31 /* Routes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494AE0B61F843CB4001A8F31 /* Routes.swift */; };
+		5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */; };
 		61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */; };
 		78AD913121C8180C0075FBCF /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 78AD913021C8180C0075FBCF /* GoogleService-Info.plist */; };
 		7D0A28E2251A8284004FB3B6 /* SubmissionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D0A28E1251A8284004FB3B6 /* SubmissionHeaderView.swift */; };
@@ -238,6 +239,7 @@
 		494AE0B51F843CB4001A8F31 /* TeacherTabBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TeacherTabBarController.swift; sourceTree = "<group>"; };
 		494AE0B61F843CB4001A8F31 /* Routes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Routes.swift; sourceTree = "<group>"; };
 		497CA7321F82ACF400501613 /* CanvasCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CanvasCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractor.swift; sourceTree = "<group>"; };
 		61BD85FB1EB2933C005A09A5 /* TeacherAppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TeacherAppDelegate.swift; sourceTree = "<group>"; };
 		78AD913021C8180C0075FBCF /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		7D0A28E1251A8284004FB3B6 /* SubmissionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionHeaderView.swift; sourceTree = "<group>"; };
@@ -484,6 +486,14 @@
 				7D0D7AE1251E6E6C00550AEC /* SubmissionListViewController.swift */,
 			);
 			path = Submissions;
+			sourceTree = "<group>";
+		};
+		5BB37BC42DB90F410096821B /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */,
+			);
+			path = Model;
 			sourceTree = "<group>";
 		};
 		7D0A28E0251A8104004FB3B6 /* SpeedGrader */ = {
@@ -792,6 +802,7 @@
 		CF0605CD2D95A56C0014C2EC /* Comments */ = {
 			isa = PBXGroup;
 			children = (
+				5BB37BC42DB90F410096821B /* Model */,
 				CF0605D12D95A60C0014C2EC /* ViewModel */,
 				CF0605CE2D95A5790014C2EC /* View */,
 			);
@@ -1520,6 +1531,7 @@
 				D9624A5029AF94D000F5303F /* QuizSubmissionListInteractorPreview.swift in Sources */,
 				CF13E54C299D090500F57F69 /* QuizSubmissionListViewModel.swift in Sources */,
 				CFCADAF62D9D89D0003796E7 /* RubricCustomRatingView.swift in Sources */,
+				5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */,
 				61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */,
 				D91C051D29AE10170032BFB1 /* QuizSubmissionListItemView.swift in Sources */,
 				7D7126BC25366DAB000DEDE4 /* SubmissionViewer.swift in Sources */,

--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -36460,6 +36460,9 @@
           }
         }
       }
+    },
+    "Write your Comment here" : {
+
     }
   },
   "version" : "1.0"

--- a/Teacher/Teacher/SpeedGrader/Comments/Model/SubmissionCommentsInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/Model/SubmissionCommentsInteractor.swift
@@ -1,0 +1,67 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Core
+import Foundation
+
+protocol SubmissionCommentsInteractor: AnyObject {
+    func getComments() -> AnyPublisher<[SubmissionComment], Error>
+    func getIsAssignmentEnhancementsEnabled() -> AnyPublisher<Bool, Error>
+}
+
+final class SubmissionCommentsInteractorLive: SubmissionCommentsInteractor {
+
+    // MARK: - Private properties
+
+    private let submissionCommentsStore: ReactiveStore<GetSubmissionComments>
+    private let featureFlagsStore: ReactiveStore<GetEnabledFeatureFlags>
+
+    // MARK: - Init
+
+    init(
+        courseID: String,
+        assignmentID: String,
+        userID: String
+    ) {
+        submissionCommentsStore = ReactiveStore(
+            useCase: GetSubmissionComments(
+                context: .course(courseID),
+                assignmentID: assignmentID,
+                userID: userID
+            )
+        )
+
+        featureFlagsStore = ReactiveStore(
+            useCase: GetEnabledFeatureFlags(context: .course(courseID))
+        )
+    }
+
+    func getComments() -> AnyPublisher<[SubmissionComment], Error> {
+        submissionCommentsStore
+            .getEntities(keepObservingDatabaseChanges: true)
+            .eraseToAnyPublisher()
+    }
+
+    func getIsAssignmentEnhancementsEnabled() -> AnyPublisher<Bool, Error> {
+        featureFlagsStore
+            .getEntities(keepObservingDatabaseChanges: true)
+            .map { $0.isFeatureFlagEnabled(.assignmentEnhancements) }
+            .eraseToAnyPublisher()
+    }
+}

--- a/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
@@ -22,24 +22,22 @@ import Foundation
 enum SubmissionCommentsAssembly {
     static func makeCommentListViewModel(
         assignment: Assignment,
-        submissions: [Submission],
-        initialSubmission: Submission,
-        initialAttemptNumber: Int?,
+        latestSubmission: Submission,
+        latestAttemptNumber: Int?,
         env: AppEnvironment
     ) -> SubmissionCommentListViewModel {
         let interactor = SubmissionCommentsInteractorLive(
             courseId: assignment.courseID,
             assignmentId: assignment.id,
-            userId: initialSubmission.userID,
+            submissionUserId: latestSubmission.userID,
             isGroupAssignment: !assignment.gradedIndividually,
             env: env
         )
 
         return SubmissionCommentListViewModel(
             assignment: assignment,
-            submissions: submissions,
-            initialSubmission: initialSubmission,
-            initialAttemptNumber: initialAttemptNumber,
+            latestSubmission: latestSubmission,
+            latestAttemptNumber: latestAttemptNumber,
             currentUserId: env.currentSession?.userID,
             interactor: interactor,
             env: env

--- a/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
@@ -1,0 +1,46 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import Foundation
+
+enum SubmissionCommentsAssembly {
+    static func makeCommentListViewModel(
+        assignment: Assignment,
+        submissions: [Submission],
+        initialSubmission: Submission,
+        initialAttemptNumber: Int?,
+        env: AppEnvironment
+    ) -> SubmissionCommentListViewModel {
+        let interactor = SubmissionCommentsInteractorLive(
+            courseId: assignment.courseID,
+            assignmentId: assignment.id,
+            userId: initialSubmission.userID,
+            isGroupAssignment: !assignment.gradedIndividually,
+            env: env
+        )
+
+        return SubmissionCommentListViewModel(
+            assignment: assignment,
+            submissions: submissions,
+            initialSubmission: initialSubmission,
+            initialAttemptNumber: initialAttemptNumber,
+            interactor: interactor
+        )
+    }
+}

--- a/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/SubmissionCommentsAssembly.swift
@@ -40,7 +40,9 @@ enum SubmissionCommentsAssembly {
             submissions: submissions,
             initialSubmission: initialSubmission,
             initialAttemptNumber: initialAttemptNumber,
-            interactor: interactor
+            currentUserId: env.currentSession?.userID,
+            interactor: interactor,
+            env: env
         )
     }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -20,153 +20,134 @@ import SwiftUI
 import Core
 
 struct SubmissionCommentListCell: View {
-    let assignment: Assignment
-    let submission: Submission
-    let comment: SubmissionComment
+    @Environment(\.appEnvironment) var env
+    @Environment(\.viewController) var controller
+
+    @ObservedObject var viewModel: SubmissionCommentListCellViewModel
 
     @Binding var attempt: Int
     @Binding var fileID: String?
 
-    @Environment(\.appEnvironment.currentSession?.userID) var currentUserID
-    @Environment(\.appEnvironment) var env
-    @Environment(\.viewController) var controller
-
     var body: some View {
-        let isAuthor = comment.authorID == currentUserID
-        VStack(alignment: isAuthor ? .trailing : .leading, spacing: 0) {
-            header
-            if let attempt = comment.attempt {
-                if submission.type == .online_upload {
-                    Spacer().frame(height: 8)
-                    ForEach(submission.attachments?.sorted(by: File.idCompare) ?? [], id: \.id) { file in
-                        Spacer().frame(height: 4)
-                        SubmissionCommentFile(file: file) {
-                            self.attempt = attempt
-                            self.fileID = file.id
-                        }
-                        .accessibilityLabel(
-                            Text(comment.accessibilityLabelForAttemptAttachment(file, submission: submission))
-                        )
-                        .accessibilityHint(Text("Double tap to view file", bundle: .core))
-                    }
-                } else {
-                    Spacer().frame(height: 12)
-                    SubmissionAttempt(submission: submission) {
-                        self.attempt = attempt
-                    }
-                    .accessibilityLabel(
-                        Text(comment.accessibilityLabelForAttempt(submission: submission))
-                    )
-                    .accessibilityHint(Text("Double tap to view attempt", bundle: .core))
-                }
-            } else if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
-                Spacer().frame(height: 12)
-                AudioPlayer(url: url)
-                    .identifier("SubmissionComments.audioCell.\(comment.id)")
-            } else if comment.mediaType == .some(.video), let url = comment.mediaLocalOrRemoteURL {
-                Spacer().frame(height: 12)
-                VideoPlayer(url: url)
-                    .cornerRadius(4)
-                    .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
-                    .identifier("SubmissionComments.videoCell.\(comment.id)")
-            } else {
-                Spacer().frame(height: 4)
-                Text(comment.comment)
-                    .font(.regular14).foregroundColor(isAuthor ? .textLightest.variantForLightMode : .textDarkest)
-                    .padding(.horizontal, 12).padding(.vertical, 8)
-                    .background(CommentBackground()
-                        .fill(isAuthor ? Color.backgroundInfo : Color.backgroundLight)
-                        .scaleEffect(x: isAuthor ? -1: 1)
-                    )
-                    .accessibilityHidden(true) // already included in header
-                    .identifier("SubmissionComments.textCell.\(comment.id)")
-                ForEach(comment.attachments?.sorted(by: File.idCompare) ?? [], id: \.id) { file in
-                    Spacer().frame(height: 4)
-                    SubmissionCommentFile(file: file) {
-                        guard let id = file.id else { return }
-                        env.router.route(
-                            to: "/files/\(id)",
-                            from: controller,
-                            options: .modal(embedInNav: true, addDoneButton: true)
-                        )
-                    }
-                    .accessibilityLabel(
-                        Text(comment.accessibilityLabelForCommentAttachment(file))
-                    )
-                    .accessibilityHint(Text("Double tap to view file", bundle: .core))
+        if viewModel.author.isCurrentUser {
+            VStack(alignment: .trailing, spacing: 2) {
+                header
+                commentView
+            }
+            .frame(maxWidth: .infinity, alignment: .trailing)
+            .paddingStyle(.horizontal, .standard)
+            .padding(.top, 2)
+            .padding(.bottom, 8)
+        } else {
+            HStack(alignment: .top, spacing: 12) {
+                avatar
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 2) {
+                    header
+                    commentView
                 }
             }
-        }
-            .padding(16)
-    }
-
-    var header: some View {
-        HStack(spacing: 12) {
-            if comment.authorID == currentUserID {
-                Spacer()
-                VStack(alignment: .trailing, spacing: 0, content: headerText)
-                    .multilineTextAlignment(.trailing)
-                avatar
-            } else {
-                avatar
-                VStack(alignment: .leading, spacing: 0, content: headerText)
-                    .multilineTextAlignment(.leading)
-                Spacer()
-            }
-        }
-        .accessibilityElement(children: .ignore)
-        .accessibilityRepresentation {
-            if assignment.anonymizeStudents && comment.authorID != currentUserID {
-                Text(comment.accessibilityLabelForHeader)
-            } else if let id = comment.authorID {
-                Button(
-                    action: { avatarButtonAction(authorId: id) },
-                    label: { Text(comment.accessibilityLabelForHeader) }
-                )
-                .accessibilityHint(Text("Double tap to view profile", bundle: .core))
-            } else {
-                Text(comment.accessibilityLabelForHeader)
-            }
+            .paddingStyle(set: .standardCell)
         }
     }
 
-    @ViewBuilder var avatar: some View {
-        if assignment.anonymizeStudents && comment.authorID != currentUserID {
-            (submission.groupID != nil ? Image.groupLine : Image.userLine)
-                .foregroundColor(.textDark)
-                .frame(width: 40, height: 40)
-                .cornerRadius(20)
-                .overlay(Circle()
-                    .stroke(Color.borderMedium, lineWidth: 1)
-                )
-        } else if let id = comment.authorID {
+    @ViewBuilder
+    private var avatar: some View {
+        let author = viewModel.author
+        if author.isAnonymized {
+            Avatar.Anonymous(isGroup: author.isGroup)
+        } else if author.hasId {
             Button(
-                action: { avatarButtonAction(authorId: id) },
-                label: { Avatar(name: comment.authorName, url: comment.authorAvatarURL) }
+                action: { avatarButtonAction() },
+                label: { Avatar(name: author.name, url: author.avatarUrl) }
             )
         } else {
-            Avatar(name: comment.authorName, url: comment.authorAvatarURL)
+            Avatar(name: author.name, url: author.avatarUrl)
         }
     }
 
-    private func avatarButtonAction(authorId: String) {
-        env.router.route(
-            to: "/courses/\(assignment.courseID)/users/\(authorId)",
-            userInfo: ["navigatorOptions": ["modal": true]], // fix nav style
-            from: controller,
-            options: .modal(embedInNav: true, addDoneButton: true)
-        )
+    private func avatarButtonAction() {
+        viewModel.didTapAvatarButton.send(controller)
     }
 
-    @ViewBuilder func headerText() -> some View {
-        Text(User.displayName(comment.authorName, pronouns: comment.authorPronouns))
-            .font(.semibold14).foregroundColor(.textDarkest)
-        Text(comment.createdAtLocalizedString)
-            .font(.medium12).foregroundColor(.textDark)
+    @ViewBuilder
+    var header: some View {
+        let a11yLabel = viewModel.accessibilityLabelForHeader
+        if viewModel.author.isCurrentUser {
+            date
+                .accessibilityLabel(a11yLabel)
+        } else {
+            HStack(alignment: .center, spacing: InstUI.Styles.Padding.standard.rawValue) {
+                authorName
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                date
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityRepresentation {
+                if viewModel.author.isAnonymized {
+                    Text(a11yLabel)
+                } else if viewModel.author.hasId {
+                    Button(
+                        action: { avatarButtonAction() },
+                        label: { Text(a11yLabel) }
+                    )
+                    .accessibilityHint(Text("Double tap to view profile", bundle: .core))
+                } else {
+                    Text(a11yLabel)
+                }
+            }
+        }
+    }
+
+    private var authorName: some View {
+        Text(User.displayName(viewModel.author.name, pronouns: viewModel.author.pronouns))
+            .font(.semibold16, lineHeight: .fit)
+            .foregroundStyle(Color.textDarkest)
+    }
+
+    private var date: some View {
+        Text(viewModel.date)
+            .font(.regular12, lineHeight: .fit)
+            .foregroundStyle(Color.textDark)
+    }
+
+    @ViewBuilder
+    private var commentView: some View {
+        switch viewModel.commentType {
+        case .text(let comment, let files):
+            Text(comment)
+                .font(.regular14, lineHeight: .fit)
+                .styleForCurrentUser(viewModel.author.isCurrentUser)
+                .accessibilityHidden(true) // already included in header
+                .identifier("SubmissionComments.textCell.\(viewModel.id)")
+            ForEach(files, id: \.id) { file in
+                Spacer().frame(height: 4)
+                AttachedFileView(file: file) {
+                    guard let id = file.id else { return }
+                    env.router.route(
+                        to: "/files/\(id)",
+                        from: controller,
+                        options: .modal(embedInNav: true, addDoneButton: true)
+                    )
+                }
+                .accessibilityLabel(
+                    Text(file.accessibilityLabelForAttachment)
+                )
+                .accessibilityHint(Text("Double tap to view file", bundle: .core))
+            }
+        case .audio(let url):
+            AudioPlayer(url: url)
+                .identifier("SubmissionComments.audioCell.\(viewModel.id)")
+        case .video(let url):
+            VideoPlayer(url: url)
+                .cornerRadius(4)
+                .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
+                .identifier("SubmissionComments.videoCell.\(viewModel.id)")
+        }
     }
 }
 
-struct SubmissionCommentFile: View {
+private struct AttachedFileView: View {
     let file: File
     let action: () -> Void
 
@@ -191,45 +172,18 @@ struct SubmissionCommentFile: View {
     }
 }
 
-struct SubmissionAttempt: View {
-    let submission: Submission
-    let action: () -> Void
-
-    var icon: Image? {
-        submission.attemptIcon.map { Image(uiImage: $0) }
+private extension View {
+    @ViewBuilder
+    func styleForCurrentUser(_ isCurrentUser: Bool) -> some View {
+        if isCurrentUser {
+            self
+                .foregroundStyle(Color.textLightest.variantForLightMode)
+                .padding(8)
+                .background(Color.red)
+                .cornerRadius(16)
+        } else {
+            self
+                .foregroundStyle(Color.textDarkest)
+        }
     }
-
-    var body: some View {
-        Button(action: action, label: {
-            HStack(alignment: .top, spacing: 6) {
-                icon?.size(18).foregroundColor(.accentColor)
-                VStack(alignment: .leading, spacing: 0) {
-                    Text(submission.attemptTitle ?? "")
-                        .font(.semibold14).foregroundColor(.textDarkest)
-                    Text(submission.attemptSubtitle ?? "")
-                        .font(.medium12).foregroundColor(.textDark)
-                        .lineLimit(1)
-                }
-                Spacer()
-            }
-                .padding(.horizontal, 8).padding(.vertical, 6)
-                .frame(width: 300)
-                .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
-        })
-    }
-}
-
-struct CommentBackground: Shape {
-    func path(in rect: CGRect) -> Path { Path { path in
-        let r: CGFloat = 12
-        path.move(to: CGPoint(x: 0, y: -5))
-        path.addLine(to: CGPoint(x: 0, y: rect.maxY - r))
-        path.addArc(tangent1End: CGPoint(x: 0, y: rect.maxY), tangent2End: CGPoint(x: r, y: rect.maxY), radius: r)
-        path.addLine(to: CGPoint(x: rect.maxX - r, y: rect.maxY))
-        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.maxY), tangent2End: CGPoint(x: rect.maxX, y: rect.maxY - r), radius: r)
-        path.addLine(to: CGPoint(x: rect.maxX, y: r))
-        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: 0), tangent2End: CGPoint(x: rect.maxX - r, y: 0), radius: r)
-        path.addLine(to: CGPoint(x: 20, y: 0))
-        path.addRelativeArc(center: CGPoint(x: 20, y: -24), radius: 24, startAngle: .radians(0.5 * .pi), delta: .degrees(56))
-    } }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -117,13 +117,11 @@ struct SubmissionCommentListCell: View {
                 .accessibilityHidden(true) // already included in header
                 .identifier("SubmissionComments.textCell.\(viewModel.id)")
             ForEach(files, id: \.id) { file in
-                Spacer().frame(height: 4)
                 CommentFileButton(file: file) {
                     viewModel.didTapFileButton.send((file.id, controller))
                 }
-                .accessibilityLabel(
-                    Text(viewModel.accessibilityLabelForCommentAttachment(file))
-                )
+                .padding(.top, 4)
+                .accessibilityLabel(viewModel.accessibilityLabelForCommentAttachment(file))
                 .accessibilityHint(Text("Double tap to view file", bundle: .core))
             }
         case .audio(let url):
@@ -134,6 +132,23 @@ struct SubmissionCommentListCell: View {
                 .cornerRadius(4)
                 .aspectRatio(CGSize(width: 16, height: 9), contentMode: .fill)
                 .identifier("SubmissionComments.videoCell.\(viewModel.id)")
+        case .attempt(let attempt, let submission):
+            AttemptFileButton(submission: submission) {
+                self.attempt = attempt
+            }
+            .padding(.top, 12)
+            .accessibilityLabel(viewModel.accessibilityLabelForAttempt)
+            .accessibilityHint(Text("Double tap to view attempt", bundle: .core))
+        case .attemptWithAttachments(let attempt, let files):
+            ForEach(files, id: \.id) { file in
+                CommentFileButton(file: file) {
+                    self.attempt = attempt
+                    self.fileID = file.id
+                }
+                .padding(.top, 4)
+                .accessibilityLabel(viewModel.accessibilityLabelForAttemptAttachment(file))
+                .accessibilityHint(Text("Double tap to view file", bundle: .core))
+            }
         }
     }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -101,7 +101,7 @@ struct SubmissionCommentListCell: View {
     }
 
     private var authorNameAndDate: some View {
-        ViewThatFits {
+        ViewThatFits(in: .horizontal) {
             HStack(spacing: Size.horizontalSpacing) {
                 authorName
                     .frame(maxWidth: .infinity, alignment: .leading)

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -122,7 +122,7 @@ struct SubmissionCommentListCell: View {
                     viewModel.didTapFileButton.send((file.id, controller))
                 }
                 .accessibilityLabel(
-                    Text(file.accessibilityLabelForAttachment)
+                    Text(viewModel.accessibilityLabelForCommentAttachment(file))
                 )
                 .accessibilityHint(Text("Double tap to view file", bundle: .core))
             }

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -135,7 +135,7 @@ struct SubmissionCommentListCell: View {
         case .text(let comment, let files):
             Text(comment)
                 .font(.regular14, lineHeight: .fit)
-                .styleForCurrentUser(viewModel.author.isCurrentUser)
+                .textCommentStyle(viewModel.author.isCurrentUser)
                 .multilineTextAlignment(.leading)
                 .accessibilityHidden(true) // already included in header
                 .identifier("SubmissionComments.textCell.\(viewModel.id)")
@@ -247,12 +247,12 @@ private struct FileButton<I: View>: View {
 
 private extension View {
     @ViewBuilder
-    func styleForCurrentUser(_ isCurrentUser: Bool) -> some View {
+    func textCommentStyle(_ isCurrentUser: Bool) -> some View {
         if isCurrentUser {
             self
                 .foregroundStyle(Color.textLightest.variantForLightMode)
                 .padding(Size.commentBubblePadding)
-                .background(Color.accentColor)
+                .background(Color.backgroundInfo)
                 .cornerRadius(Size.commentBubbleCorner)
         } else {
             self

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -30,7 +30,6 @@ private enum Size {
 }
 
 struct SubmissionCommentListCell: View {
-    @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
     @ObservedObject var viewModel: SubmissionCommentListCellViewModel

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -58,16 +58,12 @@ struct SubmissionCommentListCell: View {
             Avatar.Anonymous(isGroup: author.isGroup)
         } else if author.hasId {
             Button(
-                action: { avatarButtonAction() },
+                action: { viewModel.didTapAvatarButton.send(controller) },
                 label: { Avatar(name: author.name, url: author.avatarUrl) }
             )
         } else {
             Avatar(name: author.name, url: author.avatarUrl)
         }
-    }
-
-    private func avatarButtonAction() {
-        viewModel.didTapAvatarButton.send(controller)
     }
 
     @ViewBuilder
@@ -88,7 +84,7 @@ struct SubmissionCommentListCell: View {
                     Text(a11yLabel)
                 } else if viewModel.author.hasId {
                     Button(
-                        action: { avatarButtonAction() },
+                        action: { viewModel.didTapAvatarButton.send(controller) },
                         label: { Text(a11yLabel) }
                     )
                     .accessibilityHint(Text("Double tap to view profile", bundle: .core))
@@ -123,12 +119,7 @@ struct SubmissionCommentListCell: View {
             ForEach(files, id: \.id) { file in
                 Spacer().frame(height: 4)
                 AttachedFileView(file: file) {
-                    guard let id = file.id else { return }
-                    env.router.route(
-                        to: "/files/\(id)",
-                        from: controller,
-                        options: .modal(embedInNav: true, addDoneButton: true)
-                    )
+                    viewModel.didTapFileButton.send((file.id, controller))
                 }
                 .accessibilityLabel(
                     Text(file.accessibilityLabelForAttachment)

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListCell.swift
@@ -118,7 +118,7 @@ struct SubmissionCommentListCell: View {
                 .identifier("SubmissionComments.textCell.\(viewModel.id)")
             ForEach(files, id: \.id) { file in
                 Spacer().frame(height: 4)
-                AttachedFileView(file: file) {
+                CommentFileButton(file: file) {
                     viewModel.didTapFileButton.send((file.id, controller))
                 }
                 .accessibilityLabel(
@@ -138,28 +138,75 @@ struct SubmissionCommentListCell: View {
     }
 }
 
-private struct AttachedFileView: View {
+private struct CommentFileButton: View {
     let file: File
     let action: () -> Void
 
     var body: some View {
-        Button(action: action, label: {
+        FileButton(
+            icon: FileThumbnail(file: file, size: fileButtonIconSize),
+            title: file.displayName ?? file.filename,
+            subtitle: file.size.humanReadableFileSize,
+            hasSubtitleLineLimit: false,
+            action: action
+        )
+        .identifier("SubmissionComments.fileView.\(file.id ?? "")")
+    }
+}
+
+private struct AttemptFileButton: View {
+    let submission: Submission
+    let action: () -> Void
+
+    var body: some View {
+        let icon = submission.attemptIcon.map { Image(uiImage: $0) }
+        FileButton(
+            icon: icon?
+                .size(fileButtonIconSize)
+                .foregroundStyle(Color.accentColor),
+            title: submission.attemptTitle ?? "",
+            subtitle: submission.attemptSubtitle ?? "",
+            hasSubtitleLineLimit: true,
+            action: action
+        )
+    }
+}
+
+private let fileButtonIconSize: CGFloat = 18
+
+private struct FileButton<I: View>: View {
+
+    let icon: I?
+    let title: String
+    let subtitle: String?
+    let hasSubtitleLineLimit: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
             HStack(alignment: .top, spacing: 6) {
-                FileThumbnail(file: file, size: 18)
+                icon
                 VStack(alignment: .leading, spacing: 0) {
-                    Text(file.displayName ?? file.filename)
-                        .font(.semibold14).foregroundColor(.textDarkest)
-                        .multilineTextAlignment(.leading)
-                    Text(file.size.humanReadableFileSize)
-                        .font(.medium12).foregroundColor(.textDark)
+                    Text(title)
+                        .font(.semibold14)
+                        .foregroundColor(.textDarkest)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.medium12)
+                            .foregroundColor(.textDark)
+                            .lineLimit(hasSubtitleLineLimit ? 1 : 0)
+                    }
                 }
                 Spacer()
             }
-                .padding(.horizontal, 8).padding(.vertical, 6)
-                .frame(width: 300)
-                .background(RoundedRectangle(cornerRadius: 4).stroke(Color.borderMedium))
-        })
-            .identifier("SubmissionComments.fileView.\(file.id ?? "")")
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .frame(width: 300)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(Color.borderMedium)
+            )
+        }
     }
 }
 
@@ -170,7 +217,7 @@ private extension View {
             self
                 .foregroundStyle(Color.textLightest.variantForLightMode)
                 .padding(8)
-                .background(Color.red)
+                .background(Color.accentColor)
                 .cornerRadius(16)
         } else {
             self

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -112,9 +112,7 @@ struct SubmissionCommentListView: View {
             .scaleEffect(y: -1)
         ForEach(comments, id: \.id) { comment in
             SubmissionCommentListCell(
-                assignment: viewModel.assignment,
-                submission: viewModel.submissionForComment(comment),
-                comment: comment,
+                viewModel: viewModel.cellConfig(with: comment),
                 attempt: $attempt,
                 fileID: $fileID
             )

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -30,9 +30,9 @@ struct SubmissionCommentListView: View {
     @Environment(\.appEnvironment) var env
     @Environment(\.viewController) var controller
 
+    @ObservedObject private var viewModel: SubmissionCommentListViewModel
     @ObservedObject var commentLibrary: SubmissionCommentLibraryViewModel
 
-    @StateObject private var viewModel: SubmissionCommentListViewModel
     @State var error: Text?
     @State var showMediaOptions = false
     @State var showCommentLibrary = false
@@ -40,9 +40,7 @@ struct SubmissionCommentListView: View {
     @AccessibilityFocusState private var focusedTab: SubmissionGraderView.GraderTab?
 
     init(
-        assignment: Assignment,
-        submission: Submission,
-        attempts: [Submission],
+        viewModel: SubmissionCommentListViewModel,
         attempt: Binding<Int>,
         fileID: Binding<String?>,
         showRecorder: Binding<MediaCommentType?>,
@@ -50,6 +48,8 @@ struct SubmissionCommentListView: View {
         commentLibrary: SubmissionCommentLibraryViewModel,
         focusedTab: AccessibilityFocusState<SubmissionGraderView.GraderTab?>
     ) {
+        _viewModel = ObservedObject(wrappedValue: viewModel)
+
         self._attempt = attempt
         self._fileID = fileID
         self._showRecorder = showRecorder
@@ -57,21 +57,6 @@ struct SubmissionCommentListView: View {
         self.commentLibrary = commentLibrary
         self._focusedTab = focusedTab
 
-        let interactor = SubmissionCommentsInteractorLive(
-            courseId: assignment.courseID,
-            assignmentId: assignment.id,
-            userId: submission.userID,
-            isGroupAssignment: !assignment.gradedIndividually,
-            env: AppEnvironment.shared // TODO: env
-        )
-
-        _viewModel = StateObject(wrappedValue: SubmissionCommentListViewModel(
-            assignment: assignment,
-            submission: submission,
-            attempts: attempts,
-            attempt: attempt.wrappedValue,
-            interactor: interactor
-        ))
     }
 
     var body: some View {

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -64,8 +64,8 @@ struct SubmissionCommentListView: View {
             VStack(spacing: 0) {
                 ScrollView {
                     switch viewModel.state {
-                    case .data(let comments):
-                        LazyVStack(alignment: .leading, spacing: 0) { list(comments) }
+                    case .data:
+                        comments
                     // Assume already loaded by parent, so skip loading & error
                     case .loading, .empty, .error:
                         EmptyPanda(.NoComments, message: Text("There are no messages yet.", bundle: .teacher))
@@ -73,7 +73,7 @@ struct SubmissionCommentListView: View {
                     }
                 }
                     .background(Color.backgroundLightest)
-                    .scaleEffect(y: viewModel.state.isData ? -1 : 1)
+                    .scaleEffect(y: viewModel.state == .data ? -1 : 1)
                 Divider()
                 switch showRecorder {
                 case .audio:
@@ -105,18 +105,20 @@ struct SubmissionCommentListView: View {
     }
 
     @ViewBuilder
-    func list(_ comments: [SubmissionCommentListCellViewModel]) -> some View {
-        error?
-            .font(.semibold16).foregroundColor(.textDanger)
-            .padding(16)
-            .scaleEffect(y: -1)
-        ForEach(comments, id: \.id) { comment in
-            SubmissionCommentListCell(
-                viewModel: comment,
-                attempt: $attempt,
-                fileID: $fileID
-            )
+    private var comments: some View {
+        LazyVStack(alignment: .leading, spacing: 0) {
+            error?
+                .font(.semibold16).foregroundColor(.textDanger)
+                .padding(16)
                 .scaleEffect(y: -1)
+            ForEach(viewModel.cellViewModels, id: \.id) { cellViewModel in
+                SubmissionCommentListCell(
+                    viewModel: cellViewModel,
+                    attempt: $attempt,
+                    fileID: $fileID
+                )
+                .scaleEffect(y: -1)
+            }
         }
     }
 

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -105,14 +105,14 @@ struct SubmissionCommentListView: View {
     }
 
     @ViewBuilder
-    func list(_ comments: [SubmissionComment]) -> some View {
+    func list(_ comments: [SubmissionCommentListCellViewModel]) -> some View {
         error?
             .font(.semibold16).foregroundColor(.textDanger)
             .padding(16)
             .scaleEffect(y: -1)
         ForEach(comments, id: \.id) { comment in
             SubmissionCommentListCell(
-                viewModel: viewModel.cellConfig(with: comment),
+                viewModel: comment,
                 attempt: $attempt,
                 fileID: $fileID
             )

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
@@ -40,6 +40,8 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
         case text(String, [File])
         case audio(URL)
         case video(URL)
+        case attempt(Int, Submission)
+        case attemptWithAttachments(Int, [File])
     }
 
     // MARK: - Output
@@ -92,7 +94,14 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
         self.date = comment.createdAtLocalizedString
 
         let commentType: CommentType
-        if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
+        if let attempt = comment.attempt {
+            if submission.type == .online_upload {
+                let files = submission.attachments?.sorted(by: File.idCompare) ?? []
+                commentType = .attemptWithAttachments(attempt, files)
+            } else {
+                commentType = .attempt(attempt, submission)
+            }
+        } else if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
             commentType = .audio(url)
         } else if comment.mediaType == .some(.video), let url = comment.mediaLocalOrRemoteURL {
             commentType = .video(url)
@@ -140,8 +149,13 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
     // MARK: - Accessibility
 
     lazy var accessibilityLabelForHeader: String = comment.accessibilityLabelForHeader
+    lazy var accessibilityLabelForAttempt: String = comment.accessibilityLabelForAttempt(submission: submission)
 
     func accessibilityLabelForCommentAttachment(_ file: File) -> String {
         comment.accessibilityLabelForCommentAttachment(file)
+    }
+
+    func accessibilityLabelForAttemptAttachment(_ file: File) -> String {
+        comment.accessibilityLabelForAttemptAttachment(file, submission: submission)
     }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
@@ -54,6 +54,7 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
     // MARK: - Input
 
     let didTapAvatarButton = PassthroughSubject<WeakViewController, Never>()
+    let didTapFileButton = PassthroughSubject<(String?, WeakViewController), Never>()
 
     // MARK: - Private properties
 
@@ -104,6 +105,7 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
         self.commentType = commentType
 
         showUserDetails(on: didTapAvatarButton)
+        showFile(on: didTapFileButton)
     }
 
     private func showUserDetails(on subject: PassthroughSubject<WeakViewController, Never>) {
@@ -114,6 +116,20 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
                 router.route(
                     to: "/courses/\(courseId)/users/\(authorId)",
                     userInfo: ["navigatorOptions": ["modal": true]], // fix nav style
+                    from: controller,
+                    options: .modal(embedInNav: true, addDoneButton: true)
+                )
+            }
+            .store(in: &subscriptions)
+    }
+
+    private func showFile(on subject: PassthroughSubject<(String?, WeakViewController), Never>) {
+        subject
+            .sink { [weak self] fileId, controller in
+                guard let self, let fileId else { return }
+
+                router.route(
+                    to: "/files/\(fileId)",
                     from: controller,
                     options: .modal(embedInNav: true, addDoneButton: true)
                 )

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
@@ -101,9 +101,9 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
             } else {
                 commentType = .attempt(attempt, submission)
             }
-        } else if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
+        } else if comment.mediaType == .audio, let url = comment.mediaLocalOrRemoteURL {
             commentType = .audio(url)
-        } else if comment.mediaType == .some(.video), let url = comment.mediaLocalOrRemoteURL {
+        } else if comment.mediaType == .video, let url = comment.mediaLocalOrRemoteURL {
             commentType = .video(url)
         } else {
             let files = comment.attachments?.sorted(by: File.idCompare) ?? []

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
@@ -1,0 +1,123 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Core
+import SwiftUI
+
+final class SubmissionCommentListCellViewModel: ObservableObject {
+
+    struct Author {
+        var id: String?
+        var name: String
+        var pronouns: String?
+        var avatarUrl: URL?
+        var isCurrentUser: Bool
+        var isAnonymized: Bool
+        var isGroup: Bool
+
+        var hasId: Bool {
+            id != nil
+        }
+    }
+
+    enum CommentType {
+        case text(String, [File])
+        case audio(URL)
+        case video(URL)
+    }
+
+    // MARK: - Output
+
+    let id: String
+    let author: Author
+    let date: String
+    let commentType: CommentType
+
+    lazy var accessibilityLabelForHeader: String = comment.accessibilityLabelForHeader
+
+    // MARK: - Input
+
+    let didTapAvatarButton = PassthroughSubject<WeakViewController, Never>()
+
+    // MARK: - Private properties
+
+    private let comment: SubmissionComment
+    private let submission: Submission
+    private let courseId: String
+    private let router: Router
+
+    private var subscriptions = Set<AnyCancellable>()
+
+    // MARK: - Init
+
+    init(
+        comment: SubmissionComment,
+        assignment: Assignment,
+        submission: Submission,
+        currentUserId: String?,
+        router: Router
+    ) {
+        self.comment = comment
+        self.submission = submission
+        self.courseId = assignment.courseID
+        self.router = router
+
+        self.id = comment.id
+
+        self.author = Author(
+            id: comment.authorID,
+            name: comment.authorName,
+            pronouns: comment.authorPronouns,
+            avatarUrl: comment.authorAvatarURL,
+            isCurrentUser: comment.authorID == currentUserId,
+            isAnonymized: assignment.anonymizeStudents,
+            isGroup: submission.groupID != nil
+        )
+
+        self.date = comment.createdAtLocalizedString
+
+        let commentType: CommentType
+        if comment.mediaType == .some(.audio), let url = comment.mediaLocalOrRemoteURL {
+            commentType = .audio(url)
+        } else if comment.mediaType == .some(.video), let url = comment.mediaLocalOrRemoteURL {
+            commentType = .video(url)
+        } else {
+            let files = comment.attachments?.sorted(by: File.idCompare) ?? []
+            commentType = .text(comment.comment, files)
+        }
+        self.commentType = commentType
+
+        showUserDetails(on: didTapAvatarButton)
+    }
+
+    private func showUserDetails(on subject: PassthroughSubject<WeakViewController, Never>) {
+        subject
+            .sink { [weak self] controller in
+                guard let self, let authorId = author.id else { return }
+
+                router.route(
+                    to: "/courses/\(courseId)/users/\(authorId)",
+                    userInfo: ["navigatorOptions": ["modal": true]], // fix nav style
+                    from: controller,
+                    options: .modal(embedInNav: true, addDoneButton: true)
+                )
+            }
+            .store(in: &subscriptions)
+    }
+}

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModel.swift
@@ -49,8 +49,6 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
     let date: String
     let commentType: CommentType
 
-    lazy var accessibilityLabelForHeader: String = comment.accessibilityLabelForHeader
-
     // MARK: - Input
 
     let didTapAvatarButton = PassthroughSubject<WeakViewController, Never>()
@@ -108,6 +106,8 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
         showFile(on: didTapFileButton)
     }
 
+    // MARK: - Subscriptions
+
     private func showUserDetails(on subject: PassthroughSubject<WeakViewController, Never>) {
         subject
             .sink { [weak self] controller in
@@ -135,5 +135,13 @@ final class SubmissionCommentListCellViewModel: ObservableObject {
                 )
             }
             .store(in: &subscriptions)
+    }
+
+    // MARK: - Accessibility
+
+    lazy var accessibilityLabelForHeader: String = comment.accessibilityLabelForHeader
+
+    func accessibilityLabelForCommentAttachment(_ file: File) -> String {
+        comment.accessibilityLabelForCommentAttachment(file)
     }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
@@ -45,8 +45,8 @@ class SubmissionCommentListViewModel: ObservableObject {
     // MARK: - Private variables
 
     let assignment: Assignment
-    private let submission: Submission
-    private let attempts: [Submission]
+    private let submissions: [Submission]
+    private let initialSubmission: Submission
 
     private let interactor: SubmissionCommentsInteractor
     private var comments: [SubmissionComment] = []
@@ -60,17 +60,17 @@ class SubmissionCommentListViewModel: ObservableObject {
 
     init(
         assignment: Assignment,
-        submission: Submission,
-        attempts: [Submission],
-        attempt: Int?,
+        submissions: [Submission],
+        initialSubmission: Submission,
+        initialAttemptNumber: Int?,
         interactor: SubmissionCommentsInteractor,
         scheduler: AnySchedulerOf<DispatchQueue> = .main
     ) {
         self.assignment = assignment
-        self.submission = submission
-        self.attempts = attempts
+        self.initialSubmission = initialSubmission
+        self.submissions = submissions
 
-        self.attempt = attempt
+        self.attempt = initialAttemptNumber
 
         self.interactor = interactor
 
@@ -113,7 +113,7 @@ class SubmissionCommentListViewModel: ObservableObject {
     }
 
     func submissionForComment(_ comment: SubmissionComment) -> Submission {
-        let result = attempts.first(where: { $0.attempt == comment.attempt }) ?? submission
+        let result = submissions.first(where: { $0.attempt == comment.attempt }) ?? initialSubmission
         if result.assignment == nil {
             result.assignment = assignment
         }

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
@@ -47,8 +47,10 @@ class SubmissionCommentListViewModel: ObservableObject {
     let assignment: Assignment
     private let submissions: [Submission]
     private let initialSubmission: Submission
+    private let currentUserId: String?
 
     private let interactor: SubmissionCommentsInteractor
+    private let env: AppEnvironment
     private var comments: [SubmissionComment] = []
     private var attempt: Int?
     private var isAssignmentEnhancementsEnabled = false
@@ -63,16 +65,20 @@ class SubmissionCommentListViewModel: ObservableObject {
         submissions: [Submission],
         initialSubmission: Submission,
         initialAttemptNumber: Int?,
+        currentUserId: String?,
         interactor: SubmissionCommentsInteractor,
-        scheduler: AnySchedulerOf<DispatchQueue> = .main
+        scheduler: AnySchedulerOf<DispatchQueue> = .main,
+        env: AppEnvironment
     ) {
         self.assignment = assignment
         self.initialSubmission = initialSubmission
         self.submissions = submissions
 
         self.attempt = initialAttemptNumber
+        self.currentUserId = currentUserId
 
         self.interactor = interactor
+        self.env = env
 
         unowned let unownedSelf = self
 
@@ -110,6 +116,16 @@ class SubmissionCommentListViewModel: ObservableObject {
         self.attempt = attempt
         guard state.isData else { return }
         state = .data(filterComments(comments: comments, attempt: attempt))
+    }
+
+    func cellConfig(with comment: SubmissionComment) -> SubmissionCommentListCellViewModel {
+        .init(
+            comment: comment,
+            assignment: assignment,
+            submission: submissionForComment(comment),
+            currentUserId: currentUserId,
+            router: env.router
+        )
     }
 
     func submissionForComment(_ comment: SubmissionComment) -> Submission {

--- a/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/RubricCriterionView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/RubricCriterionView.swift
@@ -139,3 +139,18 @@ struct RubricCriterionView: View {
         .padding(.top, 8)
     }
 }
+
+private struct CommentBackground: Shape {
+    func path(in rect: CGRect) -> Path { Path { path in
+        let r: CGFloat = 12
+        path.move(to: CGPoint(x: 0, y: -5))
+        path.addLine(to: CGPoint(x: 0, y: rect.maxY - r))
+        path.addArc(tangent1End: CGPoint(x: 0, y: rect.maxY), tangent2End: CGPoint(x: r, y: rect.maxY), radius: r)
+        path.addLine(to: CGPoint(x: rect.maxX - r, y: rect.maxY))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: rect.maxY), tangent2End: CGPoint(x: rect.maxX, y: rect.maxY - r), radius: r)
+        path.addLine(to: CGPoint(x: rect.maxX, y: r))
+        path.addArc(tangent1End: CGPoint(x: rect.maxX, y: 0), tangent2End: CGPoint(x: rect.maxX - r, y: 0), radius: r)
+        path.addLine(to: CGPoint(x: 20, y: 0))
+        path.addRelativeArc(center: CGPoint(x: 20, y: -24), radius: 24, startAngle: .radians(0.5 * .pi), delta: .degrees(56))
+    } }
+}

--- a/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
@@ -364,9 +364,7 @@ struct SubmissionGraderView: View {
         let isCommentsOnScreen = isGraderTabOnScreen(.comments, isDrawer: isDrawer)
         VStack(spacing: 0) {
             SubmissionCommentListView(
-                assignment: viewModel.assignment,
-                submission: viewModel.submission,
-                attempts: viewModel.attempts,
+                viewModel: viewModel.commentListViewModel,
                 attempt: drawerAttempt,
                 fileID: fileID,
                 showRecorder: $showRecorder,

--- a/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
@@ -378,7 +378,6 @@ struct SubmissionGraderView: View {
             }
         }
         .frame(width: geometry.size.width, height: geometry.size.height)
-        .background(Color.backgroundLight)
         .accessibilityElement(children: isCommentsOnScreen ? .contain : .ignore)
         .accessibility(hidden: !isCommentsOnScreen)
     }

--- a/Teacher/Teacher/SpeedGrader/MainLayout/ViewModel/SubmissionGraderViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/ViewModel/SubmissionGraderViewModel.swift
@@ -26,7 +26,6 @@ class SubmissionGraderViewModel: ObservableObject {
 
     @Published private(set) var selectedAttemptIndex: Int
     @Published private(set) var selectedAttempt: Submission
-    @Published private(set) var studentAnnotationViewModel: StudentAnnotationSubmissionViewerViewModel
     @Published private(set) var attempts: [Submission] = []
     @Published private(set) var hasSubmissions = false
     @Published private(set) var isSingleSubmission = false
@@ -36,19 +35,37 @@ class SubmissionGraderViewModel: ObservableObject {
     let assignment: Assignment
     let submission: Submission
 
+    // sub-viewmodels
+    @Published private(set) var studentAnnotationViewModel: StudentAnnotationSubmissionViewerViewModel
+    @Published private(set) var commentListViewModel: SubmissionCommentListViewModel
+
     // MARK: - Inputs
 
     /** This is mainly used by `SubmissionCommentList` but since it's re-created on rotation and app backgrounding the entered text is lost. */
     @Published var enteredComment: String = ""
 
+    private let env: AppEnvironment
     private var subscriptions = Set<AnyCancellable>()
 
-    init(assignment: Assignment, submission: Submission) {
+    init(
+        assignment: Assignment,
+        submissions: [Submission],
+        initialSubmission: Submission,
+        env: AppEnvironment
+    ) {
         self.assignment = assignment
-        self.submission = submission
-        selectedAttempt = submission
-        selectedAttemptIndex = submission.attempt
+        self.submission = initialSubmission
+        selectedAttempt = initialSubmission
+        selectedAttemptIndex = initialSubmission.attempt
         studentAnnotationViewModel = StudentAnnotationSubmissionViewerViewModel(submission: submission)
+        commentListViewModel = SubmissionCommentsAssembly.makeCommentListViewModel(
+            assignment: assignment,
+            submissions: submissions,
+            initialSubmission: initialSubmission,
+            initialAttemptNumber: initialSubmission.attempt,
+            env: env
+        )
+        self.env = env
         observeAttemptChangesInDatabase()
         didSelectNewAttempt(attemptIndex: submission.attempt)
     }

--- a/Teacher/Teacher/SpeedGrader/StudentPager/Model/SpeedGraderInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/StudentPager/Model/SpeedGraderInteractor.swift
@@ -33,7 +33,11 @@ protocol SpeedGraderInteractor {
 
 struct SpeedGraderData {
     let assignment: Assignment
+
+    /// Latest submission for each student
     let submissions: [Submission]
+
+    /// Index for the selected student
     let focusedSubmissionIndex: Int
 }
 

--- a/Teacher/Teacher/SpeedGrader/StudentPager/View/SpeedGraderViewController.swift
+++ b/Teacher/Teacher/SpeedGrader/StudentPager/View/SpeedGraderViewController.swift
@@ -172,8 +172,7 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
             userIndexInSubmissionList: index,
             viewModel: SubmissionGraderViewModel(
                 assignment: data.assignment,
-                submissions: data.submissions,
-                initialSubmission: data.submissions[index],
+                latestSubmission: data.submissions[index],
                 env: env
             ),
             handleRefresh: { [weak self] in

--- a/Teacher/Teacher/SpeedGrader/StudentPager/View/SpeedGraderViewController.swift
+++ b/Teacher/Teacher/SpeedGrader/StudentPager/View/SpeedGraderViewController.swift
@@ -172,7 +172,9 @@ class SpeedGraderViewController: ScreenViewTrackableViewController, PagesViewCon
             userIndexInSubmissionList: index,
             viewModel: SubmissionGraderViewModel(
                 assignment: data.assignment,
-                submission: data.submissions[index]
+                submissions: data.submissions,
+                initialSubmission: data.submissions[index],
+                env: env
             ),
             handleRefresh: { [weak self] in
                 self?.interactor.refreshSubmission(forUserId: data.submissions[index].userID)

--- a/Teacher/TeacherTests/SpeedGrader/Comments/Model/SubmissionCommentsInteractorTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Comments/Model/SubmissionCommentsInteractorTests.swift
@@ -1,0 +1,118 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+@testable import Core
+@testable import Teacher
+import TestsFoundation
+import XCTest
+
+class SubmissionCommentsInteractorTests: TeacherTestCase {
+
+    private enum TestConstants {
+        static let assignmentId = "some assignmentId"
+        static let courseId = "some courseId"
+        static let submissionUserId = "some submissionUserId"
+        static let date = Date.make(year: 2048, month: 1, day: 1)
+    }
+
+    private var testee: SubmissionCommentsInteractorLive!
+
+    override func setUp() {
+        super.setUp()
+
+        testee = makeInteractor()
+    }
+
+    override func tearDown() {
+        testee = nil
+        super.tearDown()
+    }
+
+    // MARK: - Get methods
+
+    func test_getSubmissionAttempts() {
+        makeSubmission(id: "s1", attempt: 1)
+        makeSubmission(id: "s2", attempt: 2)
+
+        XCTAssertFirstValue(testee.getSubmissionAttempts()) { submissions in
+            XCTAssertEqual(submissions.map(\.id), ["s1", "s2"])
+        }
+    }
+
+    func test_getComments() {
+        api.mock(
+            GetSubmissionComments(
+                context: .course(TestConstants.courseId),
+                assignmentID: TestConstants.assignmentId,
+                userID: TestConstants.submissionUserId
+            ),
+            value: .make(
+                assignment_id: TestConstants.assignmentId,
+                submission_comments: [
+                    .make(id: "c1", created_at: TestConstants.date.addHours(1)),
+                    .make(id: "c2", created_at: TestConstants.date.addHours(2))
+                ],
+                user_id: TestConstants.submissionUserId
+            )
+        )
+
+        XCTAssertFirstValue(testee.getComments()) { comments in
+            XCTAssertEqual(comments.map(\.id), ["c2", "c1"])
+        }
+    }
+
+    func test_getIsAssignmentEnhancementsEnabled() {
+        api.mock(
+            GetEnabledFeatureFlags(context: .course(TestConstants.courseId)),
+            value: ["assignments_2_student"]
+        )
+
+        XCTAssertFirstValue(testee.getIsAssignmentEnhancementsEnabled()) { isEnabled in
+            XCTAssertEqual(isEnabled, true)
+        }
+    }
+
+    // MARK: - Private helpers
+
+    private func makeInteractor(
+        isGroupAssignment: Bool = false
+    ) -> SubmissionCommentsInteractorLive {
+        SubmissionCommentsInteractorLive(
+            courseId: TestConstants.courseId,
+            assignmentId: TestConstants.assignmentId,
+            submissionUserId: TestConstants.submissionUserId,
+            isGroupAssignment: isGroupAssignment,
+            env: environment
+        )
+    }
+
+    @discardableResult
+    private func makeSubmission(id: String, attempt: Int?) -> Submission {
+        Submission.save(
+            .make(
+                assignment_id: TestConstants.assignmentId,
+                attempt: attempt,
+                id: .init(id),
+                submitted_at: TestConstants.date,
+                user_id: TestConstants.submissionUserId
+            ),
+            in: databaseClient
+        )
+    }
+}

--- a/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListCellViewModelTests.swift
@@ -1,0 +1,329 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+@testable import Teacher
+import TestsFoundation
+import XCTest
+
+class SubmissionCommentListCellViewModelTests: TeacherTestCase {
+
+    private enum TestConstants {
+        static let commentId = "some commentId"
+        static let attemptCommentId = "x-x-42" // specific format for `SubmissionComment.attempt`
+        static let authorId = "some authorId"
+        static let authorName = "some author name"
+        static let commentText = "some comment text"
+        static let courseId = "some courseId"
+        static let currentUserId = "some currentUserId"
+    }
+
+    private var comment: SubmissionComment!
+    private var assignment: Assignment!
+    private var submission: Submission!
+
+    override func setUp() {
+        super.setUp()
+
+        comment = SubmissionComment(context: databaseClient)
+        comment.id = TestConstants.commentId
+        comment.authorID = TestConstants.authorId
+        comment.authorName = TestConstants.authorName
+        comment.createdAt = Date.make(year: 2048, month: 4, day: 14)
+        comment.comment = ""
+
+        assignment = Assignment(context: databaseClient)
+        assignment.courseID = TestConstants.courseId
+
+        submission = Submission(context: databaseClient)
+    }
+
+    override func tearDown() {
+        comment = nil
+        assignment = nil
+        submission = nil
+        super.tearDown()
+    }
+
+    // MARK: - Properties
+
+    func test_passedInProperties() {
+        comment.authorPronouns = "some pronouns"
+        let url = URL(string: "/some_author/avatar")!
+        comment.authorAvatarURL = url
+
+        let testee = makeViewModel()
+
+        XCTAssertEqual(testee.id, TestConstants.commentId)
+        XCTAssertEqual(testee.author.hasId, true)
+        XCTAssertEqual(testee.author.name, TestConstants.authorName)
+        XCTAssertEqual(testee.author.pronouns, "some pronouns")
+        XCTAssertEqual(testee.author.avatarUrl, url)
+        XCTAssertEqual(testee.date, comment.createdAtLocalizedString)
+    }
+
+    func test_authorIsCurrentUser() {
+        comment.authorID = TestConstants.authorId
+
+        var testee = makeViewModel(currentUserId: TestConstants.authorId)
+        XCTAssertEqual(testee.author.isCurrentUser, true)
+
+        testee = makeViewModel(currentUserId: TestConstants.currentUserId)
+        XCTAssertEqual(testee.author.isCurrentUser, false)
+    }
+
+    func test_authorIsAnonymized() {
+        assignment.anonymizeStudents = true
+        var testee = makeViewModel()
+        XCTAssertEqual(testee.author.isAnonymized, true)
+
+        assignment.anonymizeStudents = false
+        testee = makeViewModel()
+        XCTAssertEqual(testee.author.isAnonymized, false)
+    }
+
+    func test_authorIsGroup() {
+        submission.groupID = "some group id"
+        var testee = makeViewModel()
+        XCTAssertEqual(testee.author.isGroup, true)
+
+        submission.groupID = nil
+        testee = makeViewModel()
+        XCTAssertEqual(testee.author.isGroup, false)
+    }
+
+    // MARK: - commentType
+
+    func test_commentType_whenCommentIsText() {
+        comment.id = TestConstants.commentId
+        comment.mediaURL = nil
+
+        comment.comment = TestConstants.commentText
+        var testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.textComment, TestConstants.commentText)
+
+        // empty text -> still a text comment
+        comment.comment = ""
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.textComment, "")
+
+        // files
+        comment.attachments = [
+            makeFile(id: "c"),
+            makeFile(id: "a"),
+            makeFile(id: "b")
+        ]
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.textFiles?.map(\.id), ["a", "b", "c"])
+    }
+
+    func test_commentType_whenCommentIsMedia() {
+        let mediaUrl = URL(string: "/some_media")
+        comment.id = TestConstants.commentId
+        comment.comment = TestConstants.commentText
+
+        // audio with url -> audio
+        comment.mediaType = .audio
+        comment.mediaURL = mediaUrl
+        var testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.audioUrl, mediaUrl)
+        XCTAssertEqual(testee.commentType.textComment, nil)
+
+        // audio without url -> fallback to text
+        comment.mediaType = .audio
+        comment.mediaURL = nil
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.audioUrl, nil)
+        XCTAssertEqual(testee.commentType.textComment, TestConstants.commentText)
+
+        // video with url -> video
+        comment.mediaType = .video
+        comment.mediaURL = mediaUrl
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.videoUrl, mediaUrl)
+        XCTAssertEqual(testee.commentType.textComment, nil)
+
+        // video without url -> fallback to text
+        comment.mediaType = .video
+        comment.mediaURL = nil
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.videoUrl, nil)
+        XCTAssertEqual(testee.commentType.textComment, TestConstants.commentText)
+    }
+
+    func test_commentType_whenCommentIsOnlineUploadAttempt() {
+        comment.id = TestConstants.attemptCommentId
+        submission.type = .online_upload
+        submission.attachments = [
+            makeFile(id: "c"),
+            makeFile(id: "a"),
+            makeFile(id: "b")
+        ]
+        comment.attachments = [makeFile(id: "this should be ignored")]
+
+        var testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.attemptWithAttachmentsNumber, 42)
+        XCTAssertEqual(testee.commentType.attemptWithAttachmentsFiles?.map(\.id), ["a", "b", "c"])
+
+        // no attachments -> still an attemptWithAttachments
+        submission.type = .online_upload
+        submission.attachments = nil
+        testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.attemptWithAttachmentsNumber, 42)
+        XCTAssertEqual(testee.commentType.attemptWithAttachmentsFiles?.map(\.id), [])
+    }
+
+    func test_commentType_whenCommentIsAttemptOtherThanOnlineUpload() {
+        comment.id = TestConstants.attemptCommentId
+        submission.type = .media_recording
+        submission.attachments = [makeFile(id: "this should be ignored")]
+
+        let testee = makeViewModel()
+        XCTAssertEqual(testee.commentType.attemptNumber, 42)
+        XCTAssertEqual(testee.commentType.attemptSubmission?.id, submission.id)
+    }
+
+    // MARK: - Actions
+
+    func test_didTapAvatarButton() {
+        let sourceVC = UIViewController()
+        let testee = makeViewModel()
+
+        testee.didTapAvatarButton.send(.init(sourceVC))
+
+        let path = "/courses/\(TestConstants.courseId)/users/\(TestConstants.authorId)"
+        XCTAssertEqual(router.calls.last?.0, URLComponents(string: path))
+        XCTAssertEqual(router.calls.last?.1, sourceVC)
+        XCTAssertEqual(router.calls.last?.2, .modal(embedInNav: true, addDoneButton: true))
+    }
+
+    func test_didTapFileButton() {
+        let sourceVC = UIViewController()
+        let testee = makeViewModel()
+
+        testee.didTapFileButton.send(("some_fileId", .init(sourceVC)))
+
+        let path = "/files/some_fileId"
+        XCTAssertEqual(router.calls.last?.0, URLComponents(string: path))
+        XCTAssertEqual(router.calls.last?.1, sourceVC)
+        XCTAssertEqual(router.calls.last?.2, .modal(embedInNav: true, addDoneButton: true))
+    }
+
+    // MARK: - Accessibility
+
+    func test_accessibilityLabelForHeader() {
+        let testee = makeViewModel()
+
+        XCTAssertEqual(testee.accessibilityLabelForHeader, comment.accessibilityLabelForHeader)
+    }
+
+    func test_accessibilityLabelForAttempt() {
+        submission.attempt = 7
+        submission.type = .media_recording
+
+        let testee = makeViewModel()
+
+        XCTAssertEqual(testee.accessibilityLabelForAttempt, comment.accessibilityLabelForAttempt(submission: submission))
+    }
+
+    func test_accessibilityLabelForCommentAttachment() {
+        let file = makeFile()
+        file.displayName = "some filename"
+        file.size = 1984
+
+        let testee = makeViewModel()
+        XCTAssertEqual(
+            testee.accessibilityLabelForCommentAttachment(file),
+            comment.accessibilityLabelForCommentAttachment(file)
+        )
+    }
+
+    func test_accessibilityLabelForAttemptAttachment() {
+        submission.attempt = 7
+        submission.type = .media_recording
+        let file = makeFile()
+        file.displayName = "some filename"
+        file.size = 1984
+
+        let testee = makeViewModel()
+        XCTAssertEqual(
+            testee.accessibilityLabelForAttemptAttachment(file),
+            comment.accessibilityLabelForAttemptAttachment(file, submission: submission)
+        )
+    }
+
+    // MARK: - Private helpers
+
+    private func makeViewModel(
+        currentUserId: String? = TestConstants.currentUserId
+    ) -> SubmissionCommentListCellViewModel {
+        SubmissionCommentListCellViewModel(
+            comment: comment,
+            assignment: assignment,
+            submission: submission,
+            currentUserId: currentUserId,
+            router: router
+        )
+    }
+
+    private func makeFile(id: String = "") -> File {
+        File.save(.make(id: .init(id)), in: databaseClient)
+    }
+}
+
+private extension SubmissionCommentListCellViewModel.CommentType {
+    var textComment: String? {
+        guard case let .text(comment, _) = self else { return nil }
+        return comment
+    }
+
+    var textFiles: [File]? {
+        guard case let .text(_, files) = self else { return nil }
+        return files
+    }
+
+    var audioUrl: URL? {
+        guard case let .audio(url) = self else { return nil }
+        return url
+    }
+
+    var videoUrl: URL? {
+        guard case let .video(url) = self else { return nil }
+        return url
+    }
+
+    var attemptNumber: Int? {
+        guard case let .attempt(attemptNumber, _) = self else { return nil }
+        return attemptNumber
+    }
+
+    var attemptSubmission: Submission? {
+        guard case let .attempt(_, submission) = self else { return nil }
+        return submission
+    }
+
+    var attemptWithAttachmentsNumber: Int? {
+        guard case let .attemptWithAttachments(attemptNumber, _) = self else { return nil }
+        return attemptNumber
+    }
+
+    var attemptWithAttachmentsFiles: [File]? {
+        guard case let .attemptWithAttachments(_, files) = self else { return nil }
+        return files
+    }
+}

--- a/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModelTests.swift
@@ -16,217 +16,363 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import Combine
 @testable import Core
 @testable import Teacher
+import TestsFoundation
 import XCTest
 
 class SubmissionCommentListViewModelTests: TeacherTestCase {
+
+    private enum TestConstants {
+        static let assignmentId = "some assignmentId"
+        static let courseId = "some courseId"
+        static let submissionId = "some submissionId"
+        static let submissionUserId = "some submissionUserId"
+        static let currentUserId = "some currentUserId"
+    }
+
+    private var assignment: Assignment!
+    private var submission: Submission!
+    private var interactor: SubmissionCommentsInteractorMock!
+
     override func setUp() {
         super.setUp()
-        let comments = [
-            APICommentLibraryResponse.CommentBankItem(id: "1", comment: "First comment"),
-            APICommentLibraryResponse.CommentBankItem(id: "2", comment: "Second comment")
-        ]
-        let response = APICommentLibraryResponse(
-            data: .init(
-                user: .init(
-                    id: "1",
-                    commentBankItems: .init(
-                        nodes: comments,
-                        pageInfo: nil
-                    )
-                )
-            )
-        )
-        api.mock(APICommentLibraryRequest(userId: "1"), value: response)
+
+        assignment = Assignment(context: databaseClient)
+        assignment.id = TestConstants.assignmentId
+        assignment.courseID = TestConstants.courseId
+
+        submission = Submission(context: databaseClient)
+        submission.id = TestConstants.submissionId
+        submission.userID = TestConstants.submissionUserId
+
+        interactor = .init()
     }
 
-    func testFechComments() {
-        let testee = SubmissionCommentLibraryViewModel()
-        testee.viewDidAppear()
-        switch testee.state {
-        case let .data(comments):
-            XCTAssertEqual(comments[0].id, "1")
-            XCTAssertEqual(comments[0].text, "First comment")
-            XCTAssertEqual(comments[1].id, "2")
-            XCTAssertEqual(comments[1].text, "Second comment")
-        case .loading, .empty:
-            break
-        }
+    override func tearDown() {
+        assignment = nil
+        submission = nil
+        interactor = nil
+        super.tearDown()
     }
 
-    func testLoadingState() {
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: nil,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+    // MARK: - state
 
-        // THEN
+    func test_state_whenValueIsNotReturned_shouldBeLoading() {
+        interactor.getCommentsResult = Publishers.typedJust([])
+            .delay(for: .seconds(1), scheduler: DispatchQueue.main)
+            .eraseToAnyPublisher()
+
+        let testee = makeViewModel()
+
         XCTAssertEqual(testee.state, .loading)
     }
 
-    func testErrorState() {
-        // GIVEN
-        api.mock(
-            GetSubmissionComments(context: .course("1"), assignmentID: "1", userID: "1"),
-            error: NSError(domain: "", code: 1)
-        )
+    func test_state_whenGetSubmissionsFails_shouldBeError() {
+        interactor.getSubmissionAttemptsResult = Publishers.typedFailure(error: MockError())
 
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: nil,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+        let testee = makeViewModel()
 
-        // THEN
         XCTAssertEqual(testee.state, .error)
     }
 
-    func testEmptyState() {
-        // GIVEN
-        api.mock(
-            GetSubmissionComments(context: .course("1"), assignmentID: "1", userID: "1"),
-            value: .make()
-        )
-        api.mock(
-            GetEnabledFeatureFlags(context: .course("1")),
-            value: []
-        )
+    func test_state_whenGetCommentsFails_shouldBeError() {
+        interactor.getCommentsResult = Publishers.typedFailure(error: MockError())
 
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: nil,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+        let testee = makeViewModel()
 
-        // THEN
-        drainMainQueue()
+        XCTAssertEqual(testee.state, .error)
+    }
+
+    func test_state_whenGetFeatureFlagFails_shouldBeError() {
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedFailure(error: MockError())
+
+        let testee = makeViewModel()
+
+        XCTAssertEqual(testee.state, .error)
+    }
+
+    func test_state_whenThereAreNoComments_shouldBeEmpty() {
+        interactor.getSubmissionAttemptsResult = Publishers.typedJust([submission])
+        interactor.getCommentsResult = Publishers.typedJust([])
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+
+        let testee = makeViewModel()
+
         XCTAssertEqual(testee.state, .empty)
     }
 
-    func testFlagIsEnabledDataLoadsCommentsAreFiltered() {
-        // GIVEN
-        api.mock(
-            GetSubmissionComments(context: .course("1"), assignmentID: "1", userID: "1"),
-            value: .make(
-                submission_comments: [
-                    .make(id: "1", attempt: 1),
-                    .make(id: "2", attempt: 2)
-                ]
-            )
-        )
-        api.mock(
-            GetEnabledFeatureFlags(context: .course("1")),
-            value: ["assignments_2_student"]
-        )
+    func test_state_whenThereAreComments_shouldBeData() {
+        interactor.getSubmissionAttemptsResult = Publishers.typedJust([])
+        interactor.getCommentsResult = Publishers.typedJust([SubmissionComment(context: databaseClient)])
 
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: 2,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+        let testee = makeViewModel()
 
-        // THEN
-        drainMainQueue()
-        switch testee.state {
-        case .data(let comments):
-            XCTAssertEqual(comments.count, 1)
-            XCTAssertEqual(comments[0].id, "2")
-        default:
-            XCTFail("Expected data state")
-        }
+        XCTAssertEqual(testee.state, .data)
     }
 
-    func testFlagIsDisabledDataLoadsCommentsAreNotFiltered() {
-        // GIVEN
-        api.mock(
-            GetSubmissionComments(context: .course("1"), assignmentID: "1", userID: "1"),
-            value: .make(
-                submission_comments: [
-                    .make(id: "1", attempt: 1),
-                    .make(id: "2", attempt: 2)
-                ]
-            )
-        )
-        api.mock(
-            GetEnabledFeatureFlags(context: .course("1")),
-            value: []
-        )
+    // MARK: - filtering
 
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: 2,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+    func test_cellViewModels_whenAssignmentEnhancementsIsEnabled_shouldBeFiltered() throws {
+        interactor.getCommentsResult = Publishers.typedJust([
+            makeComment(id: "0", attempt: nil),
+            makeComment(id: "1", attempt: 1),
+            makeComment(id: "2", attempt: 2),
+            makeComment(id: "3", attempt: nil)
+        ])
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
 
-        // THEN
-        drainMainQueue()
-        switch testee.state {
-        case .data(let comments):
-            XCTAssertEqual(comments.count, 2)
-        default:
-            XCTFail("Expected data state")
-        }
+        let testee = makeViewModel(latestAttemptNumber: 2)
+
+        guard testee.cellViewModels.count == 3 else { throw InvalidCountError() }
+        XCTAssertEqual(testee.cellViewModels[0].id, "0")
+        XCTAssertEqual(testee.cellViewModels[1].id, "2")
+        XCTAssertEqual(testee.cellViewModels[2].id, "3")
     }
 
-    func testSpeedGraderAttemptPickerChangedCommentsAreUpdated() {
-        // GIVEN
-        api.mock(
-            GetSubmissionComments(context: .course("1"), assignmentID: "1", userID: "1"),
-            value: .make(
-                submission_comments: [
-                    .make(id: "1", attempt: 1),
-                    .make(id: "2", attempt: 2)
-                ]
-            )
-        )
-        api.mock(
-            GetEnabledFeatureFlags(context: .course("1")),
-            value: ["assignments_2_student"]
-        )
+    func test_cellViewModels_whenAssignmentEnhancementsIsDisabled_shouldNotBeFiltered() throws {
+        interactor.getCommentsResult = Publishers.typedJust([
+            makeComment(id: "0", attempt: nil),
+            makeComment(id: "1", attempt: 1),
+            makeComment(id: "2", attempt: 2),
+            makeComment(id: "3", attempt: nil)
+        ])
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(false)
 
-        // WHEN
-        let testee = SubmissionCommentListViewModel(
-            attempt: 1,
-            courseID: "1",
-            assignmentID: "1",
-            userID: "1",
-            scheduler: .immediate
-        )
+        let testee = makeViewModel(latestAttemptNumber: 2)
 
-        drainMainQueue()
-        switch testee.state {
-        case .data(let comments):
-            XCTAssertEqual(comments.count, 1)
-            XCTAssertEqual(comments[0].id, "1")
-        default:
-            XCTFail("Expected data state")
+        guard testee.cellViewModels.count == 4 else { throw InvalidCountError() }
+        XCTAssertEqual(testee.cellViewModels[0].id, "0")
+        XCTAssertEqual(testee.cellViewModels[1].id, "1")
+        XCTAssertEqual(testee.cellViewModels[2].id, "2")
+        XCTAssertEqual(testee.cellViewModels[3].id, "3")
+    }
+
+    // MARK: - cellViewModels
+
+    func test_cellViewModels_shouldUseTheCorrectSubmission() throws {
+        interactor.getSubmissionAttemptsResult = Publishers.typedJust([
+            makeSubmission(id: "sub2", attempt: 2),
+            makeSubmission(id: "sub1", attempt: 1)
+        ])
+        interactor.getCommentsResult = Publishers.typedJust([
+            // `id` follows specific format to make the commentType `attempt`, to allow spying on `submission`
+            makeComment(id: "x-x-1", attempt: 1),
+            makeComment(id: "x-x-2", attempt: 2)
+        ])
+
+        let testee = makeViewModel(latestAttemptNumber: 2)
+
+        guard testee.cellViewModels.count == 2 else { throw InvalidCountError() }
+        guard case let .attempt(attempt0, submission0) = testee.cellViewModels[0].commentType,
+              case let .attempt(attempt1, submission1) = testee.cellViewModels[1].commentType
+        else {
+            return XCTFail("Unexpected comment type")
         }
-        NotificationCenter.default.post(name: .SpeedGraderAttemptPickerChanged, object: 2)
+        XCTAssertEqual(attempt0, 1)
+        XCTAssertEqual(submission0.id, "sub1")
+        XCTAssertEqual(attempt1, 2)
+        XCTAssertEqual(submission1.id, "sub2")
+    }
 
-        // THEN
-        switch testee.state {
-        case .data(let comments):
-            XCTAssertEqual(comments.count, 1)
-            XCTAssertEqual(comments[0].id, "2")
-        default:
-            XCTFail("Expected data state")
-        }
+    // MARK: - Attempt change
+
+    func test_cellViewModels_whenAttemptIsChanged_shouldUpdateFiltering() throws {
+        interactor.getCommentsResult = Publishers.typedJust([
+            makeComment(id: "1", attempt: 1),
+            makeComment(id: "2", attempt: 2)
+        ])
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+        let testee = makeViewModel(latestAttemptNumber: 2)
+
+        NotificationCenter.default.post(name: .SpeedGraderAttemptPickerChanged, object: 3)
+        XCTAssertEqual(testee.state, .empty)
+        XCTAssertEqual(testee.cellViewModels.count, 0)
+
+        NotificationCenter.default.post(name: .SpeedGraderAttemptPickerChanged, object: 1)
+        XCTAssertEqual(testee.state, .data)
+        guard testee.cellViewModels.count == 1 else { throw InvalidCountError() }
+        XCTAssertEqual(testee.cellViewModels[0].id, "1")
+    }
+
+    // MARK: - Send comment
+
+    func test_attemptNumber_whenAssignmentEnhancementsIsEnabled_shouldBeUsedForNewComment() {
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+        let testee = makeViewModel(latestAttemptNumber: 42)
+
+        testee.sendTextComment("") { _ in }
+
+        XCTAssertEqual(interactor.createTextCommentInput?.attemptNumber, 42)
+    }
+
+    func test_attemptNumber_whenAssignmentEnhancementsIsDisabled_shouldNotBeUsedForNewComment() {
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(false)
+        let testee = makeViewModel(latestAttemptNumber: 42)
+
+        testee.sendTextComment("") { _ in }
+
+        XCTAssertEqual(interactor.createTextCommentInput?.attemptNumber, nil)
+    }
+
+    func test_sendTextComment() {
+        var result: Result<String, Error>?
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+        let testee = makeViewModel(latestAttemptNumber: 42)
+
+        testee.sendTextComment("some comment") { result = $0 }
+
+        XCTAssertEqual(interactor.createTextCommentCallsCount, 1)
+        XCTAssertEqual(interactor.createTextCommentInput?.text, "some comment")
+        XCTAssertEqual(interactor.createTextCommentInput?.attemptNumber, 42)
+        verifySendCommentCompletion(interactor.createTextCommentInput?.completion, result: { result })
+    }
+
+    func test_sendMediaComment() {
+        var result: Result<String, Error>?
+        let url = URL(string: "/some/url")!
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+        let testee = makeViewModel(latestAttemptNumber: 42)
+
+        testee.sendMediaComment(type: .video, url: url) { result = $0 }
+
+        XCTAssertEqual(interactor.createMediaCommentCallsCount, 1)
+        XCTAssertEqual(interactor.createMediaCommentInput?.type, .video)
+        XCTAssertEqual(interactor.createMediaCommentInput?.url, url)
+        XCTAssertEqual(interactor.createMediaCommentInput?.attemptNumber, 42)
+        verifySendCommentCompletion(interactor.createMediaCommentInput?.completion, result: { result })
+    }
+
+    func test_sendFileComment() {
+        var result: Result<String, Error>?
+        interactor.getIsAssignmentEnhancementsEnabledResult = Publishers.typedJust(true)
+        let testee = makeViewModel(latestAttemptNumber: 42)
+
+        testee.sendFileComment(batchId: "some id") { result = $0 }
+
+        XCTAssertEqual(interactor.createFileCommentCallsCount, 1)
+        XCTAssertEqual(interactor.createFileCommentInput?.batchId, "some id")
+        XCTAssertEqual(interactor.createFileCommentInput?.attemptNumber, 42)
+        verifySendCommentCompletion(interactor.createFileCommentInput?.completion, result: { result })
+    }
+
+    private func verifySendCommentCompletion(
+        _ completion: ((Result<Void, Error>) -> Void)?,
+        result: @escaping () -> Result<String, Error>?
+    ) {
+        guard let completion else { return XCTFail("Input has no value") }
+
+        // success should have success message
+        completion(.success)
+        XCTAssertEqual(result()?.value, String(localized: "Comment sent successfully", bundle: .teacher))
+
+        // failure should have error message if the error has any
+        completion(.failure(MockError(message: "some error")))
+        XCTAssertEqual(result()?.error?.localizedDescription, "some error")
+
+        // failure should have generic error message if the error has none
+        completion(.failure(MockError()))
+        XCTAssertEqual(result()?.error?.localizedDescription, String(localized: "Could not save the comment.", bundle: .teacher))
+    }
+
+    // MARK: - Private helpers
+
+    private func makeViewModel(
+        latestAttemptNumber: Int? = nil,
+        currentUserId: String? = TestConstants.currentUserId
+    ) -> SubmissionCommentListViewModel {
+        SubmissionCommentListViewModel(
+            assignment: assignment,
+            latestSubmission: submission,
+            latestAttemptNumber: latestAttemptNumber,
+            currentUserId: currentUserId,
+            interactor: interactor,
+            scheduler: .immediate,
+            env: environment
+        )
+    }
+
+    private func makeComment(
+        id: String = "",
+        attempt: Int? = nil,
+        assignmentId: String = TestConstants.assignmentId,
+        submissionUserId: String = TestConstants.submissionUserId
+    ) -> SubmissionComment {
+        SubmissionComment.save(
+            .make(id: id, attempt: attempt),
+            for: .make(
+                assignment_id: .init(assignmentId),
+                user_id: .init(submissionUserId)
+            ),
+            in: databaseClient
+        )
+    }
+
+    private func makeSubmission(
+        id: String = "",
+        attempt: Int? = nil
+    ) -> Submission {
+        Submission.save(
+            .make(attempt: attempt, id: .init(id)),
+            in: databaseClient
+        )
+    }
+}
+
+private final class SubmissionCommentsInteractorMock: SubmissionCommentsInteractor {
+
+    // MARK: - getSubmissionAttempts
+
+    var getSubmissionAttemptsCallsCount: Int = 0
+    var getSubmissionAttemptsResult: AnyPublisher<[Submission], Error>?
+    func getSubmissionAttempts() -> AnyPublisher<[Submission], Error> {
+        getSubmissionAttemptsCallsCount += 1
+        return getSubmissionAttemptsResult ?? Publishers.typedJust([])
+    }
+
+    // MARK: - getComments
+
+    var getCommentsCallsCount: Int = 0
+    var getCommentsResult: AnyPublisher<[SubmissionComment], Error>?
+    func getComments() -> AnyPublisher<[SubmissionComment], Error> {
+        getCommentsCallsCount += 1
+        return getCommentsResult ?? Publishers.typedJust([])
+    }
+
+    // MARK: - getIsAssignmentEnhancementsEnabled
+
+    var getIsAssignmentEnhancementsEnabledCallsCount: Int = 0
+    var getIsAssignmentEnhancementsEnabledResult: AnyPublisher<Bool, Error>?
+    func getIsAssignmentEnhancementsEnabled() -> AnyPublisher<Bool, Error> {
+        getIsAssignmentEnhancementsEnabledCallsCount += 1
+        return getIsAssignmentEnhancementsEnabledResult ?? Publishers.typedJust(false)
+    }
+
+    // MARK: - createTextComment
+
+    var createTextCommentCallsCount: Int = 0
+    var createTextCommentInput: (text: String, attemptNumber: Int?, completion: (Result<Void, Error>) -> Void)?
+    func createTextComment(_ text: String, attemptNumber: Int?, completion: @escaping (Result<Void, Error>) -> Void) {
+        createTextCommentCallsCount += 1
+        createTextCommentInput = (text: text, attemptNumber: attemptNumber, completion: completion)
+    }
+
+    // MARK: - createMediaComment
+
+    var createMediaCommentCallsCount: Int = 0
+    var createMediaCommentInput: (type: MediaCommentType, url: URL, attemptNumber: Int?, completion: (Result<Void, Error>) -> Void)?
+    func createMediaComment(type: MediaCommentType, url: URL, attemptNumber: Int?, completion: @escaping (Result<Void, Error>) -> Void) {
+        createMediaCommentCallsCount += 1
+        createMediaCommentInput = (type: type, url: url, attemptNumber: attemptNumber, completion: completion)
+    }
+
+    // MARK: - createFileComment
+
+    var createFileCommentCallsCount: Int = 0
+    var createFileCommentInput: (batchId: String, attemptNumber: Int?, completion: (Result<Void, Error>) -> Void)?
+    func createFileComment(batchId: String, attemptNumber: Int?, completion: @escaping (Result<Void, Error>) -> Void) {
+        createFileCommentCallsCount += 1
+        createFileCommentInput = (batchId: batchId, attemptNumber: attemptNumber, completion: completion)
     }
 }


### PR DESCRIPTION
refs: [MBL-18809](https://instructure.atlassian.net/browse/MBL-18809)
affects: Teacher
release note: none

## What's changed
- Updated SpeedGrader comment list to match new design (see specific Figma link in ticket)
- Extracted related code to viewmodels, interactor, assembly, etc.

### Chores
- Added `SwiftUI.Image.size(_ size:, paddedTo boundingSize:)` method 
  - this allows us to more easily follow bounding boxes in Figma
- Added convenience method `sinkFailureOrValue()`
- Extracted various `MockError`s to a central place

## What's not changed
- Please see ticket for detailed scope first
- New comment is displayed as Sent instantly, regardless of the API response.
  - It was like this before, it probably needs a rework.
  - Even though I've created a `SubmissionCommentsInteractor` I didn't rework the create comment methods, just used them as is for now.
  - I haven't added tests for these
- Attempts are still in the comments, their design hasn't changed yet.
- The new Submission Comment related code is still in Teacher app, even though they could reused later in S-tudent app

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b8e8eb5e-abfa-41bb-b3a2-b5f92451168d" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ee8c92c7-4648-4344-8c57-584c365a01d3" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/166bf6ee-da6e-4b6d-9c34-a108f02e1925" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/516fc180-0239-4a5b-80f3-e0e5773edd21" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product