### PR TITLE
SpeedGrader - Handle fractional late days

### DIFF
--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -784,7 +784,11 @@
         }
       }
     },
+    "%lf days late." : {
+
+    },
     "%lld days late." : {
+      "extractionState" : "stale",
       "localizations" : {
         "ar" : {
           "variations" : {

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
@@ -43,12 +43,12 @@ protocol GradeStatusInteractor {
     func observeGradeStatusChanges(
         submissionId: String,
         attempt: Int
-    ) -> AnyPublisher<(GradeStatus, daysLate: Int, dueDate: Date?), Never>
+    ) -> AnyPublisher<(GradeStatus, daysLate: Double, dueDate: Date?), Never>
 
     func updateLateDays(
         submissionId: String,
         userId: String,
-        daysLate: Int
+        daysLate: Double
     ) -> AnyPublisher<Void, Error>
 }
 
@@ -135,7 +135,7 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
     func observeGradeStatusChanges(
         submissionId: String,
         attempt: Int
-    ) -> AnyPublisher<(GradeStatus, daysLate: Int, dueDate: Date?), Never> {
+    ) -> AnyPublisher<(GradeStatus, daysLate: Double, dueDate: Date?), Never> {
         let predicate = NSPredicate.id(submissionId).and(NSPredicate(key: "attempt", equals: attempt))
         let useCase = LocalUseCase<Submission>(scope: Scope(predicate: predicate, order: []))
         let store = ReactiveStore(useCase: useCase)
@@ -152,7 +152,7 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
                     isExcused: submission.excused,
                     isLate: submission.late
                 )
-                let daysLate = Int(ceil(Double(submission.lateSeconds) / (24 * 60 * 60.0)))
+                let daysLate = Double(submission.lateSeconds) / (24 * 60 * 60.0)
                 let dueDate = submission.assignment?.dueAt
                 return (status, daysLate, dueDate)
             }
@@ -168,9 +168,9 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
     func updateLateDays(
         submissionId: String,
         userId: String,
-        daysLate: Int
+        daysLate: Double
     ) -> AnyPublisher<Void, Error> {
-        let lateSeconds = daysLate * 24 * 60 * 60
+        let lateSeconds = Int(daysLate * 24 * 60 * 60)
         let useCase = GradeSubmission(
             courseID: courseId,
             assignmentID: assignmentId,

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorPreview.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorPreview.swift
@@ -61,9 +61,9 @@ class GradeStatusInteractorPreview: GradeStatusInteractor {
         .none
     }
 
-    func observeGradeStatusChanges(submissionId: String, attempt: Int) -> AnyPublisher<(GradeStatus, daysLate: Int, dueDate: Date?), Never> {
+    func observeGradeStatusChanges(submissionId: String, attempt: Int) -> AnyPublisher<(GradeStatus, daysLate: Double, dueDate: Date?), Never> {
         if let status = previewStatus, let daysLate = previewDaysLate {
-            return Just((status, daysLate, previewDueDate)).eraseToAnyPublisher()
+            return Just((status, Double(daysLate), previewDueDate)).eraseToAnyPublisher()
         } else {
             return Empty().eraseToAnyPublisher()
         }
@@ -72,7 +72,7 @@ class GradeStatusInteractorPreview: GradeStatusInteractor {
     func updateLateDays(
         submissionId: String,
         userId: String,
-        daysLate: Int
+        daysLate: Double
     ) -> AnyPublisher<Void, Error> {
         Just(())
             .delay(for: .seconds(2), scheduler: RunLoop.main)

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusDaysLateView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/View/GradeStatusDaysLateView.swift
@@ -78,7 +78,7 @@ struct GradeStatusDaysLateView: View {
         )
         alert.addTextField { textField in
             textField.placeholder = String(localized: "Days late", bundle: .teacher)
-            textField.keyboardType = .numberPad
+            textField.keyboardType = .decimalPad
             textField.text = viewModel.daysLate
         }
         alert.addAction(UIAlertAction(
@@ -90,8 +90,8 @@ struct GradeStatusDaysLateView: View {
             title: String(localized: "OK", bundle: .teacher),
             style: .default
         ) { _ in
-            if let text = alert.textFields?.first?.text, let value = Int(text) {
-                viewModel.didChangeLateDaysValue.send(value)
+            if let text = alert.textFields?.first?.text {
+                viewModel.didChangeLateDaysValue.send(text)
             }
             isA11yFocused = true
         })

--- a/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorMock.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractorMock.swift
@@ -62,25 +62,25 @@ final class GradeStatusInteractorMock: GradeStatusInteractor {
     func observeGradeStatusChanges(
         submissionId: String,
         attempt: Int
-    ) -> AnyPublisher<(GradeStatus, daysLate: Int, dueDate: Date?), Never> {
-        observeGradeStatusChangesCalled = true
+    ) -> AnyPublisher<(GradeStatus, daysLate: Double, dueDate: Date?), Never> {
         observeGradeStatusChangesInput = (submissionId, attempt)
+        observeGradeStatusChangesCalled = true
         if let status = gradeStatuses.first {
-            return Just((status, mockDaysLate, mockDueDate)).eraseToAnyPublisher()
+            return Just((status, Double(mockDaysLate), mockDueDate)).eraseToAnyPublisher()
         } else {
             return Empty().eraseToAnyPublisher()
         }
     }
 
     var updateLateDaysCalled = false
-    var updateLateDaysParams: (submissionId: String, userId: String, daysLate: Int)?
+    var updateLateDaysParams: (submissionId: String, userId: String, daysLate: Double)?
     func updateLateDays(
         submissionId: String,
         userId: String,
-        daysLate: Int
+        daysLate: Double
     ) -> AnyPublisher<Void, Error> {
-        updateLateDaysCalled = true
         updateLateDaysParams = (submissionId, userId, daysLate)
+        updateLateDaysCalled = true
         return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
refs: [MBL-19082](https://instructure.atlassian.net/browse/MBL-19082)
affects: Teacher
release note: Added support for fractional late days number to SpeedGrader.

test plan:
- Change grade penalty to be measure in hours instead of days in web gradebook.
- Open web SpeedGrader and make the submission late by 12 hours.
- Open teacher app and check the same submission.
- Late days should show 0.5.
- Edit late days to 0.25 in the app.
- Go to web, refresh SpeedGrader.
- Late hours shold show 6 hours.
- Late penalty score should also match between app and web.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/82ed2d6b-8263-4ed9-8f2c-79ab778eda44" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/8358adac-61f0-4473-8868-41d3d61fe305" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
