### PR TITLE
[Horizon] Notebook Highlight Menu Adjustment

### DIFF
--- a/Horizon/Horizon/Sources/Features/Notebook/Common/View/HighlightWebView/HighlightWebView.swift
+++ b/Horizon/Horizon/Sources/Features/Notebook/Common/View/HighlightWebView/HighlightWebView.swift
@@ -100,7 +100,6 @@ final class HighlightWebView: CoreWebView {
     // MARK: - Override Functions
 
     override func buildMenu(with builder: any UIMenuBuilder) {
-        // Prevent overlapping highlights
         guard !isOverlapped else { return }
 
         let actions = actionDefinitions.map { actionDefinition in


### PR DESCRIPTION
https://instructure.atlassian.net/browse/CLX-2259

Adjusting the menu for highlighting for the notebook. Instead of having all the notebook options under a submenu, they now appear at the top level.


https://github.com/user-attachments/assets/13bc296a-0846-4013-8da7-1d32fa02debc


affects: Horizon
[ignore-commit-lint]