### PR TITLE
[Horizon] Inbox Loading Fix

### DIFF
--- a/Horizon/Horizon/Sources/Features/Inbox/Inbox/View/HInboxViewModel.swift
+++ b/Horizon/Horizon/Sources/Features/Inbox/Inbox/View/HInboxViewModel.swift
@@ -224,7 +224,8 @@ class HInboxViewModel {
             self.peopleSelectionViewModel.personFilterSubject
         )
         .filter { [weak self] _, announcements, _, _ in
-            self?.inboxMessageInteractor.state.value == .data && announcements != nil
+            let state = self?.inboxMessageInteractor.state.value ?? .loading
+            return (state == .data || state == .empty) && announcements != nil
         }
         .map { [weak self] _, _, filterSubject, _ in
             guard let self = self,


### PR DESCRIPTION
Fixing an issue where the Inbox spinner would not go away if the user has no messages.


https://github.com/user-attachments/assets/308c7917-8928-402c-bdd6-66b95bd06e69



affects: Horizon
[ignore-commit-lint]