### PR TITLE
Harmonize SpeedGrader and annotation toolbar colors

### DIFF
--- a/Core/Core/Features/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/Features/DocViewer/DocViewerViewController.swift
@@ -184,7 +184,6 @@ public class DocViewerViewController: UIViewController {
 
         if isAnnotatable, metadata?.annotations?.enabled == true {
             let annotationToolbar = DocViewerAnnotationToolbar(annotationStateManager: pdf.annotationStateManager)
-            annotationToolbar.tintColor = Brand.shared.primary
             annotationToolbar.backgroundView = nil
             annotationToolbar.borderedToolbarPositions = []
             annotationToolbar.isDragButtonSelected

--- a/Core/Core/Features/DocViewer/Views/DocViewerAnnotationToolsView.swift
+++ b/Core/Core/Features/DocViewer/Views/DocViewerAnnotationToolsView.swift
@@ -78,7 +78,6 @@ struct DocViewerAnnotationToolsView<AnnotationBar: View>: View {
                 .overlay(
                     buttonIcon
                         .scaledIcon(size: 20)
-                        .foregroundStyle(Brand.shared.primary.asColor)
                         .offset(x: -1, y: 0)
                 )
         }

--- a/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionView.swift
+++ b/Student/Student/Submissions/StudentAnnotationSubmission/StudentAnnotationSubmissionView.swift
@@ -38,6 +38,7 @@ public struct StudentAnnotationSubmissionView: View {
             .alert(item: $viewModel.error) {
                 Alert(title: Text($0.title), message: Text($0.message))
             }
+            .tint(viewModel.navBar.color.asColor)
     }
 
     private var closeButton: some View {

--- a/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/Ratings/RubricCircle.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/Ratings/RubricCircle.swift
@@ -41,10 +41,10 @@ struct RubricCircle<Content: View>: View {
     var body: some View {
         content
             .font(.medium20)
-            .foregroundColor(isOn ? Color(Brand.shared.buttonPrimaryText) : .textDark)
+            .foregroundColor(isOn ? .textLightest : .textDark)
             .frame(minWidth: 48, minHeight: 48, maxHeight: 48)
             .background(isOn ?
-                RoundedRectangle(cornerRadius: 24).fill(Color(Brand.shared.buttonPrimaryBackground)) :
+                RoundedRectangle(cornerRadius: 24).fill(.tint) :
                 nil
             )
             .background(!isOn ?

--- a/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/RubricCriterionView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Rubrics/View/RubricCriterionView.swift
@@ -91,7 +91,6 @@ struct RubricCriterionView: View {
                     label: {
                         Text("Add Comment", bundle: .teacher)
                             .font(.medium14)
-                            .foregroundColor(.accentColor)
                     }
                 )
                 .identifier(viewModel.addCommentButtonA11yID)
@@ -109,7 +108,6 @@ struct RubricCriterionView: View {
                     label: {
                         Text("View Long Description", bundle: .teacher)
                             .font(.medium14)
-                            .foregroundColor(.accentColor)
                     }
                 )
             }

--- a/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
+++ b/Teacher/Teacher/SpeedGrader/MainLayout/View/SubmissionGraderView.swift
@@ -99,6 +99,7 @@ struct SubmissionGraderView: View {
                 landscapeSplitLayoutViewModel.updateScreenWidth(newSize.width)
             }
         }
+        .tint(viewModel.contextColor)
         .clipped()
     }
 
@@ -219,7 +220,6 @@ struct SubmissionGraderView: View {
             ) {
                 tools(bottomInset: bottomInset, isDrawer: true)
             }
-            .tint(viewModel.contextColor)
             .accessibilityAddTraits(drawerState == .max ? .isModal : [])
         }
         .onAppear { didChangeLayout(to: .portrait) }
@@ -377,7 +377,6 @@ struct SubmissionGraderView: View {
             // Clipping won't prevent user interaction so we need to limit it not to swallow touches outside of the drawer.
             .contentShape(Rectangle())
         }
-        .tint(viewModel.contextColor)
     }
 
     private func snapDrawer(to state: DrawerState) {


### PR DESCRIPTION
refs: MBL-18978
affects: Teacher, Student
release note: none

test plan:
- SpeedGrader items should match course color.
- Student annotation toolbar should match course color.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/bb39d870-21f5-4cc0-8971-f53c6a0898df" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/89e730eb-ed2b-4f5a-8f1e-bed343239df2" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/12832fd3-7f4f-4704-9cbd-e85ed5d4f635" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/91b790ba-6e40-48a4-baf5-46dfcc1a78bb" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
