### PR TITLE
Update cell layout to support header and subtitle

### DIFF
--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/CheckboxCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/CheckboxCell.swift
@@ -27,6 +27,7 @@ extension InstUI {
         @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
         private let title: String
+        private let headerTitle: String?
         private let subtitle: String?
         @Binding private var isSelected: Bool
         private let accessoryView: (() -> Accessory)?
@@ -36,12 +37,14 @@ extension InstUI {
 
         public init(
             title: String,
+            headerTitle: String? = nil,
             subtitle: String? = nil,
             isSelected: Binding<Bool>,
             accessoryView: (() -> Accessory)?,
             dividerStyle: InstUI.Divider.Style = .full
         ) {
             self.title = title
+            self.headerTitle = headerTitle
             self.subtitle = subtitle
             self._isSelected = isSelected
             self.accessoryView = accessoryView
@@ -50,12 +53,14 @@ extension InstUI {
 
         public init(
             title: String,
+            headerTitle: String? = nil,
             subtitle: String? = nil,
             isSelected: Binding<Bool>,
             dividerStyle: InstUI.Divider.Style = .full
         ) where Accessory == SwiftUI.EmptyView {
             self.init(
                 title: title,
+                headerTitle: headerTitle,
                 subtitle: subtitle,
                 isSelected: isSelected,
                 accessoryView: nil,
@@ -76,6 +81,12 @@ extension InstUI {
                             .animation(.default, value: isSelected)
 
                         VStack(spacing: 2) {
+                            if let headerTitle {
+                                Text(headerTitle)
+                                    .textStyle(.cellLabelSubtitle)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
                             Text(title)
                                 .textStyle(.cellLabel)
                                 .multilineTextAlignment(.leading)
@@ -99,7 +110,7 @@ extension InstUI {
             }
             .accessibilityRepresentation {
                 SwiftUI.Toggle(isOn: $isSelected) {
-                    Text(title)
+                    Text([headerTitle, title, subtitle].accessibilityJoined())
                 }
             }
         }
@@ -113,8 +124,23 @@ private struct Container: View {
 
     var body: some View {
         InstUI.CheckboxCell(
-            title: "Checkbox here",
+            title: "Checkbox 1",
+            isSelected: $isSelected
+        )
+        InstUI.CheckboxCell(
+            title: "Checkbox 2",
             subtitle: "Subtitle",
+            isSelected: $isSelected
+        )
+        InstUI.CheckboxCell(
+            title: "Checkbox 2",
+            headerTitle: "Header Title",
+            subtitle: "Subtitle",
+            isSelected: $isSelected
+        )
+        InstUI.CheckboxCell(
+            title: "Checkbox 2",
+            headerTitle: "Header Title",
             isSelected: $isSelected
         )
     }

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/RadioButtonCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/RadioButtonCell.swift
@@ -25,6 +25,8 @@ extension InstUI {
 
         @Binding private var selectedValue: Value?
         private let title: String
+        private let headerTitle: String?
+        private let subtitle: String?
         private let value: Value?
         private let dividerStyle: InstUI.Divider.Style
 
@@ -33,11 +35,15 @@ extension InstUI {
         ///   - selectedValue: This binding holds the currently selected value belonging to the radio button group. The value is equatable so this cell can decide when to display the selected state.
         public init(
             title: String,
+            headerTitle: String? = nil,
+            subtitle: String? = nil,
             value: Value?,
             selectedValue: Binding<Value?>,
             dividerStyle: InstUI.Divider.Style = .full
         ) {
             self.title = title
+            self.headerTitle = headerTitle
+            self.subtitle = subtitle
             self.value = value
             self._selectedValue = selectedValue
             self.dividerStyle = dividerStyle
@@ -55,10 +61,24 @@ extension InstUI {
                         .paddingStyle(.trailing, .cellIconText)
                         .animation(.default, value: selectedValue)
 
-                        Text(title)
-                            .textStyle(.cellLabel)
-                            .multilineTextAlignment(.leading)
-                            .frame(maxWidth: .infinity, alignment: .leading)
+                        VStack(spacing: 2) {
+                            if let headerTitle {
+                                Text(headerTitle)
+                                    .textStyle(.cellLabelSubtitle)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                            Text(title)
+                                .textStyle(.cellLabel)
+                                .multilineTextAlignment(.leading)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                            if let subtitle {
+                                Text(subtitle)
+                                    .textStyle(.cellLabelSubtitle)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
+                        }
                     }
                     .paddingStyle(set: .iconCell)
                 }
@@ -74,7 +94,7 @@ extension InstUI {
         // The closing "." is needed to make VoiceOver read "Button" the same as with the trait.
         private var accessibilityLabel: String {
             let radioButton = String(localized: "Radio Button", bundle: .core, comment: "UI element type read out in VoiceOver.")
-            return "\(title), \(radioButton)."
+            return [headerTitle, title, subtitle, "\(radioButton)."].accessibilityJoined()
         }
     }
 }
@@ -92,7 +112,21 @@ extension InstUI {
         )
         InstUI.RadioButtonCell(
             title: "Value 2",
+            subtitle: "Subtitle",
             value: 2,
+            selectedValue: $selectedValue
+        )
+        InstUI.RadioButtonCell(
+            title: "Value 3",
+            headerTitle: "Header Title",
+            subtitle: "Subtitle",
+            value: 3,
+            selectedValue: $selectedValue
+        )
+        InstUI.RadioButtonCell(
+            title: "Value 4",
+            headerTitle: "Header Title",
+            value: 4,
             selectedValue: $selectedValue
         )
     }

--- a/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
+++ b/Core/Core/Common/CommonUI/InstUI/Views/Cells/TrailingCheckmarkCell.swift
@@ -25,6 +25,7 @@ extension InstUI {
 
         @Binding private var selectedValue: Value?
         private let title: String
+        private let headerTitle: String?
         private let subtitle: String?
         private let value: Value?
         private let dividerStyle: InstUI.Divider.Style
@@ -35,12 +36,14 @@ extension InstUI {
         ///                    The value is equatable so this cell can decide when to display the selected state.
         public init(
             title: String,
+            headerTitle: String? = nil,
             subtitle: String? = nil,
             value: Value?,
             selectedValue: Binding<Value?>,
             dividerStyle: InstUI.Divider.Style = .full
         ) {
             self.title = title
+            self.headerTitle = headerTitle
             self.subtitle = subtitle
             self.value = value
             self._selectedValue = selectedValue
@@ -56,6 +59,12 @@ extension InstUI {
                 } label: {
                     HStack(spacing: 0) {
                         VStack(alignment: .leading, spacing: 2) {
+                            if let headerTitle {
+                                Text(headerTitle)
+                                    .textStyle(.cellLabelSubtitle)
+                                    .multilineTextAlignment(.leading)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                            }
                             Text(title)
                                 .textStyle(.cellLabel)
                                 .multilineTextAlignment(.leading)
@@ -99,7 +108,21 @@ extension InstUI {
         .tint(.green)
         InstUI.TrailingCheckmarkCell(
             title: "Value 2",
+            subtitle: "Subtitle",
             value: 2,
+            selectedValue: $selectedValue
+        )
+        InstUI.TrailingCheckmarkCell(
+            title: "Value 3",
+            headerTitle: "Header Title",
+            subtitle: "Subtitle",
+            value: 3,
+            selectedValue: $selectedValue
+        )
+        InstUI.TrailingCheckmarkCell(
+            title: "Value 4",
+            headerTitle: "Header Title",
+            value: 4,
             selectedValue: $selectedValue
         )
     }

--- a/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItem.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/Model/OptionItem.swift
@@ -26,6 +26,7 @@ public struct OptionItem: Equatable, Hashable, Identifiable {
 
     public let id: String
     public let title: String
+    public let headerTitle: String?
     public let subtitle: String?
     public let color: Color?
     public let customAccessibilityLabel: String?
@@ -34,6 +35,7 @@ public struct OptionItem: Equatable, Hashable, Identifiable {
     public init(
         id: String,
         title: String,
+        headerTitle: String? = nil,
         subtitle: String? = nil,
         customAccessibilityLabel: String? = nil,
         colorOverride: Color? = nil,
@@ -41,6 +43,7 @@ public struct OptionItem: Equatable, Hashable, Identifiable {
     ) {
         self.id = id
         self.title = title
+        self.headerTitle = headerTitle
         self.subtitle = subtitle
         self.color = colorOverride
         self.customAccessibilityLabel = customAccessibilityLabel
@@ -67,6 +70,7 @@ extension OptionItem {
     static func make(
         id: String = "",
         title: String = "",
+        headerTitle: String? = nil,
         subtitle: String? = nil,
         customAccessibilityLabel: String? = nil,
         color: Color? = nil,
@@ -75,6 +79,7 @@ extension OptionItem {
         return OptionItem(
             id: id,
             title: title,
+            headerTitle: headerTitle,
             subtitle: subtitle,
             customAccessibilityLabel: customAccessibilityLabel,
             colorOverride: color,

--- a/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/MultiSelectionView.swift
@@ -88,6 +88,7 @@ public struct MultiSelectionView: View {
     private func optionCell(with item: OptionItem) -> some View {
         InstUI.CheckboxCell(
             title: item.title,
+            headerTitle: item.headerTitle,
             subtitle: item.subtitle,
             isSelected: selectionBinding(for: item),
             accessoryView: { item.accessoryIcon },
@@ -123,7 +124,7 @@ public struct MultiSelectionView: View {
             title: "Section 2 title",
             hasAllSelectionButton: true,
             allOptions: [
-                .make(id: "A", title: "Option A", color: .textDanger),
+                .make(id: "A", title: "Option A", headerTitle: "Header", color: .textDanger),
                 .make(id: "B", title: "Option B", color: .textSuccess),
                 .make(id: "C", title: "Option C", color: .textInfo)
             ],

--- a/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
+++ b/Core/Core/Common/CommonUI/OptionSelection/View/SingleSelectionView.swift
@@ -108,6 +108,8 @@ public struct SingleSelectionView: View {
         case .radioButton:
             InstUI.RadioButtonCell(
                 title: item.title,
+                headerTitle: item.headerTitle,
+                subtitle: item.subtitle,
                 value: item,
                 selectedValue: selectionBinding,
                 dividerStyle: viewModel.dividerStyle(for: item)
@@ -116,6 +118,7 @@ public struct SingleSelectionView: View {
         case .trailingCheckmark:
             InstUI.TrailingCheckmarkCell(
                 title: item.title,
+                headerTitle: item.headerTitle,
                 subtitle: item.subtitle,
                 value: item,
                 selectedValue: selectionBinding,
@@ -155,7 +158,7 @@ public struct SingleSelectionView: View {
         SingleSelectionView(
             title: "Radio group with colors",
             allOptions: [
-                .make(id: "A", title: "Option A", color: .textDanger),
+                .make(id: "A", title: "Option A", headerTitle: "Header", subtitle: "Subtitle", color: .textDanger),
                 .make(id: "B", title: "Option B", color: .textSuccess),
                 .make(id: "C", title: "Option C", color: .textInfo)
             ],
@@ -165,7 +168,7 @@ public struct SingleSelectionView: View {
         SingleSelectionView(
             title: "Item picker",
             allOptions: [
-                .make(id: "A", title: "Option A", color: .textDanger),
+                .make(id: "A", title: "Option A", headerTitle: "Header", subtitle: "Subtitle", color: .textDanger),
                 .make(id: "B", title: "Option B", color: .textSuccess),
                 .make(id: "C", title: "Option C", color: .textInfo)
             ],


### PR DESCRIPTION
We will need a header title to be displayed above checkboxes in the upcoming submission filter changes so I added support for it. While working on this, I noticed that the subtitle support was also inconsistent, so I modified all three selection cells (checkbox, radio, trailing checkmark) to support both header and subtitle labels. There should be no change in the existing behavior and the new layout isn't used yet. The goal of this PR is to make the submission list update PR smaller by merging this easy to review change set.

builds: Student

[ignore-commit-lint]

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/476b5f32-970c-4cb1-b745-d0ad5004ec87" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/325c4b06-f469-4a05-beb0-66609b48abaf" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/f999b79b-0792-482d-b961-c205bb35c8a9" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/4955e418-1e2e-43fd-8005-86f68d4ed33e" maxHeight=500></td>
</tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/783b7557-01cf-49c1-94c6-b855b6e97260" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/61a2ab3e-ebd5-4593-b15f-bf6c4f77948a" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet