### PR TITLE
EPIC: Restrict Student Access - Inbox, File, and Calendar Restrictions

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/GetEnvironmentFeatureFlags.swift
@@ -23,6 +23,7 @@ public enum EnvironmentFeatureFlags: String {
     case send_usage_metrics
     case mobile_offline_mode
     case account_survey_notifications
+    case restrict_student_access
 }
 
 public class GetEnvironmentFeatureFlags: CollectionUseCase {

--- a/Core/Core/Features/Inbox/ComposeMessage/ComposeMessageAssembly.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ComposeMessageAssembly.swift
@@ -38,11 +38,14 @@ public enum ComposeMessageAssembly {
         )
         let recipientInteractor = RecipientInteractorLive()
         let settingsInteractor = InboxSettingsInteractorLive(environment: env)
+        let studentAccessInteractor = StudentAccessInteractorLive(env: env)
+
         let viewModel = ComposeMessageViewModel(
             options: options,
             interactor: interactor,
             recipientInteractor: recipientInteractor,
             inboxSettingsInteractor: settingsInteractor,
+            studentAccessInteractor: studentAccessInteractor,
             env: env
         )
 
@@ -69,6 +72,7 @@ public enum ComposeMessageAssembly {
             interactor: interactor,
             recipientInteractor: RecipientInteractorLive(),
             inboxSettingsInteractor: InboxSettingsInteractorPreview(),
+            studentAccessInteractor: StudentAccessInteractorPreview(env: env),
             env: env
         )
         return ComposeMessageView(model: viewModel)

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -232,7 +232,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                 separator
             }
             subjectView
-            if !model.isIndividualDisabled {
+            if !model.isIndividualDisabled && !model.isBulkMessagingEnforcedBasedOnStudentAccessRestriction {
                 separator
                 individualView
             }

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -36,6 +36,7 @@ final class ComposeMessageViewModel: ObservableObject {
     @Published public private(set) var isMessageDisabled: Bool = false
     @Published public private(set) var isIndividualDisabled: Bool = false
     @Published public private(set) var isSendIndividualToggleDisabled: Bool = false
+    @Published public private(set) var isBulkMessagingEnforcedBasedOnStudentAccessRestriction: Bool = false
     @Published public var isShowingErrorDialog = false
     @Published private(set) var searchedRecipients: [Recipient] = []
     @Published public private(set) var expandedIncludedMessageIds = [String]()
@@ -97,6 +98,7 @@ final class ComposeMessageViewModel: ObservableObject {
     private let interactor: ComposeMessageInteractor
     private let recipientInteractor: RecipientInteractor
     private let settingsInteractor: InboxSettingsInteractor
+    private let studentAccessInteractor: StudentAccessInteractor
     private let avPermissionViewModel: AVPermissionViewModel
     private let scheduler: AnySchedulerOf<DispatchQueue>
     private var messageType: ComposeMessageOptions.MessageType
@@ -114,6 +116,7 @@ final class ComposeMessageViewModel: ObservableObject {
         scheduler: AnySchedulerOf<DispatchQueue> = .main,
         recipientInteractor: RecipientInteractor,
         inboxSettingsInteractor: InboxSettingsInteractor,
+        studentAccessInteractor: StudentAccessInteractor,
         env: AppEnvironment
     ) {
         self.interactor = interactor
@@ -121,6 +124,7 @@ final class ComposeMessageViewModel: ObservableObject {
         self.messageType = options.messageType
         self.recipientInteractor = recipientInteractor
         self.settingsInteractor = inboxSettingsInteractor
+        self.studentAccessInteractor = studentAccessInteractor
         self.avPermissionViewModel = .init()
         self.env = env
         setIncludedMessages(messageType: options.messageType)
@@ -129,6 +133,7 @@ final class ComposeMessageViewModel: ObservableObject {
         setupOutputBindings()
         setupInputBindings()
         bindSearchRecipients()
+        bindStudentAccessRestriction()
     }
 
     private func getRecipients() {
@@ -442,7 +447,8 @@ final class ComposeMessageViewModel: ObservableObject {
         /// 1. Sending a message to a group or individuals.
         /// 2. Setting it to true if you are sending a message to more than 100 recipients.
         let isExceedsRecipientsLimit = recipientIDs.count > maxRecipientCount
-        let bulkMessage = isExceedsRecipientsLimit ? true : sendIndividual
+        let bulkMessage = isExceedsRecipientsLimit || isBulkMessagingEnforcedBasedOnStudentAccessRestriction || sendIndividual
+
         return MessageParameters(
             subject: subject,
             body: body,
@@ -542,6 +548,17 @@ final class ComposeMessageViewModel: ObservableObject {
             .store(in: &subscriptions)
     }
 
+    private func bindStudentAccessRestriction() {
+        studentAccessInteractor
+            .isRestricted()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isRestricted in
+                // Enforcing bulk messaging only for Teacher app, because we want to NOT enforce it for Student/Parent apps at the moment.
+                // We assume restricted Students won't even be able to message other Students.
+                self?.isBulkMessagingEnforcedBasedOnStudentAccessRestriction = isRestricted && self?.env.app == .teacher
+            }
+            .store(in: &subscriptions)
+    }
     private func didSendMessage(viewController: WeakViewController) {
         viewController.findSnackBarViewModel()?.showSnack(InboxMessageScope.sent.localizedName)
         env.router.dismiss(viewController)

--- a/Core/Core/Features/Inbox/MessageDetails/MessageDetailsAssembly.swift
+++ b/Core/Core/Features/Inbox/MessageDetails/MessageDetailsAssembly.swift
@@ -26,8 +26,10 @@ public enum MessageDetailsAssembly {
         env: AppEnvironment
     ) -> UIViewController {
         let interactor = MessageDetailsInteractorLive(env: env, conversationID: conversationID)
+        let studentAccessInteractor = StudentAccessInteractorLive(env: env)
         let viewModel = MessageDetailsViewModel(
             interactor: interactor,
+            studentAccessInteractor: studentAccessInteractor,
             myID: env.currentSession?.userID ?? "",
             allowArchive: allowArchive,
             env: env
@@ -43,8 +45,11 @@ public enum MessageDetailsAssembly {
                                    messages: [ConversationMessage])
     -> MessageDetailsView {
         let interactor = MessageDetailsInteractorPreview(env: env, subject: subject, messages: messages)
+        let studentAccessInteractor = StudentAccessInteractorPreview(env: env)
+
         let viewModel = MessageDetailsViewModel(
             interactor: interactor,
+            studentAccessInteractor: studentAccessInteractor,
             myID: env.currentSession?.userID ?? "",
             allowArchive: true,
             env: env

--- a/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
+++ b/Core/Core/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModel.swift
@@ -129,13 +129,15 @@ class MessageDetailsViewModel: ObservableObject {
             }
         }
 
-        sheet.addAction(
-            image: .trashLine,
-            title: String(localized: "Delete Conversation", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.delete"
-        ) { [weak self] in
-            if let conversationId = self?.conversations.first?.id {
-                self?.deleteConversationDidTap.send((conversationId, viewController))
+        if !isStudentAccessRestricted {
+            sheet.addAction(
+                image: .trashLine,
+                title: String(localized: "Delete Conversation", bundle: .core),
+                accessibilityIdentifier: "MessageDetails.delete"
+            ) { [weak self] in
+                if let conversationId = self?.conversations.first?.id {
+                    self?.deleteConversationDidTap.send((conversationId, viewController))
+                }
             }
         }
         env.router.show(sheet, from: viewController, options: .modal())
@@ -165,14 +167,15 @@ class MessageDetailsViewModel: ObservableObject {
         ) { [weak self] in
             self?.forwardTapped(message: message, viewController: viewController)
         }
-
-        sheet.addAction(
-            image: .trashLine,
-            title: String(localized: "Delete Message", bundle: .core),
-            accessibilityIdentifier: "MessageDetails.delete"
-        ) { [weak self] in
-            if let conversationId = self?.conversations.first?.id, let messageId = message?.id {
-                self?.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
+        if !isStudentAccessRestricted {
+            sheet.addAction(
+                image: .trashLine,
+                title: String(localized: "Delete Message", bundle: .core),
+                accessibilityIdentifier: "MessageDetails.delete"
+            ) { [weak self] in
+                if let conversationId = self?.conversations.first?.id, let messageId = message?.id {
+                    self?.deleteConversationMessageDidTap.send((conversationId: conversationId, messageId: messageId, viewController: viewController))
+                }
             }
         }
         env.router.show(sheet, from: viewController, options: .modal())

--- a/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
+++ b/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
@@ -1,0 +1,59 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+
+protocol StudentAccessInteractor: AnyObject {
+    func isRestricted() -> AnyPublisher<Bool, Never>
+}
+
+final class StudentAccessInteractorLive: StudentAccessInteractor {
+    // MARK: - Private Properties
+    private let featureFlagsStore: ReactiveStore<GetEnvironmentFeatureFlags>
+
+    // MARK: - Init
+    public init(env: AppEnvironment) {
+        self.featureFlagsStore = ReactiveStore(
+            useCase: GetEnvironmentFeatureFlags(context: .currentUser),
+            environment: env
+        )
+    }
+
+    // MARK: - Output
+    public func isRestricted() -> AnyPublisher<Bool, Never> {
+        featureFlagsStore
+            .getEntities()
+            .map { $0.isFeatureEnabled(.restrict_student_access) }
+            .replaceError(with: false)
+            .eraseToAnyPublisher()
+    }
+}
+
+#if DEBUG
+
+class StudentAccessInteractorPreview: StudentAccessInteractor {
+    // MARK: - Init
+    public init(env: AppEnvironment) { }
+
+    // MARK: - Output
+    public func isRestricted() -> AnyPublisher<Bool, Never> {
+        Just(false).eraseToAnyPublisher()
+    }
+}
+
+#endif

--- a/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
+++ b/Core/Core/Features/RestrictedStudentAccess/StudentAccessInteractor.swift
@@ -18,11 +18,11 @@
 
 import Combine
 
-protocol StudentAccessInteractor: AnyObject {
+public protocol StudentAccessInteractor: AnyObject {
     func isRestricted() -> AnyPublisher<Bool, Never>
 }
 
-final class StudentAccessInteractorLive: StudentAccessInteractor {
+final public class StudentAccessInteractorLive: StudentAccessInteractor {
     // MARK: - Private Properties
     private let featureFlagsStore: ReactiveStore<GetEnvironmentFeatureFlags>
 

--- a/Core/CoreTests/Features/Files/View/FileList/FileListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Files/View/FileList/FileListViewControllerTests.swift
@@ -25,11 +25,11 @@ import CombineSchedulers
 class FileListViewControllerTests: CoreTestCase {
     var controller: FileListViewController!
     private var studentAccessInteractor: StudentAccessInteractorMock!
-    private var testScheduler: TestSchedulerOf<DispatchQueue>!
+    private var testScheduler: AnySchedulerOf<DispatchQueue>!
 
     override func setUp() {
         super.setUp()
-        testScheduler = DispatchQueue.test
+        testScheduler = DispatchQueue.immediate.eraseToAnyScheduler()
         controller = FileListViewController
             .create(env: environment, context: .currentUser, path: "Folder A")
         studentAccessInteractor = StudentAccessInteractorMock()
@@ -307,14 +307,11 @@ class FileListViewControllerTests: CoreTestCase {
             context: .currentUser,
             path: "Folder A",
             studentAccessInteractor: studentAccessInteractor,
-            scheduler: testScheduler.eraseToAnyScheduler()
+            scheduler: testScheduler
         )
 
         controller.view.layoutIfNeeded()
         controller.viewWillAppear(false)
-
-        // Move virtual time forward by 100ms
-        testScheduler.advance(by: .seconds(0.1))
 
         _ = controller.addButton.target?.perform(controller.addButton.action)
         let sheet = router.presented as? BottomSheetPickerViewController

--- a/Core/CoreTests/Features/Files/View/FileList/FileListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Files/View/FileList/FileListViewControllerTests.swift
@@ -393,20 +393,3 @@ class FileListViewControllerTests: CoreTestCase {
         XCTAssertEqual((router.presented as? UIAlertController)?.message, "Oops")
     }
 }
-
-private class StudentAccessInteractorMock: StudentAccessInteractor {
-    private let isStudentAccessRestricted: CurrentValueSubject<Bool, Never>
-
-    init(isRestricted: Bool = false) {
-        isStudentAccessRestricted = CurrentValueSubject(isRestricted)
-    }
-
-    func isRestricted() -> AnyPublisher<Bool, Never> {
-        isStudentAccessRestricted.eraseToAnyPublisher()
-    }
-
-    // Optional: allow changing value in test
-    func setRestricted(_ value: Bool) {
-        isStudentAccessRestricted.send(value)
-    }
-}

--- a/Core/CoreTests/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModelTests.swift
@@ -17,6 +17,7 @@
 //
 
 import Foundation
+import TestsFoundation
 import Combine
 @testable import Core
 import CoreData
@@ -26,6 +27,7 @@ class ComposeMessageViewModelTests: CoreTestCase {
     private var mockInteractor: ComposeMessageInteractorMock!
     private var recipientInteractorMock: RecipientInteractorMock!
     private var inboxSettingsInteractor: InboxSettingsInteractorMock!
+    private var studentAccessInteractor: StudentAccessInteractorMock!
     var testee: ComposeMessageViewModel!
     private var subscriptions = Set<AnyCancellable>()
 
@@ -34,6 +36,7 @@ class ComposeMessageViewModelTests: CoreTestCase {
         recipientInteractorMock = RecipientInteractorMock()
         mockInteractor = ComposeMessageInteractorMock()
         inboxSettingsInteractor = InboxSettingsInteractorMock()
+        studentAccessInteractor = StudentAccessInteractorMock()
         testee = makeViewModel(options: .init(fromType: .new))
     }
 
@@ -101,6 +104,74 @@ class ComposeMessageViewModelTests: CoreTestCase {
         XCTAssertEqual(mockInteractor.isCreateConversationCalled, false)
         testee.didTapSend.accept(WeakViewController(sourceView))
         XCTAssertEqual(mockInteractor.isCreateConversationCalled, true)
+    }
+
+    func testBulkMessageIsTrueWhenRestrictedAndTeacherApp() {
+        // Given
+        AppEnvironment.shared.app = .teacher
+        studentAccessInteractor.setRestricted(true)
+        testee.selectedContext = RecipientContext(course: Course.make())
+
+        waitUntil {
+            testee.isBulkMessagingEnforcedBasedOnStudentAccessRestriction == true
+        }
+
+        // When
+        testee.didTapSend.accept(WeakViewController())
+
+        // Then
+        XCTAssertEqual(mockInteractor.parameters?.bulkMessage, true, "bulkMessage should be true when restricted is true and app is teacher")
+    }
+
+    func testBulkMessageIsFalseWhenRestrictedIsFalseAndTeacherApp() {
+        // Given
+        AppEnvironment.shared.app = .teacher
+        studentAccessInteractor.setRestricted(false)
+        testee.selectedContext = RecipientContext(course: Course.make())
+
+        waitUntil {
+            testee.isBulkMessagingEnforcedBasedOnStudentAccessRestriction == false
+        }
+
+        // When
+        testee.didTapSend.accept(WeakViewController())
+
+        // Then
+        XCTAssertEqual(mockInteractor.parameters?.bulkMessage, false, "bulkMessage should be false when restricted is false even if app is teacher")
+    }
+
+    func testBulkMessageIsFalseWhenRestrictedIsTrueAndAppIsNotTeacher() {
+        // Given
+        AppEnvironment.shared.app = .student // Example of a non-teacher app environment
+        studentAccessInteractor.setRestricted(true)
+        testee.selectedContext = RecipientContext(course: Course.make())
+
+        waitUntil {
+            testee.isBulkMessagingEnforcedBasedOnStudentAccessRestriction == true
+        }
+
+        // When
+        testee.didTapSend.accept(WeakViewController())
+
+        // Then
+        XCTAssertEqual(mockInteractor.parameters?.bulkMessage, false, "bulkMessage should be false when restricted is true but app is not teacher")
+    }
+
+    func testBulkMessageIsFalseWhenRestrictedIsFalseAndAppIsNotTeacher() {
+        // Given
+        AppEnvironment.shared.app = .student // Example of a non-teacher app environment
+        studentAccessInteractor.setRestricted(false)
+        testee.selectedContext = RecipientContext(course: Course.make())
+
+        waitUntil {
+            testee.isBulkMessagingEnforcedBasedOnStudentAccessRestriction == false
+        }
+
+        // When
+        testee.didTapSend.accept(WeakViewController())
+
+        // Then
+        XCTAssertEqual(mockInteractor.parameters?.bulkMessage, false, "bulkMessage should be false when restricted is false and app is not teacher")
     }
 
     func testSuccessfulReplySend() {
@@ -601,6 +672,7 @@ class ComposeMessageViewModelTests: CoreTestCase {
             interactor: mockInteractor,
             recipientInteractor: recipientInteractorMock,
             inboxSettingsInteractor: inboxSettingsInteractor,
+            studentAccessInteractor: studentAccessInteractor,
             env: environment
         )
     }
@@ -702,5 +774,22 @@ private class InboxSettingsInteractorMock: InboxSettingsInteractor {
 
     func updateInboxSettings(inboxSettings: Core.CDInboxSettings) -> AnyPublisher<Void, any Error> {
         return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
+}
+
+private class StudentAccessInteractorMock: StudentAccessInteractor {
+    private let isBulkMessagingEnforcedBasedOnStudentAccessRestriction: CurrentValueSubject<Bool, Never>
+
+    init(restricted: Bool = false) {
+        self.isBulkMessagingEnforcedBasedOnStudentAccessRestriction = CurrentValueSubject(restricted)
+    }
+
+    func isRestricted() -> AnyPublisher<Bool, Never> {
+        isBulkMessagingEnforcedBasedOnStudentAccessRestriction.eraseToAnyPublisher()
+    }
+
+    // Optional: allow changing value in test
+    func setRestricted(_ value: Bool) {
+        isBulkMessagingEnforcedBasedOnStudentAccessRestriction.send(value)
     }
 }

--- a/Core/CoreTests/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModelTests.swift
@@ -776,20 +776,3 @@ private class InboxSettingsInteractorMock: InboxSettingsInteractor {
         return Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
-
-private class StudentAccessInteractorMock: StudentAccessInteractor {
-    private let isBulkMessagingEnforcedBasedOnStudentAccessRestriction: CurrentValueSubject<Bool, Never>
-
-    init(restricted: Bool = false) {
-        self.isBulkMessagingEnforcedBasedOnStudentAccessRestriction = CurrentValueSubject(restricted)
-    }
-
-    func isRestricted() -> AnyPublisher<Bool, Never> {
-        isBulkMessagingEnforcedBasedOnStudentAccessRestriction.eraseToAnyPublisher()
-    }
-
-    // Optional: allow changing value in test
-    func setRestricted(_ value: Bool) {
-        isBulkMessagingEnforcedBasedOnStudentAccessRestriction.send(value)
-    }
-}

--- a/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
@@ -29,7 +29,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
     override func setUp() {
         super.setUp()
         mockInteractor = MessageDetailsInteractorMock()
-        mockStudentAccessInteractor = StudentAccessInteractorMock(restricted: false)
+        mockStudentAccessInteractor = StudentAccessInteractorMock()
         testee = MessageDetailsViewModel(
             interactor: mockInteractor,
             studentAccessInteractor: mockStudentAccessInteractor,
@@ -206,7 +206,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
     func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllAndDeleteNotShown() {
         // Given
         mockInteractor = MessageDetailsInteractorMock()
-        mockStudentAccessInteractor = StudentAccessInteractorMock(restricted: true)
+        mockStudentAccessInteractor.setRestricted(true)
         testee = MessageDetailsViewModel(
             interactor: mockInteractor,
             studentAccessInteractor: mockStudentAccessInteractor,
@@ -457,17 +457,5 @@ private class MessageDetailsInteractorMock: MessageDetailsInteractor {
     func passConversationEvent(with cannotReply: Bool) {
         conversation.send(([
             Conversation.make(from: .make( message_count: 1, messages: [ .make() ], cannot_reply: cannotReply))]))
-    }
-}
-
-private class StudentAccessInteractorMock: StudentAccessInteractor {
-    private let restricted: Bool
-
-    init(restricted: Bool) {
-        self.restricted = restricted
-    }
-
-    func isRestricted() -> AnyPublisher<Bool, Never> {
-        Just(restricted).eraseToAnyPublisher()
     }
 }

--- a/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
+++ b/Core/CoreTests/Features/Inbox/MessageDetails/ViewModel/MessageDetailsViewModelTests.swift
@@ -203,7 +203,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
         XCTAssertTrue(router.presented is CoreHostingController<ComposeMessageView>)
     }
 
-    func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllNotShown() {
+    func test_messageMoreTapped_whenRestrictStudentAccessEnabled_replyAllAndDeleteNotShown() {
         // Given
         mockInteractor = MessageDetailsInteractorMock()
         mockStudentAccessInteractor = StudentAccessInteractorMock(restricted: true)
@@ -231,9 +231,10 @@ class MessageDetailsViewModelTests: CoreTestCase {
         let sheet = router.presented as? BottomSheetPickerViewController
         let actionTitles = sheet?.actions.map { $0.title } ?? []
         XCTAssertFalse(actionTitles.contains("Reply All"))
+        XCTAssertFalse(actionTitles.contains("Delete Message"))
     }
 
-    func test_messageMoreTapped_whenRestrictStudentAccessDisabled_replyAllShown() {
+    func test_messageMoreTapped_whenRestrictStudentAccessDisabled_replyAllAndDeleteShown() {
         // Given
         let sourceView = UIViewController()
 
@@ -251,6 +252,7 @@ class MessageDetailsViewModelTests: CoreTestCase {
         let sheet = router.presented as? BottomSheetPickerViewController
         let actionTitles = sheet?.actions.map { $0.title } ?? []
         XCTAssertTrue(actionTitles.contains("Reply All"))
+        XCTAssertTrue(actionTitles.contains("Delete Message"))
     }
 
     func test_messageMoreTapped_forward_presentComposeMessageView() {

--- a/Core/CoreTests/Features/Planner/CalendarMain/PlannerViewControllerTests.swift
+++ b/Core/CoreTests/Features/Planner/CalendarMain/PlannerViewControllerTests.swift
@@ -18,13 +18,54 @@
 
 import XCTest
 @testable import Core
+import Combine
+import CombineSchedulers
 
 class PlannerViewControllerTests: CoreTestCase {
-    lazy var controller = PlannerViewController.create(studentID: "1")
+    var controller: PlannerViewController!
+    private var studentAccessInteractor: StudentAccessInteractorMock!
+    private var testScheduler: AnySchedulerOf<DispatchQueue>!
 
     override func setUp() {
         super.setUp()
+        testScheduler = DispatchQueue.immediate.eraseToAnyScheduler()
         environment.userDefaults?.reset()
+        controller = PlannerViewController.create(studentID: "1")
+        studentAccessInteractor = StudentAccessInteractorMock()
+    }
+
+    func test_addEventButtonVisible_whenNotRestricted() {
+        studentAccessInteractor.setRestricted(false)
+        controller = PlannerViewController.create(
+            studentID: "1",
+            studentAccessInteractor: studentAccessInteractor,
+            scheduler: testScheduler
+        )
+
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+
+        let titles = controller.addButton.menu?.allActions.map { $0.title } ?? []
+
+        XCTAssertTrue(titles.contains("Add Event"), "Add Event should be visible when not restricted")
+        XCTAssertTrue(titles.contains("Add To Do"), "Add To Do should always be visible")
+    }
+
+    func test_addEventButtonHidden_whenRestricted() {
+        studentAccessInteractor.setRestricted(true)
+        controller = PlannerViewController.create(
+            studentID: "1",
+            studentAccessInteractor: studentAccessInteractor,
+            scheduler: testScheduler
+        )
+
+        controller.view.layoutIfNeeded()
+        controller.viewWillAppear(false)
+
+        let titles = controller.addButton.menu?.allActions.map { $0.title } ?? []
+
+        XCTAssertFalse(titles.contains("Add Event"), "Add Event should be hidden when restricted")
+        XCTAssertTrue(titles.contains("Add To Do"), "Add To Do should always be visible")
     }
 
     func testLayout() {

--- a/Core/CoreTests/Features/RestrictedStudentAccess/StudentAccessInteractorMock.swift
+++ b/Core/CoreTests/Features/RestrictedStudentAccess/StudentAccessInteractorMock.swift
@@ -1,0 +1,37 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+@testable import Core
+
+class StudentAccessInteractorMock: StudentAccessInteractor {
+    private let isStudentAccessRestricted: CurrentValueSubject<Bool, Never>
+
+    init(isRestricted: Bool = false) {
+        isStudentAccessRestricted = CurrentValueSubject(isRestricted)
+    }
+
+    func isRestricted() -> AnyPublisher<Bool, Never> {
+        isStudentAccessRestricted.eraseToAnyPublisher()
+    }
+
+    // Optional: allow changing value in test
+    func setRestricted(_ value: Bool) {
+        isStudentAccessRestricted.send(value)
+    }
+}

--- a/Core/CoreTests/Features/RestrictedStudentAccess/StudentAccessInteractorTests.swift
+++ b/Core/CoreTests/Features/RestrictedStudentAccess/StudentAccessInteractorTests.swift
@@ -1,0 +1,48 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+@testable import Core
+import XCTest
+
+final class StudentAccessInteractorTests: CoreTestCase {
+    private var cancellables = Set<AnyCancellable>()
+
+    func test_isRestricted_returnsTrue_whenFlagEnabled() {
+        // Arrange
+        api.mock(
+            GetEnvironmentFeatureFlagsRequest(context: .currentUser),
+            value: ["restrict_student_access": true]
+        )
+
+        let interactor = StudentAccessInteractorLive(env: environment)
+        XCTAssertCompletableSingleOutputEquals(interactor.isRestricted(), true)
+    }
+
+    func test_isRestricted_returnsFalse_whenFlagDisabled() {
+        // Arrange
+        api.mock(
+            GetEnvironmentFeatureFlagsRequest(context: .currentUser),
+            value: ["restrict_student_access": false]
+        )
+
+        let interactor = StudentAccessInteractorLive(env: environment)
+
+        XCTAssertCompletableSingleOutputEquals(interactor.isRestricted(), false)
+    }
+}

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -528,6 +528,7 @@ private func fileDetails(url: URLComponents, params: [String: String], userInfo 
             fileID: fileID.localID,
             originURL: url,
             assignmentID: assignmentID?.localID,
+            studentAccessInteractor: StudentAccessInteractorLive(env: environment),
             environment: environment
         )
 }

--- a/Student/Student/Routes.swift
+++ b/Student/Student/Routes.swift
@@ -501,7 +501,8 @@ private func fileList(url: URLComponents, params: [String: String], userInfo: [S
     return FileListViewController.create(
         env: environment,
         context: Context(path: url.path) ?? .currentUser,
-        path: params["subFolder"]
+        path: params["subFolder"],
+        studentAccessInteractor: StudentAccessInteractorLive(env: environment)
     )
 }
 

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -119,7 +119,11 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         if ExperimentalFeature.rebuiltCalendar.isEnabled {
             planner = PlannerAssembly.makeNewPlannerViewController()
         } else {
-            planner = CoreNavigationController(rootViewController: PlannerViewController.create())
+            planner = CoreNavigationController(
+                rootViewController: PlannerViewController.create(
+                    studentAccessInteractor: StudentAccessInteractorLive(env: AppEnvironment.shared)
+                )
+            )
         }
 
         split.viewControllers = [


### PR DESCRIPTION
This PR merges multiple feature updates under the **`restrict_student_access`** feature flag to enhance control over student interactions across the Canvas Student, Teacher, and Parent apps.

refs: PFS-25335
affects: Student, Teacher, Parent

release note: When the `restrict_student_access` feature flag is enabled:

* Students cannot reply-all, delete messages, upload files, share/download files, or create new calendar events.
* Teachers cannot send individual messages (bulk messaging only).
* Parent app hides reply-all and delete message options as well.

#### **Included Changes**

1. https://github.com/instructure/canvas-ios/pull/3545
2. https://github.com/instructure/canvas-ios/pull/3564
3. https://github.com/instructure/canvas-ios/pull/3585
4. https://github.com/instructure/canvas-ios/pull/3576
5. https://github.com/instructure/canvas-ios/pull/3572
6. https://github.com/instructure/canvas-ios/pull/3604

---

### **Test Plan**

1. Enable the `restrict_student_access` feature flag.
2. Launch Student, Teacher, and Parent apps.
3. Verify each feature’s restricted behavior as listed above.
4. Disable the flag and confirm that all functionality is restored.

--- edit or delete this section ---
## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
