### PR TITLE
Fix Parent E2E test crash

### DIFF
--- a/Core/TestsFoundation/UITestHelperNamespaces/ManageStudentsHelper.swift
+++ b/Core/TestsFoundation/UITestHelperNamespaces/ManageStudentsHelper.swift
@@ -41,16 +41,15 @@ public class ManageStudentsHelper: BaseHelper {
 
     public static var addStudentButton: XCUIElement { app.find(label: "addSolid", type: .button) }
 
-    public static func studentCell(student: DSUser) -> XCUIElement? {
-        let studentCells = app.findAll(idStartingWith: "StudentListCell", type: .cell)
-        for studentCell in studentCells where studentCell.find(label: student.name).isVisible {
-            return studentCell
-        }
-        return nil
+    public static func studentCell(student: DSUser) -> XCUIElement {
+        app.descendants(matching: .cell)
+            .matching(idStartingWith: "StudentListCell")
+            .containing(.staticText, identifier: student.name)
+            .firstMatch
     }
 
     public static func nameLabelOfStudentCell(student: DSUser) -> XCUIElement {
-        let cell = studentCell(student: student)!
+        let cell = studentCell(student: student)
         return cell.find(label: student.name, type: .staticText)
     }
 }

--- a/Parent/ParentE2ETests/AddStudent/AddStudentTests.swift
+++ b/Parent/ParentE2ETests/AddStudent/AddStudentTests.swift
@@ -61,7 +61,7 @@ class AddStudentTests: E2ETestCase {
         addButton.hit()
 
         // MARK: Check if student was added
-        let studentCell = ManageStudentsHelper.studentCell(student: student)!.waitUntil(.visible)
+        let studentCell = ManageStudentsHelper.studentCell(student: student).waitUntil(.visible)
         let nameLabelOfStudentCell = ManageStudentsHelper.nameLabelOfStudentCell(student: student).waitUntil(.visible)
         XCTAssertTrue(studentCell.isVisible)
         XCTAssertTrue(nameLabelOfStudentCell.isVisible)

--- a/Parent/ParentE2ETests/ManageStudents/ManageStudentsTests.swift
+++ b/Parent/ParentE2ETests/ManageStudents/ManageStudentsTests.swift
@@ -45,8 +45,8 @@ class ManageStudentsTests: E2ETestCase {
 
         // MARK: Check students
         manageStudentsButton.hit()
-        let student1cell = ManageStudentsHelper.studentCell(student: student1)!.waitUntil(.visible)
-        let student2cell = ManageStudentsHelper.studentCell(student: student2)!.waitUntil(.visible)
+        let student1cell = ManageStudentsHelper.studentCell(student: student1).waitUntil(.visible)
+        let student2cell = ManageStudentsHelper.studentCell(student: student2).waitUntil(.visible)
         XCTAssertTrue(student1cell.isVisible)
         XCTAssertTrue(student2cell.isVisible)
 


### PR DESCRIPTION
There was a force unwrap that crashed if the view could not be found on screen on the first try.

refs: MBL-19097
affects: none
release note: none

test plan:
- Run test AddStudentTests and ManageStudentsTests locally as on CI the test suite never finishes due to the beta environment being unstable.