### PR TITLE
Add file upload notification to file submission flow.

### DIFF
--- a/Core/Core/Features/Files/Model/Entities/File.swift
+++ b/Core/Core/Features/Files/Model/Entities/File.swift
@@ -245,4 +245,7 @@ extension Sequence where Element == File {
     public var containsError: Bool { contains(where: { file in file.uploadError != nil }) }
     public var containsUploading: Bool { contains(where: { file in file.isUploading }) }
     public var isAllUploaded: Bool { allSatisfy { file in file.isUploaded } }
+
+    public var uploadedFilesCount: Int { filter { $0.isUploaded }.count }
+    public var failedFilesCount: Int { filter { $0.uploadError != nil }.count }
 }

--- a/Core/CoreTests/Features/Files/UploadManagerTests.swift
+++ b/Core/CoreTests/Features/Files/UploadManagerTests.swift
@@ -311,6 +311,36 @@ class UploadManagerTests: CoreTestCase {
         XCTAssertFalse(fileManager.fileExists(atPath: binaryURL.path))
     }
 
+    func testFileUploadAnnouncementMapping() {
+        let uploadedFile = File.save(.make(id: "uploadedID"), in: context)
+        let failedFile = File.save(.make(id: "nil"), in: context)
+        failedFile.id = nil
+        failedFile.uploadError = "Upload failed."
+
+        XCTAssertEqual(
+            [uploadedFile].toUploadAnnouncement,
+            "1 file uploaded successfully."
+        )
+        XCTAssertEqual(
+            [uploadedFile, uploadedFile].toUploadAnnouncement,
+            "2 files uploaded successfully."
+        )
+        XCTAssertEqual(
+            [failedFile].toUploadAnnouncement,
+            "1 file failed to upload."
+        )
+        XCTAssertEqual(
+            [failedFile, failedFile].toUploadAnnouncement,
+            "2 files failed to upload."
+        )
+        XCTAssertEqual(
+            [failedFile, failedFile, uploadedFile].toUploadAnnouncement,
+            "1 file uploaded successfully. 2 files failed to upload."
+        )
+    }
+
+    // MARK: - Mocks
+
     private func mockSubmission(courseID: String, assignmentID: String, fileIDs: [String], comment: String? = nil, taskID: String, accessToken: String? = nil) {
         let submission = CreateSubmissionRequest.Body.Submission(
             text_comment: comment,

--- a/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
+++ b/Student/Student/Assignments/AssignmentDetails/AssignmentDetailsViewController.swift
@@ -260,6 +260,14 @@ class AssignmentDetailsViewController: ScreenViewTrackableViewController, Assign
             self?.updateGradeBorder(using: gradeSection)
         }
         presenter?.viewIsReady()
+
+        // updateSubmissionLabels is also called from the update method that is triggered by CoreData
+        // but during a file resubmission flow the presenter's onlineUploadState is updated after
+        // CoreData is modified so this class won't be notified of the change. This is the workaround.
+        presenter?.didChangeOnlineUploadState = { [weak self] state in
+            guard let state else { return }
+            self?.updateSubmissionLabels(state: state)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
### What happened?
- After file submissions from the assignment details page there were no VoiceOver announcements if the files were successfully uploaded or not.
- The best place to have this handled is the UploadManager since that's the thing controlling the upload and the submission. I added an announcement after the files have been uploaded and delayed the submission API call to give time for the announcement.
- This revealed a bug that caused the file picker to be dismissed after file uploads have completed but before the submission was actually sent and this heavily interfered with the VoiceOver announcement. I fixed this by not relying on CoreData updates but on the notification the UploadManager sends after the assignment submission have completed.
- The above fix revealed another bug: the AssignmentDetailsViewController didn't dismiss the file picker dialog after a successful submission because it didn't notice the AssignmentDetailsPresenter's state turning to completed so I had to add an extra callback for the state change.

### Remarks
- I have checked the code and only this screen submits assignments using the UploadManager so this change should not affect other file uploads.
- On iPad I had some strange VoiceOver focusing issues during state changes in the file picker dialog. I've spent some time to try to work this around but didn't succeed.

refs: MBL-18854
affects: Student
release note: none

test plan:
- Submit files from the assignment details page with voiceover on.
- After uploads finished voiceover should announce how many of those failed and succeeded.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
