### PR TITLE
Sync students order in SpeedGrader with that shown in Submissions list

### DIFF
--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -439,6 +439,21 @@ extension Submission {
     }
 }
 
+extension Submission: Comparable {
+
+    /// This nearly matching ordering used in GetSubmissions use case.
+    public static func < (lhs: Submission, rhs: Submission) -> Bool {
+        let lhsSortableName = lhs.sortableName ?? lhs.user?.sortableName
+        let rhsSortableName = rhs.sortableName ?? rhs.user?.sortableName
+
+        if let name1 = lhsSortableName, let name2 = rhsSortableName {
+            return name1 < name2
+        }
+
+        return lhs.userID < rhs.userID
+    }
+}
+
 /// This is merely used to properly describe the state of submission in certain contexts.
 /// It is not strictly matching `SubmissionStatus` in all cases. And it is not
 /// meant to replace status cases, or be used in all related areas of the apps.

--- a/Teacher/Teacher/Routes.swift
+++ b/Teacher/Teacher/Routes.swift
@@ -199,12 +199,16 @@ let router = Router(routes: [
         )
     },
 
-    RouteHandler("/courses/:courseID/assignments/:assignmentID/submissions/:userID") { url, params, _, env in
+    RouteHandler("/courses/:courseID/assignments/:assignmentID/submissions/:userID") { url, params, userInfo, env in
         guard
             let context = Context(path: url.path),
             let assignmentId = params["assignmentID"],
             let userId = params["userID"]
         else { return nil }
+
+        let sortNeedsGradingFirst = (
+            userInfo?[SpeedGraderUserInfoKey.sortNeedsGradingSubmissionsFirst] as? Bool
+        ) ?? false
 
         let filter = url
             .queryValue(for: "filter")?
@@ -217,7 +221,7 @@ let router = Router(routes: [
             assignmentId: assignmentId,
             userId: userId,
             filter: filter,
-            sortNeedsGradingSubmissionsFirst: false,
+            sortNeedsGradingSubmissionsFirst: sortNeedsGradingFirst,
             env: env
         )
     },

--- a/Teacher/Teacher/SpeedGrader/StudentPager/Model/SpeedGraderInteractorLive.swift
+++ b/Teacher/Teacher/SpeedGrader/StudentPager/Model/SpeedGraderInteractorLive.swift
@@ -182,16 +182,30 @@ public enum SpeedGraderUserInfoKey {
 private extension SpeedGraderInteractorLive {
 
     static let needsGradingFirstSortingStrategy: (Submission, Submission) -> Bool = { sub1, sub2 in
-        /// Put 'Needs Grading' first
-        if sub1.needsGrading != sub2.needsGrading {
-            return sub1.needsGrading
-        }
+        let sub1KindOrder = sub1.listSectionKind.order
+        let sub2KindOrder = sub2.listSectionKind.order
 
-        /// Put 'Graded' last
-        if sub1.isGraded != sub2.isGraded {
-            return sub2.isGraded
+        if sub1KindOrder != sub2KindOrder {
+            return sub1KindOrder < sub2KindOrder
+        } else {
+            // This is to match ordering of submission as
+            // they are being fetched to submission list
+            // via GetSubmissions use case.
+            return sub1 < sub2
         }
+    }
+}
 
-        return false
+// MARK: Sorting Helper Extensions
+
+private extension SubmissionListSection.Kind {
+    var order: Int { return Self.allCases.firstIndex(of: self) ?? -1 }
+}
+
+private extension Submission {
+    var listSectionKind: SubmissionListSection.Kind {
+        SubmissionListSection.Kind
+            .allCases
+            .first(where: { $0.filter(self) }) ?? .others
     }
 }

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -167,6 +167,7 @@ class SubmissionListViewModel: ObservableObject {
         let query = filterMode == .all ? "" : "?filter=\(filterMode.filters.map { $0.rawValue }.joined(separator: ","))"
         env.router.route(
             to: assignmentRoute + "/submissions/\(submission.originalUserID)\(query)",
+            userInfo: [SpeedGraderUserInfoKey.sortNeedsGradingSubmissionsFirst: true],
             from: controller.value,
             options: .modal(.fullScreen, isDismissable: false, embedInNav: true)
         )


### PR DESCRIPTION
refs: MBL-18890
affects: Teacher
release note: Fixed student ordering in SpeedGrader to match that used in submissions list.

## Test Plan

By opening SpeedGrader in Teacher app, either by;
1. Tapping on SpeedGrader button at the navigation bar of Assignment Details screen
2. Tapping on any user shown on the submissions lists.
Students order as you navigate through it now must match the order used in Submissions list.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
