### PR TITLE
Add swiftui preview to SubmissionsFilterScreen

### DIFF
--- a/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorPreview.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/Model/SubmissionListInteractorPreview.swift
@@ -1,0 +1,47 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import Core
+
+class SubmissionListInteractorPreview: SubmissionListInteractor {
+    let context = Context(.course, id: "1")
+    let assignmentID = "1"
+
+    var submissions: AnyPublisher<[Submission], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    var assignment: AnyPublisher<Assignment?, Never> {
+        Just(nil).eraseToAnyPublisher()
+    }
+
+    var course: AnyPublisher<Course?, Never> {
+        Just(nil).eraseToAnyPublisher()
+    }
+
+    var assigneeGroups: AnyPublisher<[AssigneeGroup], Never> {
+        Just([]).eraseToAnyPublisher()
+    }
+
+    func refresh() -> AnyPublisher<Void, Never> {
+        Just(()).eraseToAnyPublisher()
+    }
+
+    func applyFilters(_ filters: [GetSubmissions.Filter]) {}
+}

--- a/Teacher/Teacher/Submissions/SubmissionsList/SubmissionListAssembly.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/SubmissionListAssembly.swift
@@ -34,4 +34,17 @@ public enum SubmissionListAssembly {
         let view = SubmissionListScreen(viewModel: viewModel)
         return CoreHostingController(view, env: env)
     }
+
+#if DEBUG
+
+    public static func makeFilterScreenPreview() -> UIViewController {
+        let env = PreviewEnvironment()
+        let interactor = SubmissionListInteractorPreview()
+        let viewModel = SubmissionListViewModel(interactor: interactor, filterMode: .all, env: env)
+        let view = SubmissionsFilterScreen(viewModel: viewModel)
+        let hostingController = CoreHostingController(view, env: env)
+        return CoreNavigationController(rootViewController: hostingController)
+    }
+
+#endif
 }

--- a/Teacher/Teacher/Submissions/SubmissionsList/View/SubmissionsFilterScreen.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/View/SubmissionsFilterScreen.swift
@@ -18,7 +18,6 @@
 
 import SwiftUI
 import Core
-import Combine
 
 enum SubmissionFilterMode: String, CaseIterable {
     case all

--- a/Teacher/Teacher/Submissions/SubmissionsList/View/SubmissionsFilterScreen.swift
+++ b/Teacher/Teacher/Submissions/SubmissionsList/View/SubmissionsFilterScreen.swift
@@ -18,6 +18,7 @@
 
 import SwiftUI
 import Core
+import Combine
 
 enum SubmissionFilterMode: String, CaseIterable {
     case all
@@ -130,3 +131,11 @@ struct SubmissionsFilterScreen: View {
         viewModel.course.flatMap { Color(uiColor: $0.color) } ?? .accentColor
     }
 }
+
+#if DEBUG
+
+#Preview {
+    SubmissionListAssembly.makeFilterScreenPreview()
+}
+
+#endif


### PR DESCRIPTION
I'm working on SpeedGrader follow-up tickets and a preview for the filter screen would come handy but wasn't available, so I quickly created one.

[ignore-commit-lint]