### PR TITLE
Make embedded html content work

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/CoreWebViewCrossCookieInjection.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/CoreWebViewCrossCookieInjection.swift
@@ -1,0 +1,53 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import WebKit
+
+/// The "Allow Cross-Website Tracking" switch only works for trusted domains.
+/// A way to make a domain trusted is to inject a cookie for it before it's being loaded within an iframe.
+class CoreWebViewCrossCookieInjection {
+    static let safeDomains = [
+        "canvas-user-content.com"
+    ]
+
+    func injectCrossSiteCookies(
+        httpCookieStore: WKHTTPCookieStore
+    ) -> AnyPublisher<Void, Never> {
+        let crossCookies = Self.safeDomains.compactMap { domain in
+            HTTPCookie.makeCrossSiteCookie(domain: domain)
+        }
+        return httpCookieStore
+            .setCookies(crossCookies)
+            .eraseToAnyPublisher()
+    }
+}
+
+extension HTTPCookie {
+
+    static func makeCrossSiteCookie(domain: String) -> HTTPCookie? {
+        var cookieProperties: [HTTPCookiePropertyKey: Any] = [:]
+        cookieProperties[.name] = "canvas_ios_trusted_domain"
+        cookieProperties[.value] = "true"
+        cookieProperties[.domain] = ".\(domain)"
+        cookieProperties[.path] = "/"
+        cookieProperties[.sameSitePolicy] = "None"
+        cookieProperties[.version] = "1"
+        return HTTPCookie(properties: cookieProperties)
+    }
+}

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -588,11 +588,16 @@ extension CoreWebView: WKUIDelegate {
 extension CoreWebView {
     static var cookieKeepAliveTimer: Timer?
     static var cookieKeepAliveWebView = CoreWebView()
+    private static var injectionSubscription: AnyCancellable?
 
     public static func keepCookieAlive(for env: AppEnvironment) {
         guard env.api.loginSession?.accessToken != nil,
               cookieKeepAliveTimer == nil
         else { return }
+
+        injectionSubscription = CoreWebViewCrossCookieInjection()
+            .injectCrossSiteCookies(httpCookieStore: cookieKeepAliveWebView.configuration.websiteDataStore.httpCookieStore)
+            .sink()
 
         performUIUpdate {
             cookieKeepAliveTimer?.invalidate()

--- a/Core/Core/Common/Extensions/WebKit/WKHTTPCookieStoreExtensions.swift
+++ b/Core/Core/Common/Extensions/WebKit/WKHTTPCookieStoreExtensions.swift
@@ -42,6 +42,16 @@ public extension WKHTTPCookieStore {
             .eraseToAnyPublisher()
     }
 
+    func setCookies(_ cookies: [HTTPCookie]) -> AnyPublisher<Void, Never> {
+        Publishers.Sequence(sequence: cookies)
+            .flatMap(maxPublishers: .max(1)) { cookie in
+                self.setCookie(cookie)
+            }
+            .collect()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
     func setCookie(_ cookie: HTTPCookie) -> AnyPublisher<Void, Never> {
         Future { promise in
             self.setCookie(cookie) {

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCrossCookieInjectionTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCrossCookieInjectionTests.swift
@@ -1,0 +1,64 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import WebKit
+import XCTest
+import Combine
+
+class CoreWebViewCrossCookieInjectionTests: XCTestCase {
+    private var webViewConfiguration: WKWebViewConfiguration!
+    private var webView: WKWebView!
+    private var cookieStore: WKHTTPCookieStore!
+    private var testee: CoreWebViewCrossCookieInjection!
+
+    override func setUp() {
+        super.setUp()
+        webViewConfiguration = WKWebViewConfiguration()
+        webViewConfiguration.websiteDataStore = .nonPersistent()
+        webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+        cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+        testee = CoreWebViewCrossCookieInjection()
+    }
+
+    func test_injectCrossSiteCookies_createsCrossSiteCookies() {
+        // WHEN
+        XCTAssertFinish(testee.injectCrossSiteCookies(httpCookieStore: cookieStore))
+
+        // THEN
+        XCTAssertFirstValue(
+            cookieStore.getAllCookies(),
+            timeout: 10
+        ) { cookies in
+            XCTAssertEqual(
+                cookies.count,
+                CoreWebViewCrossCookieInjection.safeDomains.count
+            )
+
+            for domain in CoreWebViewCrossCookieInjection.safeDomains {
+                guard let crossCookie = cookies.first(where: { $0.domain == ".\(domain)" }) else {
+                    XCTFail("No cookie found for domain \(domain)")
+                    continue
+                }
+
+                let expectedCookie = HTTPCookie.makeCrossSiteCookie(domain: domain)!
+                XCTAssertTrue(expectedCookie.isEqualProperties(to: crossCookie))
+            }
+        }
+    }
+}

--- a/Core/CoreTests/Common/Extensions/WebKit/WKHTTPCookieStoreExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/WebKit/WKHTTPCookieStoreExtensionsTests.swift
@@ -23,6 +23,7 @@ import XCTest
 class WKHTTPCookieStoreExtensionsTests: XCTestCase {
     private var webViewConfiguration: WKWebViewConfiguration!
     private let cookie = HTTPCookie.make()
+    private let cookie2 = HTTPCookie.make(name: "testName2")
 
     override func setUp() {
         super.setUp()
@@ -70,6 +71,30 @@ class WKHTTPCookieStoreExtensionsTests: XCTestCase {
             timeout: 10,
             assertions: { [cookie] resultCookies in
                 XCTAssertTrue(cookie.isEqualProperties(to: resultCookies.first))
+            }
+        )
+    }
+
+    func testSetCookies() {
+        let webView = WKWebView(frame: .zero, configuration: webViewConfiguration)
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+        XCTAssertSingleOutputEquals(
+            cookieStore.getAllCookies(),
+            [],
+            timeout: 10
+        )
+
+        // WHEN
+        XCTAssertFinish(cookieStore.setCookies([cookie, cookie2]), timeout: 10)
+
+        // THEN
+        XCTAssertFirstValue(
+            cookieStore.getAllCookies(),
+            timeout: 10,
+            assertions: { [cookie, cookie2] resultCookies in
+                let expected = Set([cookie, cookie2])
+                let result = Set(resultCookies)
+                XCTAssertEqual(expected, result)
             }
         )
     }


### PR DESCRIPTION
### What's new?
- See the linked MBL and RCX tickets for a very detailed analysis on the problem.
- Embedded iframes can't set cookies by default.
- To allow them to set cookies you need to turn on "Allow Cross-Website Tracking" in app settings.
- Another piece is that webkit needs to trust the domain in the iframe and that can be achieved by setting a cookie for the domain before the content load takes place.

refs: [MBL-18806](https://instructure.atlassian.net/browse/MBL-18806)
affects: Student, Teacher, Parent
release note: none

test plan:
- Turn on "Allow Cross-Website Tracking" in app settings.
- See linked rcx ticket for test account.
- Embedded html content should load.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/7a4e0ecc-64e2-4c8d-a762-74c90f77af6c" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/131e5923-b761-45c7-8b3c-7d6184a7fd51" maxHeight=500></td>
</tr>
</table>

[MBL-18806]: https://instructure.atlassian.net/browse/MBL-18806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ