### PR TITLE
Fix a11y label not updating on grades list screen

### DIFF
--- a/Core/Core/Features/Grades/Model/Entities/GradeListData.swift
+++ b/Core/Core/Features/Grades/Model/Entities/GradeListData.swift
@@ -31,10 +31,14 @@ public struct GradeListData: Identifiable, Equatable {
     var currentGradingPeriodID: String?
 
     struct AssignmentSections: Identifiable, Equatable {
-        var id: String
+        let id: String
         let title: String
-        let accessibilityLabel: String
-        var assignments: [GradeListAssignment]
+        private(set) var accessibilityLabel: String = ""
+        var assignments: [GradeListAssignment] {
+            didSet {
+                accessibilityLabel = makeAccessibilityLabel()
+            }
+        }
 
         init(
             id: String,
@@ -44,7 +48,11 @@ public struct GradeListData: Identifiable, Equatable {
             self.id = id
             self.title = title
             self.assignments = assignments
-            self.accessibilityLabel = "\(title), \(String.format(numberOfItems: assignments.count))"
+            self.accessibilityLabel = makeAccessibilityLabel()
+        }
+
+        private func makeAccessibilityLabel() -> String {
+            "\(title), \(String.format(numberOfItems: assignments.count))"
         }
     }
 }

--- a/Core/Core/Features/Grades/View/List/AssignmentSection.swift
+++ b/Core/Core/Features/Grades/View/List/AssignmentSection.swift
@@ -90,6 +90,6 @@ struct AssignmentSection<Content: View>: View {
 extension AssignmentSection: Equatable {
 
     static func == (lhs: AssignmentSection<Content>, rhs: AssignmentSection<Content>) -> Bool {
-        lhs.title == rhs.title
+        lhs.title == rhs.title && lhs.titleA11yLabel == rhs.titleA11yLabel
     }
 }


### PR DESCRIPTION
- The accessibility label for grade list sections were on only updated in the initializer but the assignment array was modified from outside and the a11y label was not updated to be in sync with the new count.
- I also updated the equality check for the section view to include the a11y label.

refs: MBL-19165
builds: Student, Parent
affects: Student, Parent
release note: none

test plan:
- Go to grade screen and activate voiceover.
- Check section header labels with sections having more than one assignment.
- Assignment count should be properly announced for the given section.