### PR TITLE
[MBL-19236][Student] Fix calendar url getting deleted from profile

### DIFF
--- a/Core/Core/Features/Profile/UserProfile.swift
+++ b/Core/Core/Features/Profile/UserProfile.swift
@@ -48,7 +48,9 @@ extension UserProfile: WriteableModel {
         model.locale = item.locale
         model.loginID = item.login_id
         model.avatarURL = item.avatar_url?.rawValue
-        model.calendarURL = item.calendar?.ics
+        // In case profile is fetched via GetSelfUserIncludingUUIDRequest,
+        // the calendar url is missing from the API response so we just keep the existing DB value
+        model.calendarURL = item.calendar?.ics ?? model.calendarURL
         model.pronouns = item.pronouns
         model.isK5User = (item.k5_user == true)
         model.canUpdateName = item.permissions?.canUpdateName ?? model.canUpdateName

--- a/Core/CoreTests/Features/Profile/UserProfileTests.swift
+++ b/Core/CoreTests/Features/Profile/UserProfileTests.swift
@@ -42,4 +42,25 @@ class UserProfileTests: CoreTestCase {
         let profile = UserProfile.save(apiProfile, in: databaseClient)
         XCTAssertEqual(profile.isK5User, false)
     }
+
+    func testCalendarURLPreservedWhenAPIResponseMissingCalendar() {
+        // First, save a profile with a calendar URL
+        let originalCalendarURL = URL(string: "https://example.com/calendar.ics")!
+        let apiProfileWithCalendar = APIProfile.make(
+            calendar: .init(ics: originalCalendarURL)
+        )
+        let profile = UserProfile.save(apiProfileWithCalendar, in: databaseClient)
+        XCTAssertEqual(profile.calendarURL, originalCalendarURL)
+
+        // Then save the same profile again, but this time without calendar data
+        let apiProfileWithoutCalendar = APIProfile.make(
+            id: apiProfileWithCalendar.id,
+            calendar: nil
+        )
+        let updatedProfile = UserProfile.save(apiProfileWithoutCalendar, in: databaseClient)
+
+        // Verify the calendar URL is preserved
+        XCTAssertEqual(updatedProfile.calendarURL, originalCalendarURL)
+        XCTAssertEqual(profile.id, updatedProfile.id) // Same profile object
+    }
 }


### PR DESCRIPTION
refs: MBL-19236
builds: Student
affects: Student
release note: Fixed calendar feed not opening calendar app.

test plan:
- Calendar feed button in app settings should open device calendar.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet