### PR TITLE
Update todo view model not to trigger loading state on pull to refresh

### DIFF
--- a/Core/Core/Features/Todos/ViewModel/TodoListViewModel.swift
+++ b/Core/Core/Features/Todos/ViewModel/TodoListViewModel.swift
@@ -40,7 +40,6 @@ public class TodoListViewModel: ObservableObject {
     }
 
     public func refresh(completion: @escaping () -> Void, ignoreCache: Bool) {
-        self.state = .loading
         interactor.refresh(ignoreCache: ignoreCache)
             .sinkFailureOrValue { [weak self] _ in
                 self?.state = .error


### PR DESCRIPTION
refs: MBL-19134
builds: Student
affects: Student
release note: none

test plan:
- Go to To Do tab.
- Do a pull to refresh.
- List should stay on screen with PTR indicator spinning.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet