### PR TITLE
Hide "Reply All" button in inbox when restrict_student_access is enabled

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
@@ -23,6 +23,7 @@ public enum EnvironmentFeatureFlags: String {
     case send_usage_metrics
     case mobile_offline_mode
     case account_survey_notifications
+    case restrict_student_access
 }
 
 public class GetEnvironmentFeatureFlags: CollectionUseCase {

--- a/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -53,6 +53,9 @@ class MessageDetailsViewModel: ObservableObject {
     private let env: AppEnvironment
     private let myID: String
     private let allowArchive: Bool
+    private var environmentFeatureFlags: Store<GetEnvironmentFeatureFlags> {
+        env.subscribe(GetEnvironmentFeatureFlags(context: Context.currentUser))
+    }
 
     public init(interactor: MessageDetailsInteractor, myID: String, allowArchive: Bool, env: AppEnvironment) {
         self.interactor = interactor
@@ -71,9 +74,10 @@ class MessageDetailsViewModel: ObservableObject {
                self?.replyTapped(message: nil, viewController: viewController)
            }
 
-           addReplyAllAction(sheet) { [weak self] in
+           if !environmentFeatureFlags.isFeatureEnabled(.restrict_student_access) {
+             addReplyAllAction(sheet) { [weak self] in
                self?.replyAllTapped(message: nil, viewController: viewController)
-
+             }
            }
         }
 
@@ -143,11 +147,12 @@ class MessageDetailsViewModel: ObservableObject {
                     self?.replyTapped(message: message, viewController: viewController)
                 }
             }
-
-            addReplyAllAction(sheet) { [weak self] in
+            if !environmentFeatureFlags.isFeatureEnabled(.restrict_student_access) {
+              addReplyAllAction(sheet) { [weak self] in
                 if let message {
-                    self?.replyAllTapped(message: message, viewController: viewController)
+                  self?.replyAllTapped(message: message, viewController: viewController)
                 }
+              }
             }
         }
 

--- a/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
@@ -194,6 +194,26 @@ class MessageDetailsViewModelTests: CoreTestCase {
         XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
     }
 
+    func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllNotShown() {
+        // Given
+        let response: [String: Bool] = ["restrict_student_access": true]
+        let useCase = GetEnvironmentFeatureFlags(context: Context.currentUser)
+        useCase.write(response: response, urlResponse: nil, to: databaseClient)
+
+        let sourceView = UIViewController()
+
+        // When
+        testee.messageMoreTapped(
+            message: ConversationMessage.make(),
+            viewController: WeakViewController(sourceView)
+        )
+
+        // Then
+        let sheet = router.presented as? BottomSheetPickerViewController
+        let actionTitles = sheet?.actions.map { $0.title } ?? []
+        XCTAssertFalse(actionTitles.contains("Reply All"))
+    }
+
     func test_messageMoreTapped_forward_presentComposeMessageView() {
         // Given
         let sourceView = UIViewController()


### PR DESCRIPTION
refs: PFS-25719
affects: Student, Teacher, Parent
release note: When the `restrict_student_access` feature flag is enabled, the "Reply All" option is hidden from inbox for all users. This is to prevent students from replying to all recipients in a conversation, which may include other students.

test plan:
- Enable the `restrict_student_access` feature flag
- Launch the Canvas Student, Teacher, and Parent apps
- Navigate to Inbox and open any message thread
- Verify that the "Reply All" button is not visible
- Disable the flag and verify that "Reply All" is visible again.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
