### PR TITLE
[Horizon] Fix progress bar for course details & Scores 

### DIFF
--- a/Horizon/Horizon/Sources/Features/Learn/CourseDetails/View/CourseDetailsViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/Learn/CourseDetails/View/CourseDetailsViewModel.swift
@@ -30,6 +30,10 @@ final class CourseDetailsViewModel {
     private(set) var isLoaderVisible: Bool = false
     let scoresViewModel: ScoresViewModel
 
+    // MARK: - Inputs / Outputs
+
+    var selectedTabIndex: Int = 1
+
     // MARK: - Private
 
     private let onShowTabBar: (Bool) -> Void
@@ -66,6 +70,7 @@ final class CourseDetailsViewModel {
                 self.course.progress = max(nextProgress, currentProgress)
                 self.state = .data
                 self.isLoaderVisible = false
+                self.selectedTabIndex = course.overviewDescription.isEmpty ? 0 : 1
             }
             .store(in: &subscriptions)
 

--- a/Horizon/Horizon/Sources/Features/Learn/Scores/Data/ScoreDetails.swift
+++ b/Horizon/Horizon/Sources/Features/Learn/Scores/Data/ScoreDetails.swift
@@ -56,7 +56,7 @@ struct ScoreDetails {
                 case .dueDate:
                     return (lhs.dueAt ?? Date.distantFuture) < (rhs.dueAt ?? Date.distantFuture)
                 case .assignmentName:
-                    return lhs.name < rhs.name
+                    return lhs.name.lowercased() < rhs.name.lowercased()
                 }
             }
     }

--- a/Horizon/Horizon/Sources/Features/Learn/Scores/View/ScoresAssignmentGroupsView.swift
+++ b/Horizon/Horizon/Sources/Features/Learn/Scores/View/ScoresAssignmentGroupsView.swift
@@ -35,7 +35,7 @@ struct ScoresAssignmentGroupsView: View {
             .huiTypography(.h2)
             .foregroundStyle(Color.huiColors.text.body)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding([.leading, .trailing], .huiSpaces.space24)
+            .padding(.horizontal, .huiSpaces.space24)
             HStack(spacing: .huiSpaces.space8) {
                 arrowIcon
                 Text("Assignment Group Weights", bundle: .horizon)
@@ -49,8 +49,8 @@ struct ScoresAssignmentGroupsView: View {
                 assignmentGroupList(groups: details.assignmentGroups)
             }
         }
-        .padding(.top, .huiSpaces.space24)
-        .padding(.bottom, isExpanded ? 0 : .huiSpaces.space24)
+        .padding(.top, .huiSpaces.space16)
+        .padding(.bottom, isExpanded ? 0 : .huiSpaces.space16)
         .background(Color.huiColors.primitives.white10)
         .huiCornerRadius(level: .level5)
         .onTapGesture {
@@ -89,7 +89,7 @@ struct ScoresAssignmentGroupsView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.top, .huiSpaces.space16)
             .padding(.bottom, .huiSpaces.space24)
-            .padding([.leading, .trailing], .huiSpaces.space24)
+            .padding(.horizontal, .huiSpaces.space24)
         }
     }
 

--- a/Horizon/Horizon/Sources/Features/Learn/Scores/View/ScoresAssignmentsView.swift
+++ b/Horizon/Horizon/Sources/Features/Learn/Scores/View/ScoresAssignmentsView.swift
@@ -33,8 +33,8 @@ struct ScoresAssignmentsView: View {
                 label: String(localized: "Sort By", bundle: .horizon),
                 options: ScoreDetails.SortOption.allCases.map(\.localizedTitle)
             )
-            .padding(.horizontal, .huiSpaces.space16)
-            .padding(.top, .huiSpaces.space16)
+            .padding(.horizontal, .huiSpaces.space24)
+            .padding(.top, .huiSpaces.space24)
             VStack(spacing: .zero) {
                 ForEach(Array(details.assignments.enumerated()), id: \.offset) { index, assignment in
                     VStack(alignment: .leading, spacing: .huiSpaces.space8) {
@@ -73,7 +73,7 @@ struct ScoresAssignmentsView: View {
                     .huiTypography(.p1)
                     .foregroundStyle(Color.huiColors.text.body)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding([.top, .bottom], .huiSpaces.space16)
+                    .padding(.vertical, .huiSpaces.space16)
                     .onTapGesture {
                         openAssignmentDetails(assignment.htmlUrl)
                     }
@@ -96,6 +96,7 @@ struct ScoresAssignmentsView: View {
             .frame(maxWidth: .infinity)
             .frame(height: 1)
             .foregroundColor(Color.huiColors.surface.divider)
+            .padding(.horizontal, -(.huiSpaces.space24))
     }
 }
 


### PR DESCRIPTION
1- https://instructure.atlassian.net/browse/CLX-1068
2- https://instructure.atlassian.net/browse/CLX-1069
3- https://instructure.atlassian.net/browse/CLX-1073
4- If the course details has't overview will hide it 

<table>

<tr>
<td><img src="https://github.com/user-attachments/assets/58d4e13b-a380-423f-8b4d-a2dabbecf799" maxHeight=300>
</tr>
</table>


https://github.com/user-attachments/assets/cbd97d9d-eb02-4129-bc5c-3848b955bd2c

