### PR TITLE
[MBL-19235][Student][Teacher] - Fix issue where Assignments with `true` hideInGradeBook property are being hidden

### DIFF
--- a/Core/Core/Features/Grades/Model/UseCase/GetAssignmentsByGroup.swift
+++ b/Core/Core/Features/Grades/Model/UseCase/GetAssignmentsByGroup.swift
@@ -72,8 +72,6 @@ public class GetAssignmentsByGroup: UseCase {
                 predicate = predicate.and(NSPredicate(format: "ANY submissions.userID == %@", userID))
             }
 
-            predicate = predicate.and(NSPredicate(key: #keyPath(Assignment.hideInGradeBook), equals: false))
-
             return predicate
         }()
 

--- a/Core/CoreTests/Features/Grades/Model/UseCase/GetAssignmentsByGroupTests.swift
+++ b/Core/CoreTests/Features/Grades/Model/UseCase/GetAssignmentsByGroupTests.swift
@@ -155,7 +155,7 @@ class GetAssignmentsByGroupTests: CoreTestCase {
 
         // THEN
         waitForExpectations(timeout: 1)
-        XCTAssertEqual(store.numberOfSections, 1)
+        XCTAssertEqual(store.numberOfSections, 2)
     }
 
     func testFetchesAssignmentsForEachGradingPeriodAndReturnsAssignmentsForAGradingPeriod() {


### PR DESCRIPTION
refs: MBL-19235
affects: Student, Teacher
builds: Student, Teacher
release note: Fixed assignments not showing up in some cases.

## Test Plan

See [ticket's](https://instructure.atlassian.net/browse/MBL-19235) description.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
