### PR TITLE
Status picker improvements

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/PickerMenu.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/PickerMenu.swift
@@ -123,3 +123,67 @@ extension InstUI {
         }
     }
 }
+
+#if DEBUG
+
+struct PickerMenuPreviews: PreviewProvider {
+    static var previews: some View {
+        @Previewable @State var basicSelection: OptionItem? = OptionItem(
+            id: "option1",
+            title: "Option 1"
+        )
+        @Previewable @State var subtitleSelection: OptionItem? = OptionItem(
+            id: "red",
+            title: "Red",
+            subtitle: "Primary color"
+        )
+        @Previewable @State var iconSelection: OptionItem? = OptionItem(
+            id: "star",
+            title: "Favorite",
+            accessoryIcon: Image(systemName: "star")
+        )
+
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Basic Options")
+            InstUI.PickerMenu(
+                selectedOption: $basicSelection,
+                allOptions: [
+                    OptionItem(id: "option1", title: "Option 1"),
+                    OptionItem(id: "option2", title: "Option 2"),
+                    OptionItem(id: "option3", title: "Option 3")
+                ]
+            ) {
+                Text(basicSelection?.title ?? "Select option")
+            }
+            .padding(.bottom, 20)
+
+            Text("With Subtitles")
+            InstUI.PickerMenu(
+                selectedOption: $subtitleSelection,
+                allOptions: [
+                    OptionItem(id: "red", title: "Red", subtitle: "Primary color"),
+                    OptionItem(id: "blue", title: "Blue", subtitle: "Cool color"),
+                    OptionItem(id: "green", title: "Green", subtitle: "Nature color")
+                ]
+            ) {
+                Text(subtitleSelection?.title ?? "Select option")
+            }
+            .padding(.bottom, 20)
+
+            Text("With Icons")
+            InstUI.PickerMenu(
+                selectedOption: $iconSelection,
+                allOptions: [
+                    OptionItem(id: "star", title: "Favorite", accessoryIcon: Image(systemName: "star")),
+                    OptionItem(id: "heart", title: "Love", accessoryIcon: Image(systemName: "heart")),
+                    OptionItem(id: "bookmark", title: "Saved", accessoryIcon: Image(systemName: "bookmark"))
+                ]
+            ) {
+                Text(iconSelection?.title ?? "Select option")
+            }
+            .padding(.bottom, 20)
+        }
+    }
+}
+
+#endif

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
@@ -71,8 +71,22 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
             .map { $0.body }
             .map { [weak self] response in
                 let defaults = response.defaultGradeStatuses.map { GradeStatus(defaultStatusId: $0) }
-                let custom = response.customGradeStatuses.map { GradeStatus(userDefinedName: $0.name, id: $0.id) }
-                self?.gradeStatuses = defaults + custom
+                let custom = response.customGradeStatuses.map { GradeStatus(userDefinedName: $0.name, id: $0.id) }                
+                var sortedStatuses: [GradeStatus] = []
+                
+                // Add "None" first if it exists
+                if let noneStatus = defaults.first(where: { $0 == .none }) {
+                    sortedStatuses.append(noneStatus)
+                }
+                
+                // Add remaining standard statuses in API order
+                let remainingDefaults = defaults.filter { $0 != .none }
+                sortedStatuses.append(contentsOf: remainingDefaults)
+                
+                // Add custom statuses in API order
+                sortedStatuses.append(contentsOf: custom)
+                
+                self?.gradeStatuses = sortedStatuses
             }
             .eraseToAnyPublisher()
     }

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusView.swift
@@ -78,7 +78,7 @@ struct GradeStatusView: View {
             allOptions: viewModel.options,
             identifierGroup: "SpeedGrader.GradeStatusMenuItem",
             label: {
-                Text(viewModel.selectedOption.title)
+                Text(viewModel.shouldHideSelectedOptionTitle ? "" : viewModel.selectedOption.title)
                     .font(.regular14, lineHeight: .fit)
                 Image.chevronDown
                     .scaledIcon(size: 24)

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusView.swift
@@ -28,9 +28,15 @@ struct GradeStatusView: View {
         VStack(spacing: 0) {
             statusPickerCell
                 .identifier("SpeedGrader.statusPicker")
+                .zIndex(1)
 
             if viewModel.isShowingDaysLateSection {
                 GradeStatusDaysLateView(viewModel: viewModel)
+                    .transition(.asymmetric(
+                        insertion: .push(from: .top),
+                        removal: .push(from: .bottom)
+                    ))
+                    .zIndex(0)
                     .identifier("SpeedGrader.DaysLateButton")
             }
         }
@@ -43,11 +49,16 @@ struct GradeStatusView: View {
                 .font(.semibold16, lineHeight: .fit)
                 .foregroundColor(Color.textDarkest)
                 .frame(maxWidth: .infinity, alignment: .leading)
-            if viewModel.isLoading {
-                ProgressView().tint(nil)
-            } else {
+            // The loading and the data state have different heights, so we use a ZStack to
+            // keep both of them on screen ensuring the cell's constant height.
+            ZStack(alignment: .trailing) {
+                ProgressView()
+                    .tint(nil)
+                    .opacity(viewModel.isLoading ? 1 : 0)
                 statusDropDown
+                    .opacity(viewModel.isLoading ? 0 : 1)
             }
+            .animation(.none, value: viewModel.isLoading)
         }
         .paddingStyle(set: .standardCell)
         .background(Color.backgroundLightest)
@@ -77,6 +88,7 @@ struct GradeStatusView: View {
             isPresented: $viewModel.isShowingSaveFailedAlert,
             presenting: viewModel.errorAlertViewModel
         )
+        .animation(.none, value: viewModel.selectedOption.title)
     }
 }
 
@@ -98,6 +110,7 @@ struct GradeStatusView: View {
                 interactor: GradeStatusInteractorPreview(gradeStatuses: statuses)
             )
         )
+        .frame(maxHeight: .infinity, alignment: .top)
     }
 }
 

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModel.swift
@@ -23,7 +23,12 @@ import SwiftUI
 
 class GradeStatusViewModel: ObservableObject {
     // MARK: - Outputs
-    @Published private(set) var selectedOption: OptionItem
+    @Published private(set) var selectedOption: OptionItem {
+        didSet {
+            shouldHideSelectedOptionTitle = (selectedOption.id == GradeStatus.none.id)
+        }
+    }
+    @Published private(set) var shouldHideSelectedOptionTitle: Bool
     @Published private(set) var isLoading: Bool = false
     @Published private(set) var isShowingDaysLateSection: Bool = false
     @Published private(set) var daysLate: String = ""
@@ -62,6 +67,7 @@ class GradeStatusViewModel: ObservableObject {
         self.userId = userId
         // Placeholder until we read the actual status from the database.
         self.selectedOption = .from(.none)
+        self.shouldHideSelectedOptionTitle = true
 
         // If we receive no statuses from the API we fall back to the none status
         options = (interactor.gradeStatuses.nilIfEmpty ?? [.none])

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModel.swift
@@ -72,7 +72,6 @@ class GradeStatusViewModel: ObservableObject {
         // If we receive no statuses from the API we fall back to the none status
         options = (interactor.gradeStatuses.nilIfEmpty ?? [.none])
             .map { OptionItem.from($0) }
-            .sorted { $0.title < $1.title }
 
         uploadGradeStatus(on: didSelectGradeStatus)
         observeGradeStatusOnAttemptInDatabase(on: didChangeAttempt)

--- a/Teacher/Teacher/SpeedGrader/Grading/Points/View/SubmissionGrades.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/View/SubmissionGrades.swift
@@ -76,7 +76,7 @@ struct SubmissionGrades: View {
                                         final: false
                                     ))
                                 } else {
-                                    Image.addSolid.foregroundColor(Color(Brand.shared.linkColor))
+                                    Image.addSolid.foregroundStyle(.tint)
                                 }
                             })
                             .accessibility(hint: Text("Prompts for an updated grade", bundle: .teacher))

--- a/Teacher/Teacher/SpeedGrader/Grading/Points/View/SubmissionGrades.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/View/SubmissionGrades.swift
@@ -122,6 +122,8 @@ struct SubmissionGrades: View {
                     }
                 }.padding(.bottom, 16)
             } }
+            .animation(.smooth, value: gradeStatusViewModel.isShowingDaysLateSection)
+
             if rubricsViewModel.commentingOnCriterionID != nil {
                 commentEditor()
             }

--- a/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModelTests.swift
@@ -127,6 +127,31 @@ class GradeStatusViewModelTests: TeacherTestCase {
         }
     }
 
+    func test_didSelectGradeStatus_hidesNoneOptionTitle() {
+        let interactor = GradeStatusInteractorMock()
+        interactor.gradeStatuses = [
+            GradeStatus(defaultStatusId: "none"),
+            GradeStatus(defaultStatusId: "excused")
+        ]
+        let testee = makeViewModel(interactor: interactor)
+        XCTAssertEqual(testee.selectedOption.id, "none")
+        XCTAssertEqual(testee.shouldHideSelectedOptionTitle, true)
+
+        // WHEN
+        testee.didSelectGradeStatus.send(.init(id: "excused", title: ""))
+
+        // THEN
+        waitUntil(shouldFail: true) { testee.selectedOption.id == "excused" }
+        XCTAssertEqual(testee.shouldHideSelectedOptionTitle, false)
+
+        // WHEN
+        testee.didSelectGradeStatus.send(.init(id: "none", title: ""))
+
+        // THEN
+        waitUntil(shouldFail: true) { testee.selectedOption.id == "none" }
+        XCTAssertEqual(testee.shouldHideSelectedOptionTitle, true)
+    }
+
     func test_didChangeLateDaysValue_triggersUpdateLateDays() {
         let interactorMock = GradeStatusInteractorMock()
         let testee = makeViewModel(interactor: interactorMock)

--- a/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/ViewModel/GradeStatusViewModelTests.swift
@@ -31,14 +31,14 @@ class GradeStatusViewModelTests: TeacherTestCase {
         XCTAssertEqual(testee.selectedOption.id, "none")
     }
 
-    func test_options_sorted_optionsMatchInteractor() {
+    func test_optionsOrder_matchInteractorOrder() {
         let interactor = GradeStatusInteractorMock()
         interactor.gradeStatuses = [
             GradeStatus(defaultStatusId: "Bravo"),
             GradeStatus(defaultStatusId: "Alpha")
         ]
         let testee = makeViewModel(interactor: interactor)
-        XCTAssertEqual(testee.options.map { $0.title }, ["Alpha", "Bravo"])
+        XCTAssertEqual(testee.options.map { $0.title }, ["Bravo", "Alpha"])
     }
 
     func test_didSelectGradeStatus_triggersUpdateAndSetsSelected() {


### PR DESCRIPTION
refs: MBL-18986
affects: Teacher
release note: none

test plan:
- "None" grade status shouldn't be displayed next to the dropdown icon.
- The order of grade statuses in the menu should be: none, default statuses, custom statuses, keeping API order within these groups. As I see this matches the web order of statuses (except none).
- The animation of the late days row appearance/disappearance should be better.
- Status row's height shouldn't change when changing between loading and data states.

### + Chores
- Applied the tint color for the grade's + icon
- Added previews for InsUI.Picker. I played around with it looking for customization options and kept the previews for future.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/f3de5fd5-f1d8-42c3-8f44-37347094ceea" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/b0ba9815-780a-4041-bd24-b2a7c01eb301" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/2d857dfa-a09a-4184-a6f8-24bfefd2dbe1" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/04de3c33-b3dd-45ac-bb86-004eeebb7cab" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
