### PR TITLE
Fix issue of Groups not Showing in Submission List When Unsubmitted

### DIFF
--- a/Core/Core/Common/CommonModels/UserName/UserNameModel.swift
+++ b/Core/Core/Common/CommonModels/UserName/UserNameModel.swift
@@ -74,8 +74,8 @@ public struct UserNameModel: Equatable, Hashable {
             )
         } else if isGroup {
             self.init(
-                name: submission.groupName,
-                initials: submission.groupName.flatMap(User.initials),
+                name: submission.displayGroupName,
+                initials: submission.displayGroupName.flatMap(User.initials),
                 avatarUrl: nil, // submissions has no group avatarUrl
                 isGroup: true
             )
@@ -87,7 +87,7 @@ public struct UserNameModel: Equatable, Hashable {
     public init(submission: Submission, assignment: Assignment?, displayIndex: Int? = nil) {
         let isAnonymous = assignment?.anonymizeStudents ?? false
         let isGradedIndividually = assignment?.gradedIndividually ?? true
-        let isGroup = !isGradedIndividually && submission.groupID != nil
+        let isGroup = !isGradedIndividually && (submission.groupID != nil || submission.fetchedGroup != nil)
 
         self.init(submission: submission, isAnonymous: isAnonymous, isGroup: isGroup, displayIndex: displayIndex)
     }

--- a/Core/Core/Features/Groups/APIGroup.swift
+++ b/Core/Core/Features/Groups/APIGroup.swift
@@ -136,12 +136,16 @@ public struct GetFavoriteGroupsRequest: APIRequestable {
 }
 
 // https://canvas.instructure.com/doc/api/groups.html#method.groups.users
-struct GetGroupUsersRequest: APIRequestable {
-    typealias Response = [APIUser]
+public struct GetGroupUsersRequest: APIRequestable {
+    public typealias Response = [APIUser]
 
     let groupID: String
 
-    var path: String {
+    public init(groupID: String) {
+        self.groupID = groupID
+    }
+
+    public var path: String {
         let context = Context(.group, id: groupID)
         return "\(context.pathComponent)/users"
     }
@@ -165,10 +169,10 @@ public struct GetGroupRequest: APIRequestable {
 }
 
 // https://canvas.instructure.com/doc/api/group_categories.html#method.group_categories.groups
-struct GetGroupsInCategoryRequest: APIRequestable {
-    typealias Response = [APIGroup]
+public struct GetGroupsInCategoryRequest: APIRequestable {
+    public typealias Response = [APIGroup]
 
     let groupCategoryID: String
 
-    var path: String { "group_categories/\(groupCategoryID)/groups" }
+    public var path: String { "group_categories/\(groupCategoryID)/groups" }
 }

--- a/Core/Core/Features/Groups/GetGroups.swift
+++ b/Core/Core/Features/Groups/GetGroups.swift
@@ -93,13 +93,13 @@ public class GetDashboardGroups: CollectionUseCase {
     }
 }
 
-class GetGroupsInCategory: CollectionUseCase {
-    typealias Model = Group
-    let cacheKey: String?
-    let request: GetGroupsInCategoryRequest
-    let scope: Scope
+public class GetGroupsInCategory: CollectionUseCase {
+    public typealias Model = Group
+    public let cacheKey: String?
+    public let request: GetGroupsInCategoryRequest
+    public let scope: Scope
 
-    init(_ groupCategoryID: String?) {
+    public init(_ groupCategoryID: String?) {
         let groupCategoryID = groupCategoryID ?? ""
         cacheKey = "group_categories/\(groupCategoryID)/groups"
         request = GetGroupsInCategoryRequest(groupCategoryID: groupCategoryID)
@@ -109,13 +109,13 @@ class GetGroupsInCategory: CollectionUseCase {
         )
     }
 
-    func makeRequest(environment: AppEnvironment, completionHandler: @escaping ([APIGroup]?, URLResponse?, Error?) -> Void) {
+    public func makeRequest(environment: AppEnvironment, completionHandler: @escaping ([APIGroup]?, URLResponse?, Error?) -> Void) {
         // Skip making a request for empty groupCategoryID so this can be an empty list
         guard !request.groupCategoryID.isEmpty else { return completionHandler(nil, nil, nil) }
         environment.api.makeRequest(request, callback: completionHandler)
     }
 
-    func write(response: [APIGroup]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
+    public func write(response: [APIGroup]?, urlResponse: URLResponse?, to client: NSManagedObjectContext) {
         response?.forEach { item in
             Group.save(item, in: client)
         }

--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -34,6 +34,16 @@ public final class SubmissionList: NSManagedObject {
     }
 }
 
+public struct FetchedGroup {
+    public let id: String
+    public let name: String
+
+    public init(id: String, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
 final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var assignment: Assignment?
     @NSManaged public var assignmentID: String
@@ -77,6 +87,9 @@ final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var mediaComment: MediaComment?
     @NSManaged public var rubricAssesmentRaw: Set<RubricAssessment>?
     @NSManaged public var user: User?
+
+    public var fetchedGroup: FetchedGroup?
+    public var displayGroupName: String? { groupName ?? fetchedGroup?.name }
 
     public var rubricAssessments: RubricAssessments? {
         if let assessments = rubricAssesmentRaw, assessments.count > 0 {

--- a/Core/Core/Features/Submissions/Submission.swift
+++ b/Core/Core/Features/Submissions/Submission.swift
@@ -34,16 +34,6 @@ public final class SubmissionList: NSManagedObject {
     }
 }
 
-public struct FetchedGroup {
-    public let id: String
-    public let name: String
-
-    public init(id: String, name: String) {
-        self.id = id
-        self.name = name
-    }
-}
-
 final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var assignment: Assignment?
     @NSManaged public var assignmentID: String
@@ -88,6 +78,7 @@ final public class Submission: NSManagedObject, Identifiable {
     @NSManaged public var rubricAssesmentRaw: Set<RubricAssessment>?
     @NSManaged public var user: User?
 
+    /// Transient property to use for group resolving in Teacher's submission list
     public var fetchedGroup: FetchedGroup?
     public var displayGroupName: String? { groupName ?? fetchedGroup?.name }
 
@@ -151,6 +142,19 @@ final public class Submission: NSManagedObject, Identifiable {
 
     public var discussionEntriesOrdered: [DiscussionEntry] {
         return discussionEntries?.sorted(by: { $0.id < $1.id }) ?? []
+    }
+}
+
+extension Submission {
+
+    public struct FetchedGroup {
+        public let id: String
+        public let name: String
+
+        public init(id: String, name: String) {
+            self.id = id
+            self.name = name
+        }
     }
 }
 

--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/ViewModel/SpeedGraderPageHeaderViewModel.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/ViewModel/SpeedGraderPageHeaderViewModel.swift
@@ -32,7 +32,7 @@ class SpeedGraderPageHeaderViewModel: ObservableObject {
         submission: Submission
     ) {
         userNameModel = .init(submission: submission, assignment: assignment)
-        let isGroupSubmission = !assignment.gradedIndividually && submission.groupID != nil
+        let isGroupSubmission = !assignment.gradedIndividually && (submission.groupID != nil || submission.fetchedGroup != nil)
         routeToSubmitter = isGroupSubmission ? nil : "/courses/\(assignment.courseID)/users/\(submission.userID)"
         submissionStatus = submission.statusIncludingGradedState
         observeSubmissionStatusInDatabase(submission)

--- a/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
@@ -139,7 +139,7 @@ struct SubmissionViewer: View {
                     Text("This assignment only allows on-paper submissions.", bundle: .teacher)
                 } else if assignment.submissionTypes.contains(.none) {
                     Text("This assignment does not allow submissions.", bundle: .teacher)
-                } else if submission.groupID != nil {
+                } else if (submission.groupID != nil || submission.fetchedGroup != nil) {
                     Text("This group does not have a submission for this assignment.", bundle: .teacher)
                 } else {
                     Text("This student does not have a submission for this assignment.", bundle: .teacher)

--- a/Teacher/Teacher/Submissions/SubmissionListViewController.swift
+++ b/Teacher/Teacher/Submissions/SubmissionListViewController.swift
@@ -261,7 +261,7 @@ class SubmissionListCell: UITableViewCell {
                 avatarView.icon = .userLine
                 nameLabel.text = String(localized: "Student \(row)", bundle: .teacher)
             }
-        } else if let name = submission?.groupName {
+        } else if let name = submission?.displayGroupName {
             avatarView.name = name
             avatarView.url = nil
             nameLabel.text = name

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
@@ -25,7 +25,7 @@ public protocol SubmissionListInteractor {
     var submissions: AnyPublisher<[Submission], Never> { get }
     var assignment: AnyPublisher<Assignment?, Never> { get }
     var course: AnyPublisher<Course?, Never> { get }
-    var groupsInAssignment: AnyPublisher<[UsersGroup], Never> { get }
+    var groupsInAssignment: AnyPublisher<[GroupMemberships], Never> { get }
 
     var context: Context { get }
     var assignmentID: String { get }

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
@@ -25,6 +25,7 @@ public protocol SubmissionListInteractor {
     var submissions: AnyPublisher<[Submission], Never> { get }
     var assignment: AnyPublisher<Assignment?, Never> { get }
     var course: AnyPublisher<Course?, Never> { get }
+    var groupsInAssignment: AnyPublisher<[UsersGroup], Never> { get }
 
     var context: Context { get }
     var assignmentID: String { get }

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractor.swift
@@ -25,11 +25,39 @@ public protocol SubmissionListInteractor {
     var submissions: AnyPublisher<[Submission], Never> { get }
     var assignment: AnyPublisher<Assignment?, Never> { get }
     var course: AnyPublisher<Course?, Never> { get }
-    var groupsInAssignment: AnyPublisher<[GroupMemberships], Never> { get }
+    var assigneeGroups: AnyPublisher<[AssigneeGroup], Never> { get }
 
     var context: Context { get }
     var assignmentID: String { get }
 
     func refresh() -> AnyPublisher<Void, Never>
     func applyFilters(_ filters: [GetSubmissions.Filter])
+}
+
+public struct AssigneeGroup: Equatable {
+    let id: String
+    let name: String
+    let memberIDs: [String]
+
+    public init(group: Group, memberIDs: [String] = []) {
+        self.id = group.id
+        self.name = group.name
+        self.memberIDs = memberIDs
+    }
+
+    #if DEBUG
+    public init(id: String, name: String, memberIDs: [String] = []) {
+        self.id = id
+        self.name = name
+        self.memberIDs = memberIDs
+    }
+    #endif
+
+    public func containsUser(_ userID: String) -> Bool {
+        memberIDs.contains(userID)
+    }
+
+    public var asSubmissionFetchedGroup: Submission.FetchedGroup {
+        return .init(id: id, name: name)
+    }
 }

--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorLive.swift
@@ -94,11 +94,11 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
         submissionsSubject.eraseToAnyPublisher()
     }
 
-    var groupsInAssignment: AnyPublisher<[GroupMemberships], Never> {
+    var assigneeGroups: AnyPublisher<[AssigneeGroup], Never> {
         assignment
             .flatMap { [weak self] assignment in
                 guard let self, let categoryID = assignment?.groupCategoryID else {
-                    return Just([GroupMemberships]()).eraseToAnyPublisher()
+                    return Just([AssigneeGroup]()).eraseToAnyPublisher()
                 }
 
                 return ReactiveStore(
@@ -111,7 +111,7 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
                         .Sequence(sequence: groups)
                         .flatMap { [weak self] group in
                             guard let self else {
-                                return Just(GroupMemberships(group: group))
+                                return Just(AssigneeGroup(group: group))
                                     .eraseToAnyPublisher()
                             }
 
@@ -121,9 +121,9 @@ class SubmissionListInteractorLive: SubmissionListInteractor {
                                 .makeRequest(GetGroupUsersRequest(groupID: group.id))
                                 .map { (users: [APIUser], _) in
                                     let userIDs = users.map { $0.id.value }
-                                    return GroupMemberships(group: group, userIDs: userIDs)
+                                    return AssigneeGroup(group: group, memberIDs: userIDs)
                                 }
-                                .replaceError(with: GroupMemberships(group: group))
+                                .replaceError(with: AssigneeGroup(group: group))
                                 .eraseToAnyPublisher()
                         }
                         .collect()
@@ -161,15 +161,5 @@ private extension [Submission] {
             }
         }
         return filteredSubmissions
-    }
-}
-
-public struct GroupMemberships {
-    let group: Group
-    let userIDs: [String]
-
-    init(group: Group, userIDs: [String] = []) {
-        self.group = group
-        self.userIDs = userIDs
     }
 }

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -62,9 +62,7 @@ class SubmissionListViewModel: ObservableObject {
             var curatedList: [Submission] = list
 
             if groupsMemberships.isNotEmpty {
-                
                 curatedList.forEach { submission in
-
                     if submission.groupID == nil,
                        let memberships = groupsMemberships.first(where: { $0.userIDs.contains(submission.userID) }) {
                         submission.fetchedGroup = FetchedGroup(

--- a/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/ViewModel/SubmissionListViewModel.swift
@@ -57,20 +57,20 @@ class SubmissionListViewModel: ObservableObject {
             interactor.groupsInAssignment.receive(on: scheduler),
             $searchText.throttle(for: 1, scheduler: scheduler, latest: true)
         )
-        .map({ [weak self] (list, groups, searchText) in
+        .map({ [weak self] (list, groupsMemberships, searchText) in
             let searchTerm = searchText.lowercased()
             var curatedList: [Submission] = list
 
-            if groups.isNotEmpty {
+            if groupsMemberships.isNotEmpty {
+                
                 curatedList.forEach { submission in
 
                     if submission.groupID == nil,
-                        let group = groups.first(
-                            where: { group in group.users.contains(where: { $0.id.value == submission.userID }) }
-                        ) {
-
-                        submission.groupID = group.group.id
-                        submission.groupName = group.group.displayName
+                       let memberships = groupsMemberships.first(where: { $0.userIDs.contains(submission.userID) }) {
+                        submission.fetchedGroup = FetchedGroup(
+                            id: memberships.group.id,
+                            name: memberships.group.displayName
+                        )
                     }
                 }
             }

--- a/Teacher/TeacherTests/Submissions/SubmissionList/Utils/MockSubmissionListInteractor.swift
+++ b/Teacher/TeacherTests/Submissions/SubmissionList/Utils/MockSubmissionListInteractor.swift
@@ -39,6 +39,10 @@ final class MockSubmissionListInteractor: SubmissionListInteractor {
         courseSubject.eraseToAnyPublisher()
     }
 
+    var groupsInAssignment: AnyPublisher<[GroupMemberships], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
     var context: Context
     var assignmentID: String
 

--- a/Teacher/TeacherTests/Submissions/SubmissionList/Utils/MockSubmissionListInteractor.swift
+++ b/Teacher/TeacherTests/Submissions/SubmissionList/Utils/MockSubmissionListInteractor.swift
@@ -26,6 +26,7 @@ final class MockSubmissionListInteractor: SubmissionListInteractor {
     var submissionsSubject = PassthroughSubject<[Submission], Never>()
     var assignmentSubject = PassthroughSubject<Assignment?, Never>()
     var courseSubject = PassthroughSubject<Course?, Never>()
+    var assigneeGroupsSubject = CurrentValueSubject<[AssigneeGroup], Never>([])
 
     var submissions: AnyPublisher<[Submission], Never> {
         submissionsSubject.eraseToAnyPublisher()
@@ -39,8 +40,8 @@ final class MockSubmissionListInteractor: SubmissionListInteractor {
         courseSubject.eraseToAnyPublisher()
     }
 
-    var groupsInAssignment: AnyPublisher<[GroupMemberships], Never> {
-        Just([]).eraseToAnyPublisher()
+    var assigneeGroups: AnyPublisher<[AssigneeGroup], Never> {
+        assigneeGroupsSubject.eraseToAnyPublisher()
     }
 
     var context: Context


### PR DESCRIPTION
refs: MBL-19071
affects: Teacher
release note: Fixed issue of groups not showing in submission list when unsubmitted.

## Test Plan

Make sure to create an assignment for group set defined on your course.
For proper testing, create multiple groups so to compare between unsubmitted and submitted ones.
After that make a submission for one of them,
Check Teacher > Assignment Details > Submission List screen.
Now you should see unsubmitted group shown as expected.

See [ticket's description](https://instructure.atlassian.net/browse/MBL-19071) for more details.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
