### PR TITLE
Disable File Uploads for Students

### DIFF
--- a/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
+++ b/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
@@ -18,11 +18,11 @@
 
 import Combine
 
-protocol StudentAccessInteractor: AnyObject {
+public protocol StudentAccessInteractor: AnyObject {
     func isRestricted() -> AnyPublisher<Bool, Never>
 }
 
-final class StudentAccessInteractorLive: StudentAccessInteractor {
+final public class StudentAccessInteractorLive: StudentAccessInteractor {
     // MARK: - Private Properties
     private let featureFlagsStore: ReactiveStore<GetEnvironmentFeatureFlags>
 

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -501,7 +501,8 @@ private func fileList(url: URLComponents, params: [String: String], userInfo: [S
     return FileListViewController.create(
         env: environment,
         context: Context(path: url.path) ?? .currentUser,
-        path: params["subFolder"]
+        path: params["subFolder"],
+        studentAccessInteractor: StudentAccessInteractorLive(env: environment)
     )
 }
 


### PR DESCRIPTION
refs: PFS-25737
affects: Student
release note: When the restrict_student_access feature flag is enabled in the Student app,
    then user will not be able to upload files

test plan:
    - Enable the restrict_student_access feature flag
    - Launch the Canvas Student app
    - Navigate to Files and click on the + icon
    - Upload file button should be hidden
    - Disable the flag and verify that the Upload file button reappears

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
