### PR TITLE
SpeedGrader - Fix closing CommentLibrary hides Comment textfield behind keyboard

### DIFF
--- a/Teacher/Teacher/SpeedGrader/Comments/View/CommentInputView.swift
+++ b/Teacher/Teacher/SpeedGrader/Comments/View/CommentInputView.swift
@@ -151,7 +151,10 @@ struct CommentInputView: View {
         let icon = isCurrentlyClosed ? Image.chatLine : Image.chevronDown
         let label = isCurrentlyClosed ? Text("Open comment library", bundle: .teacher) : Text("Close comment library", bundle: .teacher)
         Button(
-            action: commentLibraryAction,
+            action: {
+                commentLibraryAction()
+                isFocused = false
+            },
             label: {
                 icon
                     .scaledIcon()


### PR DESCRIPTION
affects: Teacher
[ignore-commit-lint]

## Test plan
1. Open Comment textfield to show keyboard
2. Tap Comment Library button (enabled feature on web)
3. Close Comment Library
  a. via Done button
  b. via arrow button at bottom 
  c. via selecting an item
4. Verify the reappearing Comment textfield is not hidden behind it's keyboard

## Checklist
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet