### PR TITLE
[Horizon] Module Item Sequence Fix

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
@@ -317,6 +317,7 @@ public extension URL {
 public extension String {
     func replaceHostWithCanvasForCareer() -> String {
         replacing("pd.instructure.com", with: "pd.canvasforcareer.com")
+            .replacing("intelvio.instructure.com", with: "intelvio.canvasforcareer.com")
             .replacing("horizon.cd.instructure.com", with: "dev.cd.canvashorizon.com")
     }
 }

--- a/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetailsAssembly.swift
+++ b/Horizon/Horizon/Sources/Features/LearningObjects/Assignment/AssignmentDetailsAssembly.swift
@@ -40,7 +40,6 @@ final class AssignmentDetailsAssembly {
         let getCoursesInteractor = GetCoursesInteractorLive()
         let moduleItemInteractor = ModuleItemSequenceInteractorLive(
             courseID: courseID,
-            assetType: .assignment,
             getCoursesInteractor: getCoursesInteractor
         )
 

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/Domain/ModuleItemSequenceInteractor.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/Domain/ModuleItemSequenceInteractor.swift
@@ -23,6 +23,7 @@ import Foundation
 
 protocol ModuleItemSequenceInteractor {
     func fetchModuleItems(
+        assetType: GetModuleItemSequenceRequest.AssetType,
         assetId: String,
         moduleID: String?,
         itemID: String?
@@ -46,26 +47,24 @@ final class ModuleItemSequenceInteractorLive: ModuleItemSequenceInteractor {
     // MARK: - Dependencies
 
     private let courseID: String
-    private let assetType: AssetType
     private let offlineModeInteractor: OfflineModeInteractor
     private let getCoursesInteractor: GetCoursesInteractor
     private let scheduler: AnySchedulerOf<DispatchQueue>
 
     init(
         courseID: String,
-        assetType: AssetType,
         getCoursesInteractor: GetCoursesInteractor,
         scheduler: AnySchedulerOf<DispatchQueue> = .main,
         offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()
     ) {
         self.courseID = courseID
-        self.assetType = assetType
         self.getCoursesInteractor = getCoursesInteractor
         self.scheduler = scheduler
         self.offlineModeInteractor = offlineModeInteractor
     }
 
     func fetchModuleItems(
+        assetType: GetModuleItemSequenceRequest.AssetType,
         assetId: String,
         moduleID: String?,
         itemID: String?

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/Domain/Preview/ModuleItemSequenceInteractorPreview.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/Domain/Preview/ModuleItemSequenceInteractorPreview.swift
@@ -22,6 +22,7 @@ import Combine
 
 final class ModuleItemSequenceInteractorPreview: ModuleItemSequenceInteractor {
     func fetchModuleItems(
+        assetType: GetModuleItemSequenceRequest.AssetType,
         assetId: String,
         moduleID: String?,
         itemID: String?

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/ModuleItemSequenceAssembly.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/ModuleItemSequenceAssembly.swift
@@ -33,7 +33,6 @@ enum ModuleItemSequenceAssembly {
         let isNotebookDisabled = url.queryItems?.first(where: { $0.name == "notebook_disabled" })?.value?.boolValue ?? false
         let interactor = ModuleItemSequenceInteractorLive(
             courseID: courseID,
-            assetType: assetType,
             getCoursesInteractor: getCoursesInteractor
         )
         let stateInteractor = ModuleItemStateInteractorLive(

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
@@ -176,8 +176,12 @@ final class ModuleItemSequenceViewModel {
             itemID: itemID
         )
         .sink { [weak self] result in
-            self?.assetType = .moduleItem
             self?.isLoaderVisible = false
+            if result.1 == nil {
+                // TODO: Handle the error
+                return
+            }
+            self?.assetType = .moduleItem
             let firstSequence = result.0
             self?.sequence = firstSequence
             self?.isNextButtonEnabled = firstSequence?.next != nil

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/ModuleItemSequenceViewModel.swift
@@ -76,7 +76,7 @@ final class ModuleItemSequenceViewModel {
     private let moduleItemInteractor: ModuleItemSequenceInteractor
     private let moduleItemStateInteractor: ModuleItemStateInteractor
     private let router: Router
-    private let assetType: AssetType
+    private var assetType: AssetType
     private let assetID: String
     private let courseID: String
     private let isNotebookDisabled: Bool
@@ -170,11 +170,13 @@ final class ModuleItemSequenceViewModel {
     ) {
         isLoaderVisible = true
         moduleItemInteractor.fetchModuleItems(
+            assetType: assetType,
             assetId: assetId,
             moduleID: moduleID,
             itemID: itemID
         )
         .sink { [weak self] result in
+            self?.assetType = .moduleItem
             self?.isLoaderVisible = false
             let firstSequence = result.0
             self?.sequence = firstSequence
@@ -318,6 +320,7 @@ final class ModuleItemSequenceViewModel {
     private func refershModuleItem() {
         guard let next = sequence?.next else { return }
         moduleItemInteractor.fetchModuleItems(
+            assetType: assetType,
             assetId: next.id,
             moduleID: next.moduleID,
             itemID: next.id

--- a/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/PageDetails/PageDetailsAssembly.swift
+++ b/Horizon/Horizon/Sources/Features/ModuleItemSequence/Sequence/View/PageDetails/PageDetailsAssembly.swift
@@ -28,7 +28,6 @@ struct PageDetailsAssembly {
 
         let interactor = ModuleItemSequenceInteractorLive(
             courseID: context.id,
-            assetType: .page,
             getCoursesInteractor: GetCoursesInteractorLive()
         )
         let viewModel = PageDetailsViewModel(

--- a/Horizon/Horizon/Sources/Features/Notebook/Common/Domain/CourseNoteInteractor.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Common/Domain/CourseNoteInteractor.swift
@@ -23,8 +23,6 @@ import Foundation
 
 protocol CourseNoteInteractor {
     func add(
-        courseID: String,
-        pageURL: String,
         content: String,
         labels: [CourseNoteLabel],
         notebookHighlight: NotebookHighlight?
@@ -75,17 +73,15 @@ final class CourseNoteInteractorLive: CourseNoteInteractor {
     // MARK: - Public
 
     func add(
-        courseID: String,
-        pageURL: String,
         content: String = "",
         labels: [CourseNoteLabel] = [],
         notebookHighlight: NotebookHighlight? = nil
     ) -> AnyPublisher<CourseNotebookNote, NotebookError> {
         pageIDPublisher
             .mapError { _ in NotebookError.unknown }
-            .flatMap { pageID in
+            .flatMap { [weak self] pageID in
 
-            guard let pageID = pageID else {
+                guard let courseID = self?.objectFilters.value.courseID, let pageID = pageID else {
                 return Fail<CourseNotebookNote, NotebookError>(error: NotebookError.unableToCreateNote)
                     .eraseToAnyPublisher()
             }
@@ -320,8 +316,6 @@ struct Cursor {
 #if DEBUG
 final class CourseNoteInteractorPreview: CourseNoteInteractor {
     func add(
-        courseID: String,
-        pageURL: String,
         content: String,
         labels: [CourseNoteLabel],
         notebookHighlight: NotebookHighlight?

--- a/Horizon/Horizon/Sources/Features/Notebook/Common/View/HighlightWebView/HighlightWebView.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Common/View/HighlightWebView/HighlightWebView.swift
@@ -78,6 +78,8 @@ final class HighlightWebView: CoreWebView {
 
         super.init(features: [highlightWebFeature])
 
+        self.courseNoteInteractor.set(courseID: courseID, pageURL: pageURL)
+
         listenForSelectionChange()
         listenForHighlightTaps()
     }
@@ -215,8 +217,6 @@ final class HighlightWebView: CoreWebView {
         }
 
         courseNoteInteractor.add(
-            courseID: courseID,
-            pageURL: pageURL,
             content: "",
             labels: [label],
             notebookHighlight: notebookHighlight

--- a/Horizon/Horizon/Sources/Features/Notebook/Note/View/NotebookNoteViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Note/View/NotebookNoteViewModel.swift
@@ -111,6 +111,8 @@ final class NotebookNoteViewModel {
 
         self.courseNote = nil
 
+        self.courseNoteInteractor.set(courseID: courseID, pageURL: pageURL)
+
         initUI()
     }
 
@@ -170,6 +172,7 @@ final class NotebookNoteViewModel {
             isSavedToastVisible = true
 
             do {
+                // Allow the toast a couple of seconds to show before dismissing
                 try await Task.sleep(nanoseconds: 2_000_000_000)
             } catch { }
 
@@ -221,15 +224,9 @@ final class NotebookNoteViewModel {
     }
 
     private func tryAdd() async -> Bool {
-        guard let courseID = courseID,
-              let pageURL = pageURL else {
-            return false
-        }
         do {
             _ = try await courseNoteInteractor
                 .add(
-                    courseID: courseID,
-                    pageURL: pageURL,
                     content: note,
                     labels: labels,
                     notebookHighlight: notebookHighlight


### PR DESCRIPTION
The gist of the bug is the ModuleItemSequenceInteractor when it's first built asks for the asset type. However, after requesting the module item sequence in the ModuleItemSequenceViewModel, the asset type can change. So when the notebook initially specified a .page asset type, the next asset type in the sequence give back is a .moduleItem.

The resolution is to be able to specify the asset type in the fetchModuleItems method call to ModuleItemSequenceInteractor instead of it remaining constant when the class is first created.


https://github.com/user-attachments/assets/070823d7-9c30-4e8b-b20d-9b43cc188fd0


[ignore-commit-lint]