### PR TITLE
SpeedGrader - Add support for custom grading schemes

### DIFF
--- a/Core/Core/Features/Courses/Course.swift
+++ b/Core/Core/Features/Courses/Course.swift
@@ -63,8 +63,8 @@ final public class Course: NSManagedObject, WriteableModel {
     public var gradingScheme: GradingScheme {
         if pointsBasedGradingScheme {
             PointsBasedGradingScheme(
-                scaleFactor: scalingFactor,
-                entries: gradingSchemeEntries
+                entries: gradingSchemeEntries,
+                scaleFactor: scalingFactor
             )
         } else {
             PercentageBasedGradingScheme(entries: gradingSchemeEntries)

--- a/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
@@ -21,16 +21,31 @@ import Foundation
 public protocol GradingScheme {
     var entries: [GradingSchemeEntry] { get }
 
-    func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String?
+    var formattedEntries: [FormattedGradingSchemeEntry] { get }
+    var maxFormattedValue: String? { get }
+    func formattedEntryValue(_ value: Double) -> String?
+
     func formattedScore(from value: Double) -> String?
+    func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String?
 }
 
-public extension GradingScheme {
+extension GradingScheme {
 
-    func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String? {
+    public var formattedEntries: [FormattedGradingSchemeEntry] {
+        entries.map {
+            .init(name: $0.name, value: formattedEntryValue($0.value) ?? "")
+        }
+    }
+
+    public func convertNormalizedScoreToLetterGrade(_ normalizedScore: Double) -> String? {
         // Teachers can add extra points so the "normalized" score can be higher than 1.0. But 10 would be very suspicious.
         assert(abs(normalizedScore) < 10)
 
         return entries.first { normalizedScore >= $0.value }?.name
     }
+}
+
+public struct FormattedGradingSchemeEntry {
+    public let name: String
+    public let value: String
 }

--- a/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingScheme.swift
@@ -22,7 +22,7 @@ public protocol GradingScheme {
     var entries: [GradingSchemeEntry] { get }
 
     var formattedEntries: [FormattedGradingSchemeEntry] { get }
-    var maxFormattedValue: String? { get }
+    var formattedMaxValue: String? { get }
     func formattedEntryValue(_ value: Double) -> String?
 
     func formattedScore(from value: Double) -> String?
@@ -45,7 +45,7 @@ extension GradingScheme {
     }
 }
 
-public struct FormattedGradingSchemeEntry {
+public struct FormattedGradingSchemeEntry: Equatable {
     public let name: String
     public let value: String
 }

--- a/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PercentageBasedGradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PercentageBasedGradingScheme.swift
@@ -20,21 +20,26 @@ import Foundation
 
 public struct PercentageBasedGradingScheme: GradingScheme {
 
+    /// converts 0.1234 -> "12.34%", 0.42 -> "42%"
+    private static let percentFormatter = GradeFormatter.percentFormatter
+
     public let entries: [GradingSchemeEntry]
+
+    public init(entries: [GradingSchemeEntry]) {
+        self.entries = entries
+    }
+
+    public var maxFormattedValue: String? {
+        Self.percentFormatter.string(from: NSNumber(value: 1))
+    }
+
+    public func formattedEntryValue(_ value: Double) -> String? {
+        Self.percentFormatter.string(from: NSNumber(value: value))
+    }
 
     public func formattedScore(from value: Double) -> String? {
         Self.percentFormatter.string(from: NSNumber(value: value))
     }
-
-    private static let percentFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .percent
-        formatter.decimalSeparator = "."
-        formatter.multiplier = 1
-        formatter.maximumFractionDigits = 3
-        formatter.roundingMode = .down
-        return formatter
-    }()
 }
 
 // MARK: - Schemes for Previews & Testing

--- a/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PercentageBasedGradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PercentageBasedGradingScheme.swift
@@ -20,7 +20,6 @@ import Foundation
 
 public struct PercentageBasedGradingScheme: GradingScheme {
 
-    /// converts 0.1234 -> "12.34%", 0.42 -> "42%"
     private static let percentFormatter = GradeFormatter.percentFormatter
 
     public let entries: [GradingSchemeEntry]
@@ -29,16 +28,20 @@ public struct PercentageBasedGradingScheme: GradingScheme {
         self.entries = entries
     }
 
-    public var maxFormattedValue: String? {
+    public var formattedMaxValue: String? {
         Self.percentFormatter.string(from: NSNumber(value: 1))
     }
 
-    public func formattedEntryValue(_ value: Double) -> String? {
-        Self.percentFormatter.string(from: NSNumber(value: value))
+    // Expects GradingSchemeEntry values which are in range of [0,1]
+    public func formattedEntryValue(_ entryValue: Double) -> String? {
+        // Not scaling them up, because percentFormatter expects the same range. For example it converts 0.42 to "42%"
+        Self.percentFormatter.string(from: NSNumber(value: entryValue))
     }
 
-    public func formattedScore(from value: Double) -> String? {
-        Self.percentFormatter.string(from: NSNumber(value: value))
+    // Expects scores which are in range of [0,100+]
+    public func formattedScore(from score: Double) -> String? {
+        let normalizedScore = score / 100.0
+        return Self.percentFormatter.string(from: NSNumber(value: normalizedScore))
     }
 }
 

--- a/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PointsBasedGradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PointsBasedGradingScheme.swift
@@ -20,23 +20,31 @@ import Foundation
 
 public struct PointsBasedGradingScheme: GradingScheme {
 
-    public let scaleFactor: Double
+    /// converts 12.34 -> "12.34", 42.0 -> "42"
+    private static let numberFormatter = GradeFormatter.numberFormatter
+
     public let entries: [GradingSchemeEntry]
+    private let scaleFactor: Double
+
+    public init(entries: [GradingSchemeEntry], scaleFactor: Double) {
+        self.entries = entries
+        self.scaleFactor = scaleFactor
+    }
+
+    public var maxFormattedValue: String? {
+        Self.numberFormatter.string(from: NSNumber(value: scaleFactor))
+    }
+
+    public func formattedEntryValue(_ value: Double) -> String? {
+        let scaledValue = value * scaleFactor
+        return Self.numberFormatter.string(from: NSNumber(value: scaledValue))
+    }
 
     public func formattedScore(from value: Double) -> String? {
         let normalizedScore = value / 100.0
         let number = NSNumber(value: normalizedScore * scaleFactor)
-        return Self.pointsFormatter.string(from: number)
+        return Self.numberFormatter.string(from: number)
     }
-
-    private static let pointsFormatter: NumberFormatter = {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        formatter.multiplier = 1
-        formatter.maximumFractionDigits = 2
-        formatter.roundingMode = .halfEven
-        return formatter
-    }()
 }
 
 // MARK: - Schemes for Previews & Testing
@@ -45,7 +53,7 @@ public struct PointsBasedGradingScheme: GradingScheme {
 
 public extension PointsBasedGradingScheme {
     static var `default`: Self {
-        PointsBasedGradingScheme(scaleFactor: 4, entries: [])
+        PointsBasedGradingScheme(entries: [], scaleFactor: 4)
     }
 }
 

--- a/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PointsBasedGradingScheme.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradingSchemes/PointsBasedGradingScheme.swift
@@ -20,7 +20,6 @@ import Foundation
 
 public struct PointsBasedGradingScheme: GradingScheme {
 
-    /// converts 12.34 -> "12.34", 42.0 -> "42"
     private static let numberFormatter = GradeFormatter.numberFormatter
 
     public let entries: [GradingSchemeEntry]
@@ -31,11 +30,13 @@ public struct PointsBasedGradingScheme: GradingScheme {
         self.scaleFactor = scaleFactor
     }
 
-    public var maxFormattedValue: String? {
+    public var formattedMaxValue: String? {
         Self.numberFormatter.string(from: NSNumber(value: scaleFactor))
     }
 
+    // Expects GradingSchemeEntry values which are in range of [0,1]
     public func formattedEntryValue(_ value: Double) -> String? {
+        // Scaling it up, for example 0.75 to 3 (when max value is 4)
         let scaledValue = value * scaleFactor
         return Self.numberFormatter.string(from: NSNumber(value: scaledValue))
     }

--- a/Core/Core/Features/Grades/Model/GradeFormatter.swift
+++ b/Core/Core/Features/Grades/Model/GradeFormatter.swift
@@ -53,18 +53,18 @@ public class GradeFormatter {
     public static let numberFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.locale = Locale.current
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 0
         formatter.numberStyle = .decimal
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
         return formatter
     }()
 
     public static let percentFormatter: NumberFormatter = {
         let formatter = NumberFormatter()
         formatter.locale = Locale.current
-        formatter.maximumFractionDigits = 2
-        formatter.minimumFractionDigits = 0
         formatter.numberStyle = .percent
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
         return formatter
     }()
 

--- a/Core/Core/Features/Grades/Model/GradeFormatter.swift
+++ b/Core/Core/Features/Grades/Model/GradeFormatter.swift
@@ -56,6 +56,7 @@ public class GradeFormatter {
         formatter.numberStyle = .decimal
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 2
+        formatter.roundingMode = .halfUp // to match round() function
         return formatter
     }()
 
@@ -65,6 +66,7 @@ public class GradeFormatter {
         formatter.numberStyle = .percent
         formatter.minimumFractionDigits = 0
         formatter.maximumFractionDigits = 2
+        formatter.roundingMode = .halfUp // to match round() function
         return formatter
     }()
 

--- a/Core/CoreTests/Features/Grades/Model/Entities/GradingSchemeTestCase.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/GradingSchemeTestCase.swift
@@ -22,22 +22,21 @@ import XCTest
 class GradingSchemeTestCase: CoreTestCase {
 
     func scoreConversionEntries() -> [GradingSchemeEntry] {
-        let entryA: GradingSchemeEntry = databaseClient.insert()
-        entryA.name = "A"
-        entryA.value = 0.9
-        let entryB: GradingSchemeEntry = databaseClient.insert()
-        entryB.name = "B"
-        entryB.value = 0.3
-        let entryF: GradingSchemeEntry = databaseClient.insert()
-        entryF.name = "F"
-        entryF.value = 0
-        return [entryA, entryB, entryF]
+        [
+            makeEntry(name: "A", value: 0.9),
+            makeEntry(name: "B", value: 0.3),
+            makeEntry(name: "F", value: 0)
+        ]
     }
 
     func invalidConversionEntries() -> [GradingSchemeEntry] {
+        [makeEntry(name: "A", value: 90)]
+    }
+
+    func makeEntry(name: String = "", value: Double = 0) -> GradingSchemeEntry {
         let entry: GradingSchemeEntry = databaseClient.insert()
-        entry.name = "A"
-        entry.value = 90
-        return [entry]
+        entry.name = name
+        entry.value = value
+        return entry
     }
 }

--- a/Core/CoreTests/Features/Grades/Model/Entities/PercentageBasedGradingSchemeTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/PercentageBasedGradingSchemeTests.swift
@@ -17,6 +17,7 @@
 //
 
 @testable import Core
+import TestsFoundation
 import XCTest
 
 class PercentageBasedGradingSchemeTests: GradingSchemeTestCase {
@@ -47,19 +48,66 @@ class PercentageBasedGradingSchemeTests: GradingSchemeTestCase {
         XCTAssertNil(result)
     }
 
-    func testFormattedScorePointBasedOff() {
+    func testFormattedScore() {
         let testee = PercentageBasedGradingScheme.default
 
         var result = testee.formattedScore(from: 80)
         XCTAssertEqual(result, "80%")
 
         result = testee.formattedScore(from: 45.766777)
-        XCTAssertEqual(result, "45.766%")
+        XCTAssertEqual(result, "45.77%")
+
+        result = testee.formattedScore(from: 12.345)
+        XCTAssertEqual(result, "12.35%")
 
         result = testee.formattedScore(from: 33.43)
         XCTAssertEqual(result, "33.43%")
 
         result = testee.formattedScore(from: 87.40)
         XCTAssertEqual(result, "87.4%")
+    }
+
+    func test_formattedMaxValue_shouldAlwaysBe100Percent() {
+        var testee = PercentageBasedGradingScheme(entries: scoreConversionEntries())
+        XCTAssertEqual(testee.formattedMaxValue, "100%")
+
+        testee = PercentageBasedGradingScheme(entries: [])
+        XCTAssertEqual(testee.formattedMaxValue, "100%")
+    }
+
+    func test_formattedEntryValue() {
+        let testee = PercentageBasedGradingScheme(entries: [])
+
+        XCTAssertEqual(testee.formattedEntryValue(1), "100%")
+        XCTAssertEqual(testee.formattedEntryValue(0.42), "42%")
+        XCTAssertEqual(testee.formattedEntryValue(0.123456), "12.35%")
+        XCTAssertEqual(testee.formattedEntryValue(0), "0%")
+    }
+
+    func test_formattedEntries() throws {
+        let testee = PercentageBasedGradingScheme(entries: [
+            makeEntry(name: "A++", value: 1.23),
+            makeEntry(name: "A+", value: 1),
+            makeEntry(name: "A", value: 0.42),
+            makeEntry(name: "B", value: 0.123456),
+            makeEntry(name: "F", value: 0.01),
+            makeEntry(name: "F-", value: 0.0)
+        ])
+
+        guard testee.formattedEntries.count == 6 else { throw InvalidCountError() }
+
+        XCTAssertEqual(testee.formattedEntries[0].name, "A++")
+        XCTAssertEqual(testee.formattedEntries[1].name, "A+")
+        XCTAssertEqual(testee.formattedEntries[2].name, "A")
+        XCTAssertEqual(testee.formattedEntries[3].name, "B")
+        XCTAssertEqual(testee.formattedEntries[4].name, "F")
+        XCTAssertEqual(testee.formattedEntries[5].name, "F-")
+
+        XCTAssertEqual(testee.formattedEntries[0].value, "123%")
+        XCTAssertEqual(testee.formattedEntries[1].value, "100%")
+        XCTAssertEqual(testee.formattedEntries[2].value, "42%")
+        XCTAssertEqual(testee.formattedEntries[3].value, "12.35%")
+        XCTAssertEqual(testee.formattedEntries[4].value, "1%")
+        XCTAssertEqual(testee.formattedEntries[5].value, "0%")
     }
 }

--- a/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
@@ -23,7 +23,7 @@ import XCTest
 class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
 
     func testScoreConversion() {
-        let testee = PointsBasedGradingScheme(scaleFactor: 5, entries: scoreConversionEntries())
+        let testee = PointsBasedGradingScheme(entries: scoreConversionEntries(), scaleFactor: 5)
 
         var result = testee.convertNormalizedScoreToLetterGrade(0.90)
         XCTAssertEqual(result, "A")
@@ -42,13 +42,13 @@ class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
     }
 
     func testScoreConversionWithInvalidScheme() {
-        let testee = PointsBasedGradingScheme(scaleFactor: 4, entries: invalidConversionEntries())
+        let testee = PointsBasedGradingScheme(entries: invalidConversionEntries(), scaleFactor: 4)
         let result = testee.convertNormalizedScoreToLetterGrade(0.30)
         XCTAssertNil(result)
     }
 
     func testFormattedScorePointBasedOn() {
-        let testee = PointsBasedGradingScheme(scaleFactor: 5, entries: [])
+        let testee = PointsBasedGradingScheme(entries: [], scaleFactor: 5)
 
         var result = testee.formattedScore(from: 80)
         XCTAssertEqual(result, "4")

--- a/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/Entities/PointsBasedGradingSchemeTests.swift
@@ -17,7 +17,7 @@
 //
 
 @testable import Core
-import CoreData
+import TestsFoundation
 import XCTest
 
 class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
@@ -47,7 +47,7 @@ class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
         XCTAssertNil(result)
     }
 
-    func testFormattedScorePointBasedOn() {
+    func testFormattedScore() {
         let testee = PointsBasedGradingScheme(entries: [], scaleFactor: 5)
 
         var result = testee.formattedScore(from: 80)
@@ -58,5 +58,52 @@ class PointsBasedGradingSchemeTests: GradingSchemeTestCase {
 
         result = testee.formattedScore(from: 33.43)
         XCTAssertEqual(result, "1.67")
+    }
+
+    func test_formattedMaxValue_shouldAlwaysBeScaleFactor() {
+        var testee = PointsBasedGradingScheme(entries: scoreConversionEntries(), scaleFactor: 4)
+        XCTAssertEqual(testee.formattedMaxValue, "4")
+
+        testee = PointsBasedGradingScheme(entries: [], scaleFactor: 4)
+        XCTAssertEqual(testee.formattedMaxValue, "4")
+    }
+
+    func test_formattedEntryValue() {
+        let testee = PointsBasedGradingScheme(entries: [], scaleFactor: 4)
+
+        XCTAssertEqual(testee.formattedEntryValue(1), "4")
+        XCTAssertEqual(testee.formattedEntryValue(0.75), "3")
+        XCTAssertEqual(testee.formattedEntryValue(0.10125), "0.41")
+        XCTAssertEqual(testee.formattedEntryValue(0), "0")
+    }
+
+    func test_formattedEntries() throws {
+        let testee = PointsBasedGradingScheme(
+            entries: [
+                makeEntry(name: "A++", value: 1.23),
+                makeEntry(name: "A+", value: 1),
+                makeEntry(name: "A", value: 0.42),
+                makeEntry(name: "B", value: 0.123456),
+                makeEntry(name: "F", value: 0.01),
+                makeEntry(name: "F-", value: 0.0)
+            ],
+            scaleFactor: 10
+        )
+
+        guard testee.formattedEntries.count == 6 else { throw InvalidCountError() }
+
+        XCTAssertEqual(testee.formattedEntries[0].name, "A++")
+        XCTAssertEqual(testee.formattedEntries[1].name, "A+")
+        XCTAssertEqual(testee.formattedEntries[2].name, "A")
+        XCTAssertEqual(testee.formattedEntries[3].name, "B")
+        XCTAssertEqual(testee.formattedEntries[4].name, "F")
+        XCTAssertEqual(testee.formattedEntries[5].name, "F-")
+
+        XCTAssertEqual(testee.formattedEntries[0].value, "12.3")
+        XCTAssertEqual(testee.formattedEntries[1].value, "10")
+        XCTAssertEqual(testee.formattedEntries[2].value, "4.2")
+        XCTAssertEqual(testee.formattedEntries[3].value, "1.23")
+        XCTAssertEqual(testee.formattedEntries[4].value, "0.1")
+        XCTAssertEqual(testee.formattedEntries[5].value, "0")
     }
 }

--- a/Teacher/Teacher/Localizable.xcstrings
+++ b/Teacher/Teacher/Localizable.xcstrings
@@ -5,7 +5,7 @@
 
     },
     "%@ to %@" : {
-      "comment" : "'100% to 94%', or '400 to 230 pts'",
+      "comment" : "'100% to 94%', or '400 to 230'",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1778,11 +1778,8 @@
         }
       }
     },
-    "%lld%%" : {
-
-    },
     "< %@ to %@" : {
-      "comment" : "'< 94% to 84%', or '< 230 to 160 pts'",
+      "comment" : "'< 94% to 84%', or '< 230 to 160'",
       "localizations" : {
         "en" : {
           "stringUnit" : {

--- a/Teacher/Teacher/SpeedGrader/Grading/Points/Model/GradeStateInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/Model/GradeStateInteractor.swift
@@ -88,22 +88,19 @@ class GradeStateInteractorLive: GradeStateInteractor {
     private static func gradeOptions(for gradingType: GradingType, assignment: Assignment) -> [OptionItem] {
         switch gradingType {
         case .gpa_scale, .letter_grade:
-            guard let entries = assignment.gradingScheme?.entries else { return [] }
+            guard let gradingScheme = assignment.gradingScheme else { return [] }
 
-            // Assumptions:
-            // - values are always normalized in [0, 1]
-            // - values have 2 decimal digits at most (they can be converted to integer percents precisely)
             var items: [OptionItem] = []
-            let maxValue = String(localized: "\(100)%", bundle: .teacher)
+            let maxValue = gradingScheme.maxFormattedValue ?? ""
             var upperBound = maxValue
-            entries.forEach {
-                let lowerBound = String(localized: "\(Int($0.value * 100))%", bundle: .core)
+            gradingScheme.formattedEntries.forEach {
+                let lowerBound = $0.value
 
                 let subtitle: String
                 if upperBound == maxValue {
-                    subtitle = String(localized: "\(maxValue) to \(lowerBound)", bundle: .teacher, comment: "'100% to 94%', or '400 to 230 pts'")
+                    subtitle = String(localized: "\(maxValue) to \(lowerBound)", bundle: .teacher, comment: "'100% to 94%', or '400 to 230'")
                 } else {
-                    subtitle = String(localized: "< \(upperBound) to \(lowerBound)", bundle: .teacher, comment: "'< 94% to 84%', or '< 230 to 160 pts'")
+                    subtitle = String(localized: "< \(upperBound) to \(lowerBound)", bundle: .teacher, comment: "'< 94% to 84%', or '< 230 to 160'")
                 }
 
                 let a11yLabel = [String.accessibiltyLetterGrade($0.name), subtitle].joined(separator: ",")

--- a/Teacher/Teacher/SpeedGrader/Grading/Points/Model/GradeStateInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/Model/GradeStateInteractor.swift
@@ -91,7 +91,7 @@ class GradeStateInteractorLive: GradeStateInteractor {
             guard let gradingScheme = assignment.gradingScheme else { return [] }
 
             var items: [OptionItem] = []
-            let maxValue = gradingScheme.maxFormattedValue ?? ""
+            let maxValue = gradingScheme.formattedMaxValue ?? ""
             var upperBound = maxValue
             gradingScheme.formattedEntries.forEach {
                 let lowerBound = $0.value

--- a/Teacher/Teacher/SpeedGrader/Grading/Points/ViewModel/SpeedGraderSubmissionGradesViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/ViewModel/SpeedGraderSubmissionGradesViewModel.swift
@@ -129,7 +129,7 @@ class SpeedGraderSubmissionGradesViewModel: ObservableObject {
     }
 
     func setPercentGrade(_ percent: Double) {
-        let percentValue = "\(round(percent))%"
+        let percentValue = "\(percent)%"
         saveGrade(grade: percentValue)
     }
 

--- a/Teacher/TeacherTests/SpeedGrader/Grading/Points/ViewModel/SpeedGraderSubmissionGradesViewModelTests.swift
+++ b/Teacher/TeacherTests/SpeedGrader/Grading/Points/ViewModel/SpeedGraderSubmissionGradesViewModelTests.swift
@@ -111,18 +111,20 @@ class SpeedGraderSubmissionGradesViewModelTests: TeacherTestCase {
         XCTAssertEqual(gradeInteractorMock.lastGrade, "87.5")
     }
 
-    func test_setPercentGrade_callsSaveGradeWithRoundedPercent() {
-        viewModel.setPercentGrade(87.3)
+    func test_setPercentGrade_callsSaveGradeWithPercentageSign() {
+        viewModel.setPercentGrade(87.0)
 
         XCTAssertTrue(gradeInteractorMock.saveGradeCalled)
         XCTAssertNil(gradeInteractorMock.lastExcused)
         XCTAssertEqual(gradeInteractorMock.lastGrade, "87.0%")
     }
 
-    func test_setPercentGrade_roundsCorrectly() {
-        viewModel.setPercentGrade(87.7)
+    func test_setPercentGrade_callsSaveGradeWithoutRounding() {
+        viewModel.setPercentGrade(87.345678)
 
-        XCTAssertEqual(gradeInteractorMock.lastGrade, "88.0%")
+        XCTAssertTrue(gradeInteractorMock.saveGradeCalled)
+        XCTAssertNil(gradeInteractorMock.lastExcused)
+        XCTAssertEqual(gradeInteractorMock.lastGrade, "87.345678%")
     }
 
     // MARK: - Saving State Tests


### PR DESCRIPTION
refs: [MBL-19074](https://instructure.atlassian.net/browse/MBL-19074)
affects: Teacher, Student, Parent
release note: none

See ticket for details

Out of scope: GradePicker respecting grading scheme selection in assignment itself (it has it's own task)

(tests will follow in the followup for the main grade input task)

## TestPlan
- Set a custom grading scheme in course details
- Do NOT set a different one in the assignment (leave it on default)
- Verify these kinds of grading schemes display and work properly for all kinds of Letter Grade and GPA assignments:
  - Percentages based which has decimal values
  - Point based matching the assignment's max score
  - Point based not matching that
  - Point based which also have decimals
- Compare GradePicker subtitles with grading scheme displays in Manage Garding Scheme page

- Smoke test total grade in Student app with percent & point based schemes

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product

[MBL-19074]: https://instructure.atlassian.net/browse/MBL-19074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ