### PR TITLE
Accessibility - Date Picker

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -41,6 +41,7 @@ extension InstUI {
         private let label: Text
         private let labelTransform: (Text) -> Label
         private let customAccessibilityLabel: Text?
+        private let accessibilityIdPrefix: String?
         private let mode: Mode
         private let defaultDate: Date
         private let validFrom: Date
@@ -54,6 +55,7 @@ extension InstUI {
             label: Text,
             labelTransform: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
+            accessibilityIdPrefix: String? = nil,
             date: Binding<Date?>,
             mode: Mode = .dateAndTime,
             defaultDate: Date = .now,
@@ -65,6 +67,7 @@ extension InstUI {
             self.label = label
             self.labelTransform = labelTransform
             self.customAccessibilityLabel = customAccessibilityLabel
+            self.accessibilityIdPrefix = accessibilityIdPrefix
             self._date = date
             self.mode = mode
             self.defaultDate = defaultDate
@@ -188,6 +191,12 @@ extension InstUI {
             case .dateAndTime: [.date, .hourAndMinute]
             }
 
+            let accessibilityId = switch mode {
+            case .dateOnly: "date"
+            case .timeOnly: "time"
+            case .dateAndTime: "dateAndTime"
+            }
+
             DatePicker(
                 selection: binding,
                 in: validFrom...validUntil,
@@ -197,6 +206,7 @@ extension InstUI {
             .labelsHidden() // This is needed to avoid the empty label filling up all the space
             .accessibilityLabel(customAccessibilityLabel ?? label)
             .accessibilityValue(String.localizedAccessibilityErrorMessage(errorMessage) ?? "") // Actual value is contained already
+            .accessibilityIdentifier(accessibilityIdPrefix?.appending(".\(accessibilityId)"))
             .accessibilityRefocusingOnPopoverDismissal()
         }
 

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -39,7 +39,7 @@ extension InstUI {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
         private let label: Text
-        private let labelTransform: (Text) -> Label
+        private let labelModifiers: (Text) -> Label
         private let customAccessibilityLabel: Text?
         private let accessibilityIdPrefix: String?
         private let mode: Mode
@@ -53,7 +53,7 @@ extension InstUI {
 
         public init(
             label: Text,
-            labelTransform: @escaping (Text) -> Label = { $0 },
+            labelModifiers: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
             accessibilityIdPrefix: String? = nil,
             date: Binding<Date?>,
@@ -65,7 +65,7 @@ extension InstUI {
             isClearable: Bool = false
         ) {
             self.label = label
-            self.labelTransform = labelTransform
+            self.labelModifiers = labelModifiers
             self.customAccessibilityLabel = customAccessibilityLabel
             self.accessibilityIdPrefix = accessibilityIdPrefix
             self._date = date
@@ -121,7 +121,7 @@ extension InstUI {
         }
 
         private var labelView: some View {
-            labelTransform(label)
+            labelModifiers(label)
                 .textStyle(.cellLabel)
                 .accessibilityHidden(true)
         }
@@ -275,7 +275,7 @@ extension InstUI {
         InstUI.DatePickerCell(label: Text(verbatim: "Just Date"), date: .constant(.now), mode: .dateOnly)
         InstUI.DatePickerCell(
             label: Text(verbatim: "Important Date"),
-            labelTransform: { $0.foregroundStyle(Color.red).textStyle(.heading) },
+            labelModifiers: { $0.foregroundStyle(Color.red).textStyle(.heading) },
             date: .constant(.now)
         )
     }

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/RichContentEditorCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/RichContentEditorCell.swift
@@ -26,7 +26,7 @@ extension InstUI {
         @Environment(\.appEnvironment) private var env
 
         private let label: Text?
-        private let labelTransform: (Text) -> Label
+        private let labelModifiers: (Text) -> Label
         private let customAccessibilityLabel: Text?
         private let placeholder: String
         private let uploadParameters: RichContentEditorUploadParameters
@@ -46,7 +46,7 @@ extension InstUI {
 
         public init(
             label: Text?,
-            labelTransform: @escaping (Text) -> Label = { $0 },
+            labelModifiers: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             html: Binding<String>,
@@ -56,7 +56,7 @@ extension InstUI {
             onFocus: (() -> Void)? = nil
         ) {
             self.label = label
-            self.labelTransform = labelTransform
+            self.labelModifiers = labelModifiers
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder ?? ""
             self._html = html
@@ -77,7 +77,7 @@ extension InstUI {
         ) where Label == Text? {
             self.init(
                 label: nil,
-                labelTransform: { $0 },
+                labelModifiers: { $0 },
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
                 html: html,
@@ -92,7 +92,7 @@ extension InstUI {
             SwiftUI.Group {
                 if let label {
                     VStack(spacing: 0) {
-                        labelTransform(label)
+                        labelModifiers(label)
                             .textStyle(.cellLabel)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .paddingStyle(.top, .cellTop)
@@ -148,11 +148,7 @@ extension InstUI {
         InstUI.RichContentEditorCell(label: Text(verbatim: "Label"), placeholder: "Add text here", html: .constant(InstUI.PreviewData.loremIpsumMedium), uploadParameters: uploadParameters)
         InstUI.RichContentEditorCell(
             label: Text(verbatim: "Styled Label"),
-            labelTransform: {
-                $0
-                    .foregroundStyle(Color.red)
-                    .textStyle(.heading)
-            },
+            labelModifiers: { $0.foregroundStyle(Color.red).textStyle(.heading) },
             placeholder: "Add text here",
             html: .constant("Some text entered"),
             uploadParameters: uploadParameters

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TextEditorCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TextEditorCell.swift
@@ -24,7 +24,7 @@ extension InstUI {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
         private let label: Text?
-        private let labelTransform: (Text) -> Label
+        private let labelModifiers: (Text) -> Label
         private let customAccessibilityLabel: Text?
         private let placeholder: String?
 
@@ -41,13 +41,13 @@ extension InstUI {
 
         public init(
             label: Text?,
-            labelTransform: @escaping (Text) -> Label = { $0 },
+            labelModifiers: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
             placeholder: String? = nil,
             text: Binding<String>
         ) {
             self.label = label
-            self.labelTransform = labelTransform
+            self.labelModifiers = labelModifiers
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder
             self._text = text
@@ -60,7 +60,7 @@ extension InstUI {
         ) where Label == Text? {
             self.init(
                 label: nil,
-                labelTransform: { $0 },
+                labelModifiers: { $0 },
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
                 text: text
@@ -71,7 +71,7 @@ extension InstUI {
             SwiftUI.Group {
                 if let label {
                     VStack(spacing: 0) {
-                        labelTransform(label)
+                        labelModifiers(label)
                             .textStyle(.cellLabel)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .paddingStyle(.bottom, .cellBottom)
@@ -153,11 +153,7 @@ extension InstUI {
             InstUI.Divider()
             InstUI.TextEditorCell(
                 label: Text(verbatim: "Styled Label"),
-                labelTransform: {
-                    $0
-                        .foregroundStyle(Color.red)
-                        .textStyle(.heading)
-                },
+                labelModifiers: { $0.foregroundStyle(Color.red).textStyle(.heading) },
                 text: .constant(InstUI.PreviewData.loremIpsumLong(2))
             )
             InstUI.Divider()

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TextFieldCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TextFieldCell.swift
@@ -24,7 +24,7 @@ extension InstUI {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
         private let label: Text?
-        private let labelTransform: (Text) -> Label
+        private let labelModifiers: (Text) -> Label
         private let customAccessibilityLabel: Text?
         private let placeholder: String
 
@@ -44,13 +44,13 @@ extension InstUI {
 
         public init(
             label: Text?,
-            labelTransform: @escaping (Text) -> Label = { $0 },
+            labelModifiers: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
             placeholder: String,
             text: Binding<String>
         ) {
             self.label = label
-            self.labelTransform = labelTransform
+            self.labelModifiers = labelModifiers
             self.customAccessibilityLabel = customAccessibilityLabel
             self.placeholder = placeholder
             self._text = text
@@ -63,7 +63,7 @@ extension InstUI {
         ) where Label == Text? {
             self.init(
                 label: nil,
-                labelTransform: { $0 },
+                labelModifiers: { $0 },
                 customAccessibilityLabel: customAccessibilityLabel,
                 placeholder: placeholder,
                 text: text
@@ -75,7 +75,7 @@ extension InstUI {
                 SwiftUI.Group {
                     if let label {
                         HStack(alignment: .center, spacing: 0) {
-                            labelTransform(label)
+                            labelModifiers(label)
                                 .textStyle(.cellLabel)
                                 .paddingStyle(.trailing, .standard)
                                 .accessibility(hidden: true)
@@ -120,11 +120,7 @@ extension InstUI {
         InstUI.TextFieldCell(label: Text(verbatim: "Label"), placeholder: "Add text here", text: .constant(InstUI.PreviewData.loremIpsumMedium))
         InstUI.TextFieldCell(
             label: Text(verbatim: "Styled Label"),
-            labelTransform: {
-                $0
-                    .foregroundStyle(Color.red)
-                    .textStyle(.heading)
-            },
+            labelModifiers: { $0.foregroundStyle(Color.red).textStyle(.heading) },
             placeholder: "Add text here",
             text: .constant("Some text entered")
         )

--- a/Core/Core/Common/Extensions/Foundation/String+LocalizedFormats.swift
+++ b/Core/Core/Common/Extensions/Foundation/String+LocalizedFormats.swift
@@ -42,6 +42,13 @@ extension String {
         return String.localizedStringWithFormat(format, errorMessage)
     }
 
+    /// Localized string to be used for error messages intended for accessibility usage. Adds some context for VoiceOver users that this is an error.
+    /// The `errorMessage` itself is expected to be localized already.
+    /// Example: "Error: Invalid start time"
+    public static func localizedAccessibilityErrorMessage(_ errorMessage: String?) -> String? {
+        errorMessage.map { String.localizedAccessibilityErrorMessage($0) }
+    }
+
     /// Localized string to be used when we need attempt number. Example: "Attempt 5"
     public static func localizedAttemptNumber(_ attempt: Int) -> String {
         String.localizedStringWithFormat(String(localized: "Attempt %d", bundle: .core), attempt)

--- a/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
+++ b/Core/Core/Features/Planner/CalendarEvent/View/EditCalendarEventScreen.swift
@@ -60,15 +60,15 @@ struct EditCalendarEventScreen: View, ScreenViewTrackable {
 
                         if !viewModel.isAllDay {
                             InstUI.DatePickerCell(
-                                label: Text("From", bundle: .core)
-                                    .accessibilityLabel(Text("Start time", bundle: .core)),
+                                label: Text("From", bundle: .core),
+                                customAccessibilityLabel: Text("Start time", bundle: .core),
                                 date: $viewModel.startTime,
                                 mode: .timeOnly
                             )
 
                             InstUI.DatePickerCell(
-                                label: Text("To", bundle: .core)
-                                    .accessibilityLabel(Text("End time", bundle: .core)),
+                                label: Text("To", bundle: .core),
+                                customAccessibilityLabel: Text("End time", bundle: .core),
                                 date: $viewModel.endTime,
                                 mode: .timeOnly,
                                 errorMessage: viewModel.endTimeErrorMessage

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -50,9 +50,9 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
 
                     InstUI.DatePickerCell(
                         label: Text("Date", bundle: .core),
+                        accessibilityIdPrefix: "Calendar.Todo.datePicker",
                         date: $viewModel.date
                     )
-                    .accessibilityIdentifier("Calendar.Todo.datePicker")
 
                     InstUI.LabelValueCell(
                         label: Text("Calendar", bundle: .core),

--- a/Core/CoreTests/Common/Extensions/Foundation/String+LocalizedFormatsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/String+LocalizedFormatsTests.swift
@@ -34,6 +34,12 @@ class StringLocalizedFormatsTests: XCTestCase {
     func testLocalizedAccessibilityErrorMessage() {
         XCTAssertEqual(String.localizedAccessibilityErrorMessage("Some error description"), "Error: Some error description")
         XCTAssertEqual(String.localizedAccessibilityErrorMessage(""), "Error: ")
+
+        var optionalString: String? = "Some error description"
+        XCTAssertEqual(String.localizedAccessibilityErrorMessage(optionalString), "Error: Some error description")
+
+        optionalString = nil
+        XCTAssertEqual(String.localizedAccessibilityErrorMessage(optionalString), nil)
     }
 
     func testLocalizedAttemptNumber() {

--- a/Core/TestsFoundation/UITestHelperNamespaces/CalendarHelper.swift
+++ b/Core/TestsFoundation/UITestHelperNamespaces/CalendarHelper.swift
@@ -208,15 +208,9 @@ public class CalendarHelper: BaseHelper {
         public static var saveButton: XCUIElement { app.find(label: "Save", type: .button) }
         public static var titleInput: XCUIElement { app.find(id: "Calendar.Todo.title") }
         public static var calendarSelector: XCUIElement { app.find(id: "Calendar.Todo.calendar") }
-        public static var datePickerContainer: XCUIElement { app.find(id: "Calendar.Todo.datePicker") }
 
-        public static var datePicker: XCUIElement {
-            datePickerContainer.find(type: .button).findAll(type: .button, minimumCount: 2)[0]
-        }
-
-        public static var timePicker: XCUIElement {
-            datePickerContainer.find(type: .button).findAll(type: .button, minimumCount: 2)[1]
-        }
+        public static var datePicker: XCUIElement { app.find(id: "Calendar.Todo.datePicker.date") }
+        public static var timePicker: XCUIElement { app.find(id: "Calendar.Todo.datePicker.time") }
 
         public static var detailsInput: XCUIElement { app.find(id: "Calendar.Todo.details") }
 


### PR DESCRIPTION
refs: [MBL-18843](https://instructure.atlassian.net/browse/MBL-18843)
affects: Student, Teacher
release note: Improved accessibility on various screens.

#### Updated DatePickerCell accessibility:
- cell label itself is no longer focusable
- label is read for the picker component (date or time) which is first focused
  - error message is also read for the components
- "Date Picker" & "Time Picker" is read for each component

#### Problem with DatePicker a11y
The main hardship is that the native DatePicker control behaves differently a11y-wise when it is date-time picker than it is date or time picker only. The behaviour is not really customizable and doesn't match a11y requirements.
I ended up composing the Date&Time variant from 2 separate pickers.

#### Problem ViewThatFits performance
Nesting `ViewThatFits` calls caused visible performance issues, so I ended up using one call at the top and flattening the deeper logic into it. Note that specifying axis like `ViedThatFits(in: .horizontal)` also improves performance.

## Test plan
- Verify VoiceOver reads out date cells as expected
- Verify Font Size changes are followed properly for date cells

#### Screens using this component:
- Calendar Add/Edit Event (it has single-component pickers)
- Calendar Add/Edit Todo (it has dual-component picker)
- Calendar Custom Frequency

## Screenshots
TBA
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [x] Approve from product

[MBL-18843]: https://instructure.atlassian.net/browse/MBL-18843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ