### PR TITLE
SpeedGrader - Fix max score button

### DIFF
--- a/Teacher/Teacher/SpeedGrader/Grading/Points/View/SpeedGraderSubmissionGradesView.swift
+++ b/Teacher/Teacher/SpeedGrader/Grading/Points/View/SpeedGraderSubmissionGradesView.swift
@@ -320,9 +320,17 @@ struct SpeedGraderSubmissionGradesView: View {
 
     private func sliderButton(score: Double, isPercent: Bool) -> some View {
         Button(
-            action: { updateGrade(score) },
+            action: { updateGrade(score, isPercent: isPercent) },
             label: {
-                Text(score)
+                let label = {
+                    if isPercent {
+                        return Text(verbatim: GradeFormatter.percentFormatter.string(from: NSNumber(value: score/100)) ?? "\(score)%")
+                    } else {
+                        return Text(score)
+                    }
+                }()
+
+                label
                     .foregroundStyle(.tint)
                     .font(.semibold14)
                     .frame(height: 30)
@@ -335,13 +343,22 @@ struct SpeedGraderSubmissionGradesView: View {
         )
     }
 
-    func updateGrade(excused: Bool? = nil, noMark: Bool? = false, _ grade: Double? = nil) {
+    func updateGrade(
+        excused: Bool? = nil,
+        noMark: Bool? = false,
+        _ grade: Double? = nil,
+        isPercent: Bool = false
+    ) {
         if excused == true {
             gradeViewModel.excuseStudent()
         } else if noMark == true {
             gradeViewModel.removeGrade()
-        } else if let grade = grade {
-            gradeViewModel.setPointsGrade(grade)
+        } else if let grade {
+            if isPercent {
+                gradeViewModel.setPercentGrade(grade)
+            } else {
+                gradeViewModel.setPointsGrade(grade)
+            }
         }
     }
 


### PR DESCRIPTION
refs: [MBL-19167](https://instructure.atlassian.net/browse/MBL-19167)
builds: Teacher
affects: Teacher
release note: Fixed max score button assigning points instead of percentages in SpeedGrader when grading percentage based assignments.

test plan:
- Create a percentage based assignment with a maximum score other than 100.
- Open SpeedGrader and tap the number right to the grade slider.
- Grade should set to 100% instead of the max score of the assignment.

## Screenshots
<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/01de4c82-84cf-4852-b1bd-e2223e436e77" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/971f8e58-9f10-4cc5-ad71-dbe7d3e1c3a5" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet