### PR TITLE
Fix filter button not realizing that it should appear

### DIFF
--- a/Core/Core/Features/Grades/View/Header/GradeListFilterButton.swift
+++ b/Core/Core/Features/Grades/View/Header/GradeListFilterButton.swift
@@ -20,7 +20,7 @@ import SwiftUI
 
 struct GradeListFilterButton: View {
     @Environment(\.viewController) var viewController
-    let viewModel: GradeListViewModel
+    @ObservedObject var viewModel: GradeListViewModel
 
     var body: some View {
         Button {


### PR DESCRIPTION
refs: MBL-19165
builds: Student
affects: Student
release note: none

test plan:
- Go to grade screen and check if the filter button is there after the initial load.

## Checklist

- [x] Tested on phone
- [ ] Tested on tablet