### PR TITLE
QR login orientation fix

### DIFF
--- a/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
@@ -202,6 +202,7 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
         }
 
         let orientationDegrees = CGFloat((orientation.rawValue - 1) * 90)
+        print(orientationDegrees)
 
         guard
             let previewLayer = previewLayer,

--- a/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
@@ -192,7 +192,6 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
     }
 
     private func updateCameraPreviewOrientation() {
-
         var orientation: UIDeviceOrientation
         let supportedOrientations = Bundle.main.infoDictionary?["UISupportedInterfaceOrientations"] as? [String]
         if supportedOrientations?.count == 1,
@@ -202,10 +201,12 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
             orientation = UIDevice.current.orientation
         }
 
+        let orientationDegrees = CGFloat((orientation.rawValue - 1) * 90)
+
         guard
             let previewLayer = previewLayer,
             let connection = previewLayer.connection,
-            connection.isVideoRotationAngleSupported(CGFloat(orientation.rawValue)),
+            connection.isVideoRotationAngleSupported(orientationDegrees),
             let videoCaptureDevice = AVCaptureDevice.default(for: .video)
         else { return }
 

--- a/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
+++ b/Core/Core/Common/CommonUI/UIViews/ScannerViewController.swift
@@ -202,7 +202,6 @@ public class ScannerViewController: UIViewController, AVCaptureMetadataOutputObj
         }
 
         let orientationDegrees = CGFloat((orientation.rawValue - 1) * 90)
-        print(orientationDegrees)
 
         guard
             let previewLayer = previewLayer,


### PR DESCRIPTION
refs: [MBL-18944](https://instructure.atlassian.net/browse/MBL-18944)
affects: Student, Teacher, Parent
release note: Fixed a bug that caused the camera not appearing on the QR login screen.

Test plan:
- Test on iPad and iPhone, all screen orientation

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product