### PR TITLE
Teacher - Excused submission sorted to two sections

### DIFF
--- a/Core/Core/Features/Enrollments/Enrollment.swift
+++ b/Core/Core/Features/Enrollments/Enrollment.swift
@@ -82,7 +82,7 @@ extension Enrollment {
     }
 
     public var isStudent: Bool {
-        return type.lowercased().contains("student")
+        return type.lowercased().contains("student") && !type.lowercased().contains("view")
     }
 
     public var isTeacher: Bool {

--- a/Core/Core/Features/Enrollments/Enrollment.swift
+++ b/Core/Core/Features/Enrollments/Enrollment.swift
@@ -85,6 +85,14 @@ extension Enrollment {
         return type.lowercased().contains("student") && !type.lowercased().contains("view")
     }
 
+    public var isStudentView: Bool {
+        return isStudent && type.lowercased().contains("view")
+    }
+
+    public var isNotStudentView: Bool {
+        return !isStudentView
+    }
+
     public var isTeacher: Bool {
         return type.lowercased().contains("teacher")
     }

--- a/Core/Core/Features/Enrollments/Enrollment.swift
+++ b/Core/Core/Features/Enrollments/Enrollment.swift
@@ -82,7 +82,7 @@ extension Enrollment {
     }
 
     public var isStudent: Bool {
-        return type.lowercased().contains("student") && !type.lowercased().contains("view")
+        return type.lowercased().contains("student")
     }
 
     public var isStudentView: Bool {

--- a/Core/Core/Features/Enrollments/Enrollment.swift
+++ b/Core/Core/Features/Enrollments/Enrollment.swift
@@ -85,12 +85,10 @@ extension Enrollment {
         return type.lowercased().contains("student")
     }
 
+    /// - returns: True if the enrollment is for a test user that is created when the teacher starts the "Student View" mode.
     public var isStudentView: Bool {
+        // "StudentView" is the enrollment name
         return isStudent && type.lowercased().contains("view")
-    }
-
-    public var isNotStudentView: Bool {
-        return !isStudentView
     }
 
     public var isTeacher: Bool {

--- a/Core/CoreTests/Features/SubmitAssignmentExtension/Model/FilePreviewProviderTests.swift
+++ b/Core/CoreTests/Features/SubmitAssignmentExtension/Model/FilePreviewProviderTests.swift
@@ -72,7 +72,7 @@ class FilePreviewProviderTests: XCTestCase {
             XCTAssertNotNil(data.image)
         }
         testee.load()
-        waitForExpectations(timeout: 0.5)
+        waitForExpectations(timeout: 5)
         subscription.cancel()
     }
 

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
@@ -68,6 +68,7 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
         submissionsSubscription = submissionsStore?
             .getEntities(ignoreCache: true, keepObservingDatabaseChanges: true)
             .replaceError(with: [])
+            .map { $0.filterOutStudentViewUsers() }
             .sink { [weak self] list in
                 self?.submissionsSubject.send(list)
             }
@@ -107,5 +108,18 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
 
     func applyFilters(_ filters: [GetSubmissions.Filter]) {
         filtersSubject.send(filters)
+    }
+}
+
+private extension [Submission] {
+    
+    func filterOutStudentViewUsers() -> [Submission] {
+        var filteredSubmissions = self
+        filteredSubmissions.removeAll { submission in
+            submission.enrollments.contains { enrollment in
+                enrollment.isStudentView
+            }
+        }
+        return filteredSubmissions
     }
 }

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
@@ -112,7 +112,7 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
 }
 
 private extension [Submission] {
-    
+
     func filterOutStudentViewUsers() -> [Submission] {
         var filteredSubmissions = self
         filteredSubmissions.removeAll { submission in

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListSection.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListSection.swift
@@ -46,6 +46,7 @@ struct SubmissionListSection: Identifiable {
                 { $0.submittedAt != nil && $0.isGraded == false }
             case .unsubmitted:
                 { submission in
+                    if submission.excused == true { return false }
 
                     // This condition should be good for most cases.
                     if submission.workflowState == .unsubmitted { return true }

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -59,11 +59,9 @@ class SubmissionListViewModel: ObservableObject {
         .map({ (list, searchText) in
 
             let searchTerm = searchText.lowercased()
-            let curatedList: [Submission]
+            var curatedList: [Submission] = list.filter { $0.enrollments.first?.isStudent ?? false }
             if searchTerm.isNotEmpty {
-                curatedList = list.filter { $0.user?.nameContains(searchTerm) ?? false }
-            } else {
-                curatedList = list
+                curatedList = curatedList.filter { $0.user?.nameContains(searchTerm) ?? false }
             }
 
             var itemIndex = 0

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -59,7 +59,7 @@ class SubmissionListViewModel: ObservableObject {
         .map({ (list, searchText) in
 
             let searchTerm = searchText.lowercased()
-            var curatedList: [Submission] = list.filter { $0.enrollments.first?.isNotStudentView ?? false }
+            var curatedList: [Submission] = list
             if searchTerm.isNotEmpty {
                 curatedList = curatedList.filter { $0.user?.nameContains(searchTerm) ?? false }
             }

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -59,7 +59,7 @@ class SubmissionListViewModel: ObservableObject {
         .map({ (list, searchText) in
 
             let searchTerm = searchText.lowercased()
-            var curatedList: [Submission] = list.filter { $0.enrollments.first?.isStudent ?? false }
+            var curatedList: [Submission] = list.filter { $0.enrollments.first?.isNotStudentView ?? false }
             if searchTerm.isNotEmpty {
                 curatedList = curatedList.filter { $0.user?.nameContains(searchTerm) ?? false }
             }


### PR DESCRIPTION
## Teacher - Excused submission sorted to two sections

refs: MBL-18976
affects: Teacher
release note: Fixed a bug that caused excused submissions to get sorted into two sections.
test plan: See ticket.

## Overview

- Excused submissions were shown in two sections at once, which caused the UI to glitch. Now they should only be shown in the graded section only.
- Submissions with StudentView enrollments are now filtered out from the Submission List screen solving the previous inconsistency between the Assignment Detail and the Submission List screens.

## Checklist

- [ ] Tested on phone
- [x] Tested on tablet
