### PR TITLE
SpeedGrader - Fix LTI submissions don't load

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/URLComponentsExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/URLComponentsExtensions.swift
@@ -192,5 +192,5 @@ public extension URLComponents {
 }
 
 public extension CharacterSet {
-    static let urlSafe = CharacterSet(charactersIn: ":/?&=#%.").union(.alphanumerics)
+    static let urlSafe = CharacterSet(charactersIn: ":/?&=#%._").union(.alphanumerics)
 }

--- a/Core/CoreTests/Common/Extensions/Foundation/URLComponentsExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/URLComponentsExtensionsTests.swift
@@ -138,4 +138,10 @@ class URLComponentsExtensionsTests: XCTestCase {
         let externalURL = URLComponents.parse("https://example.com/courses")
         XCTAssertTrue(externalURL.isExternalWebsite(of: .shared))
     }
+
+    func test_underscore_notEncodedWithUrlSafeCharacters() {
+        let stringWithUnderscore = "/courses/2054/external_tools/"
+        let encoded = stringWithUnderscore.addingPercentEncoding(withAllowedCharacters: .urlSafe)
+        XCTAssertEqual(encoded, stringWithUnderscore)
+    }
 }

--- a/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
+++ b/Teacher/Teacher/SpeedGrader/SubmissionRenderer/View/SubmissionViewer.swift
@@ -41,7 +41,7 @@ struct SubmissionViewer: View {
     var body: some View {
         switch submission.type {
         case .basic_lti_launch, .external_tool:
-            WebSession(url: submission.previewUrl) { url in
+            WebSession(url: submission.previewUrl ?? submission.url) { url in
                 WebView(url: url,
                         features: [
                             .userAgent(UserAgent.safariLTI.description),


### PR DESCRIPTION
- Fall back to `submission.url` if `submission.previewUrl` is not available.
- Allow underscore as an url safe character so urls containing `/external_tools` won't be encoded to an invalid path.

refs: [MBL-19147](https://instructure.atlassian.net/browse/MBL-19147)
affects: Teacher
release note: Fixed some LTI submissions not loading in SpeedGrader.

test plan: See ticket for details.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet