### PR TITLE
Fix the issue of cross-shard user unable to view announcements details

### DIFF
--- a/Core/Core/Features/Discussions/AnnouncementListViewController.swift
+++ b/Core/Core/Features/Discussions/AnnouncementListViewController.swift
@@ -53,7 +53,7 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
 
     public static func create(context: Context, env: AppEnvironment) -> AnnouncementListViewController {
         let controller = loadFromStoryboard()
-        controller.context = context
+        controller.context = context.local
         controller.env = env
         return controller
     }
@@ -127,7 +127,7 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
         tableView.reloadData()
 
         if !selectedFirstTopic, topics.state != .loading, let id = topics.first?.id {
-            let url = "\(context.pathComponent)/announcements/\(id)"
+            let url = "/\(context.pathComponent)/announcements/\(id)"
             selectedFirstTopic = true
             if splitViewController?.isCollapsed == false, !isInSplitViewDetail {
                 env.router.route(to: url, from: self, options: .detail)
@@ -137,7 +137,7 @@ public class AnnouncementListViewController: ScreenViewTrackableViewController, 
 
     @objc func add() {
         env.router.route(
-            to: "\(context.pathComponent)/announcements/new".asRoute(in: env),
+            to: "/\(context.pathComponent)/announcements/new".asRoute(in: env),
             userInfo: [DiscussionsAssembly.SourceViewKey: self],
             from: self,
             options: .modal(isDismissable: false, embedInNav: true)
@@ -177,7 +177,7 @@ extension AnnouncementListViewController: UITableViewDataSource, UITableViewDele
 
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let id = topics[indexPath]?.id else { return }
-        env.router.route(to: "\(context.pathComponent)/announcements/\(id)", from: self, options: .detail)
+        env.router.route(to: "/\(context.pathComponent)/announcements/\(id)", from: self, options: .detail)
     }
 
     public func tableView(_ tableView: UITableView, trailingSwipeActionsConfigurationForRowAt indexPath: IndexPath) -> UISwipeActionsConfiguration? {

--- a/Core/CoreTests/Features/Discussions/AnnouncementListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Discussions/AnnouncementListViewControllerTests.swift
@@ -119,7 +119,7 @@ class AnnouncementListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.dateLabel.text, TestConstants.date20201102.dateTimeString)
 
         controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: IndexPath(row: 2, section: 0))
-        XCTAssert(router.lastRoutedTo("courses/1/announcements/3", withOptions: .detail))
+        XCTAssert(router.lastRoutedTo("/courses/1/announcements/3", withOptions: .detail))
 
         XCTAssertNoThrow(controller.viewWillDisappear(false))
     }
@@ -148,7 +148,7 @@ class AnnouncementListViewControllerTests: CoreTestCase {
         XCTAssertNotNil(controller.navigationItem.rightBarButtonItem)
 
         _ = controller.addButton.target?.perform(controller.addButton.action)
-        XCTAssert(router.lastRoutedTo("groups/1/announcements/new", withOptions: .modal(isDismissable: false, embedInNav: true)))
+        XCTAssert(router.lastRoutedTo("/groups/1/announcements/new", withOptions: .modal(isDismissable: false, embedInNav: true)))
 
         XCTAssertEqual(controller.tableView.numberOfRows(inSection: 0), 1)
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? AnnouncementListCell


### PR DESCRIPTION
refs: MBL-18886
affects: Student
release note: Fixed the issue where cross-shard user can not view announcements details.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18886) description.

#### :warning: Known issue:
When using "act as user" as login methodology, modules won't load as expected and user won't be able to preview files.
This issue is caused by an error is returned from the API when `as_user_id` query param is passed along. (Not sure why that happens?)

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
