### PR TITLE
Move NSFetchedResultsController setup to the context's thread

### DIFF
--- a/Core/Core/Common/CommonModels/Store/FetchedResultPublisher.swift
+++ b/Core/Core/Common/CommonModels/Store/FetchedResultPublisher.swift
@@ -77,15 +77,15 @@ final class FetchedResultsSubscription
               let request = request,
               let context = context else { return }
 
-        controller = NSFetchedResultsController(
-            fetchRequest: request,
-            managedObjectContext: context,
-            sectionNameKeyPath: nil,
-            cacheName: nil
-        )
-        controller?.delegate = self
-
         context.perform { [weak self] in
+            self?.controller = NSFetchedResultsController(
+                fetchRequest: request,
+                managedObjectContext: context,
+                sectionNameKeyPath: nil,
+                cacheName: nil
+            )
+            self?.controller?.delegate = self
+
             do {
                 try self?.controller?.performFetch()
             } catch {


### PR DESCRIPTION
There are crashes when setting up `NSFetchedResultsController` in `FetchedResultPublisher`. I couldn't reproduce the crash but my best guess is that the crash is caused by not setting up the controller on the managed object context's thread. All crashes come from some background thread and the context we use is mainly the view context that is associated with the main thread and this can cause strange crashes. We started investigating this crash because in the latest teacher release we started receiving these in greater numbers but the crash can be found in the Student app as well, although only in previous versions.
Let's test if this causes any unwanted issues and we'll see after releasing it if it actually solves the issue on user's side.

refs: [MBL-18964](https://instructure.atlassian.net/browse/MBL-18964)
affects: Teacher, Student, Parent
release note: none

test plan:
- Sanity test the app if it works.

## Checklist

- [ ] iOS 17 iPad
- [ ] iOS 18 iPad
- [ ] iOS 17 iPhone
- [ ] iOS 18 iPhone

[MBL-18964]: https://instructure.atlassian.net/browse/MBL-18964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ