### PR TITLE
Fix issue of WebView not resizing on Dark/Light mode switch

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -56,6 +56,7 @@ open class CoreWebView: WKWebView {
         themeSwitcher?.isThemeInverted ?? false
     }
     private var fullScreenVideoSupport: FullScreenVideoSupport?
+    private var contentHeight: CGFloat = .nan
 
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
@@ -148,7 +149,9 @@ open class CoreWebView: WKWebView {
                   let height = body["height"]
             else { return }
 
-            self.sizeDelegate?.coreWebView(self, didChangeContentHeight: height)
+            self.contentHeight = height
+            self.reportContentHeight()
+
             if self.autoresizesHeight, let constraint = self.constraints.first(where: { $0.firstItem === self && $0.firstAttribute == .height }) {
                 constraint.constant = height
                 self.setNeedsLayout()
@@ -357,12 +360,18 @@ open class CoreWebView: WKWebView {
         let traits = [UITraitUserInterfaceStyle.self]
         registerForTraitChanges(traits) { (self: CoreWebView, _) in
             self.updateInterfaceStyle()
+            self.reportContentHeight()
         }
     }
 
     func updateInterfaceStyle() {
         let traitCollection = viewController?.traitCollection ?? traitCollection
         themeSwitcher?.updateUserInterfaceStyle(with: traitCollection.userInterfaceStyle)
+    }
+
+    private func reportContentHeight() {
+        guard contentHeight.isFinite else { return }
+        sizeDelegate?.coreWebView(self, didChangeContentHeight: contentHeight)
     }
 }
 


### PR DESCRIPTION
refs: MBL-18804
affects: Student, Teacher, Parent
release note: Fixes issue of WebView not resizing on Dark/Light mode switch

## Test Plan

See ticket's description.
We also better check other places that uses WebView in resizable way. Like assignment details (description), notification cards, teacher quiz details.

## Screen Recording

https://github.com/user-attachments/assets/d0db672f-e438-4ab4-89b0-54402e6562a3

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
