### PR TITLE
Total grade not visible in Student View

### DIFF
--- a/Core/Core/Features/Grades/Model/GradeListInteractor.swift
+++ b/Core/Core/Features/Grades/Model/GradeListInteractor.swift
@@ -133,7 +133,7 @@ public final class GradeListInteractorLive: GradeListInteractor {
                 context: .course(courseID),
                 userID: userID,
                 gradingPeriodID: gradingPeriodID,
-                types: ["StudentEnrollment"],
+                types: ["StudentEnrollment", "StudentViewEnrollment"],
                 states: [.active, .completed]
             ),
             environment: env


### PR DESCRIPTION
refs: [MBL-19095](https://instructure.atlassian.net/browse/MBL-19095)
affects: Student
release note: Total grade now appears when teachers open the app in Student View.

Test plan:
- Check if total grade is not restricted in Student View. See details in ticket

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/65ee3233-a796-4d99-a9c7-59fa51d8abe9" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/a4dea26e-56a0-4e47-b079-5a58716b9b50" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
