### PR TITLE
refs: CLX-2815

### DIFF
--- a/Core/Core/Common/CommonModels/API/API.swift
+++ b/Core/Core/Common/CommonModels/API/API.swift
@@ -18,7 +18,7 @@
 
 import Foundation
 
-public class API {
+open class API {
     public var loginSession: LoginSession?
     public let baseURL: URL
     public let urlSession: URLSession
@@ -32,7 +32,7 @@ public class API {
     }
 
     @discardableResult
-    public func makeRequest<Request: APIRequestable>(
+    open func makeRequest<Request: APIRequestable>(
         _ requestable: Request,
         refreshToken: Bool = true,
         callback: @escaping (Request.Response?, URLResponse?, Error?) -> Void

--- a/Core/Core/Features/Login/LoginSession.swift
+++ b/Core/Core/Features/Login/LoginSession.swift
@@ -150,7 +150,8 @@ public struct LoginSession: Codable, Hashable {
             userName: userName,
             userEmail: userEmail,
             clientID: clientID,
-            clientSecret: clientSecret
+            clientSecret: clientSecret,
+            canvasRegion: canvasRegion
         )
     }
 

--- a/Core/Core/Features/Login/LoginWebViewController.swift
+++ b/Core/Core/Features/Login/LoginWebViewController.swift
@@ -287,7 +287,8 @@ extension LoginWebViewController: WKNavigationDelegate {
                     userID: token.user.id.value,
                     userName: token.user.name,
                     clientID: mobileVerify.client_id,
-                    clientSecret: mobileVerify.client_secret
+                    clientSecret: mobileVerify.client_secret,
+                    canvasRegion: token.canvas_region
                 )
 
                 if let completion = self.loginCompletion {

--- a/Horizon/Horizon/Sources/Common/Data/API/DomainService.swift
+++ b/Horizon/Horizon/Sources/Common/Data/API/DomainService.swift
@@ -55,13 +55,12 @@ final class DomainService {
     init(
         _ domainServiceOption: Option,
         baseURL: String = AppEnvironment.shared.currentSession?.baseURL.absoluteString ?? "",
-        region: Region? = nil,
+        region: String? = AppEnvironment.shared.currentSession?.canvasRegion,
         horizonApi: API = AppEnvironment.defaultValue.api
     ) {
-        let defaultRegion = AppEnvironment.shared.currentSession?.canvasRegion.map { Region(rawValue: $0) ?? .east1 } ?? .east1
         self.option = domainServiceOption
         self.baseURL = baseURL
-        self.region = region ?? defaultRegion
+        self.region = region.map { Region(rawValue: $0) ?? .east1 } ?? .east1
         self.horizonApi = horizonApi
     }
 
@@ -78,7 +77,10 @@ final class DomainService {
             )
             .tryMap { [weak self] response, urlResponse in
                 guard let self else { throw DomainService.Issue.unableToGetToken }
-                return try tokenResponseToUtf8String(tokenResponse: response, urlResponse: urlResponse)
+                return try tokenResponseToUtf8String(
+                    tokenResponse: response,
+                    urlResponse: urlResponse
+                )
             }
             .compactMap { [weak self] jwt in
                 guard let self else { return nil }

--- a/Horizon/HorizonTests/Common/Data/API/DomainServiceTests.swift
+++ b/Horizon/HorizonTests/Common/Data/API/DomainServiceTests.swift
@@ -1,0 +1,83 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Core
+import Foundation
+import Testing
+
+@testable import Horizon
+
+struct DomainServiceTests {
+
+    // Given the Domain Service
+    // When initilized with .cedar
+    // When initialized with the baseURL https://example.com
+    // When initialized with the us-east-1 region
+    // Then the url is https://cedar-api-production.us-east-1.temp.prod.inseng.io
+    @Test func when_initialized_with_east_1_region_then_url_is_correct() async throws {
+        // Given
+        let mockAPI = TestHooks.MockAPI()
+        mockAPI.mockResult = ["token": "dGVzdF90b2tlbg=="]
+        var subscriptions = Set<AnyCancellable>()
+
+        // When
+        let domainService = DomainService(
+            .cedar,
+            baseURL: "https://example.com",
+            region: "us-east-1",
+            horizonApi: mockAPI
+        )
+        //wait for receiveValue to get a value then continue
+        let api = try? await domainService.api().values.first { _ in true }
+
+        // Then
+        #expect(
+            api?.baseURL.absoluteString == "https://cedar-api-production.us-east-1.temp.prod.inseng.io"
+        )
+    }
+}
+
+// Test helpers
+enum TestHooks {
+    class MockAPI: API {
+        var mockResult: [String: String] = [:]
+        var requestable: (any APIRequestable)?
+
+        override func makeRequest<Request: APIRequestable>(
+            _ requestable: Request,
+            refreshToken: Bool = true,
+            callback: @escaping (Request.Response?, URLResponse?, Error?) -> Void
+        ) -> APITask? {
+            self.requestable = requestable
+            let task = MockTask()
+            task.resume()
+            let json = #"{"token": "SGVsbG8sIFJlZWQh"}"#.data(using: .utf8)!
+            let decoded = try? JSONDecoder().decode(Request.Response.self, from: json)
+            callback(decoded, nil, nil)
+            return task
+        }
+    }
+}
+
+struct MockTask: APITask {
+    var state: URLSessionTask.State = .completed
+    var taskID: String?
+    func cancel() {}
+    func resume() {}
+}


### PR DESCRIPTION
refs: CLX-2815
affects: Student
release note: Fixing a bug
builds: student

The region was not getting set on the session when a user logged in so when DomainService went to construct the URL, it was always using east for the region.