### PR TITLE
Pause media playback when swiping to the next submission

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/PagesViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/PagesViewController.swift
@@ -28,7 +28,7 @@ public protocol PagesViewControllerDataSource: AnyObject {
     @objc optional func pagesViewController(_ pages: PagesViewController, didTransitionTo page: UIViewController)
 }
 
-public final class PagesViewController: UIViewController, UIScrollViewDelegate {
+public class PagesViewController: UIViewController, UIScrollViewDelegate {
     public weak var dataSource: PagesViewControllerDataSource?
     public weak var delegate: PagesViewControllerDelegate?
     public let scrollView = UIScrollView()

--- a/Core/Core/Common/Extensions/UIKit/UIViewControllerExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIViewControllerExtensions.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import AVKit
 import UIKit
 import WebKit
 
@@ -74,6 +75,19 @@ extension UIViewController {
         } else {
             return nil
         }
+    }
+
+    public func findAllChildViewControllers<T: UIViewController>(ofType type: T.Type) -> Set<T> {
+        var result = Set<T>()
+
+        for subview in children {
+            if let match = subview as? T {
+                result.insert(match)
+            }
+            result.formUnion(subview.findAllChildViewControllers(ofType: type))
+        }
+
+        return result
     }
 
     public func addNavigationButton(_ button: UIBarButtonItem, side: NavigationItemSide) {
@@ -223,11 +237,30 @@ extension UIViewController {
         }
     }
 
-    /// Pauses media playback on all WKWebView instances in the view hierarchy.
+    /// Pauses media playback on all `WKWebView` instances in the view hierarchy.
     @objc
     public func pauseWebViewPlayback() {
         view.findAllSubviews(ofType: WKWebView.self).forEach { $0.pauseAllMediaPlayback() }
     }
+
+    /// Pauses media playback on all `AVPlayerViewController` instances in the view hierarchy.
+    @objc
+    public func pauseMediaPlayback() {
+        findAllChildViewControllers(ofType: AVPlayerViewController.self).forEach { $0.player?.pause() }
+    }
+
+#if DEBUG
+
+    public func printViewControllerHierarchy(nestingLevel: Int = 0) {
+        let prefix = (nestingLevel == 0) ? "" : String(repeating: " ", count: nestingLevel * 4).appending("|-")
+        print("\(prefix)\(type(of: self))")
+
+        for childViewController in children {
+            childViewController.printViewControllerHierarchy(nestingLevel: nestingLevel + 1)
+        }
+    }
+
+#endif
 }
 
 public class ResetTransitionDelegate: NSObject, UIViewControllerTransitioningDelegate {

--- a/Core/Core/Common/Extensions/UIKit/UIViewExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIViewExtensions.swift
@@ -144,11 +144,23 @@ extension UIView {
         for subview in subviews {
             if let match = subview as? T {
                 result.insert(match)
-            } else {
-                result.formUnion(subview.findAllSubviews(ofType: type))
             }
+            result.formUnion(subview.findAllSubviews(ofType: type))
         }
 
         return result
     }
+
+#if DEBUG
+
+    public func printViewHierarchy(nestingLevel: Int = 0) {
+        let prefix = (nestingLevel == 0) ? "" : String(repeating: " ", count: nestingLevel * 4).appending("|-")
+        print("\(prefix)\(type(of: self))")
+
+        for subview in subviews {
+            subview.printViewHierarchy(nestingLevel: nestingLevel + 1)
+        }
+    }
+
+#endif
 }

--- a/Core/CoreTests/Common/Extensions/UIKit/UIViewExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UIViewExtensionsTests.swift
@@ -109,22 +109,23 @@ class UIViewExtensionsTests: XCTestCase {
 
     func test_findAllSubviews() {
         let label1 = UILabel()
-        let nestedLabel = UILabel()
-        let containerView = UIView()
-        containerView.addSubview(label1)
-        containerView.addSubview(nestedLabel)
+        let label1_1 = UILabel()
+        label1.addSubview(label1_1)
 
+        let containerView = UIView()
         let label2 = UILabel()
         let button = UIButton()
+        containerView.addSubview(label2)
+        containerView.addSubview(button)
+
         let parentView = UIView()
-        parentView.addSubview(label2)
-        parentView.addSubview(button)
+        parentView.addSubview(label1)
         parentView.addSubview(containerView)
 
         // WHEN
         let foundLabels = parentView.findAllSubviews(ofType: UILabel.self)
 
         // THEN
-        XCTAssertEqual(foundLabels, Set([label1, label2, nestedLabel]))
+        XCTAssertEqual(foundLabels, Set([label1, label1_1, label2]))
     }
 }

--- a/Teacher/Teacher/SpeedGrader/StudentPager/ViewModel/SpeedGraderViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/StudentPager/ViewModel/SpeedGraderViewModel.swift
@@ -20,7 +20,7 @@ import Combine
 import Core
 import SwiftUI
 
-class SpeedGraderViewModel: ObservableObject, PagesViewControllerDataSource, PagesViewControllerDelegate {
+class SpeedGraderViewModel: ObservableObject {
     typealias Page = CoreHostingController<SubmissionGraderView>
 
     // MARK: - Outputs
@@ -65,58 +65,6 @@ class SpeedGraderViewModel: ObservableObject, PagesViewControllerDataSource, Pag
         updateNavigationBarTheme(onChangeOf: interactor.contextInfo)
 
         interactor.load()
-    }
-
-    // MARK: - PagesViewControllerDataSource
-
-    func pagesViewController(_ pages: PagesViewController, pageBefore page: UIViewController) -> UIViewController? {
-        (page as? Page).flatMap { controller(for: $0.rootView.content.userIndexInSubmissionList - 1) }
-    }
-
-    func pagesViewController(_ pages: PagesViewController, pageAfter page: UIViewController) -> UIViewController? {
-        (page as? Page).flatMap { controller(for: $0.rootView.content.userIndexInSubmissionList + 1) }
-    }
-
-    func controller(for index: Int) -> UIViewController? {
-        let controller = grader(for: index).map { CoreHostingController($0, env: environment) }
-        controller?.view.backgroundColor = nil
-        return controller
-    }
-
-    func grader(for index: Int) -> SubmissionGraderView? {
-        guard
-            let data = interactor.data,
-            index >= 0,
-            index < data.submissions.count
-        else { return nil }
-
-        return SubmissionGraderView(
-            env: environment,
-            userIndexInSubmissionList: index,
-            viewModel: SubmissionGraderViewModel(
-                assignment: data.assignment,
-                submission: data.submissions[index],
-                contextColor: interactor.contextInfo.compactMap { $0?.courseColor }.eraseToAnyPublisher()
-            ),
-            landscapeSplitLayoutViewModel: landscapeSplitLayoutViewModel,
-            handleRefresh: { [weak self] in
-                self?.interactor.refreshSubmission(forUserId: data.submissions[index].userID)
-            }
-        )
-    }
-
-    private func updatePages(_ pages: PagesViewController) {
-        guard let data = interactor.data else { return }
-
-        if let page = controller(for: data.focusedSubmissionIndex) {
-            pages.setCurrentPage(page)
-        }
-
-        for page in pages.children.compactMap({ $0 as? Page }) {
-            if let grader = grader(for: page.rootView.content.userIndexInSubmissionList) {
-                page.rootView.content = grader
-            }
-        }
     }
 
     // MARK: - State Subscription
@@ -194,5 +142,79 @@ class SpeedGraderViewModel: ObservableObject, PagesViewControllerDataSource, Pag
                 self?.updatePages(pages)
             }
             .store(in: &subscriptions)
+    }
+}
+
+// MARK: - PagesViewControllerDataSource
+
+extension SpeedGraderViewModel: PagesViewControllerDataSource {
+
+    func pagesViewController(
+        _ pages: PagesViewController,
+        pageBefore page: UIViewController
+    ) -> UIViewController? {
+        (page as? Page).flatMap { controller(for: $0.rootView.content.userIndexInSubmissionList - 1) }
+    }
+
+    func pagesViewController(
+        _ pages: PagesViewController,
+        pageAfter page: UIViewController
+    ) -> UIViewController? {
+        (page as? Page).flatMap { controller(for: $0.rootView.content.userIndexInSubmissionList + 1) }
+    }
+
+    private func controller(for index: Int) -> UIViewController? {
+        let controller = grader(for: index).map { CoreHostingController($0, env: environment) }
+        controller?.view.backgroundColor = nil
+        return controller
+    }
+
+    private func grader(for index: Int) -> SubmissionGraderView? {
+        guard
+            let data = interactor.data,
+            index >= 0,
+            index < data.submissions.count
+        else { return nil }
+
+        return SubmissionGraderView(
+            env: environment,
+            userIndexInSubmissionList: index,
+            viewModel: SubmissionGraderViewModel(
+                assignment: data.assignment,
+                submission: data.submissions[index],
+                contextColor: interactor.contextInfo.compactMap { $0?.courseColor }.eraseToAnyPublisher()
+            ),
+            landscapeSplitLayoutViewModel: landscapeSplitLayoutViewModel,
+            handleRefresh: { [weak self] in
+                self?.interactor.refreshSubmission(forUserId: data.submissions[index].userID)
+            }
+        )
+    }
+
+    private func updatePages(_ pages: PagesViewController) {
+        guard let data = interactor.data else { return }
+
+        if let page = controller(for: data.focusedSubmissionIndex) {
+            pages.setCurrentPage(page)
+        }
+
+        for page in pages.children.compactMap({ $0 as? Page }) {
+            if let grader = grader(for: page.rootView.content.userIndexInSubmissionList) {
+                page.rootView.content = grader
+            }
+        }
+    }
+}
+
+// MARK: - PagesViewControllerDelegate
+
+extension SpeedGraderViewModel: PagesViewControllerDelegate {
+
+    func pagesViewController(
+        _ pages: PagesViewController,
+        didTransitionTo page: UIViewController
+    ) {
+        pages.pauseWebViewPlayback()
+        pages.pauseMediaPlayback()
     }
 }

--- a/Teacher/TeacherTests/SpeedGrader/StudentPager/ViewModel/SpeedGraderViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/StudentPager/ViewModel/SpeedGraderViewModelTests.swift
@@ -19,7 +19,7 @@
 import XCTest
 import CoreData
 import Combine
-import Core
+@testable import Core
 @testable import Teacher
 import TestsFoundation
 import SwiftUI
@@ -83,6 +83,18 @@ class SpeedGraderViewModelTests: TeacherTestCase {
         XCTAssertTrue(pagesController.children.allSatisfy { $0 is CoreHostingController<SubmissionGraderView> })
     }
 
+    func test_didTransitionTo_pausesPlayback() {
+        let pagesViewController = MockPagesViewController()
+        let page = UIViewController()
+
+        // WHEN
+        testee.pagesViewController(pagesViewController, didTransitionTo: page)
+
+        // THEN
+        XCTAssertTrue(pagesViewController.webViewPlaybackPaused)
+        XCTAssertTrue(pagesViewController.mediaPlaybackPaused)
+    }
+
     // MARK: - User Actions
 
     func test_didTapPostPolicyButton() {
@@ -134,5 +146,18 @@ private class SpeedGraderInteractorMock: SpeedGraderInteractor {
             submissions: [submission],
             focusedSubmissionIndex: 0
         )
+    }
+}
+
+private class MockPagesViewController: PagesViewController {
+    var webViewPlaybackPaused = false
+    var mediaPlaybackPaused = false
+
+    override func pauseWebViewPlayback() {
+        webViewPlaybackPaused = true
+    }
+
+    override func pauseMediaPlayback() {
+        mediaPlaybackPaused = true
     }
 }


### PR DESCRIPTION
### What's new?
- The bug was about AV players not being paused on swiping to the next student but I also added pause for webviews as well. The new thing here is the `didTransitionTo` method in SpeedGraderViewModel.
- Moved pages view controller protocol conformances to extensions for better separation of concerns within SpeedGraderViewModel.
- Added a findAllChildViewControllers method to get all child view controllers of a type and also fixed the existing UIView counterpart method to properly detect when a view of the searched type is a subview of another searched type.
- Added two debug methods to print view and viewcontroller hierarchy. This comes handy when the view hierarchy debugger doesn't show the view tree properly.

refs: [MBL-18859](https://instructure.atlassian.net/browse/MBL-18859)
affects: Teacher
release note: none

test plan: See ticket for test submissions.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet