### PR TITLE
SpeedGrader - Update drawer default position

### DIFF
--- a/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
+++ b/Teacher/Teacher/SpeedGrader/SpeedGraderPage/View/SpeedGraderPageView.swift
@@ -40,7 +40,7 @@ struct SpeedGraderPageView: View {
 
     // MARK: - Tab & Drawer properties
 
-    @State private var drawerState: DrawerState = .min
+    @State private var drawerState: DrawerState = .mid
     @State private var selectedTab: SpeedGraderPageTab = .grades
     @AccessibilityFocusState private var a11yFocusedTab: SpeedGraderPageTab?
 


### PR DESCRIPTION
refs: MBL-19224
builds: Teacher
affects: Teacher
release note: Updated grade sheet to be opened when opening SpeedGrader.

test plan:
- Check if drawer is in mid position by default.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/e894f387-f1e6-472c-8157-6c2f85e89d73" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/1278b8dc-bcb0-450d-a403-cc4572271c8f" maxHeight=500></td>
</tr>
</table>

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet