### PR TITLE
Assignment List Preferences - Grading Period filter behaviour change

### DIFF
--- a/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentListPreferencesViewModel.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/ViewModel/AssignmentListPreferencesViewModel.swift
@@ -234,7 +234,7 @@ public final class AssignmentListPreferencesViewModel: ObservableObject {
 
         self.env = env
         self.courseColor = courseColor
-        self.isGradingPeriodsSectionVisible = gradingPeriods.count > 1
+        self.isGradingPeriodsSectionVisible = gradingPeriods.count > 0
     }
 
     // MARK: - Functions


### PR DESCRIPTION
## Assignment List Preferences - Grading Period filter behaviour change

refs: MBL-18974
affects: Teacher, Student
release note: None
test plan: See ticket.

If there is only 1 active grading period, we are showing the currently active grading period by default (which is correct), but if there's only 1 grading period for the course then we are not showing the grading period filter options on the preferences screen. This can cause the following problem: If there is a currently active grading period and the user has an assignment outside of that, then it will not be displayed on the assignment list.

Solution requested by product:
Show the assignment filter options even when there is only 1 grading period.

## Test

Account and user for testing the above mentioned scenario is available in the ticket.

## Checklist

- [ ] Tested
