### PR TITLE
SpeedGrader - Add workaround to detect touches on segmented picker.

### DIFF
--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageTabsView.swift
@@ -64,10 +64,10 @@ struct SpeedGraderPageTabsView: View {
             Group {
                 switch containerType {
                 case .drawer:
-                    tabPicker
+                    tabPicker(shouldOpenDrawerIfNeeded: true)
                         .padding(.bottom, 16)
                 case .splitView:
-                    tabPicker
+                    tabPicker(shouldOpenDrawerIfNeeded: false)
                         .frame(height: splitViewHeaderHeight)
                 }
             }
@@ -105,24 +105,31 @@ struct SpeedGraderPageTabsView: View {
         }
     }
 
-    private var tabPicker: some View {
-        InstUI.SegmentedPicker(
-            selection: $selectedTab,
-            onTouch: openDrawerToMidIfClosedInPortrait
-        ) {
+    @ViewBuilder
+    private func tabPicker(shouldOpenDrawerIfNeeded: Bool) -> some View {
+        let content = {
             ForEach(SpeedGraderPageTab.allCases, id: \.self) { tab in
                 Text(tab.title)
                     .tag(tab)
             }
         }
-    }
-
-    private func openDrawerToMidIfClosedInPortrait() {
-        guard containerType == .drawer, drawerState.isClosed else {
-            return
+        if shouldOpenDrawerIfNeeded {
+            InstUI.SegmentedPicker(
+                selection: $selectedTab,
+                segmentCount: SpeedGraderPageTab.allCases.count,
+                onTapSelectedTab: {
+                    if drawerState.isClosed {
+                        snapDrawer(to: .mid)
+                    }
+                },
+                content: content
+            )
+        } else {
+            InstUI.SegmentedPicker(
+                selection: $selectedTab,
+                content: content
+            )
         }
-
-        snapDrawer(to: .mid)
     }
 
     // MARK: - Tab Contents


### PR DESCRIPTION
refs: [MBL-19049](https://instructure.atlassian.net/browse/MBL-19049)
affects: Teacher
release note: Fixed SpeedGrader drawer not opening when tapping on the Grades tab.

test plan:
- See ticket.

## Checklist

- [ ] A11y checked
- [x] Tested on phone
- [x] Tested on tablet

[MBL-19049]: https://instructure.atlassian.net/browse/MBL-19049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ