### PR TITLE
SpeedGrader - Close keyboard on swipe to next student

### DIFF
--- a/Teacher/Teacher/SpeedGrader/SpeedGraderScreen/ViewModel/SpeedGraderScreenViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderScreen/ViewModel/SpeedGraderScreenViewModel.swift
@@ -228,5 +228,7 @@ extension SpeedGraderScreenViewModel: PagesViewControllerDelegate {
     ) {
         pages.pauseWebViewPlayback()
         pages.pauseMediaPlayback()
+        // Close keyboard
+        pages.view.endEditing(true)
     }
 }


### PR DESCRIPTION
refs: MBL-18714
affects: Teacher
release note: none

test plan:
- Open SpeedGrader with multiple students.
- Tap into a text field to activate on screen keyboard.
- Swipe to next student.
- Keyboard should disappear.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
