### PR TITLE
Fix swiping to next student changing the current student's attempt

### DIFF
--- a/Parent/ParentUnitTests/Inbox/ParentInboxCoursePicker/Model/ParentInboxCoursePickerInteractorLiveTests.swift
+++ b/Parent/ParentUnitTests/Inbox/ParentInboxCoursePicker/Model/ParentInboxCoursePickerInteractorLiveTests.swift
@@ -90,7 +90,7 @@ class ParentInboxCoursePickerInteractorLiveTests: ParentTestCase {
                     stateUpdate.fulfill()
                 }
             }
-        wait(for: [stateUpdate], timeout: 1)
+        wait(for: [stateUpdate], timeout: 5)
         subscription.cancel()
     }
 }

--- a/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModel.swift
@@ -86,7 +86,9 @@ class SubmissionCommentListViewModel: ObservableObject {
         .assign(to: &$state)
 
         NotificationCenter.default.publisher(for: .SpeedGraderAttemptPickerChanged)
-            .compactMap { $0.object as? Int }
+            .compactMap { $0.object as? SpeedGraderAttemptChangeInfo }
+            .filter { $0.userId == userID }
+            .map { $0.attemptIndex }
             .sink(receiveValue: { unownedSelf.updateComments(attempt: $0) })
             .store(in: &subscriptions)
     }

--- a/Teacher/Teacher/SpeedGrader/MainLayout/ViewModel/SubmissionGraderViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/ViewModel/SubmissionGraderViewModel.swift
@@ -54,7 +54,10 @@ class SubmissionGraderViewModel: ObservableObject {
     }
 
     func didSelectNewAttempt(attemptIndex: Int) {
-        NotificationCenter.default.post(name: .SpeedGraderAttemptPickerChanged, object: attemptIndex)
+        NotificationCenter.default.post(
+            name: .SpeedGraderAttemptPickerChanged,
+            object: SpeedGraderAttemptChangeInfo(attemptIndex: attemptIndex, userId: submission.userID)
+        )
         selectedAttemptIndex = attemptIndex
         selectedAttempt = attempts.first { selectedAttemptIndex == $0.attempt } ?? submission
         fileTabTitle = {
@@ -111,4 +114,9 @@ extension [Submission] {
 
 extension NSNotification.Name {
     public static var SpeedGraderAttemptPickerChanged = NSNotification.Name("com.instructure.core.speedgrader-attempt-changed")
+}
+
+struct SpeedGraderAttemptChangeInfo {
+    let attemptIndex: Int
+    let userId: String
 }

--- a/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Comments/ViewModel/SubmissionCommentListViewModelTests.swift
@@ -218,7 +218,10 @@ class SubmissionCommentListViewModelTests: TeacherTestCase {
         default:
             XCTFail("Expected data state")
         }
-        NotificationCenter.default.post(name: .SpeedGraderAttemptPickerChanged, object: 2)
+        NotificationCenter.default.post(
+            name: .SpeedGraderAttemptPickerChanged,
+            object: SpeedGraderAttemptChangeInfo(attemptIndex: 2, userId: "1")
+        )
 
         // THEN
         switch testee.state {


### PR DESCRIPTION
### What happened?
- On attempt change in SpeedGrader we fire a notification to update the submission comment list to show comments for the current attempt.
- When a new SpeedGrader page was loaded it automatically sent out this notification but it wasn't filtered to a user.
- All comment lists in memory got the notification and changed the attempt to show comments for the received attempt.

refs: [MBL-18839](https://instructure.atlassian.net/browse/MBL-18839)
affects: Teacher
release note: none

test plan:
- Turn on assignment enhancements.
- Have an assignment with multiple submissions from a user. Each submission should have a comment to easily recognise which comment is for which attempt.
- Add another student to the assignment but with only one submission.
- Start SpeedGrader with a filter that has both students in it.
- Swipe to the student with multiple attempts. Activate comments tab to see its comments.
- Slowly start swiping to the other student with one attempt.
- The current user's comment should still show the last attempt and shouldn't change to show the first attempt's comments.

## Checklist

- [x] Tested on phone
- [x] Tested on tablet

[MBL-18839]: https://instructure.atlassian.net/browse/MBL-18839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ