### PR TITLE
Fix issue of NotSubmitted filtering on Submissions list

### DIFF
--- a/Core/Core/Features/Submissions/GetSubmissions.swift
+++ b/Core/Core/Features/Submissions/GetSubmissions.swift
@@ -370,9 +370,13 @@ public class GetSubmissions: CollectionUseCase {
             case .late:
                 return NSPredicate(key: #keyPath(Submission.late), equals: true)
             case .notSubmitted:
-                return NSCompoundPredicate(type: .and, subpredicates: [
-                    NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil),
-                    NSPredicate(key: #keyPath(Submission.workflowStateRaw), equals: SubmissionWorkflowState.unsubmitted.rawValue)
+                return NSCompoundPredicate(type: .or, subpredicates: [
+                    NSPredicate(key: #keyPath(Submission.workflowStateRaw), equals: SubmissionWorkflowState.unsubmitted.rawValue),
+                    NSCompoundPredicate(type: .and, subpredicates: [
+                        NSPredicate(key: #keyPath(Submission.workflowStateRaw), equals: SubmissionWorkflowState.graded.rawValue),
+                        NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil),
+                        NSPredicate(key: #keyPath(Submission.scoreRaw), equals: nil)
+                    ])
                 ])
             case .needsGrading:
                 let notExcused = NSPredicate(format: "%K == nil OR %K != true", #keyPath(Submission.excusedRaw), #keyPath(Submission.excusedRaw))

--- a/Core/CoreTests/Features/Submissions/GetSubmissionsTests.swift
+++ b/Core/CoreTests/Features/Submissions/GetSubmissionsTests.swift
@@ -289,10 +289,7 @@ class GetSubmissionsTests: CoreTestCase {
         XCTAssertEqual(Filter.late.predicate, NSPredicate(key: #keyPath(Submission.late), equals: true))
         XCTAssertEqual(
             Filter.notSubmitted.predicate,
-            NSCompoundPredicate(type: .and, subpredicates: [
-                NSPredicate(key: #keyPath(Submission.submittedAt), equals: nil),
-                NSPredicate(key: #keyPath(Submission.workflowStateRaw), equals: SubmissionWorkflowState.unsubmitted.rawValue)
-            ])
+            NSPredicate(format: "workflowStateRaw == 'unsubmitted' OR (workflowStateRaw == 'graded' AND submittedAt == nil AND scoreRaw == nil)")
         )
         XCTAssertEqual(Filter.graded.predicate, NSPredicate(format: "%K == true OR (%K != nil AND %K == 'graded')",
             #keyPath(Submission.excusedRaw),


### PR DESCRIPTION
refs: [MBL-19048](https://instructure.atlassian.net/browse/MBL-19048)
affects: Teacher
release note: Fixed issue with Not-submitted filtering on submissions list

Updated "NotSubmitted" fetching predicate of submissions to match the one used on in `filter` function of `SubmissionListSection.Kind` type, which is also used for list sectioning. 

Mainly this is covering the case where invalid score is being submitted to rubric criteria items on SpeedGrader. Which could yield `workflow_state` to be evaluated as `graded` although no grade value is returned to it. 

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-19048) description. 

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19048]: https://instructure.atlassian.net/browse/MBL-19048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ