### PR TITLE
Fix inverted video

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
@@ -20,14 +20,20 @@ private class InvertColorsInDarkMode: CoreWebViewFeature {
     private let script: String = {
         let darkCss = """
         @media (prefers-color-scheme: dark) {
+        
+            /* Apply dark mode filter to the whole page. */
             html {
                 filter: invert(100%) hue-rotate(180deg);
             }
-            img:not(.ignore-color-scheme), video:not(.ignore-color-scheme), .ignore-color-scheme {
-                filter: invert(100%) hue-rotate(180deg) !important;
-            }
-            /* Invert old graded discussion profile images again to get them back to their original look in SpeedGrader. */
-            a.fs-exclude.avatar {
+
+            /* Apply the filter again for these selectors to get back their original colors. */
+            img,
+            video,
+            iframe,
+            canvas,
+            a.fs-exclude.avatar, /* Old graded discussion profile images */
+            .ignore-color-scheme
+            {
                 filter: invert(100%) hue-rotate(180deg) !important;
             }
         }

--- a/Core/Core/Common/CommonUI/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/Features/InvertColorsInDarkMode.swift
@@ -20,7 +20,7 @@ private class InvertColorsInDarkMode: CoreWebViewFeature {
     private let script: String = {
         let darkCss = """
         @media (prefers-color-scheme: dark) {
-        
+
             /* Apply dark mode filter to the whole page. */
             html {
                 filter: invert(100%) hue-rotate(180deg);


### PR DESCRIPTION
- Cleaned up the CSS to keep its original behavior but made it easier to understand.
- Excluded iframes and canvases from inversion. The iframe exclusion solved the inverted video issue.

refs: [MBL-18823](https://instructure.atlassian.net/browse/MBL-18823)
affects: Student, Teacher, Parent
release note: none

test plan: See ticket.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/6bde3568-17a0-4f87-b2a6-15161c129ff7" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f05117f0-b0c7-46b7-9a4a-caf350ae458f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
