### PR TITLE
Fix grade status not being cleared in SpeedGrader

### DIFF
--- a/Core/CoreTests/Common/CommonModels/BackgroundActivity/BackgroundActivityTests.swift
+++ b/Core/CoreTests/Common/CommonModels/BackgroundActivity/BackgroundActivityTests.swift
@@ -134,8 +134,9 @@ class BackgroundActivityTests: XCTestCase {
 
         // MARK: - THEN
         waitForExpectations(timeout: 1)
-        drainMainQueue()
-        XCTAssertFalse(mockProcessManager.isExecutingBackgroundBlock)
+        waitUntil(shouldFail: true) {
+            mockProcessManager.isExecutingBackgroundBlock == false
+        }
     }
 
     func testMultipleStartRequestOnlyOneBackgroundSession() {

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		B4D8E5382C773F3E0001A506 /* FirebaseRemoteConfigSwift in Frameworks */ = {isa = PBXBuildFile; productRef = B4D8E5372C773F3E0001A506 /* FirebaseRemoteConfigSwift */; };
 		B4DAD5362D84566E005F9CD5 /* Pendo in Frameworks */ = {isa = PBXBuildFile; productRef = B4DAD5352D84566E005F9CD5 /* Pendo */; };
 		CF04D3162BC5714F009D8C86 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = CF04D3152BC5714F009D8C86 /* PrivacyInfo.xcprivacy */; };
+		CF05D8622E1E561E00F98B90 /* CommentLibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05D8612E1E561E00F98B90 /* CommentLibraryScreen.swift */; };
+		CF05D8642E1E563400F98B90 /* CommentLibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF05D8632E1E563400F98B90 /* CommentLibraryViewModelTests.swift */; };
 		CF0605E32D95C5A50014C2EC /* RubricCircle.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0605E22D95C5A00014C2EC /* RubricCircle.swift */; };
 		CF06060C2D96EA100014C2EC /* RubricCriterionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF06060B2D96EA100014C2EC /* RubricCriterionView.swift */; };
 		CF0606122D9A9A990014C2EC /* RubricsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF0606112D9A9A950014C2EC /* RubricsViewModel.swift */; };
@@ -188,10 +190,8 @@
 		E841D8B123D6472F00685A63 /* Core.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D3DA83821876142000D828F /* Core.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		E841D8B423D6472F00685A63 /* TestsFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = B15CA26C221DDEB40014FB02 /* TestsFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		EB12071F2601F2C50038E875 /* GradeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB12071E2601F2C50038E875 /* GradeSlider.swift */; };
-		EB35BC5427BA4DF500166F0D /* CommentLibraryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB35BC5327BA4DF500166F0D /* CommentLibraryViewModelTests.swift */; };
 		EB71A24E261206CA0003241C /* GradeSliderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB71A24D261206CA0003241C /* GradeSliderTests.swift */; };
 		EBAF32F627AACFC9000ACD32 /* CommentLibraryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBAF32F527AACFC9000ACD32 /* CommentLibraryViewModel.swift */; };
-		EBE802AF27B41C5F0003A663 /* CommentLibraryScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBE802AE27B41C5F0003A663 /* CommentLibraryScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -376,6 +376,8 @@
 		B43562162C77486A00402DAE /* Core.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Core.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B4707B042B1DDF7900F67CA8 /* SubmissionCommentListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListViewModel.swift; sourceTree = "<group>"; };
 		CF04D3152BC5714F009D8C86 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		CF05D8612E1E561E00F98B90 /* CommentLibraryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentLibraryScreen.swift; sourceTree = "<group>"; };
+		CF05D8632E1E563400F98B90 /* CommentLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentLibraryViewModelTests.swift; sourceTree = "<group>"; };
 		CF0605E22D95C5A00014C2EC /* RubricCircle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricCircle.swift; sourceTree = "<group>"; };
 		CF06060B2D96EA100014C2EC /* RubricCriterionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricCriterionView.swift; sourceTree = "<group>"; };
 		CF0606112D9A9A950014C2EC /* RubricsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RubricsViewModel.swift; sourceTree = "<group>"; };
@@ -445,10 +447,8 @@
 		E841D8BA23D6472F00685A63 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		E8F6CFFE23045A01004347D9 /* CoreUITests.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CoreUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB12071E2601F2C50038E875 /* GradeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSlider.swift; sourceTree = "<group>"; };
-		EB35BC5327BA4DF500166F0D /* CommentLibraryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentLibraryViewModelTests.swift; sourceTree = "<group>"; };
 		EB71A24D261206CA0003241C /* GradeSliderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GradeSliderTests.swift; sourceTree = "<group>"; };
 		EBAF32F527AACFC9000ACD32 /* CommentLibraryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentLibraryViewModel.swift; sourceTree = "<group>"; };
-		EBE802AE27B41C5F0003A663 /* CommentLibraryScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentLibraryScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -975,7 +975,7 @@
 		CF0605CC2D95A5270014C2EC /* View */ = {
 			isa = PBXGroup;
 			children = (
-				EBE802AE27B41C5F0003A663 /* CommentLibraryScreen.swift */,
+				CF05D8612E1E561E00F98B90 /* CommentLibraryScreen.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1192,7 +1192,7 @@
 		CF0606032D96E4A00014C2EC /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
-				EB35BC5327BA4DF500166F0D /* CommentLibraryViewModelTests.swift */,
+				CF05D8632E1E563400F98B90 /* CommentLibraryViewModelTests.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1875,10 +1875,9 @@
 				7D64A96423620A27004EAEDF /* StatusCell.swift in Sources */,
 				3B18E82B230C683D006CAF5C /* PostGradesPresenter.swift in Sources */,
 				7D64A96123620A27004EAEDF /* DatePickerViewController.swift in Sources */,
+				CF05D8622E1E561E00F98B90 /* CommentLibraryScreen.swift in Sources */,
 				CF0606122D9A9A990014C2EC /* RubricsViewModel.swift in Sources */,
-				EBE802AF27B41C5F0003A663 /* CommentLibrarySheet.swift in Sources */,
 				CFF4AAA52DFAB93000B0351F /* GradeStatusInteractor.swift in Sources */,
-				EBE802AF27B41C5F0003A663 /* CommentLibraryScreen.swift in Sources */,
 				494AE0B91F843CB5001A8F31 /* TeacherTabBarController.swift in Sources */,
 				CFCADAEA2D9BE21F003796E7 /* RubricCriterionViewModel.swift in Sources */,
 				7D7D6D5225102052002B1485 /* SubmissionGraderView.swift in Sources */,
@@ -1915,9 +1914,7 @@
 				D9624A7E29C4AEF000F5303F /* QuizSubmissionListItemTests.swift in Sources */,
 				D9B4850029CCA8090004EBB5 /* QuizSubmissionListInteractorLiveTests.swift in Sources */,
 				7D64A983236796CC004EAEDF /* AttendanceStatusControllerTests.swift in Sources */,
-				EB35BC5427BA4DF500166F0D /* SubmissionCommentLibraryViewModelTests.swift in Sources */,
 				CFFEADB62E01B90F00277F69 /* GradeStatusInteractorMock.swift in Sources */,
-				EB35BC5427BA4DF500166F0D /* CommentLibraryViewModelTests.swift in Sources */,
 				CF0F18922DC0E7EC0054D21A /* SpeedGraderInteractorLiveTests.swift in Sources */,
 				D9B484FE29CC91A70004EBB5 /* QuizSubmissionViewModelTests.swift in Sources */,
 				D9B4851E29CDED990004EBB5 /* QuizSubmissionListFilterTests.swift in Sources */,
@@ -1939,6 +1936,7 @@
 				CF0F18942DC10DF20054D21A /* SpeedGraderViewModelTests.swift in Sources */,
 				B417C2E62B1F169000CD6FA4 /* SubmissionCommentListViewModelTests.swift in Sources */,
 				CFFEADDC2E09B05300277F69 /* UpdateSubmissionGradeStatusTests.swift in Sources */,
+				CF05D8642E1E563400F98B90 /* CommentLibraryViewModelTests.swift in Sources */,
 				7D64A9872368C6C0004EAEDF /* AttendanceViewControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorPreview.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorPreview.swift
@@ -57,8 +57,8 @@ class GradeStatusInteractorPreview: GradeStatusInteractor {
         latePolicyStatus: Core.LatePolicyStatus?,
         isExcused: Bool?,
         isLate: Bool?
-    ) -> GradeStatus? {
-        nil
+    ) -> GradeStatus {
+        .none
     }
 
     func observeGradeStatusChanges(submissionId: String, attempt: Int) -> AnyPublisher<(GradeStatus, daysLate: Int, dueDate: Date?), Never> {

--- a/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorMock.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorMock.swift
@@ -51,8 +51,8 @@ final class GradeStatusInteractorMock: GradeStatusInteractor {
         latePolicyStatus: LatePolicyStatus?,
         isExcused: Bool?,
         isLate: Bool?
-    ) -> GradeStatus? {
-        return gradeStatuses.first
+    ) -> GradeStatus {
+        return gradeStatuses.first ?? .none
     }
 
     var observeGradeStatusChangesCalled = false

--- a/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorTests.swift
@@ -52,7 +52,7 @@ class GradeStatusInteractorTests: TeacherTestCase {
             isExcused: nil,
             isLate: nil
         )
-        XCTAssertEqual(custom?.id, "custom1")
+        XCTAssertEqual(custom.id, "custom1")
 
         let excused = testee.gradeStatusFor(
             customGradeStatusId: nil,
@@ -60,7 +60,7 @@ class GradeStatusInteractorTests: TeacherTestCase {
             isExcused: true,
             isLate: nil
         )
-        XCTAssertEqual(excused?.id, "excused")
+        XCTAssertEqual(excused.id, "excused")
 
         let late = testee.gradeStatusFor(
             customGradeStatusId: nil,
@@ -68,15 +68,15 @@ class GradeStatusInteractorTests: TeacherTestCase {
             isExcused: nil,
             isLate: nil
         )
-        XCTAssertEqual(late?.id, "late")
+        XCTAssertEqual(late.id, "late")
 
-        let notFound = testee.gradeStatusFor(
+        let noStatusGiven = testee.gradeStatusFor(
             customGradeStatusId: nil,
             latePolicyStatus: nil,
             isExcused: nil,
             isLate: nil
         )
-        XCTAssertNil(notFound)
+        XCTAssertEqual(noStatusGiven, .none)
 
         let lateByIsLate = testee.gradeStatusFor(
             customGradeStatusId: nil,
@@ -84,7 +84,7 @@ class GradeStatusInteractorTests: TeacherTestCase {
             isExcused: nil,
             isLate: true
         )
-        XCTAssertEqual(lateByIsLate?.id, "late")
+        XCTAssertEqual(lateByIsLate.id, "late")
     }
 
     func test_observeGradeStatusChanges_emits() {


### PR DESCRIPTION
I changed the grade status lookup to always return a value. This fixes the issue when no status is given for a submission and also offers a better fallback in case the lookup fails because the status will show nothing instead of an invalid state.

refs: [MBL-18994](https://instructure.atlassian.net/browse/MBL-18994)
affects: Teacher
release note: Fixed grade status not being cleared in some cases in SpeedGrader.

test plan:
- In SpeedGrader set a submissions’s grade status to Excused.
- Tap on the “Excused“ grade title and in the alert tap “No Grade“.
- Grade status should clear “Excused“ state.

### Chore
- I fixed the duplicate file warning in the teacher project.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/10cb06ce-5c3e-4ca0-9b5c-72a45a41a383" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/26f41f94-126d-43c5-b5ea-85ff74590948" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-18994]: https://instructure.atlassian.net/browse/MBL-18994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ