### PR TITLE
SpeedGrader - Extract Tabs view from Page view

### DIFF
--- a/Core/Core/Common/CommonUI/SwiftUIViews/View+MeasuringSize.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/View+MeasuringSize.swift
@@ -66,4 +66,20 @@ extension View {
             binding.wrappedValue = size
         }
     }
+
+    public func onHeightChange(_ perform: @escaping (CGFloat) -> Void) -> some View {
+        onGeometryChange(for: CGFloat.self) { geometry in
+            geometry.size.height
+        } action: { height in
+            perform(height)
+        }
+    }
+
+    public func onHeightChange(update binding: Binding<CGFloat>) -> some View {
+        onGeometryChange(for: CGFloat.self) { geometry in
+            geometry.size.height
+        } action: { height in
+            binding.wrappedValue = height
+        }
+    }
 }

--- a/Teacher/Teacher.xcodeproj/project.pbxproj
+++ b/Teacher/Teacher.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		5B1C85922DE4F0EA00DB7D03 /* CommentInputView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1C85912DE4F0E000DB7D03 /* CommentInputView.swift */; };
 		5B1E28662DC0C47000540B3D /* SubmissionCommentListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */; };
 		5B4F3E602DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4F3E5F2DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift */; };
+		5B95A3382E20F74900022E70 /* SpeedGraderPageTabsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B95A3372E20F74000022E70 /* SpeedGraderPageTabsView.swift */; };
+		5B95A33C2E210DC500022E70 /* SpeedGraderPageTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B95A33B2E210DC500022E70 /* SpeedGraderPageTab.swift */; };
 		5B9C5C072DB9B04000103E21 /* SubmissionCommentsAssembly.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */; };
 		5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */; };
 		5BDD37D72DEF293700C8B7AD /* SpeedGraderPageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BDD37D62DEF293700C8B7AD /* SpeedGraderPageViewModelTests.swift */; };
@@ -302,6 +304,8 @@
 		5B1C85912DE4F0E000DB7D03 /* CommentInputView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommentInputView.swift; sourceTree = "<group>"; };
 		5B1E28652DC0C46C00540B3D /* SubmissionCommentListCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListCellViewModel.swift; sourceTree = "<group>"; };
 		5B4F3E5F2DC8B169001A9126 /* SubmissionCommentListCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentListCellViewModelTests.swift; sourceTree = "<group>"; };
+		5B95A3372E20F74000022E70 /* SpeedGraderPageTabsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderPageTabsView.swift; sourceTree = "<group>"; };
+		5B95A33B2E210DC500022E70 /* SpeedGraderPageTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderPageTab.swift; sourceTree = "<group>"; };
 		5B9C5C062DB9B03A00103E21 /* SubmissionCommentsAssembly.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsAssembly.swift; sourceTree = "<group>"; };
 		5BB37BC12DB90F270096821B /* SubmissionCommentsInteractor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubmissionCommentsInteractor.swift; sourceTree = "<group>"; };
 		5BDD37D62DEF293700C8B7AD /* SpeedGraderPageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeedGraderPageViewModelTests.swift; sourceTree = "<group>"; };
@@ -1099,8 +1103,9 @@
 			children = (
 				7D7126B02534B980000DEDE4 /* DrawerContainer.swift */,
 				7D264DC62537A6E1007CDD90 /* SimilarityScoreView.swift */,
-				7D7D6D5125102052002B1485 /* SpeedGraderPageView.swift */,
 				7D0A28E1251A8284004FB3B6 /* SpeedGraderPageHeaderView.swift */,
+				5B95A3372E20F74000022E70 /* SpeedGraderPageTabsView.swift */,
+				7D7D6D5125102052002B1485 /* SpeedGraderPageView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1231,6 +1236,7 @@
 				CF45B9F12DF2F71600BD9E41 /* SpeedGraderPageHeaderViewModel.swift */,
 				CF27D8A62DCCA379009E2057 /* SpeedGraderPageLandscapeSplitLayoutViewModel.swift */,
 				CF0E06932DA8FFC4007AC131 /* SpeedGraderPageViewModel.swift */,
+				5B95A33B2E210DC500022E70 /* SpeedGraderPageTab.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -1859,10 +1865,12 @@
 				5BB37BC22DB90F300096821B /* SubmissionCommentsInteractor.swift in Sources */,
 				61BD85FC1EB2933C005A09A5 /* TeacherAppDelegate.swift in Sources */,
 				D91C051D29AE10170032BFB1 /* QuizSubmissionListItemView.swift in Sources */,
+				5B95A33C2E210DC500022E70 /* SpeedGraderPageTab.swift in Sources */,
 				0856FCD42DB64FE8009067CF /* SubmissionListRowView.swift in Sources */,
 				CF45B9F22DF2F71800BD9E41 /* SpeedGraderPageHeaderViewModel.swift in Sources */,
 				0856FCF42DC76144009067CF /* SubmissionsFilterScreen.swift in Sources */,
 				0856FD022DCB09F5009067CF /* SubmissionListSection.swift in Sources */,
+				5B95A3382E20F74900022E70 /* SpeedGraderPageTabsView.swift in Sources */,
 				0856FCD62DB6583C009067CF /* SubmissionListAssembly.swift in Sources */,
 				0856FD002DCB09D6009067CF /* SubmissionListItem.swift in Sources */,
 				CF1247262DB012B700EB10F6 /* SpeedGraderScreenViewModel.swift in Sources */,

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -35,18 +35,18 @@ struct SubmissionCommentListView: View {
     @State private var isVideoRecorderVisible: Bool = false
     private let avPermissionViewModel: AVPermissionViewModel = .init()
 
-    @AccessibilityFocusState private var focusedTab: SpeedGraderPageTab?
+    @AccessibilityFocusState private var a11yFocusedTab: SpeedGraderPageTab?
 
     init(
         viewModel: SubmissionCommentListViewModel,
         attempt: Binding<Int>,
         fileID: Binding<String?>,
-        focusedTab: AccessibilityFocusState<SpeedGraderPageTab?>
+        a11yFocusedTab: AccessibilityFocusState<SpeedGraderPageTab?>
     ) {
         self.viewModel = viewModel
         self._attempt = attempt
         self._fileID = fileID
-        self._focusedTab = focusedTab
+        self._a11yFocusedTab = a11yFocusedTab
     }
 
     var body: some View {
@@ -112,7 +112,7 @@ struct SubmissionCommentListView: View {
             },
             sendAction: sendComment
         )
-        .accessibilityFocused($focusedTab, equals: .comments)
+        .accessibilityFocused($a11yFocusedTab, equals: .comments)
     }
 
     func sendComment() {

--- a/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/SubmissionCommentListView.swift
@@ -35,13 +35,13 @@ struct SubmissionCommentListView: View {
     @State private var isVideoRecorderVisible: Bool = false
     private let avPermissionViewModel: AVPermissionViewModel = .init()
 
-    @AccessibilityFocusState private var focusedTab: SpeedGraderPageView.GraderTab?
+    @AccessibilityFocusState private var focusedTab: SpeedGraderPageTab?
 
     init(
         viewModel: SubmissionCommentListViewModel,
         attempt: Binding<Int>,
         fileID: Binding<String?>,
-        focusedTab: AccessibilityFocusState<SpeedGraderPageView.GraderTab?>
+        focusedTab: AccessibilityFocusState<SpeedGraderPageTab?>
     ) {
         self.viewModel = viewModel
         self._attempt = attempt

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/DrawerContainer.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/DrawerContainer.swift
@@ -22,6 +22,11 @@ import Core
 enum DrawerState {
     case min, mid, max
     static let transaction = Transaction.exclusive(.easeInOut)
+
+    var isClosed: Bool { self == .min }
+    var isOpen: Bool { self != .min }
+    var isHalfOpen: Bool { self == .mid }
+    var isFullyOpen: Bool { self == .max }
 }
 
 // Place after the main content in a ZStack(alignment: .bottom)

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
@@ -74,19 +74,21 @@ struct SpeedGraderPageTabsView: View {
                 case .drawer:
                     tabPicker
                         .padding(.bottom, 16)
-                        .onChange(of: selectedTab) {
-                            if drawerState.isClosed { snapDrawer(to: .mid) }
-                            controller.view.endEditing(true)
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                                focusedTab = selectedTab
-                            }
-                        }
                 case .splitView:
                     tabPicker
                         .frame(height: splitViewHeaderHeight)
                 }
             }
             .padding(.horizontal, 16)
+            .onChange(of: selectedTab) {
+                if drawerState.isClosed {
+                    snapDrawer(to: .mid)
+                }
+                controller.view.endEditing(true)
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    focusedTab = selectedTab
+                }
+            }
             .identifier("SpeedGrader.toolPicker")
 
             InstUI.Divider()

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
@@ -34,7 +34,7 @@ struct SpeedGraderPageTabsView: View {
     private let bottomInset: CGFloat
 
     @Binding private var selectedTab: SpeedGraderPageTab
-    @AccessibilityFocusState private var focusedTab: SpeedGraderPageTab?
+    @AccessibilityFocusState private var a11yFocusedTab: SpeedGraderPageTab?
     @Binding private var drawerState: DrawerState
     @Binding private var splitViewHeaderHeight: CGFloat
 
@@ -45,7 +45,7 @@ struct SpeedGraderPageTabsView: View {
         containerType: ContainerType,
         bottomInset: CGFloat,
         selectedTab: Binding<SpeedGraderPageTab>,
-        focusedTab: AccessibilityFocusState<SpeedGraderPageTab?>,
+        a11yFocusedTab: AccessibilityFocusState<SpeedGraderPageTab?>,
         drawerState: Binding<DrawerState>,
         splitViewHeaderHeight: Binding<CGFloat>,
         viewModel: SpeedGraderPageViewModel
@@ -53,7 +53,7 @@ struct SpeedGraderPageTabsView: View {
         self.containerType = containerType
         self.bottomInset = bottomInset
         self._selectedTab = selectedTab
-        self._focusedTab = focusedTab
+        self._a11yFocusedTab = a11yFocusedTab
         self._drawerState = drawerState
         self._splitViewHeaderHeight = splitViewHeaderHeight
 
@@ -86,7 +86,7 @@ struct SpeedGraderPageTabsView: View {
                 }
                 controller.view.endEditing(true)
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                    focusedTab = selectedTab
+                    a11yFocusedTab = selectedTab
                 }
             }
             .identifier("SpeedGrader.toolPicker")
@@ -170,7 +170,7 @@ struct SpeedGraderPageTabsView: View {
         .frame(width: geometry.size.width, height: geometry.size.height)
         .accessibilityElement(children: isGradesOnScreen ? .contain : .ignore)
         .accessibility(hidden: !isGradesOnScreen)
-        .accessibilityFocused($focusedTab, equals: .grades)
+        .accessibilityFocused($a11yFocusedTab, equals: .grades)
     }
 
     @ViewBuilder
@@ -193,7 +193,7 @@ struct SpeedGraderPageTabsView: View {
                 viewModel: viewModel.commentListViewModel,
                 attempt: drawerAttempt,
                 fileID: fileID,
-                focusedTab: _focusedTab
+                a11yFocusedTab: _a11yFocusedTab
             )
             .clipped()
             if drawerState.isClosed {

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
@@ -1,0 +1,206 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import Foundation
+import SwiftUI
+
+struct SpeedGraderPageTabsView: View {
+
+    private let bottomInset: CGFloat
+    private let isDrawer: Bool
+    /// Used to match landscape drawer's segmented control height with the header height.
+
+    @Environment(\.viewController) private var controller
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    @Binding private var tab: SpeedGraderPageTab
+    @Binding private var drawerState: DrawerState
+    @Binding private var profileHeaderSize: CGSize
+
+    @AccessibilityFocusState private var focusedTab: SpeedGraderPageTab?
+
+    @StateObject private var rubricsViewModel: RubricsViewModel
+    @StateObject private var viewModel: SpeedGraderPageViewModel
+
+    init(
+        tab: Binding<SpeedGraderPageTab>,
+        drawerState: Binding<DrawerState>,
+        bottomInset: CGFloat,
+        isDrawer: Bool,
+        profileHeaderSize: Binding<CGSize>,
+        viewModel: SpeedGraderPageViewModel
+    ) {
+        self._tab = tab
+        self._drawerState = drawerState
+        self.bottomInset = bottomInset
+        self.isDrawer = isDrawer
+        self._profileHeaderSize = profileHeaderSize
+
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        _rubricsViewModel = StateObject(wrappedValue:
+                                            RubricsViewModel(
+                                                assignment: viewModel.assignment,
+                                                submission: viewModel.submission,
+                                                interactor: RubricGradingInteractorLive(assignment: viewModel.assignment, submission: viewModel.submission)
+                                            )
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Group {
+                if isDrawer {
+                    tabPicker
+                        .padding(.bottom, 16)
+                        .onChange(of: tab) {
+                            if drawerState == .min { snapDrawer(to: .mid) }
+                            controller.view.endEditing(true)
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                focusedTab = tab
+                            }
+                        }
+                } else {
+                    tabPicker
+                        .frame(height: profileHeaderSize.height)
+                }
+            }
+            .padding(.horizontal, 16)
+            .identifier("SpeedGrader.toolPicker")
+
+            InstUI.Divider()
+
+            GeometryReader { geometry in
+                HStack(spacing: 0) {
+                    let drawerFileID = Binding<String?>(
+                        get: {
+                            viewModel.selectedFile?.id
+                        },
+                        set: {
+                            viewModel.didSelectFile(fileId: $0)
+                            snapDrawer(to: .min)
+                        }
+                    )
+
+                    gradesTab(bottomInset: bottomInset, geometry: geometry)
+                        // `.clipped` and `.contentShape` don't prevent touches outside of the drawer on iOS17
+                        // and it would block interaction with the attempts picker and the submission content.
+                        .allowsHitTesting(tab == .grades)
+                    commentsTab(bottomInset: bottomInset, fileID: drawerFileID, geometry: geometry)
+                }
+                .frame(width: geometry.size.width, alignment: .leading)
+                .background(Color.backgroundLightest)
+                .offset(x: -CGFloat(tab.rawValue) * geometry.size.width)
+            }
+            // Since we are offsetting the content, we need to clip it to avoid showing other tabs outside of the drawer.
+            .clipped()
+            // Clipping won't prevent user interaction so we need to limit it not to swallow touches outside of the drawer.
+            .contentShape(Rectangle())
+        }
+    }
+
+    private var tabPicker: some View {
+        InstUI.SegmentedPicker(selection: $tab) {
+            ForEach(SpeedGraderPageTab.allCases, id: \.self) { tab in
+                Text(tab.title)
+                    .tag(tab)
+            }
+        }
+    }
+
+    private func snapDrawer(to state: DrawerState) {
+        withTransaction(DrawerState.transaction) {
+            drawerState = state
+        }
+    }
+
+    private func isTabOnScreen(_ tab: SpeedGraderPageTab) -> Bool {
+        let isTabSelected = (self.tab == tab)
+
+        if isDrawer {
+            return (drawerState != .min && isTabSelected)
+        } else {
+            return isTabSelected
+        }
+    }
+
+    // MARK: - Tab Contents
+
+    @ViewBuilder
+    private func gradesTab(
+        bottomInset: CGFloat,
+        geometry: GeometryProxy
+    ) -> some View {
+        let isGradesOnScreen = isTabOnScreen(.grades)
+        VStack(spacing: 0) {
+            SubmissionGrades(
+                assignment: viewModel.assignment,
+                containerHeight: geometry.size.height,
+                submission: viewModel.submission,
+                rubricsViewModel: rubricsViewModel,
+                gradeStatusViewModel: viewModel.gradeStatusViewModel
+            )
+            .clipped()
+            Spacer().frame(height: bottomInset)
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .accessibilityElement(children: isGradesOnScreen ? .contain : .ignore)
+        .accessibility(hidden: !isGradesOnScreen)
+        .accessibilityFocused($focusedTab, equals: .grades)
+    }
+
+    @ViewBuilder
+    private func commentsTab(
+        bottomInset: CGFloat,
+        fileID: Binding<String?>,
+        geometry: GeometryProxy
+    ) -> some View {
+        let drawerAttempt = Binding(
+            get: {
+                viewModel.selectedAttemptNumber
+            }, set: {
+                viewModel.didSelectAttempt(attemptNumber: $0)
+                snapDrawer(to: .min)
+            }
+        )
+        let isCommentsOnScreen = isTabOnScreen(.comments)
+        VStack(spacing: 0) {
+            SubmissionCommentListView(
+                viewModel: viewModel.commentListViewModel,
+                attempt: drawerAttempt,
+                fileID: fileID,
+                focusedTab: _focusedTab
+            )
+            .clipped()
+            if drawerState == .min {
+                Spacer().frame(height: bottomInset)
+            }
+        }
+        .frame(width: geometry.size.width, height: geometry.size.height)
+        .accessibilityElement(children: isCommentsOnScreen ? .contain : .ignore)
+        .accessibility(hidden: !isCommentsOnScreen)
+    }
+}
+
+#if DEBUG
+
+#Preview {
+    SpeedGraderAssembly.makeSpeedGraderViewControllerPreview(state: .data)
+}
+
+#endif

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
@@ -151,7 +151,9 @@ struct SpeedGraderPageView: View {
         .onChange(of: landscapeSplitLayoutViewModel.isRightColumnHidden) { _, isHidden in
             // Auto focus voiceover on the selected tab when the right column is shown
             if isHidden { return }
-            focusedTab = selectedTab
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                focusedTab = selectedTab
+            }
         }
     }
 

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
@@ -42,7 +42,7 @@ struct SpeedGraderPageView: View {
 
     @State private var drawerState: DrawerState = .min
     @State private var selectedTab: SpeedGraderPageTab = .grades
-    @AccessibilityFocusState private var focusedTab: SpeedGraderPageTab?
+    @AccessibilityFocusState private var a11yFocusedTab: SpeedGraderPageTab?
 
     // MARK: - Layout properties
 
@@ -152,7 +152,7 @@ struct SpeedGraderPageView: View {
             // Auto focus voiceover on the selected tab when the right column is shown
             if isHidden { return }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                focusedTab = selectedTab
+                a11yFocusedTab = selectedTab
             }
         }
     }
@@ -340,7 +340,7 @@ struct SpeedGraderPageView: View {
             containerType: tabsContainerType,
             bottomInset: bottomInset,
             selectedTab: $selectedTab,
-            focusedTab: _focusedTab,
+            a11yFocusedTab: _a11yFocusedTab,
             drawerState: $drawerState,
             splitViewHeaderHeight: $headerHeight,
             viewModel: viewModel

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/ViewModel/SpeedGraderPageTab.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/ViewModel/SpeedGraderPageTab.swift
@@ -1,0 +1,31 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+enum SpeedGraderPageTab: Int, CaseIterable {
+    case grades
+    case comments
+
+    var title: String {
+        switch self {
+        case .grades: String(localized: "Grades", bundle: .teacher)
+        case .comments: String(localized: "Comments", bundle: .teacher)
+        }
+    }
+}


### PR DESCRIPTION
refs: MBL-18907
affects: Teacher
release note: none

This is just a chore in preparation for [MBL-18907](https://instructure.atlassian.net/browse/MBL-18907).

- Extracted `SpeedGraderPageTab` model
- Extracted `SpeedGraderPageTabsView`
  - it uses the page's viewmodel at the moment, mostly to allow easier rearranging of tab content if needed
- Cleaned up `SpeedGraderPageView`
- Added some helpers to `DrawerState` to make related logic a bit more readable
- Added `onHeightChange()` methods for cases when we only interested in the `height`, not the `size`

## Test plan
- Verify SpeedGrader tab changing, focus, a11y focus, etc. work as before, both in Landscape & Portrait.
- Verify swapping Landscape/Portrait mode works as before, and it keeps the selected tab.

NOTE: Tapping on the selected tab when the drawer is closed still won't open the drawer.

## Checklist
- [x] A11y checked
- [x] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode

[MBL-18907]: https://instructure.atlassian.net/browse/MBL-18907?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ