### PR TITLE
[Horizon] Unable to Select Multiple Recipients

### DIFF
--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/MultiSelect/HorizonUI.MultiSelect.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/Inputs/MultiSelect/HorizonUI.MultiSelect.swift
@@ -357,7 +357,7 @@ extension HorizonUI {
         // MARK: - Private Functions
 
         private func onTapText() {
-            if disabled || optionsFiltered.isEmpty {
+            if disabled {
                 return
             }
             focused = !focused


### PR DESCRIPTION
This is fixing a defect where if the user filters the multiselect down to a single result and then taps in the area to add more, it does nothing.

affects: Horizon