### PR TITLE
SpeedGrader drawer tab change speedup

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/SegmentedPicker.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/SegmentedPicker.swift
@@ -37,8 +37,11 @@ extension InstUI {
         public var body: some View {
             // Simply passing a string will be treated as a localized key
             // and will create an entry in the strings dictionary.
-            Picker("" as String, selection: selection, content: content)
-                .pickerStyle(.segmented)
+            Picker("" as String,
+                   selection: selection.animation(.smooth(duration: 0.25)),
+                   content: content
+            )
+            .pickerStyle(.segmented)
         }
 
         private func updateSegmentedControlAppearance() {

--- a/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
@@ -350,7 +350,7 @@ struct SubmissionGraderView: View {
                 .identifier("SpeedGrader.toolPicker")
                 InstUI.Divider()
             } else {
-                InstUI.SegmentedPicker(selection: $tab.animation()) {
+                InstUI.SegmentedPicker(selection: $tab) {
                     ForEach(GraderTab.allCases, id: \.self) { tab in
                         Text(tab.title(viewModel: viewModel))
                             .tag(tab)


### PR DESCRIPTION
affects: Teacher

[ignore-commit-lint]

Made the Landscape mode SG tab switch animation faster to match the segmented picker's animation and to make it feel less sluggish.
Moved that into the component.

## Checklist
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product