### PR TITLE
[MBL-19255][All] Fix direct canvas file links not loading from rich content

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -516,6 +516,19 @@ extension CoreWebView: WKNavigationDelegate {
             return decisionHandler(.cancel)
         }
 
+        // Handle file links that are directly pointing to the canvas content server
+        if action.isCanvasUserContentLinkTap, let url = action.request.url, let viewController = linkDelegate?.routeLinksFrom {
+            let controller = FileViewerWebViewController(url: url)
+            let routeOptions = RouteOptions.modal(
+                .fullScreen,
+                isDismissable: false,
+                embedInNav: true,
+                addDoneButton: true
+            )
+            env.router.show(controller, from: viewController, options: routeOptions)
+            return decisionHandler(.cancel)
+        }
+
         // Forward decision to delegate
         if action.navigationType == .linkActivated, let url = action.request.url,
            linkDelegate?.handleLink(url) == true {
@@ -825,5 +838,14 @@ extension CoreWebView {
         } else {
             loadHTMLString(content ?? "", baseURL: originalBaseURL)
         }
+    }
+}
+
+// MARK: - WKNavigationAction Extensions
+
+extension WKNavigationAction {
+
+    var isCanvasUserContentLinkTap: Bool {
+        navigationType == .linkActivated && request.url?.host()?.hasSuffix(".canvas-user-content.com") == true
     }
 }

--- a/Core/Core/Common/CommonUI/CoreWebView/View/FileViewerWebViewController.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/FileViewerWebViewController.swift
@@ -1,0 +1,149 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+import WebKit
+
+// We use this controller to render file links pointing directly to canvas-user-content.com. These links need a session cookie to work,
+// which we can provide via WKWebView and its shared cookie store.
+public class FileViewerWebViewController: UIViewController {
+    let url: URL
+    private let webView: WKWebView
+    private weak var progressIndicator: CircleProgressView?
+
+    public init(url: URL) {
+        self.url = url
+        self.webView = WKWebView(
+            frame: .zero,
+            configuration: .defaultConfiguration
+        )
+        super.init(nibName: nil, bundle: nil)
+        webView.navigationDelegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        setupUI()
+        loadURL()
+    }
+
+    private func setupUI() {
+        navigationController?.navigationBar.useStyle(.global)
+        view.backgroundColor = .backgroundLightest
+        navigationItem.title = String(
+            localized: "File Viewer",
+            comment: "Title for a screen that displays the contents of a file"
+        )
+
+        view.addSubview(webView)
+        webView.pin(inside: self.view)
+
+        addProgressIndicator()
+        showProgressIndicator()
+    }
+
+    private func addProgressIndicator() {
+        let progressView = CircleProgressView()
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(progressView)
+        NSLayoutConstraint.activate([
+            progressView.widthAnchor.constraint(equalToConstant: 40),
+            progressView.heightAnchor.constraint(equalToConstant: 40),
+            progressView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            progressView.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+        self.progressIndicator = progressView
+    }
+
+    private func showProgressIndicator() {
+        progressIndicator?.startAnimating()
+        webView.alpha = 0
+    }
+
+    private func hideProgressIndicator() {
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            self?.progressIndicator?.alpha = 0
+            self?.webView.alpha = 1
+        } completion: { [weak self] _ in
+            self?.progressIndicator?.stopAnimating()
+        }
+    }
+
+    private func loadURL() {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+
+    private func showError(_ error: Error) {
+        hideProgressIndicator()
+
+        let alert = UIAlertController(
+            title: String(localized: "Failed to load file", bundle: .core),
+            message: error.localizedDescription,
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(
+            title: String(localized: "OK", bundle: .core),
+            style: .default
+        ) { [weak self] _ in
+            self?.dismiss(animated: true)
+        })
+
+        present(alert, animated: true)
+    }
+}
+
+extension FileViewerWebViewController: WKNavigationDelegate {
+
+    public func webView(
+        _ webView: WKWebView,
+        didFinish navigation: WKNavigation!
+    ) {
+        hideProgressIndicator()
+    }
+
+    public func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        showError(error)
+    }
+
+    public func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        showError(error)
+    }
+}
+
+#if DEBUG
+
+#Preview {
+    CoreNavigationController(rootViewController: FileViewerWebViewController(url: URL(string: "/")!))
+
+}
+
+#endif

--- a/Core/Core/Common/CommonUI/CoreWebView/View/FileViewerWebViewController.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/FileViewerWebViewController.swift
@@ -51,6 +51,7 @@ public class FileViewerWebViewController: UIViewController {
         view.backgroundColor = .backgroundLightest
         navigationItem.title = String(
             localized: "File Viewer",
+            bundle: .core,
             comment: "Title for a screen that displays the contents of a file"
         )
 


### PR DESCRIPTION
### What happened?
- A html link to a canvas file was added as a link in rich content that didn't point to a regular file resource, rather than pointed to the raw file on the resource server.
- Our app didn't recognize this as a valid path to a file and also the base url didn't match with the one used for login so the app treated this as an external url.
- External urls are opened externally in Safari, but to load this url, a valid session cookie was needed. In case the user didn't have such in the browser, the access was denied.
- To solve the issue, I added a logic that detects such links using their hostname that don't change.
- After this, the link is passed to a modal webview that already has a valid session cookie due to the cookie keep-alive mechanism and the file loads.

refs: [MBL-19255](https://instructure.atlassian.net/browse/MBL-19255)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: Fixed some file links not loading from rich content.

test plan:
- See ticket for video on which page to test.
- You have to turn on “Allow cross-website tracking” in the app settings for the page to load.
- Contact me for test account.

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode

[MBL-19255]: https://instructure.atlassian.net/browse/MBL-19255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ