### PR TITLE
[CLX-2681][Student] - Inbox Items Not Bold When Read

### DIFF
--- a/Horizon/Horizon/Sources/Features/Inbox/Inbox/View/HInboxView.swift
+++ b/Horizon/Horizon/Sources/Features/Inbox/Inbox/View/HInboxView.swift
@@ -169,11 +169,11 @@ struct MessageRow: View {
                 VStack(alignment: .leading) {
                     Text(viewModel.title)
                         .lineLimit(1)
-                        .huiTypography(.labelMediumBold)
+                        .huiTypography(viewModel.isNew ? .labelMediumBold : .p2)
 
                     Text(viewModel.subtitle)
                         .lineLimit(1)
-                        .huiTypography(.labelMediumBold)
+                        .huiTypography(viewModel.isNew ? .labelMediumBold : .p2)
                 }
             }
         }


### PR DESCRIPTION
builds: Student
affects: student
release note: none

test plan: Open the Inbox of Horizon and verify that the read messages in the list do not have a bold title or subtitle.

<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-09-10 at 09 49 35" src="https://github.com/user-attachments/assets/9ec1e8ef-8214-4b74-b176-f477c52886d4" />
