### PR TITLE
Label for comment field

### DIFF
--- a/Student/Student/Localizable.xcstrings
+++ b/Student/Student/Localizable.xcstrings
@@ -132804,6 +132804,9 @@
         }
       }
     },
+    "Type here..." : {
+
+    },
     "Uh-oh! No Internet Connection" : {
       "comment" : "Notification over status bar that displays when not connected to the internet.",
       "extractionState" : "manual",

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="z6Z-9B-ukp">
-                                <rect key="frame" x="0.0" y="20" width="375" height="539"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="317"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="m8y-we-Jl9">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="24"/>
@@ -397,7 +397,7 @@
                                 </variation>
                             </view>
                             <view opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="SAr-z8-Qsj">
-                                <rect key="frame" x="0.0" y="559" width="375" height="108"/>
+                                <rect key="frame" x="0.0" y="337" width="375" height="330"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4l5-MU-1OT" customClass="DividerView" customModule="Student" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -409,7 +409,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djV-o5-Xt6" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="34" width="40" height="40"/>
+                                        <rect key="frame" x="0.0" y="281" width="40" height="40"/>
                                         <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.addMediaButton"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="40" id="DoK-DZ-BLQ"/>
@@ -425,28 +425,47 @@
                                         </connections>
                                     </button>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CLU-b8-j0t">
-                                        <rect key="frame" x="40" y="4" width="319" height="100"/>
+                                        <rect key="frame" x="40" y="4" width="319" height="322"/>
                                         <subviews>
                                             <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vZr-mW-D6N">
-                                                <rect key="frame" x="0.0" y="0.0" width="319" height="50"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="319" height="272"/>
                                                 <subviews>
                                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AK9-qA-H1o">
-                                                        <rect key="frame" x="0.0" y="0.0" width="16" height="50"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="16" height="272"/>
                                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="16" id="GML-c1-2ww"/>
                                                         </constraints>
                                                     </view>
-                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pX-Dm-Wog" userLabel="Comment Label">
-                                                        <rect key="frame" x="16" y="0.0" width="303" height="50"/>
-                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                        <color key="textColor" name="borderMedium"/>
-                                                        <nil key="highlightedColor"/>
-                                                    </label>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="vKH-ti-PRW">
+                                                        <rect key="frame" x="16" y="0.0" width="303" height="272"/>
+                                                        <subviews>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="j0q-Or-nTA">
+                                                                <rect key="frame" x="0.0" y="0.0" width="303" height="4"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="4" id="8Uj-s5-e4z"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pX-Dm-Wog" userLabel="Comment Label">
+                                                                <rect key="frame" x="0.0" y="4" width="303" height="264"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <color key="textColor" name="borderMedium"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ozz-P0-P6q">
+                                                                <rect key="frame" x="0.0" y="268" width="303" height="4"/>
+                                                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="4" id="eFw-Yx-i6Q"/>
+                                                                </constraints>
+                                                            </view>
+                                                        </subviews>
+                                                    </stackView>
                                                 </subviews>
                                             </stackView>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
-                                                <rect key="frame" x="0.0" y="50" width="319" height="50"/>
+                                                <rect key="frame" x="0.0" y="272" width="319" height="50"/>
                                                 <subviews>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
                                                         <rect key="frame" x="12" y="3" width="266" height="47"/>
@@ -507,7 +526,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gze-1W-XEa">
-                                        <rect key="frame" x="0.0" y="108" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="330" width="375" height="0.0"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" id="2PL-IE-MvI"/>
@@ -522,12 +541,12 @@
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="ayE-te-ffb"/>
                                     <constraint firstItem="djV-o5-Xt6" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="dfi-A4-myE"/>
                                     <constraint firstItem="CLU-b8-j0t" firstAttribute="top" secondItem="SAr-z8-Qsj" secondAttribute="top" constant="4" id="eh3-OH-Wtc"/>
+                                    <constraint firstItem="djV-o5-Xt6" firstAttribute="centerY" secondItem="CLU-b8-j0t" secondAttribute="bottom" constant="-25" id="heE-C6-J93"/>
                                     <constraint firstAttribute="trailing" secondItem="CLU-b8-j0t" secondAttribute="trailing" constant="16" id="j1f-TB-146"/>
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="top" relation="greaterThanOrEqual" secondItem="SAr-z8-Qsj" secondAttribute="top" id="l1p-xk-3Yk"/>
                                     <constraint firstAttribute="bottom" secondItem="CLU-b8-j0t" secondAttribute="bottom" constant="4" id="leb-5f-OYB"/>
                                     <constraint firstItem="4l5-MU-1OT" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="luo-05-3XB"/>
                                     <constraint firstAttribute="trailing" secondItem="gze-1W-XEa" secondAttribute="trailing" id="mHW-fh-hDY"/>
-                                    <constraint firstItem="djV-o5-Xt6" firstAttribute="centerY" secondItem="SAr-z8-Qsj" secondAttribute="centerY" id="qYy-Rp-8VZ"/>
                                     <constraint firstAttribute="trailing" secondItem="4l5-MU-1OT" secondAttribute="trailing" id="xvA-fR-rec"/>
                                 </constraints>
                             </view>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -5,6 +5,7 @@
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -17,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="z6Z-9B-ukp">
-                                <rect key="frame" x="0.0" y="20" width="375" height="573"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="539"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="m8y-we-Jl9">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="24"/>
@@ -396,7 +397,7 @@
                                 </variation>
                             </view>
                             <view opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="SAr-z8-Qsj">
-                                <rect key="frame" x="0.0" y="593" width="375" height="74"/>
+                                <rect key="frame" x="0.0" y="559" width="375" height="108"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4l5-MU-1OT" customClass="DividerView" customModule="Student" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -408,7 +409,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djV-o5-Xt6" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="17" width="40" height="40"/>
+                                        <rect key="frame" x="0.0" y="34" width="40" height="40"/>
                                         <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.addMediaButton"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="40" id="DoK-DZ-BLQ"/>
@@ -424,16 +425,28 @@
                                         </connections>
                                     </button>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CLU-b8-j0t">
-                                        <rect key="frame" x="40" y="4" width="319" height="66"/>
+                                        <rect key="frame" x="40" y="4" width="319" height="100"/>
                                         <subviews>
-                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pX-Dm-Wog" userLabel="Comment Label">
-                                                <rect key="frame" x="0.0" y="0.0" width="319" height="16"/>
-                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                                <color key="textColor" name="borderMedium"/>
-                                                <nil key="highlightedColor"/>
-                                            </label>
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vZr-mW-D6N">
+                                                <rect key="frame" x="0.0" y="0.0" width="319" height="50"/>
+                                                <subviews>
+                                                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="AK9-qA-H1o">
+                                                        <rect key="frame" x="0.0" y="0.0" width="16" height="50"/>
+                                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="16" id="GML-c1-2ww"/>
+                                                        </constraints>
+                                                    </view>
+                                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pX-Dm-Wog" userLabel="Comment Label">
+                                                        <rect key="frame" x="16" y="0.0" width="303" height="50"/>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                        <color key="textColor" name="borderMedium"/>
+                                                        <nil key="highlightedColor"/>
+                                                    </label>
+                                                </subviews>
+                                            </stackView>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
-                                                <rect key="frame" x="0.0" y="16" width="319" height="50"/>
+                                                <rect key="frame" x="0.0" y="50" width="319" height="50"/>
                                                 <subviews>
                                                     <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
                                                         <rect key="frame" x="12" y="3" width="266" height="47"/>
@@ -494,7 +507,7 @@
                                         </subviews>
                                     </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gze-1W-XEa">
-                                        <rect key="frame" x="0.0" y="74" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="108" width="375" height="0.0"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" id="2PL-IE-MvI"/>
@@ -560,5 +573,8 @@
         <namedColor name="borderMedium">
             <color red="0.61960784313725492" green="0.65098039215686276" blue="0.67843137254901964" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
     </resources>
 </document>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -463,6 +463,9 @@
                                                         </subviews>
                                                     </stackView>
                                                 </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="vKH-ti-PRW" firstAttribute="leading" secondItem="vZr-mW-D6N" secondAttribute="leading" constant="16" id="rfd-Ya-ZBX"/>
+                                                </constraints>
                                             </stackView>
                                             <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
                                                 <rect key="frame" x="0.0" y="272" width="319" height="50"/>
@@ -541,12 +544,12 @@
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="ayE-te-ffb"/>
                                     <constraint firstItem="djV-o5-Xt6" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="dfi-A4-myE"/>
                                     <constraint firstItem="CLU-b8-j0t" firstAttribute="top" secondItem="SAr-z8-Qsj" secondAttribute="top" constant="4" id="eh3-OH-Wtc"/>
-                                    <constraint firstItem="djV-o5-Xt6" firstAttribute="centerY" secondItem="CLU-b8-j0t" secondAttribute="bottom" constant="-25" id="heE-C6-J93"/>
                                     <constraint firstAttribute="trailing" secondItem="CLU-b8-j0t" secondAttribute="trailing" constant="16" id="j1f-TB-146"/>
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="top" relation="greaterThanOrEqual" secondItem="SAr-z8-Qsj" secondAttribute="top" id="l1p-xk-3Yk"/>
                                     <constraint firstAttribute="bottom" secondItem="CLU-b8-j0t" secondAttribute="bottom" constant="4" id="leb-5f-OYB"/>
                                     <constraint firstItem="4l5-MU-1OT" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="luo-05-3XB"/>
                                     <constraint firstAttribute="trailing" secondItem="gze-1W-XEa" secondAttribute="trailing" id="mHW-fh-hDY"/>
+                                    <constraint firstItem="djV-o5-Xt6" firstAttribute="centerY" secondItem="DjR-oA-G8w" secondAttribute="centerY" id="nMT-CS-Czh"/>
                                     <constraint firstAttribute="trailing" secondItem="4l5-MU-1OT" secondAttribute="trailing" id="xvA-fR-rec"/>
                                 </constraints>
                             </view>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="22155" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22131"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
+        <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="none" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="z6Z-9B-ukp">
-                                <rect key="frame" x="0.0" y="20" width="375" height="596"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="573"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableHeaderView" contentMode="scaleToFill" id="m8y-we-Jl9">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="24"/>
@@ -396,7 +396,7 @@
                                 </variation>
                             </view>
                             <view opaque="NO" contentMode="center" translatesAutoresizingMaskIntoConstraints="NO" id="SAr-z8-Qsj">
-                                <rect key="frame" x="0.0" y="616" width="375" height="51"/>
+                                <rect key="frame" x="0.0" y="593" width="375" height="74"/>
                                 <subviews>
                                     <view opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4l5-MU-1OT" customClass="DividerView" customModule="Student" customModuleProvider="target">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="1"/>
@@ -408,7 +408,7 @@
                                         </userDefinedRuntimeAttributes>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="djV-o5-Xt6" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="5.5" width="40" height="40"/>
+                                        <rect key="frame" x="0.0" y="17" width="40" height="40"/>
                                         <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.addMediaButton"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="40" id="DoK-DZ-BLQ"/>
@@ -423,67 +423,78 @@
                                             <action selector="addMediaButtonPressed:" destination="9pN-2b-voW" eventType="touchUpInside" id="Etk-9o-30f"/>
                                         </connections>
                                     </button>
-                                    <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
-                                        <rect key="frame" x="40" y="4" width="319" height="43"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="CLU-b8-j0t">
+                                        <rect key="frame" x="40" y="4" width="319" height="66"/>
                                         <subviews>
-                                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
-                                                <rect key="frame" x="12" y="3" width="266" height="40"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.commentTextView"/>
+                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Comment" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3pX-Dm-Wog" userLabel="Comment Label">
+                                                <rect key="frame" x="0.0" y="0.0" width="319" height="16"/>
+                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                <color key="textColor" name="borderMedium"/>
+                                                <nil key="highlightedColor"/>
+                                            </label>
+                                            <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="DjR-oA-G8w">
+                                                <rect key="frame" x="0.0" y="16" width="319" height="50"/>
+                                                <subviews>
+                                                    <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="3wp-xK-HJQ">
+                                                        <rect key="frame" x="12" y="3" width="266" height="47"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.commentTextView"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" priority="700" constant="40" id="iuz-Bm-PNt"/>
+                                                        </constraints>
+                                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                        <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                                                        <connections>
+                                                            <outlet property="delegate" destination="9pN-2b-voW" id="UnK-Xf-GAt"/>
+                                                        </connections>
+                                                    </textView>
+                                                    <button opaque="NO" alpha="0.5" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="system" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uGc-Rr-ieQ" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
+                                                        <rect key="frame" x="282" y="14" width="30" height="30"/>
+                                                        <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.addCommentButton"/>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="30" id="W3o-XC-ES9"/>
+                                                            <constraint firstAttribute="height" constant="30" id="j3C-l6-NKb"/>
+                                                        </constraints>
+                                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="1"/>
+                                                        <userDefinedRuntimeAttributes>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="buttonPrimaryBackground"/>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="buttonPrimaryText"/>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="miniArrowUpSolid"/>
+                                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                                <integer key="value" value="15"/>
+                                                            </userDefinedRuntimeAttribute>
+                                                            <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
+                                                        </userDefinedRuntimeAttributes>
+                                                        <connections>
+                                                            <action selector="addCommentButtonPressed:" destination="9pN-2b-voW" eventType="touchUpInside" id="jWo-6q-LxV"/>
+                                                        </connections>
+                                                    </button>
+                                                </subviews>
+                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                 <constraints>
-                                                    <constraint firstAttribute="height" priority="700" constant="40" id="iuz-Bm-PNt"/>
+                                                    <constraint firstItem="uGc-Rr-ieQ" firstAttribute="leading" secondItem="3wp-xK-HJQ" secondAttribute="trailing" constant="4" id="0Iz-DT-rhP"/>
+                                                    <constraint firstItem="3wp-xK-HJQ" firstAttribute="top" secondItem="DjR-oA-G8w" secondAttribute="top" constant="3" id="NO7-l5-LaT"/>
+                                                    <constraint firstAttribute="bottom" secondItem="3wp-xK-HJQ" secondAttribute="bottom" id="SDb-vJ-ba3"/>
+                                                    <constraint firstItem="3wp-xK-HJQ" firstAttribute="leading" secondItem="DjR-oA-G8w" secondAttribute="leading" constant="12" id="exB-6M-zjV"/>
+                                                    <constraint firstAttribute="bottom" secondItem="uGc-Rr-ieQ" secondAttribute="bottom" constant="6" id="fXp-hw-eYd"/>
+                                                    <constraint firstItem="uGc-Rr-ieQ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DjR-oA-G8w" secondAttribute="top" constant="6" id="g54-Xx-pm9"/>
+                                                    <constraint firstAttribute="trailing" secondItem="uGc-Rr-ieQ" secondAttribute="trailing" constant="7" id="uNy-B7-wCK"/>
                                                 </constraints>
-                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
-                                                <connections>
-                                                    <outlet property="delegate" destination="9pN-2b-voW" id="UnK-Xf-GAt"/>
-                                                </connections>
-                                            </textView>
-                                            <button opaque="NO" alpha="0.5" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="fill" contentVerticalAlignment="fill" buttonType="system" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uGc-Rr-ieQ" customClass="DynamicButton" customModule="Student" customModuleProvider="target">
-                                                <rect key="frame" x="282" y="7" width="30" height="30"/>
-                                                <accessibility key="accessibilityConfiguration" identifier="SubmissionComments.addCommentButton"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="30" id="W3o-XC-ES9"/>
-                                                    <constraint firstAttribute="height" constant="30" id="j3C-l6-NKb"/>
-                                                </constraints>
-                                                <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="0.0" maxY="1"/>
                                                 <userDefinedRuntimeAttributes>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="backgroundColorName" value="buttonPrimaryBackground"/>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="buttonPrimaryText"/>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="iconName" value="miniArrowUpSolid"/>
                                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                        <integer key="value" value="15"/>
+                                                        <integer key="value" value="21"/>
                                                     </userDefinedRuntimeAttribute>
-                                                    <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="semibold16"/>
+                                                    <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
+                                                        <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
+                                                        <real key="value" value="0.5"/>
+                                                    </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
-                                                <connections>
-                                                    <action selector="addCommentButtonPressed:" destination="9pN-2b-voW" eventType="touchUpInside" id="jWo-6q-LxV"/>
-                                                </connections>
-                                            </button>
+                                            </view>
                                         </subviews>
-                                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                        <constraints>
-                                            <constraint firstItem="uGc-Rr-ieQ" firstAttribute="leading" secondItem="3wp-xK-HJQ" secondAttribute="trailing" constant="4" id="0Iz-DT-rhP"/>
-                                            <constraint firstItem="3wp-xK-HJQ" firstAttribute="top" secondItem="DjR-oA-G8w" secondAttribute="top" constant="3" id="NO7-l5-LaT"/>
-                                            <constraint firstAttribute="bottom" secondItem="3wp-xK-HJQ" secondAttribute="bottom" id="SDb-vJ-ba3"/>
-                                            <constraint firstItem="3wp-xK-HJQ" firstAttribute="leading" secondItem="DjR-oA-G8w" secondAttribute="leading" constant="12" id="exB-6M-zjV"/>
-                                            <constraint firstAttribute="bottom" secondItem="uGc-Rr-ieQ" secondAttribute="bottom" constant="6" id="fXp-hw-eYd"/>
-                                            <constraint firstItem="uGc-Rr-ieQ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="DjR-oA-G8w" secondAttribute="top" constant="6" id="g54-Xx-pm9"/>
-                                            <constraint firstAttribute="trailing" secondItem="uGc-Rr-ieQ" secondAttribute="trailing" constant="7" id="uNy-B7-wCK"/>
-                                        </constraints>
-                                        <userDefinedRuntimeAttributes>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
-                                                <integer key="value" value="21"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="color" keyPath="layer.borderColor">
-                                                <color key="value" white="0.66666666669999997" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-                                            </userDefinedRuntimeAttribute>
-                                            <userDefinedRuntimeAttribute type="number" keyPath="layer.borderWidth">
-                                                <real key="value" value="0.5"/>
-                                            </userDefinedRuntimeAttribute>
-                                        </userDefinedRuntimeAttributes>
-                                    </view>
+                                    </stackView>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gze-1W-XEa">
-                                        <rect key="frame" x="0.0" y="51" width="375" height="0.0"/>
+                                        <rect key="frame" x="0.0" y="74" width="375" height="0.0"/>
                                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         <constraints>
                                             <constraint firstAttribute="height" id="2PL-IE-MvI"/>
@@ -493,14 +504,14 @@
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="gze-1W-XEa" secondAttribute="bottom" id="5zb-w6-hFm"/>
-                                    <constraint firstItem="DjR-oA-G8w" firstAttribute="leading" secondItem="djV-o5-Xt6" secondAttribute="trailing" id="Hig-ut-XtH"/>
-                                    <constraint firstAttribute="bottom" secondItem="DjR-oA-G8w" secondAttribute="bottom" priority="750" constant="4" id="L24-Qn-hwk"/>
-                                    <constraint firstAttribute="trailing" secondItem="DjR-oA-G8w" secondAttribute="trailing" constant="16" id="P0B-2U-9pa"/>
+                                    <constraint firstItem="CLU-b8-j0t" firstAttribute="leading" secondItem="djV-o5-Xt6" secondAttribute="trailing" id="7LC-W7-MyN"/>
                                     <constraint firstItem="4l5-MU-1OT" firstAttribute="top" secondItem="SAr-z8-Qsj" secondAttribute="top" id="RFf-D0-mv2"/>
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="ayE-te-ffb"/>
-                                    <constraint firstItem="DjR-oA-G8w" firstAttribute="top" secondItem="SAr-z8-Qsj" secondAttribute="top" priority="750" constant="4" id="b2n-2Y-UfE"/>
                                     <constraint firstItem="djV-o5-Xt6" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="dfi-A4-myE"/>
+                                    <constraint firstItem="CLU-b8-j0t" firstAttribute="top" secondItem="SAr-z8-Qsj" secondAttribute="top" constant="4" id="eh3-OH-Wtc"/>
+                                    <constraint firstAttribute="trailing" secondItem="CLU-b8-j0t" secondAttribute="trailing" constant="16" id="j1f-TB-146"/>
                                     <constraint firstItem="gze-1W-XEa" firstAttribute="top" relation="greaterThanOrEqual" secondItem="SAr-z8-Qsj" secondAttribute="top" id="l1p-xk-3Yk"/>
+                                    <constraint firstAttribute="bottom" secondItem="CLU-b8-j0t" secondAttribute="bottom" constant="4" id="leb-5f-OYB"/>
                                     <constraint firstItem="4l5-MU-1OT" firstAttribute="leading" secondItem="SAr-z8-Qsj" secondAttribute="leading" id="luo-05-3XB"/>
                                     <constraint firstAttribute="trailing" secondItem="gze-1W-XEa" secondAttribute="trailing" id="mHW-fh-hDY"/>
                                     <constraint firstItem="djV-o5-Xt6" firstAttribute="centerY" secondItem="SAr-z8-Qsj" secondAttribute="centerY" id="qYy-Rp-8VZ"/>
@@ -532,6 +543,7 @@
                         <outlet property="addMediaButton" destination="djV-o5-Xt6" id="bHF-6D-e2E"/>
                         <outlet property="addMediaHeight" destination="2PL-IE-MvI" id="47L-8j-BJq"/>
                         <outlet property="addMediaView" destination="gze-1W-XEa" id="Gvh-1T-PAf"/>
+                        <outlet property="commentLabel" destination="3pX-Dm-Wog" id="oRz-Qm-ChW"/>
                         <outlet property="emptyContainer" destination="6ed-hM-HU9" id="iDh-4p-ADE"/>
                         <outlet property="emptyImageView" destination="G8F-Nx-Hbp" id="5um-cv-bSI"/>
                         <outlet property="emptyLabel" destination="vxN-b5-Dqx" id="m4o-a4-Hgu"/>
@@ -544,33 +556,9 @@
             <point key="canvasLocation" x="-254" y="33"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="5Um-tb-BF2">
-            <size key="intrinsicContentSize" width="100.5" height="20.5"/>
-        </designable>
-        <designable name="S2V-PQ-jCT">
-            <size key="intrinsicContentSize" width="163.5" height="20.5"/>
-        </designable>
-        <designable name="Thz-j3-Y3K">
-            <size key="intrinsicContentSize" width="100.5" height="20.5"/>
-        </designable>
-        <designable name="brg-4l-HGS">
-            <size key="intrinsicContentSize" width="163.5" height="20.5"/>
-        </designable>
-        <designable name="djV-o5-Xt6">
-            <size key="intrinsicContentSize" width="22" height="40"/>
-        </designable>
-        <designable name="eMn-Vx-0Ll">
-            <size key="intrinsicContentSize" width="111" height="20.5"/>
-        </designable>
-        <designable name="jQO-Zk-01K">
-            <size key="intrinsicContentSize" width="111" height="20.5"/>
-        </designable>
-        <designable name="uGc-Rr-ieQ">
-            <size key="intrinsicContentSize" width="30" height="30"/>
-        </designable>
-        <designable name="vxN-b5-Dqx">
-            <size key="intrinsicContentSize" width="614" height="20.5"/>
-        </designable>
-    </designables>
+    <resources>
+        <namedColor name="borderMedium">
+            <color red="0.61960784313725492" green="0.65098039215686276" blue="0.67843137254901964" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+    </resources>
 </document>

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -66,6 +66,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         commentLabel.text = String(localized: "Comment", bundle: .student)
         commentLabel.textColor = .textDark
         commentLabel.font = .scaledNamedFont(.regular13)
+        commentLabel.accessibilityTraits = .header
         addCommentBorderView.backgroundColor = .backgroundLightest
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -65,12 +65,13 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         tableView.backgroundColor = .backgroundLightest
         commentLabel.text = String(localized: "Comment", bundle: .student)
         commentLabel.textColor = .textDark
+        commentLabel.font = .scaledNamedFont(.regular13)
         addCommentBorderView.backgroundColor = .backgroundLightest
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale
         addCommentButton.accessibilityLabel = String(localized: "Send comment", bundle: .student)
         addCommentTextView.accessibilityLabel = String(localized: "Add a comment or reply to previous comments", bundle: .student)
-        addCommentTextView.placeholder = String(localized: "Comment", bundle: .student)
+        addCommentTextView.placeholder = String(localized: "Type here...", bundle: .student)
         addCommentTextView.placeholderColor = .textDark
         addCommentTextView.font(.scaledNamedFont(.regular16), lineHeight: .body)
         addCommentTextView.adjustsFontForContentSizeCategory = true

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -64,6 +64,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         view.backgroundColor = .backgroundLightest
         tableView.backgroundColor = .backgroundLightest
         commentLabel.text = String(localized: "Comment", bundle: .student)
+        commentLabel.textColor = .textDark
         addCommentBorderView.backgroundColor = .backgroundLightest
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale

--- a/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
+++ b/Student/Student/Submissions/SubmissionComments/SubmissionCommentsViewController.swift
@@ -22,6 +22,7 @@ import Core
 import UniformTypeIdentifiers
 
 class SubmissionCommentsViewController: UIViewController, ErrorViewController {
+    @IBOutlet weak var commentLabel: UILabel!
     @IBOutlet weak var addCommentBorderView: UIView!
     @IBOutlet weak var addCommentButton: UIButton!
     @IBOutlet weak var addCommentTextView: UITextView!
@@ -62,6 +63,7 @@ class SubmissionCommentsViewController: UIViewController, ErrorViewController {
         super.viewDidLoad()
         view.backgroundColor = .backgroundLightest
         tableView.backgroundColor = .backgroundLightest
+        commentLabel.text = String(localized: "Comment", bundle: .student)
         addCommentBorderView.backgroundColor = .backgroundLightest
         addCommentBorderView.layer.borderColor = UIColor.borderMedium.cgColor
         addCommentBorderView.layer.borderWidth = 1 / UIScreen.main.scale


### PR DESCRIPTION
### What's new?
- There's now a label over the comment textfield to make it more accessible.

refs: [MBL-18386](https://instructure.atlassian.net/browse/MBL-18386)
affects: Student
release note: none

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/ed674f37-e65f-4a61-8dad-4a8d2780a2dd" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/ae1617a9-9751-4cac-9b00-ae29176ffcae" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product


[MBL-18386]: https://instructure.atlassian.net/browse/MBL-18386?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ