### PR TITLE
[MBL-19243][Teacher] Use proper baseURL when loading html content in assignment details

### DIFF
--- a/Teacher/Teacher/Assignments/AssignmentDetails/Views/TeacherAssignmentDetailsScreen.swift
+++ b/Teacher/Teacher/Assignments/AssignmentDetails/Views/TeacherAssignmentDetailsScreen.swift
@@ -223,7 +223,7 @@ private extension TeacherAssignmentDetailsScreen {
                 .font(.regular14)
                 .foregroundColor(.textDark)
                 .padding(EdgeInsets(top: 16, leading: 16, bottom: 0, trailing: 16))
-            WebView(html: html, baseURL: URL.Directories.documents, canToggleTheme: true)
+            WebView(html: html, baseURL: env.currentSession?.baseURL, canToggleTheme: true)
                 .frameToFit()
         } else {
             Section(label: Text("Description", bundle: .teacher)) {


### PR DESCRIPTION
refs: [MBL-19243](https://instructure.atlassian.net/browse/MBL-19243)
builds: Teacher
affects: Teacher
release note: Fixed assignment details screen not loading embedded content.

test plan:
- See ticket for test data.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-19243]: https://instructure.atlassian.net/browse/MBL-19243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ