### PR TITLE
Accessibility - Radio button

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/RadioButtonCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/RadioButtonCell.swift
@@ -47,13 +47,15 @@ extension InstUI {
         }
 
         public var body: some View {
+            let isSelected = value == selectedValue
+
             VStack(spacing: 0) {
                 Button {
                     selectedValue = value
                 } label: {
                     HStack(spacing: 0) {
                         InstUI.RadioButton(
-                            isSelected: (value == selectedValue),
+                            isSelected: isSelected,
                             color: color
                         )
                         .paddingStyle(.trailing, .cellIconText)
@@ -66,19 +68,19 @@ extension InstUI {
                     }
                     .paddingStyle(set: .iconCell)
                 }
+                .accessibilityLabel(Text(accessibilityLabel))
+                .accessibilityRemoveTraits(.isButton)
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
+
                 InstUI.Divider(dividerStyle)
             }
-            .accessibilityRepresentation {
-                let binding = Binding {
-                    value == selectedValue
-                } set: { _ in
-                    selectedValue = value
-                }
+        }
 
-                SwiftUI.Toggle(isOn: binding) {
-                    Text(title)
-                }
-            }
+        // This is a workaround to not having a `isRadioButton` trait.
+        // The closing "." is needed to make VoiceOver read "Button" the same as with the trait.
+        private var accessibilityLabel: String {
+            let radioButton = String(localized: "Radio Button", bundle: .core, comment: "UI element type read out in VoiceOver.")
+            return "\(title), \(radioButton)."
         }
     }
 }


### PR DESCRIPTION
refs: [MBL-18855](https://instructure.atlassian.net/browse/MBL-18855)
affects: Student, Teacher, Parent
release note: Improved accessibility on various screens.

Since there is no `isRadioButton` trait and the a11y task asks specifically for these to be read as "Radio Button" I made a workaround.

## Test plan
Verify radio buttons read as expected via VoiceOver. Example screens:
- Add Calendar Event
- Assignment List Preferences

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product

[MBL-18855]: https://instructure.atlassian.net/browse/MBL-18855?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ