### PR TITLE
Followup: Fix (NeedsGrading & Un-submitted) Counts for Submissions Breakdown for Custom Graded ones

### DIFF
--- a/Core/Core/Features/Assignments/Assignment.swift
+++ b/Core/Core/Features/Assignments/Assignment.swift
@@ -223,7 +223,7 @@ extension Assignment {
                 atState: .submitted, .pending_review, .graded
             )
 
-        needsGradingCount = (item.needs_grading_count ?? 0) - customGradeStatedSubmittedCount
+        needsGradingCount = max((item.needs_grading_count ?? 0) - customGradeStatedSubmittedCount, 0)
         onlyVisibleToOverrides = item.only_visible_to_overrides ?? false
         pointsPossible = item.points_possible
         position = item.position ?? Int.max

--- a/Core/Core/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModel.swift
+++ b/Core/Core/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModel.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import Combine
 import SwiftUI
 
 public class AssignmentSubmissionBreakdownViewModel: SubmissionBreakdownViewModelProtocol {
@@ -41,8 +42,12 @@ public class AssignmentSubmissionBreakdownViewModel: SubmissionBreakdownViewMode
     private let assignmentID: String
     private let courseID: String
     private let submissionTypes: [SubmissionType]
-    private var summary: Store<GetSubmissionSummary>
+    private var summaryStore: ReactiveStore<GetSubmissionSummary>
+    private let submissionsStore: ReactiveStore<GetSubmissions>
+    private var summary: SubmissionSummary?
     private var submissionsPath: String { "/courses/\(courseID)/assignments/\(assignmentID)/submissions" }
+
+    private var submissionsObservation: AnyCancellable?
 
     public init(courseID: String, assignmentID: String, submissionTypes: [SubmissionType], color: UIColor? = nil, env: AppEnvironment) {
         self.assignmentID = assignmentID
@@ -51,17 +56,36 @@ public class AssignmentSubmissionBreakdownViewModel: SubmissionBreakdownViewMode
         self.color = color?.asColor ?? .accentColor
         self.env = env
 
-        summary = env.subscribe(GetSubmissionSummary(
-            context: .course(courseID),
-            assignmentID: assignmentID
-        ))
+        summaryStore = ReactiveStore(
+            useCase: GetSubmissionSummary(
+                context: .course(courseID),
+                assignmentID: assignmentID
+            ),
+            environment: env)
+        submissionsStore = ReactiveStore(
+            useCase: GetSubmissions(context: .course(courseID), assignmentID: assignmentID, filter: []),
+            environment: env
+        )
     }
 
     public func viewDidAppear() {
-        summary.eventHandler = { [weak self] in
-            self?.update()
-        }
-        summary.refresh(force: true)
+        let summaryPublisher = summaryStore
+            .getEntities(ignoreCache: true)
+            .map(\.first)
+            .ignoreFailure()
+        let submissionsPublisher = submissionsStore
+            .getEntities(
+                ignoreCache: true,
+                loadAllPages: true,
+                keepObservingDatabaseChanges: true,
+            )
+            .ignoreFailure()
+
+        submissionsObservation = Publishers.CombineLatest(summaryPublisher, submissionsPublisher)
+            .sink { [weak self] summary, _ in
+                self?.summary = summary
+                self?.update()
+            }
     }
 
     public func routeToAll(router: Router, viewController: WeakViewController) {
@@ -87,7 +111,7 @@ public class AssignmentSubmissionBreakdownViewModel: SubmissionBreakdownViewMode
             for: .submitted, .pending_review, .graded
         )
 
-        let summaryValues = self.summary.first
+        let summaryValues = summary
 
         graded = (summaryValues?.graded ?? 0) + customSubmitted + customUnsubmitted
         ungraded = max((summaryValues?.ungraded ?? 0) - customSubmitted, 0)

--- a/Core/Core/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModel.swift
+++ b/Core/Core/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModel.swift
@@ -87,11 +87,13 @@ public class AssignmentSubmissionBreakdownViewModel: SubmissionBreakdownViewMode
             for: .submitted, .pending_review, .graded
         )
 
-        graded = (summary.first?.graded ?? 0) + customSubmitted + customUnsubmitted
-        ungraded = (summary.first?.ungraded ?? 0) - customSubmitted
-        unsubmitted = (summary.first?.unsubmitted ?? 0) - customUnsubmitted
+        let summaryValues = self.summary.first
 
-        submissionCount = summary.first?.submissionCount ?? 0
+        graded = (summaryValues?.graded ?? 0) + customSubmitted + customUnsubmitted
+        ungraded = max((summaryValues?.ungraded ?? 0) - customSubmitted, 0)
+        unsubmitted = max((summaryValues?.unsubmitted ?? 0) - customUnsubmitted, 0)
+
+        submissionCount = summaryValues?.submissionCount ?? 0
         isReady = true
     }
 

--- a/Core/CoreTests/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModelTests.swift
+++ b/Core/CoreTests/Features/Assignments/AssignmentDetails/AssignmentSubmissionBreakdownViewModelTests.swift
@@ -18,6 +18,7 @@
 
 import XCTest
 @testable import Core
+import TestsFoundation
 
 class AssignmentSubmissionBreakdownViewModelTests: CoreTestCase {
     func testProperties() {
@@ -26,6 +27,8 @@ class AssignmentSubmissionBreakdownViewModelTests: CoreTestCase {
         api.mock(useCase, value: submissionSummary)
         let testee = AssignmentSubmissionBreakdownViewModel(courseID: "1", assignmentID: "2", submissionTypes: [], env: environment)
         testee.viewDidAppear()
+
+        waitUntil { testee.isReady }
 
         XCTAssertEqual(testee.graded, 1)
         XCTAssertEqual(testee.ungraded, 2)


### PR DESCRIPTION
refs: MBL-18954
affects: Teacher
release note: none.

This is to defend against the possible case where a submission with needsGrading or un-submitted status is not being counted as "graded" of submission summary API response. And it is not counted as "unsubmitted" or "ungraded" as well. 

## Test Plan

A found use case,
Grade a a student with no submission with "Missing" label, submit that on SpeedGrader, then go back to the same student and assign a custom label to it, then submit again. 
As consequence, Graded count on submissions summary won't include that, it will be also excluded from Ungraded & Un-submitted count. 

Now count for needsGrading and un-submitted upon showing submissions list shouldn't show minus value (-1).

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
