### PR TITLE
Accessibility - Item Picker screens

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/DatePickerCell.swift
@@ -41,7 +41,7 @@ extension InstUI {
         private let label: Text
         private let labelModifiers: (Text) -> Label
         private let customAccessibilityLabel: Text?
-        private let accessibilityIdPrefix: String?
+        private let identifierGroup: String?
         private let mode: Mode
         private let defaultDate: Date
         private let validFrom: Date
@@ -55,7 +55,7 @@ extension InstUI {
             label: Text,
             labelModifiers: @escaping (Text) -> Label = { $0 },
             customAccessibilityLabel: Text? = nil,
-            accessibilityIdPrefix: String? = nil,
+            identifierGroup: String? = nil,
             date: Binding<Date?>,
             mode: Mode = .dateAndTime,
             defaultDate: Date = .now,
@@ -67,7 +67,7 @@ extension InstUI {
             self.label = label
             self.labelModifiers = labelModifiers
             self.customAccessibilityLabel = customAccessibilityLabel
-            self.accessibilityIdPrefix = accessibilityIdPrefix
+            self.identifierGroup = identifierGroup
             self._date = date
             self.mode = mode
             self.defaultDate = defaultDate
@@ -206,8 +206,8 @@ extension InstUI {
             .labelsHidden() // This is needed to avoid the empty label filling up all the space
             .accessibilityLabel(customAccessibilityLabel ?? label)
             .accessibilityValue(String.localizedAccessibilityErrorMessage(errorMessage) ?? "") // Actual value is contained already
-            .accessibilityIdentifier(accessibilityIdPrefix?.appending(".\(accessibilityId)"))
             .accessibilityRefocusingOnPopoverDismissal()
+            .identifier(identifierGroup, accessibilityId)
         }
 
         // MARK: - Placeholder

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
@@ -1,0 +1,120 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension InstUI {
+
+    public struct TrailingCheckmarkCell<Value: Equatable>: View {
+        @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+        @Binding private var selectedValue: Value?
+        private let title: String
+        private let subtitle: String?
+        private let value: Value?
+        private let color: Color
+        private let dividerStyle: InstUI.Divider.Style
+
+        /// - parameters:
+        ///   - value: The value represented by this cell that will be passed to the `selectedValue` binding upon tap.
+        ///   - selectedValue: This binding holds the currently selected value belonging to the item picker group.
+        ///                    The value is equatable so this cell can decide when to display the selected state.
+        public init(
+            title: String,
+            subtitle: String? = nil,
+            value: Value?,
+            selectedValue: Binding<Value?>,
+            color: Color,
+            dividerStyle: InstUI.Divider.Style = .full
+        ) {
+            self.title = title
+            self.subtitle = subtitle
+            self.value = value
+            self._selectedValue = selectedValue
+            self.color = color
+            self.dividerStyle = dividerStyle
+        }
+
+        public var body: some View {
+            let isSelected = value == selectedValue
+
+            VStack(spacing: 0) {
+                Button {
+                    selectedValue = value
+                } label: {
+                    HStack(spacing: 0) {
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(title)
+                                .textStyle(.cellLabel)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            if let subtitle {
+                                Text(subtitle)
+                                    .textStyle(.cellLabelSubtitle)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
+
+                        if isSelected {
+                            Image.checkSolid
+                                .scaledIcon(size: 18)
+                                .foregroundStyle(color)
+                                .layoutPriority(1)
+                                .paddingStyle(.leading, .cellAccessoryPadding)
+                                .animation(.default, value: selectedValue)
+                        }
+                    }
+                    .paddingStyle(set: .iconCell)
+                }
+                .accessibilityAddTraits(isSelected ? .isSelected : [])
+
+                InstUI.Divider(dividerStyle)
+            }
+        }
+    }
+}
+
+#if DEBUG
+
+private struct Container: View {
+    @State var selectedValue: Int?
+
+    var body: some View {
+        VStack(spacing: 0) {
+            InstUI.TrailingCheckmarkCell(
+                title: "Value 1",
+                value: 1,
+                selectedValue: $selectedValue,
+                color: .orange
+            )
+            InstUI.TrailingCheckmarkCell(
+                title: "Value 2",
+                value: 2,
+                selectedValue: $selectedValue,
+                color: .red
+            )
+        }
+    }
+}
+
+#Preview {
+    Container()
+}
+
+#endif

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
@@ -77,7 +77,6 @@ extension InstUI {
                                 .foregroundStyle(color)
                                 .layoutPriority(1)
                                 .paddingStyle(.leading, .cellAccessoryPadding)
-                                .animation(.default, value: selectedValue)
                         }
                     }
                     .paddingStyle(set: .standardCell)

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
@@ -80,7 +80,7 @@ extension InstUI {
                                 .animation(.default, value: selectedValue)
                         }
                     }
-                    .paddingStyle(set: .iconCell)
+                    .paddingStyle(set: .standardCell)
                 }
                 .accessibilityAddTraits(isSelected ? .isSelected : [])
 

--- a/Core/Core/Common/CommonUI/InstUI/Views/ListSectionHeader.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/ListSectionHeader.swift
@@ -24,21 +24,24 @@ extension InstUI {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
         private let title: String?
+        private let itemCount: Int
         private let buttonLabel: ButtonLabel?
         private let buttonAction: (() -> Void)?
 
         public init(
             title: String?,
+            itemCount: Int,
             buttonLabel: ButtonLabel?,
             buttonAction: (() -> Void)? = nil
         ) {
             self.title = title
+            self.itemCount = itemCount
             self.buttonLabel = buttonLabel
             self.buttonAction = buttonAction
         }
 
-        public init(title: String?) where ButtonLabel == SwiftUI.EmptyView {
-            self.init(title: title, buttonLabel: nil)
+        public init(title: String?, itemCount: Int) where ButtonLabel == SwiftUI.EmptyView {
+            self.init(title: title, itemCount: itemCount, buttonLabel: nil)
         }
 
         @ViewBuilder
@@ -49,6 +52,7 @@ extension InstUI {
                         Text(title)
                             .textStyle(.sectionHeader)
                             .frame(maxWidth: .infinity, alignment: .leading)
+                            .accessibilityLabel(title + ", " + String.localizedAccessibilityListCount(itemCount))
                             .accessibilityAddTraits([.isHeader])
 
                         if let buttonLabel {
@@ -79,10 +83,10 @@ extension InstUI {
 #Preview {
     VStack(spacing: 0) {
         InstUI.Divider()
-        InstUI.ListSectionHeader(title: "Section Header Cell")
-        InstUI.ListSectionHeader(title: "Section Header with Button", buttonLabel: Text("Select all"))
-        InstUI.ListSectionHeader(title: "Section Header with red Button", buttonLabel: Text("Delete all").foregroundStyle(Color.textDanger))
-        InstUI.ListSectionHeader(title: "Section Header with custom styled Button", buttonLabel: Text("This is a big button").textStyle(.heading))
+        InstUI.ListSectionHeader(title: "Section Header Cell", itemCount: 0)
+        InstUI.ListSectionHeader(title: "Section Header with Button", itemCount: 0, buttonLabel: Text("Select all"))
+        InstUI.ListSectionHeader(title: "Section Header with red Button", itemCount: 0, buttonLabel: Text("Delete all").foregroundStyle(Color.textDanger))
+        InstUI.ListSectionHeader(title: "Section Header with custom styled Button", itemCount: 0, buttonLabel: Text("This is a big button").textStyle(.heading))
     }
 }
 

--- a/Core/Core/Common/CommonUI/InstUI/Views/NavigationBarButton.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/NavigationBarButton.swift
@@ -59,7 +59,7 @@ extension InstUI {
             button
                 .foregroundStyle(color)
                 .environment(\.isEnabled, isEnabled)
-                .accessibilityIdentifier(accessibilityId)
+                .identifier(accessibilityId)
         }
 
         @ViewBuilder

--- a/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItem.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItem.swift
@@ -53,6 +53,12 @@ public struct OptionItem: Equatable, Hashable, Identifiable {
     }
 }
 
+extension Array<OptionItem> {
+    public func option(with id: String?) -> OptionItem? {
+        first { $0.id == id }
+    }
+}
+
 #if DEBUG
 extension OptionItem {
     static func make(

--- a/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItemIdentifiable.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItemIdentifiable.swift
@@ -1,0 +1,55 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public protocol OptionItemIdentifiable {
+    var optionItemId: String { get }
+
+    func isMatch(for optionItem: OptionItem?) -> Bool
+}
+
+extension OptionItemIdentifiable {
+    public func isMatch(for optionItem: OptionItem?) -> Bool {
+        optionItemId == optionItem?.id
+    }
+}
+
+// MARK: - Conformances
+
+extension OptionItemIdentifiable where Self: Identifiable<String> {
+    public var optionItemId: String { id }
+}
+
+extension OptionItemIdentifiable where Self: RawRepresentable<String> {
+    public var optionItemId: String { rawValue }
+}
+
+// MARK: - Arrays
+
+extension Array where Element: OptionItemIdentifiable {
+    public func element(for optionItem: OptionItem?) -> Element? {
+        first { $0.optionItemId == optionItem?.id }
+    }
+}
+
+extension Array<OptionItem> {
+    public func option(for item: (some OptionItemIdentifiable)?) -> OptionItem? {
+        first { $0.id == item?.optionItemId }
+    }
+}

--- a/Core/Core/Common/CommonUI/OptionSelection/Model/SingleSelectionOptions.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/Model/SingleSelectionOptions.swift
@@ -48,6 +48,15 @@ public struct SingleSelectionOptions {
         self.init(all: all, selected: .init(initial), initial: initial)
     }
 
+    /// Uses `initialId` to create the `initial` value and the `selected` subject.
+    public init(
+        all: [OptionItem],
+        initialId: String?
+    ) {
+        let initial = all.option(with: initialId)
+        self.init(all: all, selected: .init(initial), initial: initial)
+    }
+
     /// Uses `selected` subject's current value as `initial` value.
     public init(
         all: [OptionItem],

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -28,7 +28,7 @@ public struct ItemPickerScreen: View {
     private let selectedOption: CurrentValueSubject<OptionItem?, Never>
 
     @State private var isInitialPublish: Bool = true
-    private let didSelect: ((Int) -> Void)?
+    private let didSelectOption: ((OptionItem) -> Void)?
 
     public init(
         pageTitle: String,
@@ -40,7 +40,21 @@ public struct ItemPickerScreen: View {
         self.identifierGroup = identifierGroup
         self.allOptions = allOptions
         self.selectedOption = selectedOption
-        self.didSelect = nil
+        self.didSelectOption = nil
+    }
+
+    public init(
+        pageTitle: String,
+        identifierGroup: String? = nil,
+        allOptions: [OptionItem],
+        initialOptionId: String?,
+        didSelectOption: @escaping (OptionItem) -> Void
+    ) {
+        self.pageTitle = pageTitle
+        self.identifierGroup = identifierGroup
+        self.allOptions = allOptions
+        self.selectedOption = .init(allOptions.option(with: initialOptionId))
+        self.didSelectOption = didSelectOption
     }
 
     public init(
@@ -61,7 +75,7 @@ public struct ItemPickerScreen: View {
         identifierGroup: String? = nil,
         items: [ItemPickerItem],
         initialSelectionIndex: Int?,
-        didSelect: ((Int) -> Void)?
+        didSelectIndex: @escaping ((Int) -> Void)
     ) {
         self.pageTitle = pageTitle
         self.identifierGroup = identifierGroup
@@ -70,8 +84,10 @@ public struct ItemPickerScreen: View {
         let initialOption = allOptions[safeIndex: initialSelectionIndex ?? -1]
         self.allOptions = allOptions
         self.selectedOption = .init(initialOption)
-
-        self.didSelect = didSelect
+        self.didSelectOption = {
+            guard let id = Int($0.id) else { return }
+            didSelectIndex(id)
+        }
     }
 
     public var body: some View {
@@ -91,8 +107,10 @@ public struct ItemPickerScreen: View {
                 isInitialPublish = false
                 return
             }
-            guard let option, let id = Int(option.id) else { return }
-            didSelect?(id)
+
+            guard let option else { return }
+
+            didSelectOption?(option)
         }
     }
 }

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -22,7 +22,7 @@ import SwiftUI
 public struct ItemPickerScreen: View {
 
     private let pageTitle: String
-    private let accessibilityIdentifier: String?
+    private let identifierGroup: String?
 
     private let allOptions: [OptionItem]
     private let selectedOption: CurrentValueSubject<OptionItem?, Never>
@@ -32,12 +32,12 @@ public struct ItemPickerScreen: View {
 
     public init(
         pageTitle: String,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         allOptions: [OptionItem],
         selectedOption: CurrentValueSubject<OptionItem?, Never>
     ) {
         self.pageTitle = pageTitle
-        self.accessibilityIdentifier = accessibilityIdentifier
+        self.identifierGroup = identifierGroup
         self.allOptions = allOptions
         self.selectedOption = selectedOption
         self.didSelect = nil
@@ -45,12 +45,12 @@ public struct ItemPickerScreen: View {
 
     public init(
         pageTitle: String,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         options: SingleSelectionOptions
     ) {
         self.init(
             pageTitle: pageTitle,
-            accessibilityIdentifier: accessibilityIdentifier,
+            identifierGroup: identifierGroup,
             allOptions: options.all,
             selectedOption: options.selected
         )
@@ -58,13 +58,13 @@ public struct ItemPickerScreen: View {
 
     public init(
         pageTitle: String,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         items: [ItemPickerItem],
         initialSelectionIndex: Int?,
         didSelect: ((Int) -> Void)?
     ) {
         self.pageTitle = pageTitle
-        self.accessibilityIdentifier = accessibilityIdentifier
+        self.identifierGroup = identifierGroup
 
         let allOptions = items.indices.map { items[$0].optionItem(id: $0) }
         let initialOption = allOptions[safeIndex: initialSelectionIndex ?? -1]
@@ -78,7 +78,7 @@ public struct ItemPickerScreen: View {
         InstUI.BaseScreen(state: .data, config: .init(refreshable: false, scrollBounce: .automatic)) { _ in
             SingleSelectionView(
                 title: nil,
-                accessibilityIdentifier: accessibilityIdentifier,
+                identifierGroup: identifierGroup,
                 allOptions: allOptions,
                 selectedOption: selectedOption,
                 style: .trailingCheckmark

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -27,7 +27,6 @@ public struct ItemPickerScreen: View {
     private let allOptions: [OptionItem]
     private let selectedOption: CurrentValueSubject<OptionItem?, Never>
 
-    @State private var isInitialPublish: Bool = true
     private let didSelectOption: ((OptionItem) -> Void)?
 
     public init(
@@ -82,14 +81,7 @@ public struct ItemPickerScreen: View {
         }
         .navigationBarTitleView(pageTitle)
         .navigationBarStyle(.modal)
-        .onReceive(selectedOption) { option in
-            if isInitialPublish {
-                isInitialPublish = false
-                return
-            }
-
-            guard let option else { return }
-
+        .onReceive(selectedOption.dropFirst().compactMap(\.self)) { option in
             didSelectOption?(option)
         }
     }

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -27,6 +27,7 @@ public struct ItemPickerScreen: View {
     private let allOptions: [OptionItem]
     private let selectedOption: CurrentValueSubject<OptionItem?, Never>
 
+    @State private var isInitialPublish: Bool = true
     private let didSelect: ((Int) -> Void)?
 
     public init(
@@ -86,6 +87,10 @@ public struct ItemPickerScreen: View {
         .navigationBarTitleView(pageTitle)
         .navigationBarStyle(.modal)
         .onReceive(selectedOption) { option in
+            if isInitialPublish {
+                isInitialPublish = false
+                return
+            }
             guard let option, let id = Int(option.id) else { return }
             didSelect?(id)
         }

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -70,26 +70,6 @@ public struct ItemPickerScreen: View {
         )
     }
 
-    public init(
-        pageTitle: String,
-        identifierGroup: String? = nil,
-        items: [ItemPickerItem],
-        initialSelectionIndex: Int?,
-        didSelectIndex: @escaping ((Int) -> Void)
-    ) {
-        self.pageTitle = pageTitle
-        self.identifierGroup = identifierGroup
-
-        let allOptions = items.indices.map { items[$0].optionItem(id: $0) }
-        let initialOption = allOptions[safeIndex: initialSelectionIndex ?? -1]
-        self.allOptions = allOptions
-        self.selectedOption = .init(initialOption)
-        self.didSelectOption = {
-            guard let id = Int($0.id) else { return }
-            didSelectIndex(id)
-        }
-    }
-
     public var body: some View {
         InstUI.BaseScreen(state: .data, config: .init(refreshable: false, scrollBounce: .automatic)) { _ in
             SingleSelectionView(
@@ -112,15 +92,5 @@ public struct ItemPickerScreen: View {
 
             didSelectOption?(option)
         }
-    }
-}
-
-private extension ItemPickerItem {
-    func optionItem(id: Int) -> OptionItem {
-        .init(
-            id: String(id),
-            title: title,
-            subtitle: subtitle
-        )
     }
 }

--- a/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/ItemPickerScreen.swift
@@ -1,0 +1,103 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import SwiftUI
+
+public struct ItemPickerScreen: View {
+
+    private let pageTitle: String
+    private let accessibilityIdentifier: String?
+
+    private let allOptions: [OptionItem]
+    private let selectedOption: CurrentValueSubject<OptionItem?, Never>
+
+    private let didSelect: ((Int) -> Void)?
+
+    public init(
+        pageTitle: String,
+        accessibilityIdentifier: String? = nil,
+        allOptions: [OptionItem],
+        selectedOption: CurrentValueSubject<OptionItem?, Never>
+    ) {
+        self.pageTitle = pageTitle
+        self.accessibilityIdentifier = accessibilityIdentifier
+        self.allOptions = allOptions
+        self.selectedOption = selectedOption
+        self.didSelect = nil
+    }
+
+    public init(
+        pageTitle: String,
+        accessibilityIdentifier: String? = nil,
+        options: SingleSelectionOptions
+    ) {
+        self.init(
+            pageTitle: pageTitle,
+            accessibilityIdentifier: accessibilityIdentifier,
+            allOptions: options.all,
+            selectedOption: options.selected
+        )
+    }
+
+    public init(
+        pageTitle: String,
+        accessibilityIdentifier: String? = nil,
+        items: [ItemPickerItem],
+        initialSelectionIndex: Int?,
+        didSelect: ((Int) -> Void)?
+    ) {
+        self.pageTitle = pageTitle
+        self.accessibilityIdentifier = accessibilityIdentifier
+
+        let allOptions = items.indices.map { items[$0].optionItem(id: $0) }
+        let initialOption = allOptions[safeIndex: initialSelectionIndex ?? -1]
+        self.allOptions = allOptions
+        self.selectedOption = .init(initialOption)
+
+        self.didSelect = didSelect
+    }
+
+    public var body: some View {
+        InstUI.BaseScreen(state: .data, config: .init(refreshable: false, scrollBounce: .automatic)) { _ in
+            SingleSelectionView(
+                title: nil,
+                accessibilityIdentifier: accessibilityIdentifier,
+                allOptions: allOptions,
+                selectedOption: selectedOption,
+                style: .trailingCheckmark
+            )
+        }
+        .navigationBarTitleView(pageTitle)
+        .navigationBarStyle(.modal)
+        .onReceive(selectedOption) { option in
+            guard let option, let id = Int(option.id) else { return }
+            didSelect?(id)
+        }
+    }
+}
+
+private extension ItemPickerItem {
+    func optionItem(id: Int) -> OptionItem {
+        .init(
+            id: String(id),
+            title: title,
+            subtitle: subtitle
+        )
+    }
+}

--- a/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
@@ -24,17 +24,17 @@ public struct MultiSelectionView: View {
 
     @StateObject private var viewModel: MultiSelectionViewModel
 
-    private let accessibilityIdentifier: String?
+    private let identifierGroup: String?
     private let hasAllSelectionButton: Bool
 
     public init(
         title: String?,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         hasAllSelectionButton: Bool = false,
         allOptions: [OptionItem],
         selectedOptions: CurrentValueSubject<Set<OptionItem>, Never>
     ) {
-        self.accessibilityIdentifier = accessibilityIdentifier
+        self.identifierGroup = identifierGroup
         self.hasAllSelectionButton = hasAllSelectionButton
 
         self._viewModel = StateObject(wrappedValue: .init(
@@ -46,13 +46,13 @@ public struct MultiSelectionView: View {
 
     public init(
         title: String?,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         hasAllSelectionButton: Bool = false,
         options: MultiSelectionOptions
     ) {
         self.init(
             title: title,
-            accessibilityIdentifier: accessibilityIdentifier,
+            identifierGroup: identifierGroup,
             hasAllSelectionButton: hasAllSelectionButton,
             allOptions: options.all,
             selectedOptions: options.selected
@@ -65,6 +65,7 @@ public struct MultiSelectionView: View {
             Section {
                 ForEach(viewModel.allOptions) { item in
                     optionCell(with: item)
+                        .identifier(identifierGroup, item.id)
                 }
             } header: {
                 if hasAllSelectionButton {
@@ -93,7 +94,6 @@ public struct MultiSelectionView: View {
             accessoryView: { item.accessoryIcon?.foregroundStyle(item.color) },
             dividerStyle: viewModel.dividerStyle(for: item)
         )
-        .accessibilityIdentifier(accessibilityIdentifier(for: item))
     }
 
     private func selectionBinding(for item: OptionItem) -> Binding<Bool> {
@@ -102,10 +102,6 @@ public struct MultiSelectionView: View {
         } set: { newValue in
             viewModel.didToggleSelection.send((option: item, isSelected: newValue))
         }
-    }
-
-    private func accessibilityIdentifier(for item: OptionItem) -> String {
-        [accessibilityIdentifier, item.id].joined(separator: ".")
     }
 }
 
@@ -116,7 +112,6 @@ public struct MultiSelectionView: View {
         InstUI.Divider()
         MultiSelectionView(
             title: "Section 1 title",
-            accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "1", title: "Option 1"),
                 .make(id: "2", title: "Option 2"),
@@ -126,7 +121,6 @@ public struct MultiSelectionView: View {
         )
         MultiSelectionView(
             title: "Section 2 title",
-            accessibilityIdentifier: nil,
             hasAllSelectionButton: true,
             allOptions: [
                 .make(id: "A", title: "Option A", color: .textDanger),

--- a/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
@@ -24,7 +24,6 @@ public struct MultiSelectionView: View {
 
     @StateObject private var viewModel: MultiSelectionViewModel
 
-    private let title: String?
     private let accessibilityIdentifier: String?
     private let hasAllSelectionButton: Bool
 
@@ -35,11 +34,11 @@ public struct MultiSelectionView: View {
         allOptions: [OptionItem],
         selectedOptions: CurrentValueSubject<Set<OptionItem>, Never>
     ) {
-        self.title = title
         self.accessibilityIdentifier = accessibilityIdentifier
         self.hasAllSelectionButton = hasAllSelectionButton
 
         self._viewModel = StateObject(wrappedValue: .init(
+            title: title,
             allOptions: allOptions,
             selectedOptions: selectedOptions
         ))
@@ -70,15 +69,18 @@ public struct MultiSelectionView: View {
             } header: {
                 if hasAllSelectionButton {
                     InstUI.ListSectionHeader(
-                        title: title,
+                        title: viewModel.title,
+                        itemCount: viewModel.optionCount,
                         buttonLabel: Text(viewModel.allSelectionButtonTitle),
                         buttonAction: { viewModel.didTapAllSelectionButton.send() }
                     )
                 } else {
-                    InstUI.ListSectionHeader(title: title)
+                    InstUI.ListSectionHeader(title: viewModel.title, itemCount: viewModel.optionCount)
                 }
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(viewModel.listLevelAccessibilityLabel)
     }
 
     @ViewBuilder

--- a/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
@@ -30,7 +30,6 @@ public struct SingleSelectionView: View {
 
     @StateObject private var viewModel: SingleSelectionViewModel
 
-    private let title: String?
     private let accessibilityIdentifier: String?
     private let style: Style
 
@@ -41,11 +40,11 @@ public struct SingleSelectionView: View {
         selectedOption: CurrentValueSubject<OptionItem?, Never>,
         style: Style = .radioButton
     ) {
-        self.title = title
         self.accessibilityIdentifier = accessibilityIdentifier
         self.style = style
 
         self._viewModel = StateObject(wrappedValue: .init(
+            title: title,
             allOptions: allOptions,
             selectedOption: selectedOption
         ))
@@ -75,9 +74,11 @@ public struct SingleSelectionView: View {
                         .accessibilityIdentifier(accessibilityIdentifier(for: item))
                 }
             } header: {
-                InstUI.ListSectionHeader(title: title)
+                InstUI.ListSectionHeader(title: viewModel.title, itemCount: viewModel.optionCount)
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(viewModel.listLevelAccessibilityLabel)
     }
 
     @ViewBuilder

--- a/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
@@ -30,17 +30,17 @@ public struct SingleSelectionView: View {
 
     @StateObject private var viewModel: SingleSelectionViewModel
 
-    private let accessibilityIdentifier: String?
+    private let identifierGroup: String?
     private let style: Style
 
     public init(
         title: String?,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         allOptions: [OptionItem],
         selectedOption: CurrentValueSubject<OptionItem?, Never>,
         style: Style = .radioButton
     ) {
-        self.accessibilityIdentifier = accessibilityIdentifier
+        self.identifierGroup = identifierGroup
         self.style = style
 
         self._viewModel = StateObject(wrappedValue: .init(
@@ -52,13 +52,13 @@ public struct SingleSelectionView: View {
 
     public init(
         title: String?,
-        accessibilityIdentifier: String? = nil,
+        identifierGroup: String? = nil,
         options: SingleSelectionOptions,
         style: Style = .radioButton
     ) {
         self.init(
             title: title,
-            accessibilityIdentifier: accessibilityIdentifier,
+            identifierGroup: identifierGroup,
             allOptions: options.all,
             selectedOption: options.selected,
             style: style
@@ -71,7 +71,7 @@ public struct SingleSelectionView: View {
             Section {
                 ForEach(viewModel.allOptions) { item in
                     optionCell(with: item)
-                        .accessibilityIdentifier(accessibilityIdentifier(for: item))
+                        .identifier(identifierGroup, item.id)
                 }
             } header: {
                 InstUI.ListSectionHeader(title: viewModel.title, itemCount: viewModel.optionCount)
@@ -111,10 +111,6 @@ public struct SingleSelectionView: View {
             viewModel.selectedOption.send(selectedValue)
         }
     }
-
-    private func accessibilityIdentifier(for item: OptionItem) -> String {
-        [accessibilityIdentifier, item.id].joined(separator: ".")
-    }
 }
 
 #if DEBUG
@@ -124,7 +120,6 @@ public struct SingleSelectionView: View {
         InstUI.Divider()
         SingleSelectionView(
             title: "Radio group",
-            accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "1", title: "Option 1"),
                 .make(id: "2", title: "Option 2"),
@@ -134,7 +129,6 @@ public struct SingleSelectionView: View {
         )
         SingleSelectionView(
             title: "Radio group with colors",
-            accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "A", title: "Option A", color: .textDanger),
                 .make(id: "B", title: "Option B", color: .textSuccess),
@@ -144,7 +138,6 @@ public struct SingleSelectionView: View {
         )
         SingleSelectionView(
             title: "Item picker",
-            accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "A", title: "Option A", color: .textDanger),
                 .make(id: "B", title: "Option B", color: .textSuccess),

--- a/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
@@ -20,21 +20,30 @@ import Combine
 import SwiftUI
 
 public struct SingleSelectionView: View {
+
+    public enum Style {
+        case radioButton
+        case trailingCheckmark
+    }
+
     @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     @StateObject private var viewModel: SingleSelectionViewModel
 
     private let title: String?
     private let accessibilityIdentifier: String?
+    private let style: Style
 
     public init(
         title: String?,
         accessibilityIdentifier: String? = nil,
         allOptions: [OptionItem],
-        selectedOption: CurrentValueSubject<OptionItem?, Never>
+        selectedOption: CurrentValueSubject<OptionItem?, Never>,
+        style: Style = .radioButton
     ) {
         self.title = title
         self.accessibilityIdentifier = accessibilityIdentifier
+        self.style = style
 
         self._viewModel = StateObject(wrappedValue: .init(
             allOptions: allOptions,
@@ -45,13 +54,15 @@ public struct SingleSelectionView: View {
     public init(
         title: String?,
         accessibilityIdentifier: String? = nil,
-        options: SingleSelectionOptions
+        options: SingleSelectionOptions,
+        style: Style = .radioButton
     ) {
         self.init(
             title: title,
             accessibilityIdentifier: accessibilityIdentifier,
             allOptions: options.all,
-            selectedOption: options.selected
+            selectedOption: options.selected,
+            style: style
         )
     }
 
@@ -61,6 +72,7 @@ public struct SingleSelectionView: View {
             Section {
                 ForEach(viewModel.allOptions) { item in
                     optionCell(with: item)
+                        .accessibilityIdentifier(accessibilityIdentifier(for: item))
                 }
             } header: {
                 InstUI.ListSectionHeader(title: title)
@@ -70,14 +82,25 @@ public struct SingleSelectionView: View {
 
     @ViewBuilder
     private func optionCell(with item: OptionItem) -> some View {
-        InstUI.RadioButtonCell(
-            title: item.title,
-            value: item,
-            selectedValue: selectionBinding,
-            color: item.color,
-            dividerStyle: viewModel.dividerStyle(for: item)
-        )
-        .accessibilityIdentifier(accessibilityIdentifier(for: item))
+        switch style {
+        case .radioButton:
+            InstUI.RadioButtonCell(
+                title: item.title,
+                value: item,
+                selectedValue: selectionBinding,
+                color: item.color,
+                dividerStyle: viewModel.dividerStyle(for: item)
+            )
+        case .trailingCheckmark:
+            InstUI.TrailingCheckmarkCell(
+                title: item.title,
+                subtitle: item.subtitle,
+                value: item,
+                selectedValue: selectionBinding,
+                color: item.color,
+                dividerStyle: viewModel.dividerStyle(for: item)
+            )
+        }
     }
 
     private var selectionBinding: Binding<OptionItem?> {
@@ -99,7 +122,7 @@ public struct SingleSelectionView: View {
     VStack(spacing: 0) {
         InstUI.Divider()
         SingleSelectionView(
-            title: "Section 1 title",
+            title: "Radio group",
             accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "1", title: "Option 1"),
@@ -109,7 +132,7 @@ public struct SingleSelectionView: View {
             selectedOption: .init(nil)
         )
         SingleSelectionView(
-            title: "Section 2 title",
+            title: "Radio group with colors",
             accessibilityIdentifier: nil,
             allOptions: [
                 .make(id: "A", title: "Option A", color: .textDanger),
@@ -117,6 +140,17 @@ public struct SingleSelectionView: View {
                 .make(id: "C", title: "Option C", color: .textInfo)
             ],
             selectedOption: .init(nil)
+        )
+        SingleSelectionView(
+            title: "Item picker",
+            accessibilityIdentifier: nil,
+            allOptions: [
+                .make(id: "A", title: "Option A", color: .textDanger),
+                .make(id: "B", title: "Option B", color: .textSuccess),
+                .make(id: "C", title: "Option C", color: .textInfo)
+            ],
+            selectedOption: .init(nil),
+            style: .trailingCheckmark
         )
     }
 }

--- a/Core/Core/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModel.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModel.swift
@@ -51,7 +51,7 @@ final class MultiSelectionViewModel: ObservableObject {
             self.listLevelAccessibilityLabel = nil
         } else {
             // if there is no title -> add list count to first focused option
-            self.listLevelAccessibilityLabel = String.localizedAccessibilityListCount(optionCount)
+            self.listLevelAccessibilityLabel = String.localizedNumberOfItems(optionCount)
         }
 
         selectedOptions

--- a/Core/Core/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModel.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModel.swift
@@ -21,9 +21,14 @@ import UIKit
 
 final class MultiSelectionViewModel: ObservableObject {
 
+    let title: String?
+
     let allOptions: [OptionItem]
     let selectedOptions: CurrentValueSubject<Set<OptionItem>, Never>
     var allSelectionButtonTitle: String = ""
+
+    let optionCount: Int
+    let listLevelAccessibilityLabel: String?
 
     let didToggleSelection = PassthroughSubject<(option: OptionItem, isSelected: Bool), Never>()
     let didTapAllSelectionButton = PassthroughSubject<Void, Never>()
@@ -31,11 +36,23 @@ final class MultiSelectionViewModel: ObservableObject {
     private var subscriptions = Set<AnyCancellable>()
 
     init(
+        title: String?,
         allOptions: [OptionItem],
         selectedOptions: CurrentValueSubject<Set<OptionItem>, Never>
     ) {
+        self.title = title
+
         self.allOptions = allOptions
         self.selectedOptions = selectedOptions
+
+        self.optionCount = allOptions.count
+        if title != nil {
+            // if there is a title -> list count is already in section header
+            self.listLevelAccessibilityLabel = nil
+        } else {
+            // if there is no title -> add list count to first focused option
+            self.listLevelAccessibilityLabel = String.localizedAccessibilityListCount(optionCount)
+        }
 
         selectedOptions
             .removeDuplicates()

--- a/Core/Core/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModel.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModel.swift
@@ -20,17 +20,34 @@ import Combine
 
 final class SingleSelectionViewModel: ObservableObject {
 
+    let title: String?
+
     let allOptions: [OptionItem]
     let selectedOption: CurrentValueSubject<OptionItem?, Never>
+
+    let optionCount: Int
+    let listLevelAccessibilityLabel: String?
 
     private var subscriptions = Set<AnyCancellable>()
 
     init(
+        title: String?,
         allOptions: [OptionItem],
         selectedOption: CurrentValueSubject<OptionItem?, Never>
     ) {
+        self.title = title
+
         self.allOptions = allOptions
         self.selectedOption = selectedOption
+
+        self.optionCount = allOptions.count
+        if title != nil {
+            // if there is a title -> list count is already in section header
+            self.listLevelAccessibilityLabel = nil
+        } else {
+            // if there is no title -> add list count to first focused option
+            self.listLevelAccessibilityLabel = String.localizedAccessibilityListCount(optionCount)
+        }
 
         selectedOption
             .removeDuplicates()

--- a/Core/Core/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModel.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModel.swift
@@ -46,7 +46,7 @@ final class SingleSelectionViewModel: ObservableObject {
             self.listLevelAccessibilityLabel = nil
         } else {
             // if there is no title -> add list count to first focused option
-            self.listLevelAccessibilityLabel = String.localizedAccessibilityListCount(optionCount)
+            self.listLevelAccessibilityLabel = String.localizedNumberOfItems(optionCount)
         }
 
         selectedOption

--- a/Core/Core/Common/CommonUI/UIViews/CoreSwitch.swift
+++ b/Core/Core/Common/CommonUI/UIViews/CoreSwitch.swift
@@ -119,7 +119,7 @@ private struct ToggleWrapper: View {
             .environment(\.isEnabled, toggleViewModel.isEnabled)
             .accentColor(toggleViewModel.tintColor)
             .accessibilityLabel(toggleViewModel.accessibilityLabel)
-            .accessibilityIdentifier(toggleViewModel.accessibilityIdentifier)
+            .identifier(toggleViewModel.accessibilityIdentifier)
             // Voiceover recognizes the toggle's check icon and adds the image trait automatically.
             // If we hide that image from accessibility the whole switch will be inaccessible,
             // so we just remove the image trait.

--- a/Core/Core/Common/CommonUI/ViewModifiers/TestIdentifier.swift
+++ b/Core/Core/Common/CommonUI/ViewModifiers/TestIdentifier.swift
@@ -152,10 +152,6 @@ extension View {
         self
     }
     #endif
-
-    public func identifier(_ id: String) -> some View {
-        accessibility(identifier: id).testID(id)
-    }
 }
 
 extension Text {

--- a/Core/Core/Common/Extensions/SwiftUI/View+Accessibility.swift
+++ b/Core/Core/Common/Extensions/SwiftUI/View+Accessibility.swift
@@ -30,4 +30,22 @@ extension View {
             self
         }
     }
+
+    @ViewBuilder
+    public func accessibilityLabel(_ label: String?) -> some View {
+        if let label {
+            self.accessibilityLabel(Text(label))
+        } else {
+            self
+        }
+    }
+
+    @ViewBuilder
+    public func accessibilityLabel(_ label: Text?) -> some View {
+        if let label {
+            self.accessibilityLabel(label)
+        } else {
+            self
+        }
+    }
 }

--- a/Core/Core/Common/Extensions/SwiftUI/View+Accessibility.swift
+++ b/Core/Core/Common/Extensions/SwiftUI/View+Accessibility.swift
@@ -20,17 +20,8 @@ import SwiftUI
 
 extension View {
 
-    /// This is a convenience overload of the `accessibilityIdentifier` function but this accepts an optional.
-    /// If the passed `identifier` is nil this method does nothing.
-    @ViewBuilder
-    public func accessibilityIdentifier(_ identifier: String?) -> some View {
-        if let identifier {
-            self.accessibilityIdentifier(identifier)
-        } else {
-            self
-        }
-    }
-
+    /// This is a convenience overload of the `accessibilityLabel` method but this accepts an optional.
+    /// If the passed `label` is nil this method does nothing.
     @ViewBuilder
     public func accessibilityLabel(_ label: String?) -> some View {
         if let label {
@@ -40,6 +31,8 @@ extension View {
         }
     }
 
+    /// This is a convenience overload of the `accessibilityLabel` method but this accepts an optional.
+    /// If the passed `label` is nil this method does nothing.
     @ViewBuilder
     public func accessibilityLabel(_ label: Text?) -> some View {
         if let label {

--- a/Core/Core/Common/Extensions/SwiftUI/View+Identifier.swift
+++ b/Core/Core/Common/Extensions/SwiftUI/View+Identifier.swift
@@ -1,0 +1,53 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension View {
+
+    /// This is an abstraction above `accessibilityIdentifier` with multiple purposes.
+    /// - It acts as a single point of definition for any other identifier modifier used for testing or analytics purposes.
+    /// - It is a convenience for `accessibilityIdentifier` which accepts an optional.
+    ///   If the passed `identifier` is nil this method does nothing.
+    @ViewBuilder
+    public func identifier(_ identifier: String?) -> some View {
+        if let identifier {
+            self
+                .accessibilityIdentifier(identifier)
+                .testID(identifier)
+        } else {
+            self
+        }
+    }
+
+    /// This is an abstraction above `accessibilityIdentifier` with multiple purposes.
+    /// - It acts as a single point of definition for any other identifier modifier used for testing or analytics purposes.
+    /// - It is a convenience for `accessibilityIdentifier` which accepts an optional.
+    ///   If the passed `identifier` is nil this method does nothing.
+    @ViewBuilder
+    public func identifier(_ group: String?, _ identifier: String?) -> some View {
+        if let identifier {
+            let value = [group, identifier].joined(separator: ".")
+            self
+                .accessibilityIdentifier(value)
+                .testID(value)
+        } else {
+            self
+        }
+    }
+}

--- a/Core/Core/Common/Extensions/UIKit/UIUserInterfaceStyleExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIUserInterfaceStyleExtensions.swift
@@ -30,3 +30,23 @@ extension UIUserInterfaceStyle {
         return style
     }
 }
+
+extension UIUserInterfaceStyle: OptionItemIdentifiable {
+    public var optionItemId: String {
+        switch self {
+        case .unspecified: "system"
+        case .light: "light"
+        case .dark: "dark"
+        @unknown default: "_unknown"
+        }
+    }
+
+    public var settingsTitle: String {
+        switch self {
+        case .unspecified: String(localized: "System Settings", bundle: .core)
+        case .light: String(localized: "Light Theme", bundle: .core)
+        case .dark: String(localized: "Dark Theme", bundle: .core)
+        @unknown default: ""
+        }
+    }
+}

--- a/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListPreferencesScreen.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/View/AssignmentListPreferencesScreen.swift
@@ -76,7 +76,7 @@ public struct AssignmentListPreferencesScreen: View {
     private var studentFilterSection: some View {
         MultiSelectionView(
             title: String(localized: "Assignment Filter", bundle: .core),
-            accessibilityIdentifier: "AssignmentFilter.studentFilterOptions",
+            identifierGroup: "AssignmentFilter.studentFilterOptions",
             options: viewModel.studentFilterOptions
         )
     }
@@ -85,7 +85,7 @@ public struct AssignmentListPreferencesScreen: View {
     private var teacherFilterSection: some View {
         SingleSelectionView(
             title: String(localized: "Assignment Filter", bundle: .core),
-            accessibilityIdentifier: "AssignmentFilter.teacherFilterOptions",
+            identifierGroup: "AssignmentFilter.teacherFilterOptions",
             options: viewModel.teacherFilterOptions
         )
     }
@@ -93,7 +93,7 @@ public struct AssignmentListPreferencesScreen: View {
     private var teacherPublishStatusFilterSection: some View {
         SingleSelectionView(
             title: String(localized: "Status Filter", bundle: .core),
-            accessibilityIdentifier: "AssignmentFilter.teacherPublishStatusFilterOptions",
+            identifierGroup: "AssignmentFilter.teacherPublishStatusFilterOptions",
             options: viewModel.teacherPublishStatusFilterOptions
         )
     }
@@ -101,7 +101,7 @@ public struct AssignmentListPreferencesScreen: View {
     private var sortBySection: some View {
         SingleSelectionView(
             title: String(localized: "Grouped By", bundle: .core),
-            accessibilityIdentifier: "AssignmentFilter.sortModeOptions",
+            identifierGroup: "AssignmentFilter.sortModeOptions",
             options: viewModel.sortModeOptions
         )
     }
@@ -109,7 +109,7 @@ public struct AssignmentListPreferencesScreen: View {
     private var gradingPeriodsSection: some View {
         SingleSelectionView(
             title: String(localized: "Grading Periods", bundle: .core),
-            accessibilityIdentifier: "AssignmentFilter.gradingPeriodOption",
+            identifierGroup: "AssignmentFilter.gradingPeriodOption",
             options: viewModel.gradingPeriodOptions
         )
     }

--- a/Core/Core/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
@@ -45,8 +45,7 @@ public enum CourseSyncFrequency: Int, CaseIterable {
         }
     }
 
-    static var itemPickerData: [ItemPickerSection] {
-        let pickerRows = allCases.map { ItemPickerItem(title: $0.stringValue) }
-        return [ItemPickerSection(items: pickerRows)]
+    static var itemPickerData: [ItemPickerItem] {
+        allCases.map { ItemPickerItem(title: $0.stringValue) }
     }
 }

--- a/Core/Core/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequency.swift
@@ -44,8 +44,16 @@ public enum CourseSyncFrequency: Int, CaseIterable {
         case .weekly: return date.addingTimeInterval(7 * 24 * 60 * 60)
         }
     }
+}
 
-    static var itemPickerData: [ItemPickerItem] {
-        allCases.map { ItemPickerItem(title: $0.stringValue) }
+extension CourseSyncFrequency: OptionItemIdentifiable {
+    public var optionItemId: String {
+        switch self {
+        #if DEBUG
+        case .osBased: "osBased"
+        #endif
+        case .daily: "daily"
+        case .weekly: "weekly"
+        }
     }
 }

--- a/Core/Core/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
@@ -171,27 +171,31 @@ class CourseSyncSettingsViewModel: ObservableObject {
                                                 sourceController: UIViewController)
     -> AnyPublisher<CourseSyncFrequency, Never> {
         Future<CourseSyncFrequency, Never> { promise in
-            let selection = IndexPath(row: previousSelection, section: 0)
-            let handleNewSelection: (IndexPath) -> Void = { newSelection in
+            let handleNewSelection: (Int) -> Void = { newSelection in
                 defer {
                     DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(300)) {
-                        if sourceController.navigationController?.topViewController is ItemPickerViewController {
+                        if sourceController.navigationController?.topViewController is CoreHostingController<ItemPickerScreen> {
                             sourceController.navigationController?.popViewController(animated: true)
                         }
                     }
                 }
-                guard let newFrequency = CourseSyncFrequency(rawValue: newSelection.row) else {
+                guard let newFrequency = CourseSyncFrequency(rawValue: newSelection) else {
                     return
                 }
 
                 promise(.success(newFrequency))
             }
-            let picker = ItemPickerViewController
-                .create(title: String(localized: "Sync Frequency", bundle: .core),
-                        sections: CourseSyncFrequency.itemPickerData,
-                        selected: selection,
-                        didSelect: handleNewSelection)
-            sourceController.show(picker, sender: sourceController)
+
+            let pageTitle = String(localized: "Sync Frequency", bundle: .core)
+            let picker = ItemPickerScreen(
+                pageTitle: pageTitle,
+                items: CourseSyncFrequency.itemPickerData,
+                initialSelectionIndex: previousSelection,
+                didSelect: handleNewSelection
+            )
+            let pickerVC = CoreHostingController(picker)
+            pickerVC.navigationItem.title = pageTitle
+            sourceController.show(pickerVC, sender: self)
         }
         .eraseToAnyPublisher()
     }

--- a/Core/Core/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModel.swift
@@ -189,6 +189,7 @@ class CourseSyncSettingsViewModel: ObservableObject {
             let pageTitle = String(localized: "Sync Frequency", bundle: .core)
             let picker = ItemPickerScreen(
                 pageTitle: pageTitle,
+                identifierGroup: "Settings.OfflineSync.syncFrequencyOptions",
                 items: CourseSyncFrequency.itemPickerData,
                 initialSelectionIndex: previousSelection,
                 didSelect: handleNewSelection

--- a/Core/Core/Features/Grades/Model/API/APIPostPolicyInfo.swift
+++ b/Core/Core/Features/Grades/Model/API/APIPostPolicyInfo.swift
@@ -123,7 +123,7 @@ extension Array where Element: PostPolicyLogicProtocol {
     }
 }
 
-public enum PostGradePolicy: String, CaseIterable {
+public enum PostGradePolicy: String, CaseIterable, OptionItemIdentifiable {
     case everyone, graded
 }
 

--- a/Core/Core/Features/Grades/View/GradeFilterView.swift
+++ b/Core/Core/Features/Grades/View/GradeFilterView.swift
@@ -51,7 +51,7 @@ public struct GradeFilterView: View {
     private var gradingPeriodSection: some View {
         SingleSelectionView(
             title: String(localized: "Grading Periods", bundle: .core),
-            accessibilityIdentifier: "GradeFilter.gradingPeriodOptions",
+            identifierGroup: "GradeFilter.gradingPeriodOptions",
             options: viewModel.gradingPeriodOptions
         )
     }
@@ -59,7 +59,7 @@ public struct GradeFilterView: View {
     private var sortBySection: some View {
         SingleSelectionView(
             title: String(localized: "Grouped By", bundle: .core),
-            accessibilityIdentifier: "GradeFilter.sortModeOptions",
+            identifierGroup: "GradeFilter.sortModeOptions",
             options: viewModel.sortModeOptions
         )
     }

--- a/Core/Core/Features/Inbox/InboxCoursePicker/View/InboxCoursePickerView.swift
+++ b/Core/Core/Features/Inbox/InboxCoursePicker/View/InboxCoursePickerView.swift
@@ -88,7 +88,7 @@ public struct InboxCoursePickerView: View {
             Section {
                 ForEach(courses, id: \.id) { courseRow($0) }
             } header: {
-                InstUI.ListSectionHeader(title: title)
+                InstUI.ListSectionHeader(title: title, itemCount: courses.count)
             }
         }
     }
@@ -102,7 +102,7 @@ public struct InboxCoursePickerView: View {
                     }
                 } header: {
                     VStack(spacing: 0) {
-                        InstUI.ListSectionHeader(title: String(localized: "Groups", bundle: .core))
+                        InstUI.ListSectionHeader(title: String(localized: "Groups", bundle: .core), itemCount: groups.count)
                     }
                 }
             }

--- a/Core/Core/Features/Notifications/API/APINotificationPreferences.swift
+++ b/Core/Core/Features/Notifications/API/APINotificationPreferences.swift
@@ -25,7 +25,7 @@ public struct APINotificationPreference: Codable {
     let frequency: NotificationFrequency
 }
 
-public enum NotificationFrequency: String, CaseIterable, Codable {
+public enum NotificationFrequency: String, CaseIterable, Codable, OptionItemIdentifiable {
     case immediately, daily, weekly, never
 
     var name: String {

--- a/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
+++ b/Core/Core/Features/Planner/CalendarToDo/View/EditCalendarToDoScreen.swift
@@ -46,11 +46,11 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
                         text: $viewModel.title
                     )
                     .focused($focusedInput, equals: .title)
-                    .accessibilityIdentifier("Calendar.Todo.title")
+                    .identifier("Calendar.Todo.title")
 
                     InstUI.DatePickerCell(
                         label: Text("Date", bundle: .core),
-                        accessibilityIdPrefix: "Calendar.Todo.datePicker",
+                        identifierGroup: "Calendar.Todo.datePicker",
                         date: $viewModel.date
                     )
 
@@ -61,14 +61,14 @@ struct EditCalendarToDoScreen: View, ScreenViewTrackable {
                             viewModel.showCalendarSelector.send(viewController)
                         }
                     )
-                    .accessibilityIdentifier("Calendar.Todo.calendar")
+                    .identifier("Calendar.Todo.calendar")
 
                     InstUI.TextEditorCell(
                         label: Text("Details", bundle: .core),
                         text: $viewModel.details
                     )
                     .focused($focusedInput, equals: .details)
-                    .accessibilityIdentifier("Calendar.Todo.details")
+                    .identifier("Calendar.Todo.details")
                 }
                 // defocus inputs when otherwise non-tappable area is tapped
                 .background(

--- a/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
@@ -229,17 +229,21 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
             selectedCategory = (row.category, row.notifications)
 
             let pageTitle = categoryMap[row.category]?.1 ?? ""
+            let allCases = NotificationFrequency.allCases
+
             let picker = ItemPickerScreen(
                 pageTitle: pageTitle,
-                items: NotificationFrequency.allCases.map { frequency in
-                    ItemPickerItem(title: frequency.name, subtitle: frequency.label)
-                },
-                initialSelectionIndex: NotificationFrequency.allCases.firstIndex(of: row.frequency),
-                didSelect: { [weak self] in
-                    guard let self, let (category, notifications) = selectedCategory else { return }
-                    update(category, notifications: notifications, frequency: NotificationFrequency.allCases[$0])
+                allOptions: allCases.map { OptionItem(id: $0.optionItemId, title: $0.name, subtitle: $0.label) },
+                initialOptionId: row.frequency.optionItemId,
+                didSelectOption: { [weak self] in
+                    guard let self,
+                          let (category, notifications) = selectedCategory,
+                          let selectedCase = allCases.element(for: $0)
+                    else { return }
+                    update(category, notifications: notifications, frequency: selectedCase)
                 }
             )
+
             let pickerVC = CoreHostingController(picker)
             pickerVC.navigationItem.title = pageTitle
             self.show(pickerVC, sender: self)

--- a/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
@@ -227,15 +227,22 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
         } else {
             let row = sections[indexPath.section].rows[indexPath.row]
             selectedCategory = (row.category, row.notifications)
-            show(ItemPickerViewController.create(
-                title: categoryMap[row.category]?.1 ?? "",
-                sections: [ ItemPickerSection(items: NotificationFrequency.allCases.map { frequency in
+
+            let pageTitle = categoryMap[row.category]?.1 ?? ""
+            let picker = ItemPickerScreen(
+                pageTitle: pageTitle,
+                items: NotificationFrequency.allCases.map { frequency in
                     ItemPickerItem(title: frequency.name, subtitle: frequency.label)
-                }) ],
-                selected: NotificationFrequency.allCases.firstIndex(of: row.frequency)
-                    .flatMap { IndexPath(row: $0, section: 0) },
-                delegate: self
-            ), sender: self)
+                },
+                initialSelectionIndex: NotificationFrequency.allCases.firstIndex(of: row.frequency),
+                didSelect: { [weak self] in
+                    guard let self, let (category, notifications) = selectedCategory else { return }
+                    update(category, notifications: notifications, frequency: NotificationFrequency.allCases[$0])
+                }
+            )
+            let pickerVC = CoreHostingController(picker)
+            pickerVC.navigationItem.title = pageTitle
+            self.show(pickerVC, sender: self)
         }
     }
 
@@ -250,12 +257,5 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
                 ))
             }
         }
-    }
-}
-
-extension NotificationCategoriesViewController: ItemPickerDelegate {
-    func itemPicker(_ itemPicker: ItemPickerViewController, didSelectRowAt indexPath: IndexPath) {
-        guard let (category, notifications) = selectedCategory else { return }
-        update(category, notifications: notifications, frequency: NotificationFrequency.allCases[indexPath.row])
     }
 }

--- a/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
+++ b/Core/Core/Features/Profile/Settings/NotificationCategoriesViewController.swift
@@ -233,6 +233,7 @@ extension NotificationCategoriesViewController: UITableViewDataSource, UITableVi
 
             let picker = ItemPickerScreen(
                 pageTitle: pageTitle,
+                identifierGroup: "Settings.\(channelType.rawValue)Notifications.\(row.category)",
                 allOptions: allCases.map { OptionItem(id: $0.optionItemId, title: $0.name, subtitle: $0.label) },
                 initialOptionId: row.frequency.optionItemId,
                 didSelectOption: { [weak self] in

--- a/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
@@ -250,6 +250,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
                 let pageTitle = String(localized: "Appearance", bundle: .core)
                 let picker = ItemPickerScreen(
                     pageTitle: pageTitle,
+                    identifierGroup: "Settings.appearanceOptions",
                     items: options,
                     initialSelectionIndex: selectedStyleIndex,
                     didSelect: {
@@ -273,6 +274,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
                 let pageTitle = String(localized: "Landing Page", bundle: .core)
                 let picker = ItemPickerScreen(
                     pageTitle: pageTitle,
+                    identifierGroup: "Settings.landingPageOptions",
                     items: LandingPage.appCases.map { page in
                         ItemPickerItem(title: page.name)
                     },

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/Model/OptionItemIdentifiableTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/Model/OptionItemIdentifiableTests.swift
@@ -1,0 +1,87 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+import TestsFoundation
+@testable import Core
+
+final class OptionItemIdentifiableTests: XCTestCase {
+
+    func test_isMatch() {
+        let testee = OptionItemIdentifiableMock("42")
+
+        XCTAssertEqual(testee.isMatch(for: OptionItem(id: "42", title: "7")), true)
+
+        XCTAssertEqual(testee.isMatch(for: OptionItem(id: "7", title: "42")), false)
+        XCTAssertEqual(testee.isMatch(for: OptionItem(id: "", title: "42")), false)
+    }
+
+    func test_optionItemId_whenIdentifiable() {
+        let testee = IdentifiableMock(id: "42")
+
+        XCTAssertEqual(testee.optionItemId, "42")
+    }
+
+    func test_optionItemId_whenStringRawRepresentable() {
+        let testee = StringRawRepresentableMock.someExampleCase
+
+        XCTAssertEqual(testee.optionItemId, "someExampleCase")
+    }
+
+    func test_elementForOptionItem() {
+        let testee = [
+            OptionItemIdentifiableMock("0"),
+            OptionItemIdentifiableMock("1"),
+            OptionItemIdentifiableMock("2"),
+            OptionItemIdentifiableMock("3")
+        ]
+
+        XCTAssertEqual(testee.element(for: OptionItem(id: "2", title: "")), testee[2])
+        XCTAssertEqual(testee.element(for: OptionItem(id: "42", title: "")), nil)
+    }
+
+    func test_optionForItem() {
+        let testee = [
+            OptionItem(id: "0", title: ""),
+            OptionItem(id: "1", title: ""),
+            OptionItem(id: "2", title: ""),
+            OptionItem(id: "3", title: "")
+        ]
+
+        XCTAssertEqual(testee.option(for: OptionItemIdentifiableMock("2")), testee[2])
+        XCTAssertEqual(testee.option(for: OptionItemIdentifiableMock("42")), nil)
+    }
+}
+
+// MARK: - Private helpers
+
+private struct OptionItemIdentifiableMock: OptionItemIdentifiable, Equatable {
+    var optionItemId: String = ""
+
+    init(_ optionItemId: String) {
+        self.optionItemId = optionItemId
+    }
+}
+
+private struct IdentifiableMock: Identifiable, OptionItemIdentifiable {
+    var id: String = ""
+}
+
+private enum StringRawRepresentableMock: String, OptionItemIdentifiable {
+    case someExampleCase
+}

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/Model/SingleSelectionOptionsTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/Model/SingleSelectionOptionsTests.swift
@@ -40,6 +40,23 @@ final class SingleSelectionOptionsTests: XCTestCase {
         XCTAssertEqual(testee.selected.value, TestConstants.items[3])
     }
 
+    func test_init_whenInitialIdIsProvided_shouldPopulateInitialAndSelected() {
+        let testee = SingleSelectionOptions(
+            all: TestConstants.items,
+            initialId: "3"
+        )
+
+        XCTAssertEqual(testee.selected.value, TestConstants.items[3])
+
+        // select something else
+        testee.selected.send(TestConstants.items[1])
+        XCTAssertEqual(testee.selected.value, TestConstants.items[1])
+
+        // reset to initial
+        testee.resetSelection()
+        XCTAssertEqual(testee.selected.value, TestConstants.items[3])
+    }
+
     func test_init_whenSelectedIsProvided_shouldPopulateInitial() {
         let testee = SingleSelectionOptions(
             all: TestConstants.items,

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModelTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModelTests.swift
@@ -24,6 +24,7 @@ import Combine
 final class MultiSelectionViewModelTests: XCTestCase {
 
     private enum TestConstants {
+        static let title = "some title"
         static let allItems: [OptionItem] = [
             .make(id: "0"),
             .make(id: "1"),
@@ -47,6 +48,7 @@ final class MultiSelectionViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         testee = MultiSelectionViewModel(
+            title: TestConstants.title,
             allOptions: TestConstants.allItems,
             selectedOptions: inputSelectedOptions
         )
@@ -57,8 +59,28 @@ final class MultiSelectionViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_title() {
+        XCTAssertEqual(testee.title, TestConstants.title)
+    }
+
     func test_allOptions() {
         XCTAssertEqual(testee.allOptions, TestConstants.allItems)
+    }
+
+    func test_optionsCounts_whenSectionHasTitle() {
+        XCTAssertEqual(testee.optionCount, TestConstants.allItems.count)
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, nil)
+    }
+
+    func test_optionsCounts_whenSectionHasNoTitle() {
+        testee = MultiSelectionViewModel(
+            title: nil,
+            allOptions: TestConstants.allItems,
+            selectedOptions: inputSelectedOptions
+        )
+
+        XCTAssertEqual(testee.optionCount, TestConstants.allItems.count)
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, "List, \(TestConstants.allItems.count) items")
     }
 
     func test_selectedOption_shouldMatchInputSubject() {

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModelTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/MultiSelectionViewModelTests.swift
@@ -80,7 +80,7 @@ final class MultiSelectionViewModelTests: XCTestCase {
         )
 
         XCTAssertEqual(testee.optionCount, TestConstants.allItems.count)
-        XCTAssertEqual(testee.listLevelAccessibilityLabel, "List, \(TestConstants.allItems.count) items")
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, "\(TestConstants.allItems.count) items")
     }
 
     func test_selectedOption_shouldMatchInputSubject() {

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModelTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModelTests.swift
@@ -71,7 +71,7 @@ final class SingleSelectionViewModelTests: XCTestCase {
         )
 
         XCTAssertEqual(testee.optionCount, TestConstants.items.count)
-        XCTAssertEqual(testee.listLevelAccessibilityLabel, "List, \(TestConstants.items.count) items")
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, "\(TestConstants.items.count) items")
     }
 
     func test_selectedOption_shouldMatchInputSubject() {

--- a/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModelTests.swift
+++ b/Core/CoreTests/Common/CommonUI/OptionSelection/ViewModel/SingleSelectionViewModelTests.swift
@@ -24,6 +24,7 @@ import Combine
 final class SingleSelectionViewModelTests: XCTestCase {
 
     private enum TestConstants {
+        static let title = "some title"
         static let items: [OptionItem] = [
             .make(id: "0"),
             .make(id: "1"),
@@ -38,6 +39,7 @@ final class SingleSelectionViewModelTests: XCTestCase {
     override func setUp() {
         super.setUp()
         testee = SingleSelectionViewModel(
+            title: TestConstants.title,
             allOptions: TestConstants.items,
             selectedOption: inputSelectedOption
         )
@@ -48,8 +50,28 @@ final class SingleSelectionViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_title() {
+        XCTAssertEqual(testee.title, TestConstants.title)
+    }
+
     func test_allOptions() {
         XCTAssertEqual(testee.allOptions, TestConstants.items)
+    }
+
+    func test_optionsCounts_whenSectionHasTitle() {
+        XCTAssertEqual(testee.optionCount, TestConstants.items.count)
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, nil)
+    }
+
+    func test_optionsCounts_whenSectionHasNoTitle() {
+        testee = SingleSelectionViewModel(
+            title: nil,
+            allOptions: TestConstants.items,
+            selectedOption: inputSelectedOption
+        )
+
+        XCTAssertEqual(testee.optionCount, TestConstants.items.count)
+        XCTAssertEqual(testee.listLevelAccessibilityLabel, "List, \(TestConstants.items.count) items")
     }
 
     func test_selectedOption_shouldMatchInputSubject() {

--- a/Core/CoreTests/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequencyTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequencyTests.swift
@@ -17,6 +17,7 @@
 //
 
 @testable import Core
+import TestsFoundation
 import XCTest
 
 class CourseSyncFrequencyTests: XCTestCase {
@@ -26,24 +27,19 @@ class CourseSyncFrequencyTests: XCTestCase {
         XCTAssertEqual(CourseSyncFrequency.daily.stringValue, "Daily")
     }
 
-    func testSyncFrequenciesToItemPickerData() {
+    func testSyncFrequenciesToItemPickerData() throws {
         let testee = CourseSyncFrequency.itemPickerData
-        XCTAssertEqual(testee.count, 1)
 
-        guard let section = testee.first else {
-            return XCTFail()
-        }
+        guard testee.count == 3 else { throw InvalidCountError() }
 
-        XCTAssertNil(section.title)
-        XCTAssertEqual(section.items.count, 3)
         // First entry is a debug one which we don't test
-        XCTAssertEqual(section.items[1].title, "Daily")
-        XCTAssertEqual(section.items[1].accessibilityIdentifier, nil)
-        XCTAssertEqual(section.items[1].image, nil)
-        XCTAssertEqual(section.items[1].subtitle, nil)
-        XCTAssertEqual(section.items[2].title, "Weekly")
-        XCTAssertEqual(section.items[2].accessibilityIdentifier, nil)
-        XCTAssertEqual(section.items[2].image, nil)
-        XCTAssertEqual(section.items[2].subtitle, nil)
+        XCTAssertEqual(testee[1].title, "Daily")
+        XCTAssertEqual(testee[1].accessibilityIdentifier, nil)
+        XCTAssertEqual(testee[1].image, nil)
+        XCTAssertEqual(testee[1].subtitle, nil)
+        XCTAssertEqual(testee[2].title, "Weekly")
+        XCTAssertEqual(testee[2].accessibilityIdentifier, nil)
+        XCTAssertEqual(testee[2].image, nil)
+        XCTAssertEqual(testee[2].subtitle, nil)
     }
 }

--- a/Core/CoreTests/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequencyTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncSettings/Model/CourseSyncFrequencyTests.swift
@@ -23,23 +23,12 @@ import XCTest
 class CourseSyncFrequencyTests: XCTestCase {
 
     func testSyncFrequencyNames() {
-        XCTAssertEqual(CourseSyncFrequency.weekly.stringValue, "Weekly")
         XCTAssertEqual(CourseSyncFrequency.daily.stringValue, "Daily")
+        XCTAssertEqual(CourseSyncFrequency.weekly.stringValue, "Weekly")
     }
 
-    func testSyncFrequenciesToItemPickerData() throws {
-        let testee = CourseSyncFrequency.itemPickerData
-
-        guard testee.count == 3 else { throw InvalidCountError() }
-
-        // First entry is a debug one which we don't test
-        XCTAssertEqual(testee[1].title, "Daily")
-        XCTAssertEqual(testee[1].accessibilityIdentifier, nil)
-        XCTAssertEqual(testee[1].image, nil)
-        XCTAssertEqual(testee[1].subtitle, nil)
-        XCTAssertEqual(testee[2].title, "Weekly")
-        XCTAssertEqual(testee[2].accessibilityIdentifier, nil)
-        XCTAssertEqual(testee[2].image, nil)
-        XCTAssertEqual(testee[2].subtitle, nil)
+    func testSyncFrequencyOptionItemId() throws {
+        XCTAssertEqual(CourseSyncFrequency.daily.optionItemId, "daily")
+        XCTAssertEqual(CourseSyncFrequency.weekly.optionItemId, "weekly")
     }
 }

--- a/Core/CoreTests/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModelTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncSettings/ViewModel/CourseSyncSettingsViewModelTests.swift
@@ -31,7 +31,7 @@ class CourseSyncSettingsViewModelTests: XCTestCase {
 
         drainMainQueue()
         XCTAssertEqual(navigation.children.count, 2)
-        XCTAssertTrue(navigation.children.last is ItemPickerViewController)
+        XCTAssertTrue(navigation.children.last is CoreHostingController<ItemPickerScreen>)
     }
 
     func testTogglesAllSettingsVisibility() {

--- a/Core/TestsFoundation/UITestExtensions/XCUIElementExtensions.swift
+++ b/Core/TestsFoundation/UITestExtensions/XCUIElementExtensions.swift
@@ -297,6 +297,14 @@ public extension XCUIElement {
         return descendants(matching: type).matching(idStartingWith: prefix).firstMatch
     }
 
+    func find(idStartingWith idPrefix: String, label: String) -> XCUIElement {
+        return descendants(matching: .any).matching(idStartingWith: idPrefix).matching(label: label).firstMatch
+    }
+
+    func find(idStartingWith idPrefix: String, labelContaining labelPart: String) -> XCUIElement {
+        return descendants(matching: .any).matching(idStartingWith: idPrefix).matching(labelContaining: labelPart).firstMatch
+    }
+
     func find(value: String, type: ElementType = .any) -> XCUIElement {
         return descendants(matching: type).matching(value: value).firstMatch
     }

--- a/Core/TestsFoundation/UITestHelperNamespaces/SettingsHelper.swift
+++ b/Core/TestsFoundation/UITestHelperNamespaces/SettingsHelper.swift
@@ -30,18 +30,17 @@ public enum SettingsMenuItem: String {
 }
 
 public enum LandingPageMenuItem: String {
-    case dashboard = "Dashboard"
-    case calendar = "Calendar"
-    case toDo = "To Do"
-    case notifications = "Notifications"
-    case inbox = "Inbox"
-    case courses = "Courses"
+    case dashboard
+    case calendar
+    case todo
+    case notifications
+    case inbox
 }
 
-public enum AppearanceMenuItem: Int {
-    case system = 0
-    case light = 1
-    case dark = 2
+public enum AppearanceMenuItem: String {
+    case system
+    case light
+    case dark
 }
 
 public class SettingsHelper: BaseHelper {
@@ -91,7 +90,7 @@ public class SettingsHelper: BaseHelper {
         public static var QRCodeImage: XCUIElement { app.find(id: "QRCodeImage") }
 
         public static func landingPageMenuItem(item: LandingPageMenuItem) -> XCUIElement {
-            return app.find(idStartingWith: "Settings.landingPageOptions", label: item.rawValue)
+            return app.find(id: "Settings.landingPageOptions.\(item.rawValue)")
         }
 
         public static func appearanceMenuItem(item: AppearanceMenuItem) -> XCUIElement {
@@ -124,9 +123,9 @@ public class SettingsHelper: BaseHelper {
         public struct SyncFrequency {
             private static let group = "Settings.OfflineSync.syncFrequencyOptions"
 
-            public static var asTheOsAllows: XCUIElement { app.find(idStartingWith: group, labelContaining: "as the OS allows") }
-            public static var daily: XCUIElement { app.find(idStartingWith: group, label: "Daily") }
-            public static var weekly: XCUIElement { app.find(idStartingWith: group, label: "Weekly") }
+            public static var asTheOsAllows: XCUIElement { app.find(id: "\(group).osBased") }
+            public static var daily: XCUIElement { app.find(id: "\(group).daily") }
+            public static var weekly: XCUIElement { app.find(id: "\(group).weekly") }
         }
     }
 }

--- a/Core/TestsFoundation/UITestHelperNamespaces/SettingsHelper.swift
+++ b/Core/TestsFoundation/UITestHelperNamespaces/SettingsHelper.swift
@@ -91,11 +91,11 @@ public class SettingsHelper: BaseHelper {
         public static var QRCodeImage: XCUIElement { app.find(id: "QRCodeImage") }
 
         public static func landingPageMenuItem(item: LandingPageMenuItem) -> XCUIElement {
-            return app.find(type: .table).find(label: item.rawValue, type: .staticText)
+            return app.find(idStartingWith: "Settings.landingPageOptions", label: item.rawValue)
         }
 
         public static func appearanceMenuItem(item: AppearanceMenuItem) -> XCUIElement {
-            return app.find(id: "ItemPickerItem.0-\(item.rawValue)")
+            return app.find(id: "Settings.appearanceOptions.\(item.rawValue)")
         }
 
         public static var backButton: XCUIElement { app.find(label: "Settings", type: .button) }
@@ -122,9 +122,11 @@ public class SettingsHelper: BaseHelper {
         public static var turnOffButton: XCUIElement { app.find(label: "Turn Off", type: .button) }
 
         public struct SyncFrequency {
-            public static var asTheOsAllows: XCUIElement { app.find(labelContaining: "as the OS allows", type: .staticText) }
-            public static var daily: XCUIElement { app.find(label: "Daily", type: .staticText) }
-            public static var weekly: XCUIElement { app.find(label: "Weekly", type: .staticText) }
+            private static let group = "Settings.OfflineSync.syncFrequencyOptions"
+
+            public static var asTheOsAllows: XCUIElement { app.find(idStartingWith: group, labelContaining: "as the OS allows") }
+            public static var daily: XCUIElement { app.find(idStartingWith: group, label: "Daily") }
+            public static var weekly: XCUIElement { app.find(idStartingWith: group, label: "Weekly") }
         }
     }
 }

--- a/Parent/Parent/Localizable.xcstrings
+++ b/Parent/Parent/Localizable.xcstrings
@@ -6919,6 +6919,7 @@
       }
     },
     "Dark Theme" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -12808,6 +12809,7 @@
       }
     },
     "Light Theme" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
@@ -21003,6 +21005,7 @@
       }
     },
     "System Settings" : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "stringUnit" : {

--- a/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
+++ b/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
@@ -116,6 +116,7 @@ extension ProfileSettingsViewModel {
         let pageTitle = String(localized: "Appearance", bundle: .core)
         let picker = ItemPickerScreen(
             pageTitle: pageTitle,
+            identifierGroup: "Settings.appearanceOptions",
             items: options,
             initialSelectionIndex: selectedStyleIndex,
             didSelect: { [weak self] in

--- a/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
+++ b/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
@@ -112,18 +112,23 @@ extension ProfileSettingsViewModel {
 
     private func showAppereanceItemPicker(controller: WeakViewController, selectedIndex: CurrentValueSubject<Int, Never>, options: [ItemPickerItem]) {
         let selectedStyleIndex = environment.userDefaults?.interfaceStyle?.rawValue ?? 0
-        let pickerVC = ItemPickerViewController.create(
-            title: String(localized: "Appearance", bundle: .core),
-            sections: [ ItemPickerSection(items: options) ],
-            selected: IndexPath(row: selectedStyleIndex, section: 0)
-        ) { [weak self] indexPath in
-            if let window = self?.environment.window, let style = UIUserInterfaceStyle(rawValue: indexPath.row) {
-                window.updateInterfaceStyle(style)
-                self?.environment.userDefaults?.interfaceStyle = style
-            }
 
-            selectedIndex.send(indexPath.row)
-        }
+        let pageTitle = String(localized: "Appearance", bundle: .core)
+        let picker = ItemPickerScreen(
+            pageTitle: pageTitle,
+            items: options,
+            initialSelectionIndex: selectedStyleIndex,
+            didSelect: { [weak self] in
+                if let window = self?.environment.window, let style = UIUserInterfaceStyle(rawValue: $0) {
+                    window.updateInterfaceStyle(style)
+                    self?.environment.userDefaults?.interfaceStyle = style
+                }
+
+                selectedIndex.send($0)
+            }
+        )
+        let pickerVC = CoreHostingController(picker)
+        pickerVC.navigationItem.title = pageTitle
         controller.value.show(pickerVC, sender: controller)
     }
 }

--- a/Parent/ParentUnitTests/Profile/Settings/ViewModel/ProfileSettingsViewModelTests.swift
+++ b/Parent/ParentUnitTests/Profile/Settings/ViewModel/ProfileSettingsViewModelTests.swift
@@ -24,11 +24,6 @@ import XCTest
 class ProfileSettingsViewModelTests: ParentTestCase {
     private let inboxSettingsInteractor = InboxSettingsInteractorMock()
     private let offlineInteractor = OfflineInteractorMock()
-    private let options = [
-        ItemPickerItem(title: String(localized: "System Settings", bundle: .core)),
-        ItemPickerItem(title: String(localized: "Light Theme", bundle: .core)),
-        ItemPickerItem(title: String(localized: "Dark Theme", bundle: .core))
-    ]
 
     private var testee: ProfileSettingsViewModel!
 
@@ -52,7 +47,7 @@ class ProfileSettingsViewModelTests: ParentTestCase {
     func testAllGroupItemsAreDisplayed() {
         XCTAssertEqual(testee.settingsGroups[0].viewModel.itemViews.count, 2)
         XCTAssertEqual(testee.settingsGroups[0].viewModel.itemViews[0].viewModel.title, "Appearance")
-        let expectedAppearanceValue = options[env.userDefaults?.interfaceStyle?.rawValue ?? 0].title
+        let expectedAppearanceValue = (env.userDefaults?.interfaceStyle ?? .unspecified).settingsTitle
         XCTAssertEqual(testee.settingsGroups[0].viewModel.itemViews[0].viewModel.valueLabel, expectedAppearanceValue)
         XCTAssertEqual(testee.settingsGroups[0].viewModel.itemViews[1].viewModel.title, "About")
         XCTAssertEqual(testee.settingsGroups[0].viewModel.itemViews[1].viewModel.valueLabel, nil)

--- a/Student/StudentE2ETests/Settings/SettingsTests.swift
+++ b/Student/StudentE2ETests/Settings/SettingsTests.swift
@@ -82,7 +82,7 @@ class SettingsTests: E2ETestCase {
         let landingPageNavBar = SubSettingsHelper.landingPageNavBar.waitUntil(.visible)
         let dashboard = SubSettingsHelper.landingPageMenuItem(item: .dashboard).waitUntil(.visible)
         let calendar = SubSettingsHelper.landingPageMenuItem(item: .calendar).waitUntil(.visible)
-        let toDo = SubSettingsHelper.landingPageMenuItem(item: .toDo).waitUntil(.visible)
+        let toDo = SubSettingsHelper.landingPageMenuItem(item: .todo).waitUntil(.visible)
         let notifications = SubSettingsHelper.landingPageMenuItem(item: .notifications).waitUntil(.visible)
         let inbox = SubSettingsHelper.landingPageMenuItem(item: .inbox).waitUntil(.visible)
         let backButton = SubSettingsHelper.backButton.waitUntil(.visible)

--- a/Teacher/Teacher/Submissions/HideGradesViewController.swift
+++ b/Teacher/Teacher/Submissions/HideGradesViewController.swift
@@ -133,7 +133,7 @@ extension HideGradesViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         paging.willSelectRow(at: indexPath)
-        return nil
+        return indexPath
     }
 
     @objc

--- a/Teacher/Teacher/Submissions/PostGradesViewController.swift
+++ b/Teacher/Teacher/Submissions/PostGradesViewController.swift
@@ -158,16 +158,25 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
         tableView.deselectRow(at: indexPath, animated: true)
 
         if let row = Row(rawValue: indexPath.row), row == .postTo {
-            show(ItemPickerViewController.create(
-                title: String(localized: "Post to...", bundle: .teacher),
-                sections: [ ItemPickerSection(items: PostGradePolicy.allCases.map {
-                    ItemPickerItem(title: $0.title, subtitle: $0.subtitle, accessibilityIdentifier: "PostToSelection.\($0.rawValue)")
-                }) ],
-                selected: PostGradePolicy.allCases.firstIndex(of: postPolicy).flatMap {
-                    IndexPath(row: $0, section: 0)
-                },
-                delegate: self
-            ), sender: self)
+            let pageTitle = String(localized: "Post to...", bundle: .teacher)
+            let allCases = PostGradePolicy.allCases
+
+            let picker = ItemPickerScreen(
+                pageTitle: pageTitle,
+                identifierGroup: "PostPolicy.postToOptions",
+                allOptions: allCases.map { OptionItem(id: $0.optionItemId, title: $0.title, subtitle: $0.subtitle) },
+                initialOptionId: postPolicy.optionItemId,
+                didSelectOption: { [weak self] in
+                    guard let selectedCase = allCases.element(for: $0) else { return }
+
+                    self?.postPolicy = selectedCase
+                    self?.tableView.reloadData()
+                }
+            )
+
+            let pickerVC = CoreHostingController(picker)
+            pickerVC.navigationItem.title = pageTitle
+            show(pickerVC, sender: self)
         }
     }
 
@@ -230,13 +239,6 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
         required init?(coder aDecoder: NSCoder) {
             fatalError("init(coder:) has not been implemented")
         }
-    }
-}
-
-extension PostGradesViewController: ItemPickerDelegate {
-    func itemPicker(_ itemPicker: ItemPickerViewController, didSelectRowAt indexPath: IndexPath) {
-        postPolicy = PostGradePolicy.allCases[indexPath.row]
-        tableView.reloadData()
     }
 }
 

--- a/Teacher/Teacher/Submissions/PostGradesViewController.swift
+++ b/Teacher/Teacher/Submissions/PostGradesViewController.swift
@@ -177,7 +177,7 @@ extension PostGradesViewController: UITableViewDelegate, UITableViewDataSource {
 
     func tableView(_ tableView: UITableView, willSelectRowAt indexPath: IndexPath) -> IndexPath? {
         paging.willSelectRow(at: indexPath)
-        return nil
+        return indexPath
     }
 
     @objc

--- a/Teacher/Teacher/Submissions/SubmissionListViewController.swift
+++ b/Teacher/Teacher/Submissions/SubmissionListViewController.swift
@@ -138,7 +138,11 @@ class SubmissionListViewController: ScreenViewTrackableViewController, ColoredNa
     }
 
     @objc func openPostPolicy() {
-        env.router.route(to: "/\(context.pathComponent)/assignments/\(assignmentID)/post_policy", from: self, options: .modal(embedInNav: true))
+        env.router.route(
+            to: "/\(context.pathComponent)/assignments/\(assignmentID)/post_policy",
+            from: self,
+            options: .modal(embedInNav: true, addDoneButton: true)
+        )
     }
 
     @objc func messageUsers() {

--- a/Teacher/TeacherE2ETests/Settings/SettingsTests.swift
+++ b/Teacher/TeacherE2ETests/Settings/SettingsTests.swift
@@ -66,8 +66,8 @@ class SettingsTests: E2ETestCase {
 
         landingPage.hit()
         let landingPageNavBar = SubSettingsHelper.landingPageNavBar.waitUntil(.visible)
-        let courses = SubSettingsHelper.landingPageMenuItem(item: .courses).waitUntil(.visible)
-        let toDo = SubSettingsHelper.landingPageMenuItem(item: .toDo).waitUntil(.visible)
+        let courses = SubSettingsHelper.landingPageMenuItem(item: .dashboard).waitUntil(.visible)
+        let toDo = SubSettingsHelper.landingPageMenuItem(item: .todo).waitUntil(.visible)
         let inbox = SubSettingsHelper.landingPageMenuItem(item: .inbox).waitUntil(.visible)
         let backButton = SubSettingsHelper.backButton.waitUntil(.visible)
         XCTAssertTrue(landingPageNavBar.isVisible)

--- a/Teacher/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
+++ b/Teacher/TeacherTests/Submissions/SubmissionListViewControllerTests.swift
@@ -121,7 +121,7 @@ class SubmissionListViewControllerTests: TeacherTestCase {
         XCTAssertEqual(controller.emptyView.isHidden, false)
 
         _ = controller.postPolicyButton.target?.perform(controller.postPolicyButton.action)
-        XCTAssert(router.lastRoutedTo("/courses/1/assignments/1/post_policy", withOptions: .modal(embedInNav: true)))
+        XCTAssert(router.lastRoutedTo("/courses/1/assignments/1/post_policy", withOptions: .modal(embedInNav: true, addDoneButton: true)))
 
         _ = controller.messageUsersButton.target?.perform(controller.messageUsersButton.action)
         XCTAssert(router.lastRoutedTo("/conversations/compose", withOptions: .modal(embedInNav: true)))


### PR DESCRIPTION
refs: [MBL-18856](https://instructure.atlassian.net/browse/MBL-18856)
affects: Student, Teacher, Parent
release note: none

## What's changed
- Fixed dynamic font size issues on Item Picker screens in Settings
- Added list count to Single/MultiSelection views
  - read for section header or for first focused item if there is no header
- Updated `accessibilityIdentifier`s for Settings to have string values instead of order-dependent numbers
  - less error-prone both for E2E tests and analytics

### Chores
- Added `ItemPickerScreen` to replace `ItemPickerViewController`
  - replaced usage only for Settings
  - reused `SingleSelectionView`, added new style (aligned with UX, we keep the checkmark style for now)
- Added helpers around `OptionItem`
- Extracted existing `.identifier()` modifier method to it's own file, added variant
  - the point is to have a single id for `accessibilityIdentifier` and any other similar usages (like analytics, etc.)
  - if we uses this appwide we will have a single place where we can define these usages

## Test plan
- Verify cells and fonts resize dynamically on item picker screens
  - in Settings (especially notification options, those have subtitles)
  - on Error Report > Impact Level screen
  - Teacher > Post Settings > Post to... screen
- Smoke test Settings screens (landing page, appearance, notifications, offline sync)
- Verify list count is read via VoiceOver for
  - item picker screens in Settings
  - selection screens (filter screens, calendar selectors, etc)

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode

[MBL-18856]: https://instructure.atlassian.net/browse/MBL-18856?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ