### PR TITLE
Use grade formatter to display score

### DIFF
--- a/Core/Core/Common/CommonUI/ViewableModels/GradeViewable.swift
+++ b/Core/Core/Common/CommonUI/ViewableModels/GradeViewable.swift
@@ -64,11 +64,15 @@ extension GradeViewable {
 
     /** This is used to communicate the original score received before late penalty is deducted. */
     public var enteredGradeText: String? {
-        if let score = viewableEnteredScore {
-            return String(localized: "Your Grade: \(score, specifier: "%.0f") pt",
-                          bundle: .core)
-        }
-        return nil
+        guard let score = viewableEnteredScore else { return nil }
+
+        let truncatedScore = GradeFormatter.truncate(score)
+        let formattedGrade = GradeFormatter.numberFormatter.string(from: truncatedScore)
+
+        guard let formattedGrade else { return nil }
+
+        let format = String(localized: "your_grade_pts", bundle: .core)
+        return String.localizedStringWithFormat(format, score, formattedGrade)
     }
 
     public var finalGradeText: String? {

--- a/Core/CoreTests/Common/CommonUI/ViewableModels/GradeViewableTests.swift
+++ b/Core/CoreTests/Common/CommonUI/ViewableModels/GradeViewableTests.swift
@@ -77,6 +77,6 @@ class GradeViewableTests: XCTestCase {
     func testEnteredGradeText() {
         XCTAssertNil(Model(viewableEnteredScore: nil).enteredGradeText)
         XCTAssertEqual(Model(viewableEnteredScore: 1).enteredGradeText, "Your Grade: 1 pt")
-        XCTAssertEqual(Model(viewableEnteredScore: 99).enteredGradeText, "Your Grade: 99 pts")
+        XCTAssertEqual(Model(viewableEnteredScore: 99.5).enteredGradeText, "Your Grade: 99.5 pts")
     }
 }


### PR DESCRIPTION
refs: [MBL-18861](https://instructure.atlassian.net/browse/MBL-18861)
affects: Student
release note: Fixed score being rounded on assignment details screen when late penalty was applied.

test plan: See ticket.

[MBL-18861]: https://instructure.atlassian.net/browse/MBL-18861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ