### PR TITLE
Student - Tapping reply on a conversation results in all audience added to the recipient list

### DIFF
--- a/Core/Core/Features/Inbox/ComposeMessage/Model/ComposeMessageOptions.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/Model/ComposeMessageOptions.swift
@@ -236,6 +236,9 @@ extension ComposeMessageOptions {
                     )
                 }
             }
+        } else if let author = conversation.audience.first {
+            // according to the API docs: audience list is ordered by participation level (author is the first one)
+            recipients = [Recipient(conversationParticipant: author)]
         } else {
             recipients = conversation.audience.map { Recipient(conversationParticipant: $0) }
         }


### PR DESCRIPTION
refs: MBL-19111
affects: Student, Teacher, Parent
release note: Fixed an issue that caused tapping the reply button on a conversation resulting in all audience added as recipients.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Approve from product