### PR TITLE
Fix "Submission & Rubric" page displaying assignment's details in parent app

### DIFF
--- a/Parent/ParentUnitTests/Assignments/Model/ParentSubmissionInteractorTests.swift
+++ b/Parent/ParentUnitTests/Assignments/Model/ParentSubmissionInteractorTests.swift
@@ -34,7 +34,8 @@ class ParentSubmissionInteractorTests: ParentTestCase {
             userName: "Test Parent"
         )
         let assignmentURL = URL(string: "https://\(host)/assignment/123/submissions")!
-        let authenticatedSessionURL = URL(string: "https://authenticated")!
+        let authenticatedSessionURL = URL(string: "https://authenticated?display=borderless")!
+        let expectedSessionURL = URL(string: "https://authenticated?embedded=true")!
         let sessionRequested = expectation(description: "sessionRequested")
         api.mock(GetWebSessionRequest(to: assignmentURL)) { _ in
             sessionRequested.fulfill()
@@ -75,7 +76,7 @@ class ParentSubmissionInteractorTests: ParentTestCase {
                 XCTAssertTrue(expectedCookie.isEqualProperties(to: cookies.first))
             }
         )
-        XCTAssertEqual(mockWebView.receivedRequestToLoad, URLRequest(url: authenticatedSessionURL))
+        XCTAssertEqual(mockWebView.receivedRequestToLoad, URLRequest(url: expectedSessionURL))
         XCTAssertEqual(mockWebView.isLoadingChecked, true)
     }
 }


### PR DESCRIPTION
The "Submission & Rubric" screen in the parent app displayed the assignment's details but not the user's submission. Turned out we use the "display=embedded" url query when opening the page and it no longer opens the proper page. Replacing this query with "embedded=true" as on the android client solves the issue.

refs: [MBL-18896](https://instructure.atlassian.net/browse/MBL-18896)
affects: Parent
release note: Fixed "Submission & Rubric" page displaying only the assignment's details.

test plan:
- Check submission screen for elementary students.
- Check submission screen for regular students with both assignment enhancements turned on and off.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">Assignment Enhancements On</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/b17c0061-01f9-4444-aa73-78c372b91d76" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/900cbbbd-0ced-434a-ba06-077eb827a259" maxHeight=500></td>
</tr>
<tr><th colspan="2">Assignment Enhancements Off</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/ddd63569-3432-45de-8eaa-fd9fba5636b3" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/d37d38b8-a47f-4f33-940a-22131c07454b" maxHeight=500></td>
</tr>
<tr><th colspan="2">Elementary</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/4c2516b8-0435-4dd7-9b5e-2935337c47d1" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/4d0373bc-5dba-45fc-9346-b3196ded980f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-18896]: https://instructure.atlassian.net/browse/MBL-18896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ