### PR TITLE
[MBL-19292] Update Nutrient SDK

### DIFF
--- a/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Canvas.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "257ce0b596a02f742731a202b60715b4aacdb586de9dd5e4871c9baa633e1e71",
+  "originHash" : "102d90cdfa1716b86d908a5b9c78094cc7e8ac6573d7ecb6e8ea7a20d67852e4",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PSPDFKit/PSPDFKit-SP",
       "state" : {
-        "revision" : "34567b2d180a86afb3925b1749f25ea9f40af586",
-        "version" : "13.9.1"
+        "revision" : "3cdcac00ee7bce16b96d7aafcdc56b5837773d55",
+        "version" : "14.2.0"
       }
     },
     {

--- a/Core/Core/Features/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/Features/DocViewer/DocViewerViewController.swift
@@ -83,6 +83,7 @@ public class DocViewerViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
+		
 
         loadingView.color = nil
         self.view.backgroundColor = .backgroundMedium

--- a/Core/Core/Features/DocViewer/DocViewerViewController.swift
+++ b/Core/Core/Features/DocViewer/DocViewerViewController.swift
@@ -83,7 +83,6 @@ public class DocViewerViewController: UIViewController {
 
     public override func viewDidLoad() {
         super.viewDidLoad()
-		
 
         loadingView.color = nil
         self.view.backgroundColor = .backgroundMedium

--- a/Core/project.yml
+++ b/Core/project.yml
@@ -32,7 +32,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   Swifter:
     url: https://github.com/httpswift/swifter
     version: 1.5.0

--- a/Core/project.yml
+++ b/Core/project.yml
@@ -32,7 +32,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   Swifter:
     url: https://github.com/httpswift/swifter
     version: 1.5.0

--- a/Horizon/project.yml
+++ b/Horizon/project.yml
@@ -37,7 +37,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Horizon/project.yml
+++ b/Horizon/project.yml
@@ -37,7 +37,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Parent/project-ci.yml
+++ b/Parent/project-ci.yml
@@ -31,7 +31,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Parent/project-ci.yml
+++ b/Parent/project-ci.yml
@@ -31,7 +31,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Parent/project.yml
+++ b/Parent/project.yml
@@ -33,7 +33,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Parent/project.yml
+++ b/Parent/project.yml
@@ -33,7 +33,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Student/project-ci.yml
+++ b/Student/project-ci.yml
@@ -35,7 +35,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Student/project-ci.yml
+++ b/Student/project-ci.yml
@@ -35,7 +35,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Student/project.yml
+++ b/Student/project.yml
@@ -37,7 +37,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Student/project.yml
+++ b/Student/project.yml
@@ -37,7 +37,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Teacher/project-ci.yml
+++ b/Teacher/project-ci.yml
@@ -31,7 +31,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Teacher/project-ci.yml
+++ b/Teacher/project-ci.yml
@@ -31,7 +31,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Teacher/project.yml
+++ b/Teacher/project.yml
@@ -33,7 +33,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 13.9.1
+    exactVersion: 26.0.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1

--- a/Teacher/project.yml
+++ b/Teacher/project.yml
@@ -33,7 +33,7 @@ packages:
     exactVersion: 3.7.5
   PSPDFKit:
     url: https://github.com/PSPDFKit/PSPDFKit-SP
-    exactVersion: 26.0.0
+    exactVersion: 14.2.0
   FirebaseCrashlytics:
     url: https://github.com/firebase/firebase-ios-sdk.git
     exactVersion: 10.23.1


### PR DESCRIPTION
Upgrade Nutrient (PSPDFKit) to version 14.2. Version 26.0 is the newest, but is incompatible with Xcode 16.4. We should upgrade to the newest version when we upgrade to Xcode 26.

Checked all annotation features and they work as expected.

refs: MBL-19292
builds: Student, Parent, Teacher
affects: Student, Parent, Teacher
release note: none

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [x] Tested in dark mode
- [x] Tested in light mode
- [x] Approve from product
