### PR TITLE
Skip offline tests

### DIFF
--- a/TestPlans/StudentE2E.xctestplan
+++ b/TestPlans/StudentE2E.xctestplan
@@ -29,6 +29,23 @@
   },
   "testTargets" : [
     {
+      "skippedTests" : [
+        "FeatureFlagOfflineTests",
+        "FeatureFlagOfflineTests\/testDiscussionsFallbackToNativeAppearanceWhenOffline()",
+        "OfflineContentSyncTests",
+        "OfflineContentSyncTests\/testAssignmentSync()",
+        "OfflineContentSyncTests\/testDiscussionsSync()",
+        "OfflineContentSyncTests\/testGradesSync()",
+        "OfflineContentSyncTests\/testPagesSync()",
+        "OfflineContentSyncTests\/testPeopleSync()",
+        "OfflineContentSyncTests\/testSyllabusSync()",
+        "OfflineTests",
+        "OfflineTests\/testManageOfflineContentScreen()",
+        "OfflineTests\/testNetworkConnectionLose()",
+        "OfflineTests\/testOfflineContentSync()",
+        "OfflineTests\/testOfflineCourseAvailabilityAndAlertMessageAndStarButton()",
+        "OfflineTests\/testOfflineSynchronizationSetting()"
+      ],
       "target" : {
         "containerPath" : "container:Student.xcodeproj",
         "identifier" : "A5253DAAB36ECE6D2EB5B620",


### PR DESCRIPTION
Offline tests cause a "Lost connection to build agent" abort so we skip these for now.

[ignore-commit-lint]