### PR TITLE
[Horizon] Making Assist Aware of Learn Tab Course ID

### DIFF
--- a/Horizon/Horizon/Sources/Features/HorizonTabBarController.swift
+++ b/Horizon/Horizon/Sources/Features/HorizonTabBarController.swift
@@ -25,6 +25,16 @@ final class HorizonTabBarController: UITabBarController, UITabBarControllerDeleg
 
     private let horizonTabBar = HorizonTabBar()
     private let router = AppEnvironment.shared.router
+    private var learnTabCourseID: String? {
+        var courseID: String?
+        if let selectedViewController = viewControllers?[selectedIndex],
+           let selectedNavigationController = selectedViewController as? UINavigationController,
+           let learnHostingController = selectedNavigationController.viewControllers.last as? CoreHostingController<LearnView>,
+           let courseDetailsViewModel = learnHostingController.rootView.content.viewModel.courseDetailsViewModel {
+           courseID = courseDetailsViewModel.course.id
+        }
+        return courseID
+    }
 
     // MARK: - Life Cycle
 
@@ -53,7 +63,7 @@ final class HorizonTabBarController: UITabBarController, UITabBarControllerDeleg
     // MARK: - Functions
 
     private func presentChatBot() {
-        let vc = AssistAssembly.makeAssistChatView()
+        let vc = AssistAssembly.makeAssistChatView(courseId: learnTabCourseID)
         vc.modalPresentationStyle = .pageSheet
         router.show(vc, from: self, options: .modal(isDismissable: false))
     }


### PR DESCRIPTION
The purpose of this is to make Assist aware of which course is currently being viewed from the learn tab so that the user can ask questions about that course instead of having to select the course from within Assist.


https://github.com/user-attachments/assets/2e5c948b-0e19-4cc5-8ef2-081fdef923b7



affects: Horizon