### PR TITLE
Horizon Core changes #4

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/APIBrandVariables.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/APIBrandVariables.swift
@@ -36,6 +36,7 @@ public struct APIBrandVariables: Codable, Equatable {
     let nav_text_color: String?
     let nav_text_color_active: String?
     let primary: String?
+    let institutionLogo: URL?
 
     enum CodingKeys: String, CodingKey {
         case button_primary_bgd = "ic-brand-button--primary-bgd"
@@ -54,6 +55,7 @@ public struct APIBrandVariables: Codable, Equatable {
         case nav_text_color = "ic-brand-global-nav-menu-item__text-color"
         case nav_text_color_active = "ic-brand-global-nav-menu-item__text-color--active"
         case primary = "ic-brand-primary"
+        case institutionLogo = "ic-brand-mobile-global-nav-logo"
     }
 }
 
@@ -93,7 +95,8 @@ extension APIBrandVariables {
             nav_icon_fill_active: nav_icon_fill_active,
             nav_text_color: nav_text_color,
             nav_text_color_active: nav_text_color_active,
-            primary: primary
+            primary: primary,
+            institutionLogo: nil
         )
     }
 }

--- a/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/Brand.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/Brand.swift
@@ -21,6 +21,7 @@ import UIKit
 public struct Brand: Equatable {
 
     public var headerImage: UIImage?
+    public var institutionLogo: URL?
 
     public var buttonPrimaryBackground: UIColor {
         UIColor.getColor(dark: buttonPrimaryBackgroundDark, light: buttonPrimaryBackgroundLight)
@@ -119,10 +120,11 @@ public struct Brand: Equatable {
         navIconFillActive: UIColor?,
         navTextColor: UIColor?,
         navTextColorActive: UIColor?,
-        primary: UIColor?
+        primary: UIColor?,
+        institutionLogo: URL?
     ) {
         self.headerImage = headerImage ?? UIImage(named: "defaultHeaderImage", in: .core, compatibleWith: nil)
-
+        self.institutionLogo = institutionLogo
         self.buttonPrimaryBackgroundLight = buttonPrimaryBackground ?? .backgroundInfo
         self.buttonPrimaryTextLight = buttonPrimaryText != nil ? buttonPrimaryText!.ensureContrast(against: self.buttonPrimaryBackgroundLight) : .textLightest.variantForLightMode
         self.buttonSecondaryBackgroundLight = buttonSecondaryBackground ?? .backgroundDarkest
@@ -156,7 +158,11 @@ public struct Brand: Equatable {
         self.primaryDark = primary != nil ? primary!.ensureContrast(against: .backgroundLightest) : .textInfo
     }
 
-    public init(response: APIBrandVariables, headerImage: UIImage?) {
+    public init(
+        response: APIBrandVariables,
+        headerImage: UIImage?,
+        institutionLogo: URL?
+    ) {
         self.init(
             buttonPrimaryBackground: UIColor(hexString: response.button_primary_bgd),
             buttonPrimaryText: UIColor(hexString: response.button_primary_text),
@@ -173,7 +179,8 @@ public struct Brand: Equatable {
             navIconFillActive: UIColor(hexString: response.nav_icon_fill_active),
             navTextColor: UIColor(hexString: response.nav_text_color),
             navTextColorActive: UIColor(hexString: response.nav_text_color_active),
-            primary: UIColor(hexString: response.primary)
+            primary: UIColor(hexString: response.primary),
+            institutionLogo: institutionLogo
         )
     }
 
@@ -193,7 +200,8 @@ public struct Brand: Equatable {
         navIconFillActive: nil,
         navTextColor: nil,
         navTextColorActive: nil,
-        primary: nil
+        primary: nil,
+        institutionLogo: nil
     )
 
     public func color(_ name: String) -> UIColor? {

--- a/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/CDBrandVariables.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/BrandStyle/CDBrandVariables.swift
@@ -23,6 +23,7 @@ public final class CDBrandVariables: NSManagedObject {
     /// An `APIBrandVariables` object encoded as JSON.
     @NSManaged public var apiBrandVariablesRaw: String
     @NSManaged public var headerImageRaw: Data?
+    @NSManaged public var institutionLogo: URL?
 
     public private(set) lazy var brandVariables: APIBrandVariables? = {
         let decoder = JSONDecoder()
@@ -55,12 +56,33 @@ public final class CDBrandVariables: NSManagedObject {
         let dbEntity: CDBrandVariables = context.first(scope: .all) ?? context.insert()
         dbEntity.apiBrandVariablesRaw = json
         dbEntity.headerImageRaw = headerImageData
+        dbEntity.institutionLogo = getInstitutionLogoURL(item.institutionLogo)
         return dbEntity
     }
 
     public func applyBrandTheme() {
         guard let brandVariables else { return }
 
-        Brand.shared = Brand(response: brandVariables, headerImage: headerImage)
+        Brand.shared = Brand(
+            response: brandVariables,
+            headerImage: headerImage,
+            institutionLogo: Self.getInstitutionLogoURL(brandVariables.institutionLogo)
+        )
+    }
+
+    private static func getInstitutionLogoURL(_ url: URL?) -> URL? {
+        guard let url else { return nil }
+
+        // If the URL is already absolute (has a scheme), return it as-is
+        if url.scheme != nil {
+            return url
+        }
+
+        // Otherwise, resolve it relative to the base URL
+        guard let baseURL = AppEnvironment.shared.currentSession?.baseURL else {
+            return nil
+        }
+
+        return URL(string: url.absoluteString, relativeTo: baseURL)
     }
 }

--- a/Core/Core/Common/CommonUI/SwiftUIViews/Pandas/InteractivePandaConfig.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/Pandas/InteractivePandaConfig.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 public extension InteractivePanda {
     struct Config: Equatable {
@@ -41,6 +42,30 @@ public extension InteractivePanda {
 }
 
 public extension InteractivePanda.Config {
+
+    static func horizonError(
+        scene: PandaScene = (HorizonPanda() as PandaScene),
+        title: String = String(localized: "Something Went Wrong", bundle: .core),
+        subtitle: String = String(localized: "Pull to refresh to try again", bundle: .core)
+    ) -> Self {
+        .init(
+            scene: scene,
+            title: title,
+            subtitle: subtitle
+        )
+    }
+
+    static func horizonEmpty(
+        scene: PandaScene = (HorizonPanda() as PandaScene),
+        title: String = String(localized: "This screen is empty", bundle: .core),
+        subtitle: String = String(localized: "Pull to refresh to reload", bundle: .core)
+    ) -> Self {
+        .init(
+            scene: scene,
+            title: title,
+            subtitle: subtitle
+        )
+    }
 
     static func error(
         scene: PandaScene = (NoResultsPanda() as PandaScene),

--- a/Core/Core/Common/CommonUI/SwiftUIViews/Pandas/Scenes/HorizonError.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/Pandas/Scenes/HorizonError.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public struct HorizonPanda: PandaScene {
+    public var name: String { "HorizonError" }
+    public var foreground: AnyView { AnyView(SwiftUI.EmptyView()) }
+    public var background: AnyView { AnyView(SwiftUI.EmptyView()) }
+    public var isParallaxDisabled: Bool { false }
+
+    public var offset: (background: CGSize, foreground: CGSize) {(
+        background: CGSize(width: 0, height: 0),
+        foreground: CGSize(width: 0, height: 0))
+    }
+    public var height: CGFloat { 0 }
+
+    public init() {}
+}

--- a/Core/Core/Common/CommonUI/SwiftUIViews/WebView.swift
+++ b/Core/Core/Common/CommonUI/SwiftUIViews/WebView.swift
@@ -32,6 +32,7 @@ public struct WebView: UIViewRepresentable {
     private let features: [CoreWebViewFeature]
     private let baseURL: URL?
 
+    private var isScrollEnabled: Bool = true
     @Environment(\.appEnvironment) private var env
     @Environment(\.viewController) private var controller
 
@@ -40,6 +41,7 @@ public struct WebView: UIViewRepresentable {
     public init(url: URL?,
                 features: [CoreWebViewFeature] = [],
                 canToggleTheme: Bool = false,
+                isScrollEnabled: Bool = true,
                 configuration: WKWebViewConfiguration = .defaultConfiguration
     ) {
         source = url.map { .request(URLRequest(url: $0)) }
@@ -53,12 +55,14 @@ public struct WebView: UIViewRepresentable {
                 baseURL: URL? = nil,
                 features: [CoreWebViewFeature] = [],
                 canToggleTheme: Bool = false,
+                isScrollEnabled: Bool = true,
                 configuration: WKWebViewConfiguration = .defaultConfiguration
     ) {
         source = html.map { .html($0) }
         self.baseURL = baseURL
         self.features = features
         self.canToggleTheme = canToggleTheme
+        self.isScrollEnabled = isScrollEnabled
         self.configuration = configuration
     }
 
@@ -129,6 +133,7 @@ public struct WebView: UIViewRepresentable {
             webView.pin(inside: webViewContainer)
         }
         webView.autoresizesHeight = true
+        webView.scrollView.isScrollEnabled = isScrollEnabled
         webView.scrollView.showsVerticalScrollIndicator = false
         webView.scrollView.alwaysBounceVertical = false
         webView.backgroundColor = .backgroundLightest

--- a/Core/Core/Features/Assignments/APIAssignmentGroup.swift
+++ b/Core/Core/Features/Assignments/APIAssignmentGroup.swift
@@ -22,6 +22,7 @@ public struct APIAssignmentGroup: Codable, Equatable {
     let id: ID
     let name: String
     let position: Int
+    let group_weight: Double?
     var assignments: [APIAssignment]?
 }
 
@@ -31,12 +32,14 @@ extension APIAssignmentGroup {
         id: ID = "1",
         name: String = "Assignment Group A",
         position: Int = 1,
+        group_weight: Double? = nil,
         assignments: [APIAssignment]? = nil
         ) -> APIAssignmentGroup {
         return APIAssignmentGroup(
             id: id,
             name: name,
             position: position,
+            group_weight: group_weight,
             assignments: assignments
         )
     }

--- a/Core/Core/Features/Assignments/AssignmentGroup.swift
+++ b/Core/Core/Features/Assignments/AssignmentGroup.swift
@@ -26,6 +26,7 @@ public final class AssignmentGroup: NSManagedObject {
     @NSManaged public var name: String
     @NSManaged public var position: Int
     @NSManaged public var courseID: String
+    @NSManaged public var groupWeight: NSNumber?
     @NSManaged public var assignments: Set<Assignment>?
 
     @discardableResult
@@ -34,6 +35,9 @@ public final class AssignmentGroup: NSManagedObject {
         model.id = item.id.value
         model.name = item.name
         model.position = item.position
+        if let groupWeight = item.group_weight {
+            model.groupWeight = NSNumber(value: groupWeight)
+        }
         model.courseID = courseID
 
         for a in item.assignments ?? [] {

--- a/Core/Core/Features/Courses/APICourse.swift
+++ b/Core/Core/Features/Courses/APICourse.swift
@@ -37,7 +37,7 @@ public struct APICourse: Codable, Equatable {
     let start_at: Date?
     let end_at: Date?
     let locale: String?
-    var enrollments: [APIEnrollment]?
+    public var enrollments: [APIEnrollment]?
     var grading_periods: [APIGradingPeriod]?
     // let total_students: Int? // include[]=total_students
     // let calendar: ?
@@ -109,6 +109,7 @@ public struct APICourseSettings: Codable, Equatable {
     let usage_rights_required: Bool?
     let syllabus_course_summary: Bool?
     let restrict_quantitative_data: Bool?
+    let hide_final_grade: Bool?
 }
 
 public enum CourseDefaultView: String, Codable, CaseIterable {
@@ -225,12 +226,14 @@ extension APICourseSettings {
     public static func make(
         usage_rights_required: Bool = false,
         syllabus_course_summary: Bool = true,
-        restrict_quantitative_data: Bool? = nil
+        restrict_quantitative_data: Bool? = nil,
+        hide_final_grade: Bool? = nil
     ) -> APICourseSettings {
         APICourseSettings(
             usage_rights_required: usage_rights_required,
             syllabus_course_summary: syllabus_course_summary,
-            restrict_quantitative_data: restrict_quantitative_data
+            restrict_quantitative_data: restrict_quantitative_data,
+            hide_final_grade: hide_final_grade
         )
     }
 }
@@ -351,7 +354,7 @@ public struct GetCourseRequest: APIRequestable {
 
     var include: [Include] = defaultIncludes
 
-    init(courseID: String, include: [Include] = defaultIncludes) {
+    public init(courseID: String, include: [Include] = defaultIncludes) {
         self.courseID = courseID
         self.include = include
     }

--- a/Core/Core/Features/Files/Model/API/APIFile.swift
+++ b/Core/Core/Features/Files/Model/API/APIFile.swift
@@ -21,7 +21,7 @@ import Foundation
 // https://canvas.instructure.com/doc/api/files.html#filePath
 public struct APIFile: Codable, Equatable {
     let id: ID
-    let uuid: String
+    let uuid: String?
     let folder_id: ID
     let display_name: String
     let filename: String
@@ -137,7 +137,7 @@ public struct APIFile: Codable, Equatable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         id = try container.decode(ID.self, forKey: .id)
-        uuid = try container.decode(String.self, forKey: .uuid)
+        uuid = try container.decodeIfPresent(String.self, forKey: .uuid)
         folder_id = try container.decode(ID.self, forKey: .folder_id)
         display_name = try container.decode(String.self, forKey: .display_name)
         contentType = try container.decode(String.self, forKey: .contentType)
@@ -427,7 +427,7 @@ public struct PostFileUploadRequest: APIRequestable {
     public let fileURL: URL
     public let target: FileUploadTarget
     public let loadBodyFromURL: Bool
-
+    public var shouldAddNoVerifierQuery: Bool
     /**
          Creates an `APIRequestable` instance for file upload.
          - Parameters:
@@ -438,10 +438,12 @@ public struct PostFileUploadRequest: APIRequestable {
     public init(
         fileURL: URL,
         target: FileUploadTarget,
-        isBodyFromURL: Bool = true
+        isBodyFromURL: Bool = true,
+        shouldAddNoVerifierQuery: Bool = true
     ) {
         self.fileURL = fileURL
         self.target = target
+        self.shouldAddNoVerifierQuery = shouldAddNoVerifierQuery
         loadBodyFromURL = isBodyFromURL
     }
 

--- a/Core/Core/Features/Login/APIOAuth.swift
+++ b/Core/Core/Features/Login/APIOAuth.swift
@@ -39,6 +39,7 @@ public struct APIOAuthToken: Codable, Equatable {
     let user: APIOAuthUser
     let real_user: RealUser?
     let expires_in: TimeInterval?
+    let canvas_region: String?
 }
 
 public struct APIOAuthUser: Codable, Equatable {
@@ -56,7 +57,8 @@ extension APIOAuthToken {
         tokenType: String = "token-type",
         user: APIOAuthUser = .make(),
         realUser: APIOAuthToken.RealUser? = nil,
-        expiresIn: TimeInterval? = nil
+        expiresIn: TimeInterval? = nil,
+        canvasRegion: String? = nil
     ) -> APIOAuthToken {
         return APIOAuthToken(
             access_token: accessToken,
@@ -64,7 +66,8 @@ extension APIOAuthToken {
             token_type: tokenType,
             user: user,
             real_user: realUser,
-            expires_in: expiresIn
+            expires_in: expiresIn,
+            canvas_region: canvasRegion
         )
     }
 }

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -32,6 +32,7 @@ public struct LoginSession: Codable, Hashable {
     public let userEmail: String?
     public let clientID: String?
     public let clientSecret: String?
+    public let canvasRegion: String?
 
     /** Returns the acted user's ID. If the session isn't masquaraded this property returns nil. */
     public var actAsUserID: String? {
@@ -74,7 +75,8 @@ public struct LoginSession: Codable, Hashable {
         userEmail: String? = nil,
         clientID: String? = nil,
         clientSecret: String? = nil,
-        isFakeStudent: Bool = false
+        canvasRegion: String? = nil,
+        isFakeStudent: Bool = false,
     ) {
         self.accessToken = accessToken
         // remove trailing slash
@@ -92,6 +94,7 @@ public struct LoginSession: Codable, Hashable {
         self.userEmail = userEmail
         self.clientID = clientID
         self.clientSecret = clientSecret
+        self.canvasRegion = canvasRegion
     }
 
     // Only keep 1 entry per account user

--- a/Core/Core/Features/People/APIUser.swift
+++ b/Core/Core/Features/People/APIUser.swift
@@ -146,6 +146,17 @@ public struct APIProfile: Codable, Equatable {
     public let uuid: String?
     public let account_uuid: String?
     public let time_zone: String?
+    public let permissions: APIProfile.Permissions?
+
+    public struct Permissions: Codable, Equatable {
+        public let canUpdateName: Bool?
+        public let canUpdateAvatar: Bool?
+
+        enum CodingKeys: String, CodingKey {
+            case canUpdateName = "can_update_name"
+            case canUpdateAvatar = "can_update_avatar"
+        }
+    }
 }
 
 #if DEBUG
@@ -244,7 +255,8 @@ extension APIProfile {
         k5_user: Bool? = nil,
         uuid: String? = nil,
         account_uuid: String? = nil,
-        time_zone: String? = nil
+        time_zone: String? = nil,
+        permissions: APIProfile.Permissions? = nil
     ) -> APIProfile {
         return APIProfile(
             id: id,
@@ -259,7 +271,8 @@ extension APIProfile {
             k5_user: k5_user,
             uuid: uuid,
             account_uuid: account_uuid,
-            time_zone: time_zone
+            time_zone: time_zone,
+            permissions: permissions
         )
     }
 }

--- a/Core/Core/Features/Profile/UserProfile.swift
+++ b/Core/Core/Features/Profile/UserProfile.swift
@@ -33,6 +33,8 @@ public final class UserProfile: NSManagedObject {
     @NSManaged public var uuid: String?
     @NSManaged public var accountUUID: String?
     @NSManaged public var defaultTimeZone: String?
+    @NSManaged public var canUpdateName: Bool
+    @NSManaged public var canUpdateAvatar: Bool
 }
 
 extension UserProfile: WriteableModel {
@@ -42,14 +44,15 @@ extension UserProfile: WriteableModel {
         model.id = item.id.value
         model.name = item.name
         model.shortName = item.short_name
-        model.email = item.primary_email
+        model.email = item.primary_email ?? model.email
         model.locale = item.locale
         model.loginID = item.login_id
         model.avatarURL = item.avatar_url?.rawValue
         model.calendarURL = item.calendar?.ics
         model.pronouns = item.pronouns
         model.isK5User = (item.k5_user == true)
-
+        model.canUpdateName = item.permissions?.canUpdateName ?? model.canUpdateName
+        model.canUpdateAvatar = item.permissions?.canUpdateAvatar ?? model.canUpdateAvatar
         // The "/users/self/profile" api does not return accountUUID and since they share
         // the same Core Data entity, it would get overriden with a null value after fetching "/users/self"
         if model.uuid == nil {

--- a/Core/Core/Features/Submissions/GetSubmissionComments.swift
+++ b/Core/Core/Features/Submissions/GetSubmissionComments.swift
@@ -23,13 +23,15 @@ public class GetSubmissionComments: APIUseCase {
     let assignmentID: String
     let context: Context
     let userID: String
+    let isAscendingOrder: Bool
 
     public typealias Model = SubmissionComment
 
-    public init(context: Context, assignmentID: String, userID: String) {
+    public init(context: Context, assignmentID: String, userID: String, isAscendingOrder: Bool = false) {
         self.assignmentID = assignmentID
         self.context = context
         self.userID = userID
+        self.isAscendingOrder = isAscendingOrder
     }
 
     public var cacheKey: String? {
@@ -49,11 +51,11 @@ public class GetSubmissionComments: APIUseCase {
                 #keyPath(SubmissionComment.userID),
                 userID
             ),
-            order: [NSSortDescriptor(key: #keyPath(SubmissionComment.createdAt), ascending: false)]
+            order: [NSSortDescriptor(key: #keyPath(SubmissionComment.createdAt), ascending: isAscendingOrder)]
         )
     }
 
-    public func write(response: APISubmission?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+    public func write(response: APISubmission?, urlResponse _: URLResponse?, to client: NSManagedObjectContext) {
         guard let item = response else { return }
         Submission.save(item, in: client)
     }

--- a/Core/Core/Features/Submissions/GetSubmissions.swift
+++ b/Core/Core/Features/Submissions/GetSubmissions.swift
@@ -55,6 +55,8 @@ public class CreateSubmission: APIUseCase {
     let context: Context
     let assignmentID: String
     let userID: String
+    let moduleID: String?
+    let moduleItemID: String?
     public let request: CreateSubmissionRequest
     public typealias Model = Submission
 
@@ -72,11 +74,15 @@ public class CreateSubmission: APIUseCase {
         fileIDs: [String]? = nil,
         mediaCommentID: String? = nil,
         mediaCommentType: MediaCommentType? = nil,
-        annotatableAttachmentID: String? = nil
+        annotatableAttachmentID: String? = nil,
+        moduleID: String? = nil,
+        moduleItemID: String? = nil
     ) {
         self.context = context
         self.assignmentID = assignmentID
         self.userID = userID
+        self.moduleID = moduleID
+        self.moduleItemID = moduleItemID
 
         let submission = CreateSubmissionRequest.Body.Submission(
             annotatable_attachment_id: annotatableAttachmentID,
@@ -116,7 +122,18 @@ public class CreateSubmission: APIUseCase {
 
             if error == nil {
                 NotificationCenter.default.post(moduleItem: .assignment(self.assignmentID), completedRequirement: .submit, courseID: self.context.id)
-                NotificationCenter.default.post(name: .moduleItemRequirementCompleted, object: nil)
+                if let moduleID = self.moduleID, let moduleItemID = self.moduleItemID {
+                    NotificationCenter.default.post(
+                        name: .moduleItemRequirementCompleted,
+                        object: ModuleItemAttributes(
+                            courseID: self.context.id,
+                            moduleID: moduleID,
+                            itemID: moduleItemID
+                        )
+                    )
+                } else {
+                    NotificationCenter.default.post(name: .moduleItemRequirementCompleted, object: nil)
+                }
             }
 
             UIAccessibility

--- a/Core/Core/Features/Submissions/SubmissionComment/CDHCommentAttachment.swift
+++ b/Core/Core/Features/Submissions/SubmissionComment/CDHCommentAttachment.swift
@@ -1,0 +1,42 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import CoreData
+
+final public class CDHCommentAttachment: NSManagedObject {
+    @NSManaged public var id: String
+    @NSManaged public var url: String?
+    @NSManaged public var displayName: String?
+
+    @discardableResult
+    public static func save(
+        _ apiEntity: GetHSubmissionCommentsResponse.Attachment,
+        in context: NSManagedObjectContext
+    ) -> CDHCommentAttachment {
+
+        let dbEntity: CDHCommentAttachment = context.first(
+            where: #keyPath(CDHCommentAttachment.id),
+            equals: apiEntity.id
+        ) ?? context.insert()
+        dbEntity.id = apiEntity.id
+        dbEntity.url = apiEntity.url
+        dbEntity.displayName = apiEntity.displayName
+        return dbEntity
+    }
+}

--- a/Core/Core/Features/Submissions/SubmissionComment/CDHSubmissionComment.swift
+++ b/Core/Core/Features/Submissions/SubmissionComment/CDHSubmissionComment.swift
@@ -18,7 +18,7 @@
 
 import CoreData
 
-final public class CDHSubmissionComment: NSManagedObject {
+public final class CDHSubmissionComment: NSManagedObject {
     @NSManaged public var id: String
     @NSManaged public var attemptFromAPI: NSNumber?
     @NSManaged public var authorID: String?
@@ -26,6 +26,7 @@ final public class CDHSubmissionComment: NSManagedObject {
     @NSManaged public var comment: String?
     @NSManaged public var createdAt: Date?
     @NSManaged public var isRead: Bool
+    @NSManaged public var attachments: Set<CDHCommentAttachment>?
 
     public var attempt: Int? {
         if let attemptFromAPI {
@@ -38,10 +39,9 @@ final public class CDHSubmissionComment: NSManagedObject {
     @discardableResult
     public static func save(
         _ apiEntity: GetHSubmissionCommentsResponse.Comment?,
-        assignmentID: String,
+        assignmentID _: String,
         in context: NSManagedObjectContext
     ) -> CDHSubmissionComment {
-
         let dbEntity: CDHSubmissionComment = context.first(
             where: #keyPath(CDHSubmissionComment.id),
             equals: apiEntity?.id
@@ -54,6 +54,15 @@ final public class CDHSubmissionComment: NSManagedObject {
         dbEntity.comment = apiEntity?.comment
         dbEntity.createdAt = apiEntity?.createdAt
         dbEntity.isRead = apiEntity?.read ?? true
+
+        if let attachments = apiEntity?.attachments {
+            let attachmentsEntities: [CDHCommentAttachment] = attachments.map { apiItem in
+                CDHCommentAttachment.save(apiItem, in: context)
+            }
+            dbEntity.attachments = Set(attachmentsEntities)
+        } else {
+            dbEntity.attachments = []
+        }
 
         return dbEntity
     }

--- a/Core/Core/Features/Submissions/SubmissionComment/GetHSubmissionCommentsRequest.swift
+++ b/Core/Core/Features/Submissions/SubmissionComment/GetHSubmissionCommentsRequest.swift
@@ -63,7 +63,11 @@ public struct GetHSubmissionCommentsRequest: APIGraphQLRequestable {
                        read
                        updatedAt
                        createdAt
-                     }
+                    attachments {
+                      _id
+                      url
+                      displayName
+                    }
                    }
                  }
                }

--- a/Core/Core/Features/Submissions/SubmissionComment/GetHSubmissionCommentsResponse.swift
+++ b/Core/Core/Features/Submissions/SubmissionComment/GetHSubmissionCommentsResponse.swift
@@ -36,8 +36,8 @@ public struct GetHSubmissionCommentsResponse: Codable {
         public let edges: [Edge]?
     }
 
-  public struct Edge: Codable {
-      public let node: Comment?
+    public struct Edge: Codable {
+        public let node: Comment?
     }
 
     public struct Comment: Codable {
@@ -47,6 +47,7 @@ public struct GetHSubmissionCommentsResponse: Codable {
         public let comment: String?
         public let read: Bool?
         public let updatedAt, createdAt: Date?
+        public let attachments: [Attachment]?
     }
 
     public struct Author: Codable {
@@ -63,5 +64,16 @@ public struct GetHSubmissionCommentsResponse: Codable {
     struct PageInfo: Codable {
         let endCursor, startCursor: String?
         let hasPreviousPage, hasNextPage: Bool?
+    }
+
+    public struct Attachment: Codable {
+        let id: String
+        let url: String?
+        let displayName: String?
+
+        enum CodingKeys: String, CodingKey {
+            case id = "_id"
+            case url, displayName
+        }
     }
 }

--- a/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -197,6 +197,12 @@
         <attribute name="disableInboxSignatureBlockForStudents" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="enableInboxSignatureBlock" attributeType="Boolean" usesScalarValueType="YES"/>
     </entity>
+    <entity name="CDHCommentAttachment" representedClassName="Core.CDHCommentAttachment" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="id" attributeType="String"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+        <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDHSubmissionComment" inverseName="attachments" inverseEntity="CDHSubmissionComment"/>
+    </entity>
     <entity name="CDHCourse" representedClassName="Core.CDHCourse" syncable="YES">
         <attribute name="completionPercentage" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="courseID" attributeType="String"/>
@@ -291,6 +297,7 @@
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="isRead" attributeType="Boolean" usesScalarValueType="YES"/>
+        <relationship name="attachments" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="CDHCommentAttachment" inverseName="relationship" inverseEntity="CDHCommentAttachment"/>
         <relationship name="relationship" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="CDHSubmission" inverseName="comments" inverseEntity="CDHSubmission"/>
     </entity>
     <entity name="CDHSubmissionScores" representedClassName="Core.CDHSubmissionScores" syncable="YES">

--- a/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1258,6 +1258,8 @@
         <attribute name="accountUUID" optional="YES" attributeType="String"/>
         <attribute name="avatarURL" optional="YES" attributeType="URI"/>
         <attribute name="calendarURL" optional="YES" attributeType="URI"/>
+        <attribute name="canUpdateAvatar" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="canUpdateName" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="defaultTimeZone" optional="YES" attributeType="String"/>
         <attribute name="email" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>

--- a/Core/CoreTests/Common/CommonUI/NavigationBar/NavigationBarColorConfigurationTests.swift
+++ b/Core/CoreTests/Common/CommonUI/NavigationBar/NavigationBarColorConfigurationTests.swift
@@ -28,7 +28,8 @@ class NavigationBarColorConfigurationTests: XCTestCase {
             link_color: "#FF0000",
             nav_text_color: "#0000FF"
         ),
-        headerImage: nil
+        headerImage: nil,
+        institutionLogo: nil    
     )
 
     func test_colors_whenStyleIsModal() {

--- a/Core/CoreTests/Common/CommonUI/NavigationBar/NavigationBarColorConfigurationTests.swift
+++ b/Core/CoreTests/Common/CommonUI/NavigationBar/NavigationBarColorConfigurationTests.swift
@@ -29,7 +29,7 @@ class NavigationBarColorConfigurationTests: XCTestCase {
             nav_text_color: "#0000FF"
         ),
         headerImage: nil,
-        institutionLogo: nil    
+        institutionLogo: nil
     )
 
     func test_colors_whenStyleIsModal() {

--- a/Core/CoreTests/Common/CommonUI/NavigationBar/UIKit/UINavigationBarExtensionsTests.swift
+++ b/Core/CoreTests/Common/CommonUI/NavigationBar/UIKit/UINavigationBarExtensionsTests.swift
@@ -54,7 +54,8 @@ class UINavigationBarExtensionsTests: XCTestCase {
             navIconFillActive: .textLightest.variantForLightMode,
             navTextColor: .textLightest.variantForLightMode,
             navTextColorActive: .textLightest.variantForLightMode,
-            primary: .textLightest.variantForLightMode
+            primary: .textLightest.variantForLightMode,
+            institutionLogo: nil
         )
         bar.useGlobalNavStyle(brand: shiny)
         XCTAssertEqual(bar.barStyle, .default)

--- a/Core/CoreTests/Common/Extensions/UIKit/UITabBarExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UITabBarExtensionsTests.swift
@@ -24,7 +24,8 @@ class UITabBarExtensionsTests: XCTestCase {
     func testUseGlobalNavStyle() {
         Brand.shared = Brand(
             response: APIBrandVariables.make(primary: "#333"),
-            headerImage: nil
+            headerImage: nil,
+            institutionLogo: nil
         )
         let tabBar = UITabBar()
         tabBar.items = [ UITabBarItem(title: "", image: nil, selectedImage: nil) ]
@@ -46,7 +47,7 @@ class UITabBarExtensionsTests: XCTestCase {
         let shiny = Brand(response: APIBrandVariables.make(
             nav_text_color: "#333",
             primary: "#ffffff"
-        ), headerImage: nil)
+        ), headerImage: nil, institutionLogo: nil)
         tabBar.useGlobalNavStyle(brand: shiny)
         XCTAssertEqual(tabBar.standardAppearance.stackedLayoutAppearance.selected.iconColor?.hexString, shiny.primary.darkenToEnsureContrast(against: .backgroundLightest).hexString)
     }

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncSyllabusInteractorLiveTests.swift
@@ -53,7 +53,8 @@ class CourseSyncSyllabusInteractorLiveTests: CoreTestCase {
         api.mock(GetCourseSettings(courseID: "testCourse"),
                  value: .init(usage_rights_required: false,
                               syllabus_course_summary: true,
-                              restrict_quantitative_data: false))
+                              restrict_quantitative_data: false,
+                              hide_final_grade: false))
         api.mock(GetCalendarEvents(context: .course("testCourse"),
                                    type: .assignment),
                  value: [.make(id: "1")])

--- a/Core/CoreTests/Features/Courses/CourseSettingsTests.swift
+++ b/Core/CoreTests/Features/Courses/CourseSettingsTests.swift
@@ -22,7 +22,8 @@ import XCTest
 class CourseSettingsTests: CoreTestCase {
     private let emptyAPIResponse = APICourseSettings(usage_rights_required: nil,
                                                      syllabus_course_summary: nil,
-                                                     restrict_quantitative_data: nil)
+                                                     restrict_quantitative_data: nil,
+                                                     hide_final_grade: nil)
 
     func testSavesDefaultValues() {
         let testee = CourseSettings.save(emptyAPIResponse, courseID: "1", in: databaseClient)
@@ -35,7 +36,8 @@ class CourseSettingsTests: CoreTestCase {
     func testSavesAPIValues() {
         let apiResponse = APICourseSettings(usage_rights_required: true,
                                             syllabus_course_summary: true,
-                                            restrict_quantitative_data: true)
+                                            restrict_quantitative_data: true,
+                                            hide_final_grade: false)
         let testee = CourseSettings.save(apiResponse, courseID: "1", in: databaseClient)
 
         XCTAssertTrue(testee.restrictQuantitativeData)
@@ -47,7 +49,8 @@ class CourseSettingsTests: CoreTestCase {
         AppEnvironment.shared.app = .teacher
         let apiResponse = APICourseSettings(usage_rights_required: true,
                                             syllabus_course_summary: true,
-                                            restrict_quantitative_data: true)
+                                            restrict_quantitative_data: true,
+                                            hide_final_grade: false)
         let testee = CourseSettings.save(apiResponse, courseID: "1", in: databaseClient)
 
         XCTAssertFalse(testee.restrictQuantitativeData)

--- a/Core/CoreTests/Features/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
+++ b/Core/CoreTests/Features/Dashboard/K5/Model/Schedule/K5ScheduleItemInfoTests.swift
@@ -62,7 +62,8 @@ class K5ScheduleItemInfoTests: CoreTestCase {
                              navIconFillActive: nil,
                              navTextColor: nil,
                              navTextColorActive: nil,
-                             primary: .red)
+                             primary: .red,
+                             institutionLogo: nil)
         XCTAssertEqual(APIPlannable.make(course_id: ID("testID")).k5ScheduleSubject(courseInfoByCourseIDs: ["testID": (color: .green,
                                                                                                                        image: nil,
                                                                                                                        isHomeroom: false,

--- a/Core/CoreTests/Features/Discussions/DiscussionDetailsViewControllerTests.swift
+++ b/Core/CoreTests/Features/Discussions/DiscussionDetailsViewControllerTests.swift
@@ -509,7 +509,8 @@ class DiscussionDetailsViewControllerTests: CoreTestCase {
                 settings: APICourseSettings(
                     usage_rights_required: nil,
                     syllabus_course_summary: nil,
-                    restrict_quantitative_data: restrict_quantitative_data
+                    restrict_quantitative_data: restrict_quantitative_data,
+                    hide_final_grade: nil
                 )
             )
         )

--- a/Core/CoreTests/Features/Discussions/DiscussionListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Discussions/DiscussionListViewControllerTests.swift
@@ -194,7 +194,8 @@ class DiscussionListViewControllerTests: CoreTestCase {
                 settings: APICourseSettings(
                     usage_rights_required: nil,
                     syllabus_course_summary: nil,
-                    restrict_quantitative_data: restrict_quantitative_data
+                    restrict_quantitative_data: restrict_quantitative_data,
+                    hide_final_grade: nil
                 )
             )
         )

--- a/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
+++ b/Core/CoreTests/Features/Login/LoginWebViewControllerTests.swift
@@ -121,7 +121,8 @@ class LoginWebViewControllerTests: CoreTestCase {
                 effective_locale: "pt",
                 email: nil),
             real_user: nil,
-            expires_in: nil
+            expires_in: nil,
+            canvas_region: nil
         )
         api.mock(PostLoginOAuthRequest(client: controller.mobileVerifyModel!, code: "c"), value: token)
         action.mockRequest = URLRequest(url: URL(string: "https://canvas/login?code=c")!)

--- a/Core/CoreTests/Features/Modules/ModuleList/ModuleListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Modules/ModuleList/ModuleListViewControllerTests.swift
@@ -575,7 +575,8 @@ class ModuleListViewControllerTests: CoreTestCase {
                 settings: APICourseSettings(
                     usage_rights_required: nil,
                     syllabus_course_summary: nil,
-                    restrict_quantitative_data: restrict_quantitative_data
+                    restrict_quantitative_data: restrict_quantitative_data,
+                    hide_final_grade: nil
                 )
             )
         )

--- a/Core/CoreTests/Features/People/ContextCard/Course/ContextCardTests.swift
+++ b/Core/CoreTests/Features/People/ContextCard/Course/ContextCardTests.swift
@@ -121,7 +121,8 @@ class ContextCardTests: CoreTestCase {
                 settings: APICourseSettings(
                     usage_rights_required: nil,
                     syllabus_course_summary: nil,
-                    restrict_quantitative_data: restrict_quantitative_data
+                    restrict_quantitative_data: restrict_quantitative_data,
+                    hide_final_grade: nil
                 )
             )
         )

--- a/Core/CoreTests/Features/Submissions/SubmissionComment/CDHCommentAttachmentTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionComment/CDHCommentAttachmentTests.swift
@@ -1,0 +1,75 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+//
+
+@testable import Core
+import XCTest
+
+final class CDHCommentAttachmentTests: CoreTestCase {
+    func testSave() {
+        let apiEntity = GetHSubmissionCommentsResponse.Attachment(
+            id: "attachment-123",
+            url: "https://example.com/test.pdf",
+            displayName: "test.pdf"
+        )
+
+        let savedEntity = CDHCommentAttachment.save(apiEntity, in: databaseClient)
+
+        XCTAssertEqual(savedEntity.id, "attachment-123")
+        XCTAssertEqual(savedEntity.displayName, "test.pdf")
+        XCTAssertEqual(savedEntity.url, "https://example.com/test.pdf")
+
+        let fetchedEntity: CDHCommentAttachment? = databaseClient.first(where: #keyPath(CDHCommentAttachment.id), equals: "attachment-123")
+        XCTAssertNotNil(fetchedEntity)
+        XCTAssertEqual(fetchedEntity?.id, "attachment-123")
+    }
+
+    func testSaveWithExistingEntity() {
+        let attachmentId = "attachment-123"
+        let initialEntity: CDHCommentAttachment = databaseClient.insert()
+        initialEntity.id = attachmentId
+        initialEntity.displayName = "old.pdf"
+        initialEntity.url = "https://example.com/old.pdf"
+        try! databaseClient.save()
+
+        let apiEntity = GetHSubmissionCommentsResponse.Attachment(
+            id: attachmentId,
+            url: "https://example.com/new.pdf",
+            displayName: "new.pdf"
+        )
+
+        let updatedEntity = CDHCommentAttachment.save(apiEntity, in: databaseClient)
+
+        XCTAssertEqual(updatedEntity.objectID, initialEntity.objectID)
+        XCTAssertEqual(updatedEntity.displayName, "new.pdf")
+        XCTAssertEqual(updatedEntity.url, "https://example.com/new.pdf")
+    }
+
+    func testSaveWithNilValues() {
+        let apiEntity = GetHSubmissionCommentsResponse.Attachment(
+            id: "attachment-123",
+            url: nil,
+            displayName: nil
+        )
+
+        let savedEntity = CDHCommentAttachment.save(apiEntity, in: databaseClient)
+
+        XCTAssertEqual(savedEntity.id, "attachment-123")
+        XCTAssertNil(savedEntity.displayName)
+        XCTAssertNil(savedEntity.url)
+    }
+}

--- a/Core/CoreTests/Features/Submissions/SubmissionComment/CDHCommentAttachmentTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionComment/CDHCommentAttachmentTests.swift
@@ -13,7 +13,7 @@
 // GNU Affero General Public License for more details.
 //
 // You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see &lt;https://www.gnu.org/licenses/&gt;.
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
 @testable import Core

--- a/Core/CoreTests/Features/Submissions/SubmissionComment/CDHSubmissionCommentTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionComment/CDHSubmissionCommentTests.swift
@@ -40,7 +40,8 @@ class CDHSubmissionCommentTests: CoreTestCase {
             comment: commentText,
             read: true,
             updatedAt: createdAt,
-            createdAt: createdAt
+            createdAt: createdAt,
+            attachments: nil
         )
 
         let savedComment = CDHSubmissionComment.save(comment, assignmentID: assignmentId, in: databaseClient)
@@ -78,7 +79,8 @@ class CDHSubmissionCommentTests: CoreTestCase {
             comment: "First comment",
             read: true,
             updatedAt: Date(),
-            createdAt: Date()
+            createdAt: Date(),
+            attachments: nil
         )
 
         let savedComment1 = CDHSubmissionComment.save(comment1, assignmentID: "assignment-123", in: databaseClient)
@@ -94,7 +96,8 @@ class CDHSubmissionCommentTests: CoreTestCase {
             comment: "Updated comment",
             read: false,
             updatedAt: Date(),
-            createdAt: Date()
+            createdAt: Date(),
+            attachments: nil
         )
 
         let savedComment2 = CDHSubmissionComment.save(comment2, assignmentID: "assignment-123", in: databaseClient)

--- a/Core/CoreTests/Features/Submissions/SubmissionComment/CDHSubmissionTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionComment/CDHSubmissionTests.swift
@@ -37,7 +37,8 @@ class CDHSubmissionTests: CoreTestCase {
             comment: "This is a test comment",
             read: false,
             updatedAt: Date(),
-            createdAt: Date()
+            createdAt: Date(),
+            attachments: nil
         )
 
         let edge = GetHSubmissionCommentsResponse.Edge(node: comment)

--- a/Core/CoreTests/Features/Submissions/SubmissionComment/GetHSubmissionCommentsUseCaseTests.swift
+++ b/Core/CoreTests/Features/Submissions/SubmissionComment/GetHSubmissionCommentsUseCaseTests.swift
@@ -53,7 +53,8 @@ class GetHSubmissionCommentsUseCaseTests: CoreTestCase {
             comment: "This is a test comment",
             read: true,
             updatedAt: Date(),
-            createdAt: Date()
+            createdAt: Date(),
+            attachments: nil
         )
 
         let edge = GetHSubmissionCommentsResponse.Edge(node: comment)

--- a/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
+++ b/Core/CoreTests/Features/TokenRefresh/Model/AccessTokenRefreshInteractorTests.swift
@@ -54,7 +54,9 @@ class AccessTokenRefreshInteractorTests: CoreTestCase {
                 email: "new_email"
             ),
             real_user: .init(id: "new_real_id", name: "new_real_name"),
-            expires_in: 0)
+            expires_in: 0,
+            canvas_region: "dub"
+        )
         api.mock(request, value: response)
         let expectedToken = loginSession.refresh(
             accessToken: response.access_token,

--- a/Core/CoreTests/TestHelpers/CoreTestCase.swift
+++ b/Core/CoreTests/TestHelpers/CoreTestCase.swift
@@ -153,7 +153,8 @@ class CoreTestCase: XCTestCase {
             navIconFillActive: nil,
             navTextColor: nil,
             navTextColorActive: nil,
-            primary: nil
+            primary: nil,
+            institutionLogo: nil
         )
     }
 }

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Button/HorizonUI.ButtonStyles.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Button/HorizonUI.ButtonStyles.swift
@@ -171,7 +171,7 @@ struct HorizonButtonModifier: ViewModifier {
         let foreground = type.foregroundColor(configuration)
         let background = type.background(configuration, isTextUnderlined: isTextUnderlined)
         return content
-            .background(background)
+            .background(background.opacity(isEnabled ? 1.0 : 0.5))
             .foregroundStyle(foreground)
             .overlay(configuration.isPressed && type.hasDarkOverlayWhenPressed ? .black.opacity(0.2) : .clear)
             .huiCornerRadius(level: .level6)
@@ -179,7 +179,6 @@ struct HorizonButtonModifier: ViewModifier {
                 RoundedRectangle(cornerRadius: HorizonUI.CornerRadius.level6.attributes.radius)
                     .strokeBorder(type.border(configuration, isTextUnderlined: isTextUnderlined), lineWidth: 1)
             }
-            .opacity(isEnabled ? 1.0 : 0.5)
             .animation(.easeInOut, value: isEnabled)
     }
 }

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Cards/LearningObjectItem/HorizonUI.LearningObjectItem.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Cards/LearningObjectItem/HorizonUI.LearningObjectItem.swift
@@ -23,7 +23,7 @@ public extension HorizonUI {
         // MARK: - Properties
 
         private let cornerRadius: CornerRadius = .level3
-
+        private let screenWidth = UIScreen.main.bounds.width
         // MARK: - Dependencies
 
         private let name: String
@@ -98,7 +98,10 @@ public extension HorizonUI {
                     .multilineTextAlignment(.leading)
                     .huiTypography(.p2)
 
-                HStack(spacing: .huiSpaces.space16) {
+                HFlow(
+                    spacing: .huiSpaces.space16,
+                    lineSpacing: .huiSpaces.space4
+                ) {
                     HorizonUI.Pill(
                         title: type.name,
                         style: .inline(
@@ -121,23 +124,18 @@ public extension HorizonUI {
                             .foregroundStyle(Color.huiColors.text.timestamp)
                             .huiTypography(.labelSmall)
                     }
-                }
-                .padding(.top, .huiSpaces.space4)
 
-                HStack(spacing: .zero) {
                     if let dueDate {
                         dueDateView(dueDate)
-                            .padding(.top, .huiSpaces.space4)
-                            .padding(.trailing, .huiSpaces.space16)
                     }
 
                     if let points {
                         Text("\(points) pts")
                             .foregroundStyle(Color.huiColors.text.timestamp)
-                            .padding(.top, .huiSpaces.space4)
+                            .huiTypography(.labelSmall)
                     }
                 }
-                .huiTypography(.labelSmall)
+                .padding(.top, .huiSpaces.space4)
             }
         }
 

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/HFlow/HFlow.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/HFlow/HFlow.swift
@@ -1,0 +1,89 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public extension HorizonUI {
+    struct HFlow: Layout {
+        private let spacing: CGFloat
+        private let lineSpacing: CGFloat
+
+        public init(
+            spacing: CGFloat = 8,
+            lineSpacing: CGFloat = 8
+        ) {
+            self.spacing = spacing
+            self.lineSpacing = lineSpacing
+        }
+
+        public func sizeThatFits(
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) -> CGSize {
+            let maxWidth = (proposal.width ?? 0) - spacing
+            var width: CGFloat = 0
+            var height: CGFloat = 0
+            var currentLineWidth: CGFloat = 0
+            var currentLineHeight: CGFloat = 0
+
+            for view in subviews {
+                let size = view.sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
+
+                if currentLineWidth + size.width > maxWidth {
+                    width = max(width, currentLineWidth)
+                    height += currentLineHeight + lineSpacing
+                    currentLineWidth = 0
+                    currentLineHeight = 0
+                }
+
+                currentLineWidth += size.width + spacing
+                currentLineHeight = max(currentLineHeight, size.height)
+            }
+
+            width = max(width, currentLineWidth)
+            height += currentLineHeight
+            return CGSize(width: width, height: height)
+        }
+
+        public func placeSubviews(
+            in bounds: CGRect,
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache: inout ()
+        ) {
+            var x: CGFloat = bounds.minX
+            var y: CGFloat = bounds.minY
+            var lineHeight: CGFloat = 0
+
+            for view in subviews {
+                let size = view.sizeThatFits(ProposedViewSize(width: bounds.width, height: nil))
+
+                if x + size.width > bounds.maxX {
+                    x = bounds.minX
+                    y += lineHeight + lineSpacing
+                    lineHeight = 0
+                }
+
+                view.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(width: size.width, height: size.height))
+                x += size.width + spacing
+                lineHeight = max(lineHeight, size.height)
+            }
+        }
+    }
+}

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/SingleSelect/HorizonUI.SingleSelect.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/SingleSelect/HorizonUI.SingleSelect.swift
@@ -51,7 +51,7 @@ extension HorizonUI {
         @State private var errorHeight: CGFloat = 0
 
         @Binding private var focused: Bool
-        @FocusState private var searchFocuse: Bool
+        @FocusState private var isSearchFocused: Bool
 
         // The computed height of the label
         @State private var labelMeasuredHeight: CGFloat = 0

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/SingleSelect/HorizonUI.SingleSelect.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/SingleSelect/HorizonUI.SingleSelect.swift
@@ -24,6 +24,7 @@ extension HorizonUI {
         // MARK: Dependencies
 
         private let disabled: Bool
+        private let isSearchable: Bool
         private let error: String?
         private let label: String?
         private let options: [String]
@@ -32,6 +33,8 @@ extension HorizonUI {
 
         // MARK: Properties
 
+        private var originalSelection: String
+        @State private var text: String = ""
         private var bodyHeight: CGFloat {
             textInputMeasuredHeight + displayedOptionHeight + errorHeight
         }
@@ -48,7 +51,7 @@ extension HorizonUI {
         @State private var errorHeight: CGFloat = 0
 
         @Binding private var focused: Bool
-        private let focusedBinding: Binding<Bool>?
+        @FocusState private var searchFocuse: Bool
 
         // The computed height of the label
         @State private var labelMeasuredHeight: CGFloat = 0
@@ -57,12 +60,14 @@ extension HorizonUI {
         // of the entire component so when the options are displayed, it doesnt
         // push the content below it down
         @State private var textInputMeasuredHeight: CGFloat = 0
+        @State private var filteredItems: [String] = []
 
         // MARK: - Init
 
         public init(
             selection: Binding<String>,
             focused: Binding<Bool>,
+            isSearchable: Bool = true,
             label: String? = nil,
             options: [String],
             disabled: Bool = false,
@@ -75,8 +80,11 @@ extension HorizonUI {
             self.disabled = disabled
             self.placeholder = placeholder
             self.error = error
-            self.focusedBinding = focused
             self._focused = focused
+            self.text = selection.wrappedValue
+            self.isSearchable = isSearchable
+            self.filteredItems = options
+            self.originalSelection = selection.wrappedValue
         }
 
         public var body: some View {
@@ -101,7 +109,7 @@ extension HorizonUI {
         private var displayedOptions: some View {
             ScrollView {
                 VStack(spacing: .zero) {
-                    ForEach(options, id: \.self) { item in
+                    ForEach(filteredItems, id: \.self) { item in
                         displayedOption(item)
                     }
                 }
@@ -138,6 +146,7 @@ extension HorizonUI {
                 .onTapGesture {
                     focused = false
                     selection = text
+                    searchFocuse = false
                 }
         }
 
@@ -187,13 +196,28 @@ extension HorizonUI {
 
         private var textInput: some View {
             ZStack(alignment: .trailing) {
-                Text(selection.isEmpty ? placeholder ?? "" : selection)
-                    .huiTypography(.p1)
-                    .foregroundColor(textInputTextColor)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(HorizonUI.spaces.space12)
-                    .padding(.trailing, .huiSpaces.space24)
-                    .overlay(textOverlay(isOuter: false))
+                if isSearchable {
+                    TextField(selection.isEmpty ? placeholder ?? "" : selection, text: $text)
+                        .focused($searchFocuse)
+                        .huiTypography(.p1)
+                        .foregroundColor(textInputTextColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(HorizonUI.spaces.space12)
+                        .padding(.trailing, .huiSpaces.space24)
+                        .overlay(textOverlay(isOuter: false))
+                        .onChange(of: searchFocuse, onFocusChange)
+                        .onChange(of: text, onTextChange)
+                        .onChange(of: selection) { _, newValue in text = newValue }
+                        .onChange(of: focused) { _, newValue in searchFocuse = newValue }
+                } else {
+                    Text(selection.isEmpty ? placeholder ?? "" : selection)
+                        .huiTypography(.p1)
+                        .foregroundColor(textInputTextColor)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(HorizonUI.spaces.space12)
+                        .padding(.trailing, .huiSpaces.space24)
+                        .overlay(textOverlay(isOuter: false))
+                }
                 Image.huiIcons.chevronRight
                     .padding(.horizontal, .huiSpaces.space12)
                     .tint(Color.huiColors.icon.default)
@@ -261,6 +285,40 @@ extension HorizonUI {
                 }
             }
             return .huiColors.text.error
+        }
+
+        private func onFocusChange(oldValue: Bool, newValue: Bool) {
+            focused = newValue
+            if newValue {
+                filteredItems = options
+            } else {
+                let firstMatch = options.first { $0.lowercased() == text.lowercased() }
+                if firstMatch == nil {
+                    selection = originalSelection
+                    text = originalSelection
+                }
+            }
+        }
+
+        private func onTextChange(oldValue: String, newValue: String) {
+            if !focused {
+                return
+            }
+
+            // If the text input is empty, display all items
+            if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                filteredItems = options
+                return
+            }
+
+            // Display only the items that match what the user's input
+            filteredItems = options.filter { $0.lowercased().contains(text.lowercased()) }
+
+            // If what they've typed leaves no filtered items, display all options
+
+            if filteredItems.isEmpty {
+                filteredItems = options
+            }
         }
     }
 

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Spinner/HorizonUI.Spinner.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Spinner/HorizonUI.Spinner.swift
@@ -29,15 +29,22 @@ public extension HorizonUI {
         // MARK: - Private
 
         private let spinDuration = 3.0
-        private let backgroundColor: Color = Color.huiColors.lineAndBorders.lineDivider
-        private let foregroundColor = Color.huiColors.surface.institution
+        private let backgroundColor: Color
+        private let foregroundColor: Color
         @State private var rotation: Double = 0
 
         // MARK: - Init
 
-        public init(size: HorizonUI.Spinner.Size = .medium, showBackground: Bool = false) {
+        public init(
+            size: HorizonUI.Spinner.Size = .medium,
+            showBackground: Bool = false,
+            backgroundColor: Color = Color.huiColors.lineAndBorders.lineDivider,
+            foregroundColor: Color = Color.huiColors.surface.institution
+        ) {
             self.size = size
             self.showBackground = showBackground
+            self.backgroundColor = backgroundColor
+            self.foregroundColor = foregroundColor
         }
 
         public var body: some View {


### PR DESCRIPTION
Adds:
- `institutionLogo` to `Brand`
- Scroll enablement to `WebView`
- `groupWeight` to `AssignmentGroup`
- `hideFinalGrade` to `CourseSettings`
- makes the `uuid` field of `File` optional
- `canvasRegion` to `LoginSession` that comes from `APIOAuthUser`
- `canUpdateName` and `canUpdateAvatar` to `UserProfile`


affects: Student, Parent, Teacher