### PR TITLE
Fixed issue of duplicate rows showing for same event on Planner view on tapping To-do widget day button

### DIFF
--- a/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerViewController.swift
@@ -212,7 +212,11 @@ public class PlannerViewController: VisibilityObservedViewController {
         selectedDate = date
         calendar.showDate(date)
         calendar.accessibilityFocusOnSelectedButton()
-        updateList(date)
+        updateList(date) { listPage in
+            // Refresh lightly to resolve the issue of duplicate rows
+            // showing when calling this method with the same date multiple times
+            listPage?.refresh()
+        }
     }
 
     private func updateTodayButton() {


### PR DESCRIPTION
refs: MBL-18900
affects: Student
release note: Fixed issue of duplicate rows showing for same event on Planner view on tapping To-do widget day button

## Root cause analysis

The issue primarily caused by internal flaw with legacy `Store` object, by which objects get reported duplicate via `NSFetchedResultsController` delegate method `controllerDidChangeContent`.

Elaborating more on the first point for this context, as per @vargaat request:
Both `CalendarDaysViewController` & `PlannerListViewController` using a store observing `GetPlannables` use case. 
For the natural use case, those refresh on both stores are called subsequently on each navigation to calendar page. So, they both get to reset their objects before dealing with new ones.

While for the case when user tap on a To-do widget button, the following stack get called each time, 
```
- PlannerViewController.selectDate(..)
- CalendarViewController.showDate(..)
- CalendarDaysViewController.create(..)
- CalendarDaysViewController.viewDidLoad(...)
- CalendarDaysViewController.refresh(..)
- Store<GetPlannables>.refresh(..)
```

Which will lead for store living on `CalendarDaysViewController` to be called each time. And objects saved to store at the moment, will get reported to store living on `PlannerListViewController` before it get the chance to do any `reset` for the old ones, leading to a situation where duplicate objects being reported to the table as a consequence.

## Resolution

To avoid playing around with `Store`, the issue was resolved by recreating the store on `PlannerListViewController` for the specific method used to show a day list which `selectDate()`. This achieved by simply calling the `refresh()` method on it. I think this solution can be acceptable over going into the nuances of `Store` fetching mechanism, which at the end can break a lot on the way.

You can still break this solution if you tried hard enough, but this need to be really hard to be apparent for good network condition. On other hand, it will more likely to be apparent with worse network conditions. As they both will be racing to against each other to finish the api request. 

A more valid solution, which has its own drawback, would be to introduce another property and use to scope objects based on the originating view, the downside would be duplicating `Plannable` objects in the database for each view accessing `GetPlannables` use case.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-18900) description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
