### PR TITLE
Fix the issue of cross-shared user unable to preview files added to Modules

### DIFF
--- a/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
+++ b/Core/Core/Features/Modules/ModuleList/ModuleListViewController.swift
@@ -29,7 +29,7 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
     @IBOutlet weak var tableView: UITableView!
     public let titleSubtitleView = TitleSubtitleView.create()
 
-    private let env = AppEnvironment.shared
+    private var env: AppEnvironment = .shared
     public var color: UIColor?
     private var courseID = ""
     private var moduleID: String?
@@ -53,18 +53,19 @@ public final class ModuleListViewController: ScreenViewTrackableViewController, 
     private var isPageDisabled: Bool {
         tabs.first { $0.id == "modules" } == nil && courses.first?.defaultView != .modules
     }
-    private var collapsedIDs: [String: [String]] = AppEnvironment.shared.userDefaults?.collapsedModules ?? [:] {
+    private lazy var collapsedIDs: [String: [String]] = env.userDefaults?.collapsedModules ?? [:] {
         didSet {
-            AppEnvironment.shared.userDefaults?.collapsedModules = collapsedIDs
+            env.userDefaults?.collapsedModules = collapsedIDs
         }
     }
-    private lazy var publishInteractor = ModulesAssembly.publishInteractor(for: courseID)
+    private lazy var publishInteractor = ModulesAssembly.publishInteractor(for: courseID, env: env)
     private var subscriptions = Set<AnyCancellable>()
 
-    public static func create(courseID: String, moduleID: String? = nil) -> ModuleListViewController {
+    public static func create(env: AppEnvironment, courseID: String, moduleID: String? = nil) -> ModuleListViewController {
         let controller = loadFromStoryboard()
         controller.courseID = courseID
         controller.moduleID = moduleID
+        controller.env = env
         return controller
     }
 

--- a/Core/Core/Features/Modules/ModulesAssembly.swift
+++ b/Core/Core/Features/Modules/ModulesAssembly.swift
@@ -23,19 +23,24 @@ class ModulesAssembly {
     private static var publishInteractorsByCourseIds: [String: ModulePublishInteractor] = [:]
     private static var subscriptions = Set<AnyCancellable>()
 
-    public static func publishInteractor(for courseId: String) -> ModulePublishInteractor {
+    public static func publishInteractor(for courseId: String, env: AppEnvironment) -> ModulePublishInteractor {
         if let interactor = publishInteractorsByCourseIds[courseId] {
             return interactor
         }
 
-        let interactor = ModulePublishInteractorLive(courseId: courseId)
+        let interactor = ModulePublishInteractorLive(
+            app: env.app,
+            courseId: courseId,
+            api: env.api
+        )
+
         publishInteractorsByCourseIds[courseId] = interactor
 
         interactor
             .statusUpdates
             .receive(on: RunLoop.main)
             .sink { update in
-                AppEnvironment.shared.topViewController?.findSnackBarViewModel()?.showSnack(update)
+                env.topViewController?.findSnackBarViewModel()?.showSnack(update)
             }
             .store(in: &subscriptions)
 

--- a/Core/CoreTests/Features/Modules/ModuleList/ModuleListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Modules/ModuleList/ModuleListViewControllerTests.swift
@@ -31,7 +31,7 @@ class ModuleListViewControllerTests: CoreTestCase {
         }
     }
 
-    lazy var viewController = ModuleListViewController.create(courseID: "1")
+    lazy var viewController = ModuleListViewController.create(env: environment, courseID: "1")
     var save: XCTestExpectation?
 
     func loadView() {
@@ -258,7 +258,7 @@ class ModuleListViewControllerTests: CoreTestCase {
             GetModuleItemsRequest(courseID: "1", moduleID: "7", include: [.content_details, .mastery_paths]),
             value: [.make(id: "7")]
         )
-        let viewController = ModuleListViewController.create(courseID: "1", moduleID: "5")
+        let viewController = ModuleListViewController.create(env: environment, courseID: "1", moduleID: "5")
         viewController.view.layoutIfNeeded()
         drainMainQueue()
         XCTAssertEqual(viewController.tableView.numberOfSections, 7)
@@ -317,7 +317,7 @@ class ModuleListViewControllerTests: CoreTestCase {
         XCTAssertFalse(after.isExpanded)
         XCTAssertEqual(before.accessibilityLabel, "Module 1, expanded")
 
-        let viewController = ModuleListViewController.create(courseID: "1")
+        let viewController = ModuleListViewController.create(env: environment, courseID: "1")
         viewController.view.layoutIfNeeded()
         drainMainQueue()
         let later = viewController.tableView.headerView(forSection: 0) as! ModuleSectionHeaderView

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -312,7 +312,7 @@ let router = Router(routes: [
     RouteHandler("/courses/:courseID/modules/items/:itemID") { url, params, _, env in
         guard let courseID = params["courseID"], let itemID = params["itemID"] else { return nil }
         return ModuleItemSequenceViewController.create(
-            env: env,  
+            env: env,
             courseID: courseID.localID,
             assetType: .moduleItem,
             assetID: itemID.localID,

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -513,13 +513,20 @@ private func fileDetails(url: URLComponents, params: [String: String], userInfo 
     if !url.originIsModuleItemDetails, !url.skipModuleItemSequence, let context = context, context.contextType == .course {
         return ModuleItemSequenceViewController.create(
             env: environment,
-            courseID: context.id,
+            courseID: context.id.localID,
             assetType: .file,
-            assetID: fileID,
+            assetID: fileID.localID,
             url: url
         )
     }
-    return FileDetailsViewController.create(context: context, fileID: fileID, originURL: url, assignmentID: assignmentID, environment: environment)
+    return FileDetailsViewController
+        .create(
+            context: context?.local,
+            fileID: fileID.localID,
+            originURL: url,
+            assignmentID: assignmentID?.localID,
+            environment: environment
+        )
 }
 
 private func offlineFileDetails(url _: URLComponents, params: [String: String], userInfo _: [String: Any]?, environment: AppEnvironment) -> UIViewController? {

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -297,45 +297,47 @@ let router = Router(routes: [
         )
     },
 
-    RouteHandler("/courses/:courseID/modules") { _, params, _ in
+    RouteHandler("/courses/:courseID/modules") { _, params, _, env in
         guard let courseID = params["courseID"] else { return nil }
-        return ModuleListViewController.create(courseID: courseID)
+        return ModuleListViewController
+            .create(env: env, courseID: courseID.localID)
     },
 
-    RouteHandler("/courses/:courseID/modules/:moduleID") { _, params, _ in
+    RouteHandler("/courses/:courseID/modules/:moduleID") { _, params, _, env in
         guard let courseID = params["courseID"], let moduleID = params["moduleID"] else { return nil }
-        return ModuleListViewController.create(courseID: courseID, moduleID: moduleID)
+        return ModuleListViewController
+            .create(env: env, courseID: courseID.localID, moduleID: moduleID.localID)
     },
 
-    RouteHandler("/courses/:courseID/modules/items/:itemID") { url, params, _ in
+    RouteHandler("/courses/:courseID/modules/items/:itemID") { url, params, _, env in
         guard let courseID = params["courseID"], let itemID = params["itemID"] else { return nil }
         return ModuleItemSequenceViewController.create(
-            env: .shared,
-            courseID: courseID,
+            env: env,  
+            courseID: courseID.localID,
             assetType: .moduleItem,
-            assetID: itemID,
+            assetID: itemID.localID,
             url: url
         )
     },
 
-    RouteHandler("/courses/:courseID/modules/:moduleID/items/:itemID") { url, params, _ in
+    RouteHandler("/courses/:courseID/modules/:moduleID/items/:itemID") { url, params, _, env in
         guard let courseID = params["courseID"], let itemID = params["itemID"] else { return nil }
         return ModuleItemSequenceViewController.create(
-            env: .shared,
-            courseID: courseID,
+            env: env,
+            courseID: courseID.localID,
             assetType: .moduleItem,
-            assetID: itemID,
+            assetID: itemID.localID,
             url: url
         )
     },
 
-    RouteHandler("/courses/:courseID/module_item_redirect/:itemID") { url, params, _ in
+    RouteHandler("/courses/:courseID/module_item_redirect/:itemID") { url, params, _, env in
         guard let courseID = params["courseID"], let itemID = params["itemID"] else { return nil }
         return ModuleItemSequenceViewController.create(
-            env: .shared,
-            courseID: courseID,
+            env: env,
+            courseID: courseID.localID,
             assetType: .moduleItem,
-            assetID: itemID,
+            assetID: itemID.localID,
             url: url
         )
     },

--- a/Teacher/Teacher/Routes.swift
+++ b/Teacher/Teacher/Routes.swift
@@ -292,14 +292,14 @@ let router = Router(routes: [
     RouteHandler("/:context/:contextID/files/:fileID/preview", factory: fileDetails),
     RouteHandler("/:context/:contextID/files/:fileID/edit", factory: fileEditor),
 
-    RouteHandler("/courses/:courseID/modules") { _, params, _ in
+    RouteHandler("/courses/:courseID/modules") { _, params, _, env in
         guard let courseID = params["courseID"] else { return nil }
-        return ModuleListViewController.create(courseID: courseID)
+        return ModuleListViewController.create(env: env, courseID: courseID)
     },
 
-    RouteHandler("/courses/:courseID/modules/:moduleID") { _, params, _ in
+    RouteHandler("/courses/:courseID/modules/:moduleID") { _, params, _, env in
         guard let courseID = params["courseID"], let moduleID = params["moduleID"] else { return nil }
-        return ModuleListViewController.create(courseID: courseID, moduleID: moduleID)
+        return ModuleListViewController.create(env: env, courseID: courseID, moduleID: moduleID)
     },
 
     RouteHandler("/courses/:courseID/modules/:moduleID/items/:itemID") { url, params, _ in


### PR DESCRIPTION
refs: MBL-18871
affects: Student
release note: Fixed the issue where cross-shared user not being able to preview files when added to Modules.

## Test Plan
See [ticket's](https://instructure.atlassian.net/browse/MBL-18871) description.

#### :warning: Known issue:
~~When using "act as user" as login methodology, modules won't load as expected and user won't be able to preview files.
This issue is caused by an error is returned from the API when `as_user_id` query param is passed along. (Not sure why that happens?)~~

Just tested this issue today, seems to work normally, same way as the ordinary login way. See recording below:

https://github.com/user-attachments/assets/1e880c00-58fd-45b9-a228-29e269ef4a02

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
