### PR TITLE
Fix issue with submission list where NotSubmitted ones being sorted under Others section

### DIFF
--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListSection.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListSection.swift
@@ -49,7 +49,19 @@ struct SubmissionListSection: Identifiable {
                     && (submission.excused ?? false) == false
                 }
             case .unsubmitted:
-                { $0.workflowState == .unsubmitted }
+                { submission in
+
+                    // This condition should be good for most cases.
+                    if submission.workflowState == .unsubmitted { return true }
+
+                    // For the case where rubrics assessment is submitted, but
+                    // with invalid values, which would render score to be `nil`
+                    if submission.workflowState == .graded {
+                        return submission.submittedAt == nil && submission.score == nil
+                    }
+
+                    return false
+                }
             case .graded:
                 { $0.isGraded }
             case .others:

--- a/Teacher/TeacherTests/Submissions/SubmissionList/SubmissionListViewModelTests.swift
+++ b/Teacher/TeacherTests/Submissions/SubmissionList/SubmissionListViewModelTests.swift
@@ -117,8 +117,46 @@ final class SubmissionListViewModelTests: TeacherTestCase {
         interactor.submissionsSubject.send(mocks)
 
         // Then
-        XCTAssertEqual(viewModel.sections.count, 3)
         XCTAssertEqual(viewModel.state, .data)
+        XCTAssertEqual(viewModel.sections.count, 3)
+        XCTAssertEqual(viewModel.sections[safeIndex: 0]?.kind, .submitted)
+        XCTAssertEqual(viewModel.sections[safeIndex: 1]?.kind, .unsubmitted)
+        XCTAssertEqual(viewModel.sections[safeIndex: 2]?.kind, .graded)
+    }
+
+    func testNeedsGradingAndInvalidGradingSubmissions() {
+        // Given
+        let mocks = TestConstants.createSubmissions(
+            in: databaseClient,
+            count: 2,
+            customizer: { (submission, index, client) in
+                switch index {
+                case 0:
+                    submission.userID = "u0"
+                    submission.user = User.save(.make(id: "u0", name: "John"), in: client)
+                    submission.workflowState = .pending_review
+                    submission.type = .online_text_entry
+                    submission.score = nil
+                    submission.submittedAt = Date()
+                default:
+                    submission.userID = "u1"
+                    submission.user = User.save(.make(id: "u1", name: "Jane"), in: client)
+                    submission.workflowState = .graded
+                    submission.score = nil
+                    submission.submittedAt = nil
+                }
+            }
+        )
+
+        // When
+        interactor.submissionsSubject.send(mocks)
+
+        // Then
+        XCTAssertEqual(viewModel.state, .data)
+        XCTAssertEqual(viewModel.sections.count, 2)
+        XCTAssertEqual(viewModel.sections[safeIndex: 0]?.kind, .submitted)
+        XCTAssertEqual(viewModel.sections[safeIndex: 0]?.items.first?.needsGrading, true)
+        XCTAssertEqual(viewModel.sections[safeIndex: 1]?.kind, .unsubmitted)
     }
 
     func testSearchTextFiltering() {


### PR DESCRIPTION
refs: MBL-18892
affects: Teacher
release note: Fixed issue with submission list where NotSubmitted ones being sorted under Others section

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18892) description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
