### PR TITLE
[Horizon] WrappingHStack Improvement

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/View/WrappingHStack.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/WrappingHStack.swift
@@ -51,6 +51,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
     private func generateContent(in geometry: GeometryProxy) -> some View {
         var width = CGFloat.zero
         var height = CGFloat.zero
+        var priorHeight = CGFloat.zero
 
         return ZStack(alignment: .topLeading) {
             ForEach(self.models, id: \.self) { models in
@@ -60,7 +61,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
                     .alignmentGuide(.leading, computeValue: { dimension in
                         if (abs(width - dimension.width) > geometry.size.width) {
                             width = 0
-                            height -= dimension.height
+                            height -= priorHeight
                         }
                         let result = width
                         if models == self.models.last! {
@@ -68,6 +69,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
                         } else {
                             width -= dimension.width
                         }
+                        priorHeight = dimension.height
                         return result
                     })
                     .alignmentGuide(.top, computeValue: { _ in

--- a/Core/Core/Features/Inbox/ComposeMessage/View/WrappingHStack.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/WrappingHStack.swift
@@ -51,7 +51,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
     private func generateContent(in geometry: GeometryProxy) -> some View {
         var width = CGFloat.zero
         var height = CGFloat.zero
-        var priorHeight = CGFloat.zero
+        var previousHight = CGFloat.zero
 
         return ZStack(alignment: .topLeading) {
             ForEach(self.models, id: \.self) { models in
@@ -61,7 +61,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
                     .alignmentGuide(.leading, computeValue: { dimension in
                         if (abs(width - dimension.width) > geometry.size.width) {
                             width = 0
-                            height -= priorHeight
+                            height -= previousHight
                         }
                         let result = width
                         if models == self.models.last! {
@@ -69,7 +69,7 @@ public struct WrappingHStack<Model, V>: View where Model: Hashable, V: View {
                         } else {
                             width -= dimension.width
                         }
-                        priorHeight = dimension.height
+                        previousHight = dimension.height
                         return result
                     })
                     .alignmentGuide(.top, computeValue: { _ in

--- a/Horizon/Horizon/Resources/Localizable.xcstrings
+++ b/Horizon/Horizon/Resources/Localizable.xcstrings
@@ -442,7 +442,7 @@
     "Hello, Career!" : {
 
     },
-    "Hello! Which course you'd like to discuss today?" : {
+    "Hello! Which course would you like to discuss today?" : {
 
     },
     "Helsinki (+02:00/+03:00)" : {

--- a/Horizon/Horizon/Sources/Features/Assist/AssistChat/Domain/Goal/AssistSelectCourseGoal.swift
+++ b/Horizon/Horizon/Sources/Features/Assist/AssistChat/Domain/Goal/AssistSelectCourseGoal.swift
@@ -71,7 +71,7 @@ class AssistSelectCourseGoal: AssistGoal {
     }
 
     private func initialPrompt(history: [AssistChatMessage]) -> AnyPublisher<AssistChatMessage?, any Error> {
-        let promptFirstTime = String(localized: "Hello! Which course you'd like to discuss today?", bundle: .horizon)
+        let promptFirstTime = String(localized: "Hello! Which course would you like to discuss today?", bundle: .horizon)
         let promptAgain = String(localized: "Sorry, can we try that again? Which course is it you'd like to discuss?", bundle: .horizon)
         let didIJustAskThis = history.count > 1 && history[history.count - 2].text?.contains(promptFirstTime) == true
         let prompt = didIJustAskThis ? promptAgain : promptFirstTime


### PR DESCRIPTION
This is not perfect, but it is an improvement. It keeps items from overlapping each other, but doesn't allow for vertically centering row items.

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-18 at 13 37 53" src="https://github.com/user-attachments/assets/e82df44e-f6d7-4e20-bfa9-285da2520cdb" />
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-07-18 at 14 35 40" src="https://github.com/user-attachments/assets/79e4c879-9acf-427a-a619-fbf8d151a513" />

[ignore-commit-lint]
affects: Horizon
