### PR TITLE
Trap voiceover into webview when a web dialog is displayed

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -18,6 +18,7 @@
 
 @preconcurrency import WebKit
 import Combine
+import UIKit
 
 @IBDesignable
 open class CoreWebView: WKWebView {
@@ -46,6 +47,7 @@ open class CoreWebView: WKWebView {
     }
 
     var downloadingAttachment: CoreWebAttachment?
+    internal var a11yHelper = CoreWebViewAccessibilityHelper()
 
     private(set) var features: [CoreWebViewFeature] = []
     private var htmlString: String?
@@ -160,6 +162,18 @@ open class CoreWebView: WKWebView {
         handle("loadFrameSource") { [weak self] message in
             guard let src = message.body as? String else { return }
             self?.loadFrame(src: src)
+        }
+        handle("modalPresentation") { [weak self] message in
+            guard let self,
+                  let body = message.body as? [String: Bool],
+                  let isPresentingModal = body["open"]
+            else { return }
+
+            self.a11yHelper.setExclusiveAccessibility(
+                for: self,
+                isExclusive: isPresentingModal,
+                viewController: self.viewController
+            )
         }
 
         registerForTraitChanges()


### PR DESCRIPTION
refs: [MBL-18901](https://instructure.atlassian.net/browse/MBL-18901)
affects: Student, Teacher
release note: none

test plan:
- Go to a discussion and start editing it.
- Locate the accessibility checker icon below the text box.
- Turn on voiceover.
- Activate the a11y check button.
- A dialog should appear inside the webview.
- Swipe left and right to make sure you can only access the contents of this dialog.
- Close the dialog.
- Check if you can now move around the app with voiceover focus.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet