### PR TITLE
Hide "Delete Message" button in inbox when restrict_student_access is enabled

### DIFF
--- a/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -129,13 +129,15 @@ class MessageDetailsViewModel: ObservableObject {
             }
         }
 
-        sheet.addAction(
-            image: .trashLine,
-            title: String(localized: "Delete Conversation", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.delete"
-        ) { [weak self] in
-            if let conversationId = self?.conversations.first?.id {
-                self?.deleteConversationDidTap.send((conversationId, viewController))
+        if !isStudentAccessRestricted {
+            sheet.addAction(
+                image: .trashLine,
+                title: String(localized: "Delete Conversation", bundle: .core),
+                accessibilityIdentifier: "MessageDetails.delete"
+            ) { [weak self] in
+                if let conversationId = self?.conversations.first?.id {
+                    self?.deleteConversationDidTap.send((conversationId, viewController))
+                }
             }
         }
         env.router.show(sheet, from: viewController, options: .modal())
@@ -165,14 +167,15 @@ class MessageDetailsViewModel: ObservableObject {
         ) { [weak self] in
             self?.forwardTapped(message: message, viewController: viewController)
         }
-
-        sheet.addAction(
-            image: .trashLine,
-            title: String(localized: "Delete Message", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.delete"
-        ) { [weak self] in
-            if let conversationId = self?.conversations.first?.id, let messageId = message?.id {
-                self?.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
+        if !isStudentAccessRestricted {
+            sheet.addAction(
+                image: .trashLine,
+                title: String(localized: "Delete Message", bundle: .core),
+                accessibilityIdentifier: "MessageDetails.delete"
+            ) { [weak self] in
+                if let conversationId = self?.conversations.first?.id, let messageId = message?.id {
+                    self?.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
+                }
             }
         }
         env.router.show(sheet, from: viewController, options: .modal())

--- a/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
@@ -203,7 +203,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
         XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
     }
 
-    func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllNotShown() {
+    func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllAndDeleteNotShown() {
         // Given
         mockInteractor = MessageDetailsInteractorMock()
         mockStudentAccessInteractor = StudentAccessInteractorMock(restricted: true)
@@ -231,9 +231,10 @@ class MessageDetailsViewModelTests: CoreTestCase {
         let sheet = router.presented as? BottomSheetPickerViewController
         let actionTitles = sheet?.actions.map { $0.title } ?? []
         XCTAssertFalse(actionTitles.contains("Reply All"))
+        XCTAssertFalse(actionTitles.contains("Delete Message"))
     }
 
-    func test_messageMoreTapped_whenRestrictStudentAccessDisabled_replyAllShown() {
+    func test_messageMoreTapped_whenRestrictStudentAccessDisabled_replyAllAndDeleteShown() {
         // Given
         let sourceView = UIViewController()
 
@@ -251,6 +252,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
         let sheet = router.presented as? BottomSheetPickerViewController
         let actionTitles = sheet?.actions.map { $0.title } ?? []
         XCTAssertTrue(actionTitles.contains("Reply All"))
+        XCTAssertTrue(actionTitles.contains("Delete Message"))
     }
 
     func test_messageMoreTapped_forward_presentComposeMessageView() {


### PR DESCRIPTION
refs: PFS-25722
affects: Student, Teacher, Parent
release note: When the restrict_student_access feature flag is enabled, the "Delete Message" option is hidden from inbox for all users.

test plan:
- Enable the restrict_student_access feature flag
- Launch the Canvas Student, Teacher, and Parent apps
- Navigate to Inbox and open any message thread
- Verify that the "Delete Message" button is not visible
- Disable the flag and verify that "Delete Message" is visible again.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
