### PR TITLE
SpeedGrader - Support user level due dates

### DIFF
--- a/Core/Core/Features/Submissions/APISubmission.swift
+++ b/Core/Core/Features/Submissions/APISubmission.swift
@@ -25,6 +25,7 @@ public struct APISubmission: Codable, Equatable {
     let attachments: [APIFile]?
     let attempt: Int?
     let body: String?
+    let cached_due_date: Date?
     let custom_grade_status_id: String?
     let discussion_entries: [APIDiscussionEntry]?
     let entered_grade: String?
@@ -147,6 +148,7 @@ extension APISubmission {
         attachments: [APIFile]? = nil,
         attempt: Int? = nil,
         body: String? = nil,
+        cached_due_date: Date? = nil,
         custom_grade_status_id: String? = nil,
         discussion_entries: [APIDiscussionEntry]? = nil,
         entered_grade: String? = nil,
@@ -185,6 +187,7 @@ extension APISubmission {
             attachments: attachments,
             attempt: attempt,
             body: body,
+            cached_due_date: cached_due_date,
             custom_grade_status_id: custom_grade_status_id,
             discussion_entries: discussion_entries,
             entered_grade: entered_grade,

--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -42,6 +42,7 @@ final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var body: String?
     @NSManaged public var customGradeStatusId: String?
     @NSManaged public var discussionEntries: Set<DiscussionEntry>?
+    @NSManaged public var dueAt: Date?
     @NSManaged public var enteredGrade: String?
     @NSManaged var enteredScoreRaw: NSNumber?
     @NSManaged var excusedRaw: NSNumber?
@@ -161,6 +162,7 @@ extension Submission: WriteableModel {
         model.attempt = item.attempt ?? 0
         model.body = item.body
         model.customGradeStatusId = item.custom_grade_status_id
+        model.dueAt = item.cached_due_date
         model.enteredGrade = item.entered_grade
         model.enteredScore = item.entered_score
         model.excused = item.excused
@@ -453,6 +455,8 @@ extension Submission: Comparable {
         return lhs.userID < rhs.userID
     }
 }
+
+extension Submission: DueViewable {}
 
 /// This is merely used to properly describe the state of submission in certain contexts.
 /// It is not strictly matching `SubmissionStatus` in all cases. And it is not

--- a/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1165,6 +1165,7 @@
         <attribute name="attempt" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="body" optional="YES" attributeType="String"/>
         <attribute name="customGradeStatusId" optional="YES" attributeType="String"/>
+        <attribute name="dueAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="enteredGrade" optional="YES" attributeType="String"/>
         <attribute name="enteredScoreRaw" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <attribute name="excusedRaw" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
@@ -153,7 +153,7 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
                     isLate: submission.late
                 )
                 let daysLate = Int(ceil(Double(submission.lateSeconds) / (24 * 60 * 60.0)))
-                let dueDate = submission.assignment?.dueAt
+                let dueDate = submission.dueAt ?? submission.assignment?.dueAt
                 return (status, daysLate, dueDate)
             }
             .removeDuplicates {

--- a/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/GradeStatus/Model/GradeStatusInteractor.swift
@@ -153,7 +153,7 @@ class GradeStatusInteractorLive: GradeStatusInteractor {
                     isLate: submission.late
                 )
                 let daysLate = Int(ceil(Double(submission.lateSeconds) / (24 * 60 * 60.0)))
-                let dueDate = submission.dueAt ?? submission.assignment?.dueAt
+                let dueDate = submission.dueAt
                 return (status, daysLate, dueDate)
             }
             .removeDuplicates {

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageHeaderView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageHeaderView.swift
@@ -109,7 +109,9 @@ struct SpeedGraderPageHeaderView: View {
     }
 
     private var dueText: some View {
-        Text(assignment.dueText)
+        let dueText = submission.dueAt != nil ? submission.dueText
+                                              : assignment.dueText
+        return Text(dueText)
             .font(.regular14)
             .foregroundStyle(.textDark)
     }

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageHeaderView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageHeaderView.swift
@@ -109,9 +109,7 @@ struct SpeedGraderPageHeaderView: View {
     }
 
     private var dueText: some View {
-        let dueText = submission.dueAt != nil ? submission.dueText
-                                              : assignment.dueText
-        return Text(dueText)
+        Text(submission.dueText)
             .font(.regular14)
             .foregroundStyle(.textDark)
     }


### PR DESCRIPTION
### What's new?
- SpeedGrader always displayed the assignment's due date ignoring due date overrides assigned to individual students.
- The submission's API response contains a field called `cached_due_date` that has the proper due date that is assigned to the student.
- I modified the logic to show the submission's due date if available and if not

refs: [MBL-19096](https://instructure.atlassian.net/browse/MBL-19096)
affects: Teacher
release note: none

test plan:
- Create an assignment with a due date.
- Assign a different due date to one of the students.
- Open SpeedGrader.
- Set both student submission's to late.
- Check if due dates displayed below "Days Late" and in the header matches the due date of the student.
- You can act as the student and go to assignments to check the due date because SpeedGrader on web doesn't display this.

## Screenshots

<table>
<tr>
<td colspan="2"><img src="https://github.com/user-attachments/assets/9005831f-5f2c-4c5f-8a77-0a65adcbce9d" maxHeight=500></td>
</tr>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/c022f279-2719-4a37-a6d7-42f747c0223e" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/f49ade5d-b8bb-494e-ab82-2b680c93fd49" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
