### PR TITLE
Fixed issue of disappearing groups on dashboard on first refresh after login

### DIFF
--- a/Core/Core/Features/Groups/GetGroups.swift
+++ b/Core/Core/Features/Groups/GetGroups.swift
@@ -70,15 +70,26 @@ public class GetDashboardGroups: CollectionUseCase {
     public var request: GetFavoriteGroupsRequest { GetFavoriteGroupsRequest(context: .currentUser) }
     public var scope: Scope {
         let showOnDashboard = NSPredicate(key: #keyPath(Group.showOnDashboard), equals: true)
+        let isFavorite = NSPredicate(key: #keyPath(Group.isFavorite), equals: true)
         let accessRestrictedByDate = NSCompoundPredicate(orPredicateWithSubpredicates: [
             NSPredicate(key: #keyPath(Group.course.accessRestrictedByDate), equals: false),
             NSPredicate(format: "%K == nil", #keyPath(Group.course))
         ])
-        let predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [showOnDashboard, accessRestrictedByDate])
-        return Scope(predicate: predicate,
-                     order: [NSSortDescriptor(key: #keyPath(Group.name), ascending: true, naturally: true),
-                             NSSortDescriptor(key: #keyPath(Group.id), ascending: true, naturally: true)
-                     ])
+        let predicate = NSCompoundPredicate(
+            andPredicateWithSubpredicates: [
+                showOnDashboard,
+                isFavorite,
+                accessRestrictedByDate
+            ]
+        )
+
+        return Scope(
+            predicate: predicate,
+            order: [
+                NSSortDescriptor(key: #keyPath(Group.name), ascending: true, naturally: true),
+                NSSortDescriptor(key: #keyPath(Group.id), ascending: true, naturally: true)
+            ]
+        )
     }
 }
 

--- a/Core/Core/Features/Groups/Group.swift
+++ b/Core/Core/Features/Groups/Group.swift
@@ -68,6 +68,10 @@ public final class Group: NSManagedObject, WriteableModel {
         model.id = item.id.value
         model.name = item.name
         model.showOnDashboard = !item.concluded
+
+        // `is_favorite` always has value when retrieved via `/api/v1/{context}/groups` api,
+        // while for api `/api/v1/users/self/favorites/groups`, it always received with no value.
+        // That's why we can assume the value to be `true` if not present.
         model.isFavorite = item.is_favorite ?? true
 
         if let contextColor: ContextColor = context.fetch(scope: .where(#keyPath(ContextColor.canvasContextID), equals: model.canvasContextID)).first {


### PR DESCRIPTION
refs: MBL-18822
affects: Student
release note: Fixed issue of disappearing groups on dashboard on first refresh after login

## Root Cause Analysis

The issue occurs after each login, because API request in `GetGroups` use case is made right after the one made by `GetDashboardGroups`. The `GetGroups` instance that is responsible for this is the one living in `TodoListViewController`.  And this interference only occurs after login, if user close the app then relaunch it again it will go away. 

Although, the disappearing group "Education 2" is not marked as favorite _- You can find about that if you go to "All Courses" screen -_, still this interference could cause it to show up as groups fetched in `GetDashboardGroups` are not scoped to ones that were marked as favorite.

Therefore, **_The resolution_** is basically to limit the scope of `GetDashboardGroups` to include `isFavorite` check, as this use case is concerned only in those groups. This way, this group won't make it to the list even if that interference occurred for some reason, which is the correct behavior. 

**_One note, though,_**
According to the [API docs](https://canvas.instructure.com/doc/api/favorites.html#method.favorites.list_favorite_groups), used in `GetDashboardGroups`, it responds with favorite groups if available, or "selected" ones if there is no favorites. (Not sure what "selected" means). After doing multiple tests, apparently, the API always respond with objects with `is_favorite` attribute set to `nil`. While for [the API](https://canvas.instructure.com/doc/api/groups.html#method.groups.index) used in `GetGroups`, the response of groups always include `is_favorite` attribute set to some value `true` or `false`. 

Therefore, we are relying on setting to `isFavorite` on local objects to `true` if value received `nil`, in order to have this scope limiting solution working as expected.

## Test Plan

See ticket's description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
