### PR TITLE
[MBL-19120] [S/T] DCP - Update Discussion List

### DIFF
--- a/Core/Core/Common/CommonUI/Formatters/DueDateSummary.swift
+++ b/Core/Core/Common/CommonUI/Formatters/DueDateSummary.swift
@@ -27,10 +27,10 @@ public enum DueDateSummary: Equatable {
     case multipleDueDates
 
     public init(_ dueDate: Date?, lockDate: Date? = nil, hasOverrides: Bool = false) {
-        if let lockDate, Clock.now > lockDate {
-            self = .availabilityClosed
-        } else if hasOverrides {
+        if hasOverrides {
             self = .multipleDueDates
+        } else if let lockDate, Clock.now > lockDate {
+            self = .availabilityClosed
         } else if let dueDate {
             self = .dueDate(dueDate)
         } else {
@@ -49,13 +49,13 @@ public enum DueDateSummary: Equatable {
 
 extension Array<DueDateSummary> {
 
-    /// Returns multiple due dates when all cases are regular due dates,
+    /// Returns more than one due date cases when all cases are regular due dates,
     /// or a single special case when any element matches that special case.
     public func reduceIfNeeded() -> [DueDateSummary] {
-        if contains(.availabilityClosed) {
-            [.availabilityClosed]
-        } else if contains(.multipleDueDates) {
+        if contains(.multipleDueDates) {
             [.multipleDueDates]
+        } else if contains(.availabilityClosed) {
+            [.availabilityClosed]
         } else {
             self
         }

--- a/Core/Core/Features/Assignments/Assignment/Model/Entities/CDAssignmentCheckpoint.swift
+++ b/Core/Core/Features/Assignments/Assignment/Model/Entities/CDAssignmentCheckpoint.swift
@@ -32,7 +32,7 @@ public class CDAssignmentCheckpoint: NSManagedObject {
 
     @NSManaged private var pointsPossibleRaw: NSNumber?
     public var pointsPossible: Double? {
-        get { return pointsPossibleRaw?.doubleValue } set { pointsPossibleRaw = .init(newValue) }
+        get { pointsPossibleRaw?.doubleValue } set { pointsPossibleRaw = .init(newValue) }
     }
 
     @NSManaged public var dueDate: Date?

--- a/Core/Core/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProvider.swift
+++ b/Core/Core/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProvider.swift
@@ -1,0 +1,60 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+public protocol AssignmentDueDateTextsProvider {
+
+    /// Return an array of formatted due dates, or only a single item
+    /// if any of the dates is a special case which overrules them.
+    func formattedDueDates(for assignment: Assignment) -> [String]
+}
+
+extension AssignmentDueDateTextsProvider where Self == AssignmentDueDateTextsProviderLive {
+    public static var live: AssignmentDueDateTextsProviderLive { .init() }
+}
+
+public struct AssignmentDueDateTextsProviderLive: AssignmentDueDateTextsProvider {
+
+    public init() {}
+
+    public func formattedDueDates(for assignment: Assignment) -> [String] {
+        let isTeacher = AppEnvironment.shared.app == .teacher
+
+        if assignment.hasSubAssignments {
+            return assignment.checkpoints
+                .map {
+                    DueDateSummary(
+                        $0.dueDate,
+                        lockDate: $0.lockDate,
+                        hasOverrides: isTeacher && $0.overrides.isNotEmpty
+                    )
+                }
+                .reduceIfNeeded()
+                .map(\.text)
+        } else {
+            return [
+                DueDateFormatter.format(
+                    assignment.dueAt,
+                    lockDate: assignment.lockAt,
+                    hasOverrides: isTeacher && assignment.hasOverrides
+                )
+            ]
+        }
+    }
+}

--- a/Core/Core/Features/Assignments/AssignmentList/Model/StudentAssignmentListItem.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/Model/StudentAssignmentListItem.swift
@@ -45,23 +45,17 @@ struct StudentAssignmentListItem: Equatable, Identifiable {
 
     let route: URL?
 
-    init(assignment: Assignment) {
+    init(
+        assignment: Assignment,
+        dueDateTextsProvider: AssignmentDueDateTextsProvider = .live
+    ) {
         let hasSubAssignments = assignment.hasSubAssignments
 
         self.id = assignment.id
         self.title = assignment.name
         self.icon = assignment.icon.asImage
 
-        if hasSubAssignments {
-            self.dueDates = assignment.checkpoints
-                .map { DueDateSummary($0.dueDate, lockDate: $0.lockDate) }
-                .reduceIfNeeded()
-                .map(\.text)
-        } else {
-            self.dueDates = [
-                DueDateFormatter.format(assignment.dueAt, lockDate: assignment.lockAt)
-            ]
-        }
+        self.dueDates = dueDateTextsProvider.formattedDueDates(for: assignment)
 
         let status = assignment.submission?.status ?? .notSubmitted
         self.submissionStatus = .init(status: status)

--- a/Core/Core/Features/Assignments/AssignmentList/Model/TeacherAssignmentListItem.swift
+++ b/Core/Core/Features/Assignments/AssignmentList/Model/TeacherAssignmentListItem.swift
@@ -44,7 +44,10 @@ struct TeacherAssignmentListItem: Equatable, Identifiable {
 
     let route: URL?
 
-    init(assignment: Assignment) {
+    init(
+        assignment: Assignment,
+        dueDateTextsProvider: AssignmentDueDateTextsProvider = .live
+    ) {
         let hasSubAssignments = assignment.hasSubAssignments
 
         self.id = assignment.id
@@ -52,20 +55,7 @@ struct TeacherAssignmentListItem: Equatable, Identifiable {
         self.icon = assignment.icon.asImage
         self.isPublished = assignment.published
 
-        if hasSubAssignments {
-            self.dueDates = assignment.checkpoints
-                .map { DueDateSummary($0.dueDate, lockDate: $0.lockDate, hasOverrides: $0.overrides.isNotEmpty) }
-                .reduceIfNeeded()
-                .map(\.text)
-        } else {
-            self.dueDates = [
-                DueDateFormatter.format(
-                    assignment.dueAt,
-                    lockDate: assignment.lockAt,
-                    hasOverrides: assignment.hasOverrides
-                )
-            ]
-        }
+        self.dueDates = dueDateTextsProvider.formattedDueDates(for: assignment)
 
         let canBeGraded = assignment.gradingType != .not_graded
         self.needsGrading = canBeGraded ? String.format(needsGrading: assignment.needsGradingCount) : nil

--- a/Core/Core/Features/Discussions/DiscussionListViewController.storyboard
+++ b/Core/Core/Features/Discussions/DiscussionListViewController.storyboard
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,14 +13,14 @@
             <objects>
                 <viewController storyboardIdentifier="DiscussionListViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Eid-ih-Lsr" customClass="DiscussionListViewController" customModule="Core" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="y7J-Xp-eWA">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="639"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="Yvs-Fy-07Z">
-                                <rect key="frame" x="0.0" y="0.0" width="414" height="725"/>
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="639"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="Aec-hZ-1GY" customClass="ListBackgroundView" customModule="Core">
-                                    <rect key="frame" x="0.0" y="137" width="414" height="319.5"/>
+                                    <rect key="frame" x="0.0" y="182" width="414" height="319.5"/>
                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                     <subviews>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Cnr-AZ-0HU" customClass="CircleProgressView" customModule="Core">
@@ -95,10 +94,10 @@
                                 </view>
                                 <prototypes>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="DiscussionListCell" id="COV-AQ-Vvf" customClass="DiscussionListCell" customModule="Core" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="44.5" width="414" height="70"/>
+                                        <rect key="frame" x="0.0" y="50" width="414" height="104"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="COV-AQ-Vvf" id="ShE-DQ-DQ8">
-                                            <rect key="frame" x="0.0" y="0.0" width="385.5" height="70"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="383.5" height="104"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <view userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="fBl-nW-0Y3" customClass="AccessIconView" customModule="Core" customModuleProvider="target">
@@ -109,7 +108,7 @@
                                                     </constraints>
                                                 </view>
                                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="tha-Th-Ssc">
-                                                    <rect key="frame" x="58" y="8" width="327.5" height="53.5"/>
+                                                    <rect key="frame" x="58" y="8" width="325.5" height="87.5"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Discussion Name" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="l2k-wU-iWr" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                             <rect key="frame" x="0.0" y="0.0" width="130.5" height="19.5"/>
@@ -120,41 +119,35 @@
                                                                 <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDarkest"/>
                                                             </userDefinedRuntimeAttributes>
                                                         </label>
-                                                        <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="XmS-Jz-fto">
-                                                            <rect key="frame" x="0.0" y="19.5" width="215.5" height="17"/>
-                                                            <subviews>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="Closed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hEo-pg-5ik" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="0.0" width="46" height="17"/>
-                                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                                                    <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="  •  " textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="psK-eK-CAY" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="46" y="0.0" width="17" height="17"/>
-                                                                    <fontDescription key="fontDescription" type="system" pointSize="10"/>
-                                                                    <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textStyle" value="regular10"/>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </label>
-                                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Aug 2, 2018 at 1:57 PM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6gN-fR-Erq" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
-                                                                    <rect key="frame" x="63" y="0.0" width="152.5" height="17"/>
-                                                                    <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
-                                                                    <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                    <nil key="highlightedColor"/>
-                                                                    <userDefinedRuntimeAttributes>
-                                                                        <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
-                                                                    </userDefinedRuntimeAttributes>
-                                                                </label>
-                                                            </subviews>
-                                                        </stackView>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Aug 2, 2018 at 1:57 PM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6gN-fR-Erq" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="19.5" width="182.5" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                                            <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Due Aug 2, 2018 at 1:57 PM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aYP-AS-U9J" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="36.5" width="182.5" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                                            <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Last post Aug 2, 2018 at 1:57 PM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mnh-S7-FP0" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
+                                                            <rect key="frame" x="0.0" y="53.5" width="217" height="17"/>
+                                                            <fontDescription key="fontDescription" type="system" weight="medium" pointSize="14"/>
+                                                            <color key="textColor" red="0.5450980392" green="0.58823529409999997" blue="0.61960784310000006" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                            <userDefinedRuntimeAttributes>
+                                                                <userDefinedRuntimeAttribute type="string" keyPath="textColorName" value="textDark"/>
+                                                            </userDefinedRuntimeAttributes>
+                                                        </label>
                                                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="c2z-XH-uuR">
-                                                            <rect key="frame" x="0.0" y="36.5" width="212" height="17"/>
+                                                            <rect key="frame" x="0.0" y="70.5" width="212" height="17"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="100 pts" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Oou-Q6-BY0" customClass="DynamicLabel" customModule="Core" customModuleProvider="target">
                                                                     <rect key="frame" x="0.0" y="0.0" width="49.5" height="17"/>
@@ -236,14 +229,14 @@
                                         <color key="backgroundColor" systemColor="tableCellGroupedBackgroundColor"/>
                                         <inset key="separatorInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                         <connections>
-                                            <outlet property="dateLabel" destination="6gN-fR-Erq" id="t2E-Ma-0rS"/>
+                                            <outlet property="dueDateLabel1" destination="6gN-fR-Erq" id="eBY-ce-uWd"/>
+                                            <outlet property="dueDateLabel2" destination="aYP-AS-U9J" id="YSL-Ks-rl2"/>
                                             <outlet property="iconImageView" destination="fBl-nW-0Y3" id="Xkc-8G-SfH"/>
+                                            <outlet property="lastPostLabel" destination="mnh-S7-FP0" id="Suf-YU-mZc"/>
                                             <outlet property="pointsDot" destination="NJY-WE-Ess" id="cyE-UX-URg"/>
                                             <outlet property="pointsLabel" destination="Oou-Q6-BY0" id="uSI-JT-GEL"/>
                                             <outlet property="repliesDot" destination="0Nw-ey-8dG" id="qfQ-LS-9wU"/>
                                             <outlet property="repliesLabel" destination="gqZ-db-Po7" id="zdv-Qu-YmB"/>
-                                            <outlet property="statusDot" destination="psK-eK-CAY" id="eDD-O4-Amv"/>
-                                            <outlet property="statusLabel" destination="hEo-pg-5ik" id="P5q-R8-YXw"/>
                                             <outlet property="titleLabel" destination="l2k-wU-iWr" id="rSU-Vf-tie"/>
                                             <outlet property="unreadDot" destination="4tN-f7-RVG" id="ljs-II-73o"/>
                                             <outlet property="unreadLabel" destination="9h0-n1-dhS" id="FJ2-I9-FFL"/>
@@ -281,48 +274,10 @@
             <point key="canvasLocation" x="138" y="127"/>
         </scene>
     </scenes>
-    <designables>
-        <designable name="0Nw-ey-8dG">
-            <size key="intrinsicContentSize" width="17" height="12"/>
-        </designable>
-        <designable name="6gN-fR-Erq">
-            <size key="intrinsicContentSize" width="152.5" height="17"/>
-        </designable>
-        <designable name="9h0-n1-dhS">
-            <size key="intrinsicContentSize" width="61" height="17"/>
-        </designable>
-        <designable name="NJY-WE-Ess">
-            <size key="intrinsicContentSize" width="17" height="12"/>
-        </designable>
-        <designable name="Oou-Q6-BY0">
-            <size key="intrinsicContentSize" width="49.5" height="17"/>
-        </designable>
-        <designable name="Yvn-3z-8fm">
-            <size key="intrinsicContentSize" width="452.5" height="19.5"/>
-        </designable>
-        <designable name="gfn-Ag-u41">
-            <size key="intrinsicContentSize" width="174" height="217"/>
-        </designable>
-        <designable name="gqZ-db-Po7">
-            <size key="intrinsicContentSize" width="67.5" height="17"/>
-        </designable>
-        <designable name="hEo-pg-5ik">
-            <size key="intrinsicContentSize" width="46" height="17"/>
-        </designable>
-        <designable name="l2k-wU-iWr">
-            <size key="intrinsicContentSize" width="130.5" height="19.5"/>
-        </designable>
-        <designable name="li2-4d-zcI">
-            <size key="intrinsicContentSize" width="144.5" height="24"/>
-        </designable>
-        <designable name="psK-eK-CAY">
-            <size key="intrinsicContentSize" width="17" height="12"/>
-        </designable>
-    </designables>
     <resources>
         <image name="PandaNoDiscussions" width="174" height="217"/>
         <namedColor name="textDark">
-            <color red="0.33333333333333331" green="0.396078431372549" blue="0.44705882352941179" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.40000000000000002" green="0.44313725490196076" blue="0.48627450980392156" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="tableCellGroupedBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Core/Core/Features/Discussions/DiscussionTopic.swift
+++ b/Core/Core/Features/Discussions/DiscussionTopic.swift
@@ -67,7 +67,7 @@ public final class DiscussionTopic: NSManagedObject, WriteableModel {
     @NSManaged public var isCheckpointed: Bool
     @NSManaged private var requiredReplyCountRaw: NSNumber?
     public var requiredReplyCount: Int? {
-        get { return requiredReplyCountRaw?.intValue } set { requiredReplyCountRaw = .init(newValue) }
+        get { requiredReplyCountRaw?.intValue } set { requiredReplyCountRaw = .init(newValue) }
     }
     @NSManaged public var hasSubAssignments: Bool
     @NSManaged private var checkpointsRaw: NSOrderedSet

--- a/Core/CoreTests/Common/CommonUI/Formatters/DueDateSummaryTests.swift
+++ b/Core/CoreTests/Common/CommonUI/Formatters/DueDateSummaryTests.swift
@@ -93,10 +93,10 @@ final class DueDateSummaryTests: CoreTestCase {
         XCTAssertEqual(testee, .multipleDueDates)
     }
 
-    func test_init_whenHasOverridesAndLockDateInPast_shouldReturnAvailabilityClosed() {
+    func test_init_whenHasOverridesAndLockDateInPast_shouldReturnMultipleDueDates() {
         let testee = DueDateSummary(testData.dateFuture, lockDate: testData.lockDatePast, hasOverrides: true)
 
-        XCTAssertEqual(testee, .availabilityClosed)
+        XCTAssertEqual(testee, .multipleDueDates)
     }
 
     func test_init_whenNoDueDateAndHasOverrides_shouldReturnMultipleDueDates() {
@@ -165,7 +165,7 @@ final class DueDateSummaryTests: CoreTestCase {
 
     // MARK: - Array Extension - reduceIfNeeded
 
-    func test_reduceIfNeeded_whenContainsAvailabilityClosed_shouldReturnOnlyAvailabilityClosed() {
+    func test_reduceIfNeeded_whenContainsMultipleDueDates_shouldReturnOnlyMultipleDueDates() {
         let array: [DueDateSummary] = [
             .noDueDate,
             .dueDate(testData.dateFuture),
@@ -175,20 +175,20 @@ final class DueDateSummaryTests: CoreTestCase {
 
         let result = array.reduceIfNeeded()
 
-        XCTAssertEqual(result, [.availabilityClosed])
+        XCTAssertEqual(result, [.multipleDueDates])
     }
 
-    func test_reduceIfNeeded_whenContainsMultipleDueDatesButNoAvailabilityClosed_shouldReturnOnlyMultipleDueDates() {
+    func test_reduceIfNeeded_whenContainsAvailabilityClosedButNoMultipleDueDates_shouldReturnAvailabilityClosed() {
         let array: [DueDateSummary] = [
             .noDueDate,
             .dueDate(testData.dateFuture),
-            .multipleDueDates,
+            .availabilityClosed,
             .dueDate(testData.datePast)
         ]
 
         let result = array.reduceIfNeeded()
 
-        XCTAssertEqual(result, [.multipleDueDates])
+        XCTAssertEqual(result, [.availabilityClosed])
     }
 
     func test_reduceIfNeeded_whenContainsOnlyNoDueDateAndDueDate_shouldReturnOriginalArray() {

--- a/Core/CoreTests/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProviderMock.swift
+++ b/Core/CoreTests/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProviderMock.swift
@@ -1,0 +1,33 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Core
+
+final class AssignmentDueDateTextsProviderMock: AssignmentDueDateTextsProvider {
+
+    var formattedDueDatesCallsCount: Int = 0
+    var formattedDueDatesInput: Assignment?
+    var formattedDueDatesResult: [String] = []
+
+    public func formattedDueDates(for assignment: Assignment) -> [String] {
+        formattedDueDatesCallsCount += 1
+        formattedDueDatesInput = assignment
+        return formattedDueDatesResult
+    }
+}

--- a/Core/CoreTests/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProviderTests.swift
+++ b/Core/CoreTests/Features/Assignments/Assignment/Model/Utilities/AssignmentDueDateTextsProviderTests.swift
@@ -1,0 +1,342 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+import TestsFoundation
+
+final class AssignmentDueDateTextsProviderTests: CoreTestCase {
+
+    private static let testData = (
+        dueDate1: Date.make(year: 2025, month: 9, day: 15),
+        dueDate2: Date.make(year: 2025, month: 9, day: 20),
+        dueDate3: Date.make(year: 2025, month: 9, day: 18),
+        lockDate: Date.make(year: 2025, month: 9, day: 22)
+    )
+    private lazy var testData = Self.testData
+
+    private var testee: AssignmentDueDateTextsProviderLive!
+
+    override func setUp() {
+        super.setUp()
+        testee = .init()
+    }
+
+    override func tearDown() {
+        testee = nil
+        Clock.reset()
+        super.tearDown()
+    }
+
+    // MARK: - Due dates for not Teacher app
+
+    func test_dueDates_withNoSubAssignments_shouldHaveSingleItem() {
+        // WHEN available
+        Clock.mockNow(testData.lockDate.addDays(-1))
+        var assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: false
+        ))
+        var dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate1))
+
+        // WHEN closed
+        Clock.mockNow(testData.lockDate.addDays(1))
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: false
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.availabilityClosedText)
+
+        // WHEN multiple in Student/Parent app
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_overrides: true,
+            has_sub_assignments: false
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate1))
+    }
+
+    func test_dueDates_withSubAssignmentsAndNoDueDate_shouldHaveMultipleItems() {
+        // WHEN one is nil
+        var assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2),
+                .make(tag: "tag2", due_at: nil)
+            ]
+        ))
+        var dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
+        XCTAssertEqual(dueDates.last, DueDateFormatter.noDueDateText)
+
+        // WHEN all are nil
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: nil),
+                .make(tag: "tag2", due_at: nil)
+            ]
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.noDueDateText)
+        XCTAssertEqual(dueDates.last, DueDateFormatter.noDueDateText)
+    }
+
+    func test_dueDates_withSubAssignmentsAndBeforeLockDate_shouldHaveMultipleItems() {
+        Clock.mockNow(testData.lockDate.addDays(-1))
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2, lock_at: testData.lockDate),
+                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
+        XCTAssertEqual(dueDates.last, DueDateFormatter.dateText(testData.dueDate3))
+    }
+
+    func test_dueDates_withSubAssignmentsAndAfterLockDate_shouldHaveSingleClosedItem() {
+        Clock.mockNow(testData.lockDate.addDays(1))
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2),
+                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.availabilityClosedText)
+    }
+
+    func test_dueDatesForStudent_withSubAssignmentsAndOverrides_shouldIgnoreOverrides() {
+        Clock.mockNow(testData.lockDate.addDays(1))
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2, lock_at: testData.lockDate),
+                .make(tag: "tag2", due_at: testData.dueDate3, overrides: [.make()])
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.availabilityClosedText)
+    }
+
+    // MARK: - Due dates for Teacher app
+
+    func test_dueDatesForTeacher_withNoSubAssignments_shouldHaveSingleItem() {
+        environment.app = .teacher
+
+        // WHEN available
+        Clock.mockNow(testData.lockDate.addDays(-1))
+        var assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: false
+        ))
+        var dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate1))
+
+        // WHEN closed
+        Clock.mockNow(testData.lockDate.addDays(1))
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: false
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.availabilityClosedText)
+
+        // WHEN multiple
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_overrides: true,
+            has_sub_assignments: false
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.multipleDueDatesText)
+    }
+
+    func test_dueDatesForTeacher_withSubAssignmentsAndNoDueDate_shouldHaveMultipleItems() {
+        environment.app = .teacher
+
+        // WHEN one is nil
+        var assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2),
+                .make(tag: "tag2", due_at: nil)
+            ]
+        ))
+        var dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
+        XCTAssertEqual(dueDates.last, DueDateFormatter.noDueDateText)
+
+        // WHEN all are nil
+        assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: nil),
+                .make(tag: "tag2", due_at: nil)
+            ]
+        ))
+        dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.noDueDateText)
+        XCTAssertEqual(dueDates.last, DueDateFormatter.noDueDateText)
+    }
+
+    func test_dueDatesForTeacher_withSubAssignmentsAndBeforeLockDate_shouldHaveMultipleItems() {
+        environment.app = .teacher
+        Clock.mockNow(testData.lockDate.addDays(-1))
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            lock_at: testData.lockDate,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2, lock_at: testData.lockDate),
+                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 2)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
+        XCTAssertEqual(dueDates.last, DueDateFormatter.dateText(testData.dueDate3))
+    }
+
+    func test_dueDatesForTeacher_withSubAssignmentsAndAfterLockDate_shouldHaveSingleClosedItem() {
+        environment.app = .teacher
+        Clock.mockNow(testData.lockDate.addDays(1))
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2),
+                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.availabilityClosedText)
+    }
+
+    func test_dueDatesForTeacher_withSubAssignmentsAndOverrides_shouldHaveSingleItem() {
+        environment.app = .teacher
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2),
+                .make(tag: "tag2", due_at: testData.dueDate3, overrides: [.make()])
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.multipleDueDatesText)
+    }
+
+    // MARK: - Special case priority
+
+    func test_dueDatesForTeacher_withNoSubAssignmentsAndLockedAndHasOverrides_shouldHaveMultipleCase() {
+        Clock.mockNow(testData.lockDate.addDays(1))
+        environment.app = .teacher
+
+        // WHEN multiple
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_overrides: true,
+            lock_at: testData.lockDate,
+            has_sub_assignments: false
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+        // THEN
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.multipleDueDatesText)
+    }
+
+    func test_dueDatesForTeacher_withSubAssignmentsAndLockedAndHasOverrides_shouldHaveMultipleCase() {
+        Clock.mockNow(testData.lockDate.addDays(1))
+        environment.app = .teacher
+
+        let assignment = makeAssignment(.make(
+            due_at: testData.dueDate1,
+            has_sub_assignments: true,
+            checkpoints: [
+                .make(tag: "tag1", due_at: testData.dueDate2, lock_at: testData.lockDate),
+                .make(tag: "tag2", due_at: testData.dueDate3, overrides: [.make()])
+            ]
+        ))
+        let dueDates = testee.formattedDueDates(for: assignment)
+
+        XCTAssertEqual(dueDates.count, 1)
+        XCTAssertEqual(dueDates.first, DueDateFormatter.multipleDueDatesText)
+    }
+
+    // MARK: - Private helpers
+
+    private func makeAssignment(_ apiModel: APIAssignment) -> Assignment {
+        .make(from: apiModel, in: databaseClient)
+    }
+}

--- a/Core/CoreTests/Features/Assignments/AssignmentList/Model/StudentAssignmentListItemTests.swift
+++ b/Core/CoreTests/Features/Assignments/AssignmentList/Model/StudentAssignmentListItemTests.swift
@@ -38,9 +38,16 @@ final class StudentAssignmentListItemTests: CoreTestCase {
     private lazy var testData = Self.testData
 
     private var testee: StudentAssignmentListItem!
+    private var dueDateTextsProvider: AssignmentDueDateTextsProviderMock!
+
+    override func setUp() {
+        super.setUp()
+        dueDateTextsProvider = .init()
+    }
 
     override func tearDown() {
         testee = nil
+        dueDateTextsProvider = nil
         Clock.reset()
         super.tearDown()
     }
@@ -78,92 +85,17 @@ final class StudentAssignmentListItemTests: CoreTestCase {
 
     // MARK: - Due dates
 
-    func test_dueDates_withNoSubAssignments_shouldHaveSingleItem() {
-        // WHEN available
-        Clock.mockNow(testData.lockDate.addDays(-1))
+    func test_dueDates_shouldCallDueDateTextsProviderAndUseItsResult() {
+        dueDateTextsProvider.formattedDueDatesResult = ["dd1", "dd2"]
         testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            lock_at: testData.lockDate,
-            has_sub_assignments: false
+            id: ID(testData.assignmentId)
         ))
-        // THEN
-        XCTAssertEqual(testee.dueDates.count, 1)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.dateText(testData.dueDate1))
 
-        // WHEN closed
-        Clock.mockNow(testData.lockDate.addDays(1))
-        testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            lock_at: testData.lockDate,
-            has_sub_assignments: false
-        ))
-        // THEN
-        XCTAssertEqual(testee.dueDates.count, 1)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.availabilityClosedText)
-    }
-
-    func test_dueDates_withSubAssignmentsAndNoDueDate_shouldHaveMultipleItems() {
-        // WHEN one is nil
-        testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            has_sub_assignments: true,
-            checkpoints: [
-                .make(tag: "tag1", due_at: testData.dueDate2),
-                .make(tag: "tag2", due_at: nil)
-            ]
-        ))
-        // THEN
+        XCTAssertEqual(dueDateTextsProvider.formattedDueDatesCallsCount, 1)
+        XCTAssertEqual(dueDateTextsProvider.formattedDueDatesInput?.id, testData.assignmentId)
         XCTAssertEqual(testee.dueDates.count, 2)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
-        XCTAssertEqual(testee.dueDates.last, DueDateFormatter.noDueDateText)
-
-        // WHEN all are nil
-        testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            has_sub_assignments: true,
-            checkpoints: [
-                .make(tag: "tag1", due_at: nil),
-                .make(tag: "tag2", due_at: nil)
-            ]
-        ))
-        // THEN
-        XCTAssertEqual(testee.dueDates.count, 2)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.noDueDateText)
-        XCTAssertEqual(testee.dueDates.last, DueDateFormatter.noDueDateText)
-    }
-
-    func test_dueDates_withSubAssignmentsAndBeforeLockDate_shouldHaveMultipleItems() {
-        Clock.mockNow(testData.lockDate.addDays(-1))
-
-        testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            lock_at: testData.lockDate,
-            has_sub_assignments: true,
-            checkpoints: [
-                .make(tag: "tag1", due_at: testData.dueDate2, lock_at: testData.lockDate),
-                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
-            ]
-        ))
-
-        XCTAssertEqual(testee.dueDates.count, 2)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.dateText(testData.dueDate2))
-        XCTAssertEqual(testee.dueDates.last, DueDateFormatter.dateText(testData.dueDate3))
-    }
-
-    func test_dueDates_withSubAssignmentsAndAfterLockDate_shouldHaveSingleClosedItem() {
-        Clock.mockNow(testData.lockDate.addDays(1))
-
-        testee = makeListItem(.make(
-            due_at: testData.dueDate1,
-            has_sub_assignments: true,
-            checkpoints: [
-                .make(tag: "tag1", due_at: testData.dueDate2),
-                .make(tag: "tag2", due_at: testData.dueDate3, lock_at: testData.lockDate)
-            ]
-        ))
-
-        XCTAssertEqual(testee.dueDates.count, 1)
-        XCTAssertEqual(testee.dueDates.first, DueDateFormatter.availabilityClosedText)
+        XCTAssertEqual(testee.dueDates.first, "dd1")
+        XCTAssertEqual(testee.dueDates.last, "dd2")
     }
 
     // MARK: - Status
@@ -407,6 +339,9 @@ final class StudentAssignmentListItemTests: CoreTestCase {
     // MARK: - Private helpers
 
     private func makeListItem(_ apiModel: APIAssignment) -> StudentAssignmentListItem {
-        StudentAssignmentListItem(assignment: .make(from: apiModel, in: databaseClient))
+        StudentAssignmentListItem(
+            assignment: .make(from: apiModel, in: databaseClient),
+            dueDateTextsProvider: dueDateTextsProvider
+        )
     }
 }

--- a/Core/CoreTests/Features/Discussions/DiscussionListViewControllerTests.swift
+++ b/Core/CoreTests/Features/Discussions/DiscussionListViewControllerTests.swift
@@ -98,7 +98,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.iconImageView.icon, .discussionLine)
         XCTAssertEqual(cell?.iconImageView.state, .published)
         XCTAssertEqual(cell?.titleLabel.text, "Alien invasion probabilities")
-        XCTAssertEqual(cell?.dateLabel.text, "Last post " + TestConstants.date1103.dateTimeString)
+        XCTAssertEqual(cell?.lastPostLabel.text, "Last post " + TestConstants.date1103.dateTimeString)
 
         let actions = controller.tableView.delegate?.tableView?(controller.tableView, trailingSwipeActionsConfigurationForRowAt: IndexPath(row: 0, section: 0))?.actions
         XCTAssertEqual(actions?.count, 3)
@@ -123,7 +123,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.iconImageView.icon, .assignmentLine)
         XCTAssertEqual(cell?.iconImageView.state, .published)
         XCTAssertEqual(cell?.titleLabel.text, "Dude")
-        XCTAssertEqual(cell?.dateLabel.text, "Due " + TestConstants.date1031.relativeDateTimeString)
+        XCTAssertEqual(cell?.dueDateLabel1.text, "Due " + TestConstants.date1031.relativeDateTimeString)
 
         XCTAssertEqual(controller.tableView.delegate?.tableView?(
             controller.tableView, trailingSwipeActionsConfigurationForRowAt: IndexPath(row: 0, section: 1)
@@ -133,8 +133,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.iconImageView.icon, .assignmentLine)
         XCTAssertEqual(cell?.iconImageView.state, .published)
         XCTAssertEqual(cell?.titleLabel.text, "Locked")
-        XCTAssertEqual(cell?.statusLabel.text, "Closed")
-        XCTAssertEqual(cell?.dateLabel.text, "Due " + TestConstants.date1031.relativeDateTimeString)
+        XCTAssertEqual(cell?.dueDateLabel1.text, DueDateFormatter.availabilityClosedText)
 
         controller.tableView.delegate?.tableView?(controller.tableView, didSelectRowAt: IndexPath(row: 0, section: 2))
         XCTAssert(router.lastRoutedTo("/courses/1/discussion_topics/3", withOptions: .detail))
@@ -243,7 +242,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
         XCTAssertEqual(cell?.iconImageView.icon, .discussionLine)
         XCTAssertEqual(cell?.iconImageView.state, nil)
         XCTAssertEqual(cell?.titleLabel.text, "Study group tomorrow")
-        XCTAssertEqual(cell?.dateLabel.text, "Last post " + TestConstants.date1103.dateTimeString)
+        XCTAssertEqual(cell?.lastPostLabel.text, "Last post " + TestConstants.date1103.dateTimeString)
 
         api.mock(controller.topics, error: NSError.internalError())
         controller.tableView.refreshControl?.sendActions(for: .primaryActionTriggered)
@@ -271,7 +270,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
 
         // Then
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? Core.DiscussionListCell
-        XCTAssertEqual(cell?.statusLabel.text, "Not supported")
+        XCTAssertEqual(cell?.dueDateLabel1.text, "Not supported")
         XCTAssertEqual(cell?.contentView.alpha, 0.5)
     }
 
@@ -291,7 +290,7 @@ class DiscussionListViewControllerTests: CoreTestCase {
 
         // Then
         let cell = controller.tableView.cellForRow(at: IndexPath(row: 0, section: 0)) as? Core.DiscussionListCell
-        XCTAssertEqual(cell?.statusLabel.text, "Closed")
+        XCTAssertEqual(cell?.dueDateLabel1.text, DueDateFormatter.noDueDateText)
         XCTAssertEqual(cell?.contentView.alpha, 1)
     }
 }

--- a/Core/CoreTests/Features/Discussions/DiscussionTopicTests.swift
+++ b/Core/CoreTests/Features/Discussions/DiscussionTopicTests.swift
@@ -109,33 +109,34 @@ class DiscussionTopicTests: CoreTestCase {
     }
 
     func test_updateCheckpoints_whenNilOrEmpty() {
-        var item = APIDiscussionTopic.make(checkpoints: nil)
+        var item = APIDiscussionTopic.make(assignment: .make(), checkpoints: nil)
         var testee = saveModel(item)
         XCTAssertEqual(testee.checkpoints.isEmpty, true)
 
-        item = APIDiscussionTopic.make(checkpoints: [])
+        item = APIDiscussionTopic.make(assignment: .make(), checkpoints: [])
         testee = saveModel(item)
         XCTAssertEqual(testee.checkpoints.isEmpty, true)
 
         // set some value
-        item = APIDiscussionTopic.make(checkpoints: [.make()])
+        item = APIDiscussionTopic.make(assignment: .make(), checkpoints: [.make()])
         testee = saveModel(item)
         XCTAssertEqual(testee.checkpoints.isEmpty, false)
 
         // nil should not clear values
-        item = APIDiscussionTopic.make(checkpoints: nil)
+        item = APIDiscussionTopic.make(assignment: .make(), checkpoints: nil)
         testee = saveModel(item)
         XCTAssertEqual(testee.checkpoints.isEmpty, false)
 
         // [] should clear values
-        item = APIDiscussionTopic.make(checkpoints: [])
+        item = APIDiscussionTopic.make(assignment: .make(), checkpoints: [])
         testee = saveModel(item)
         XCTAssertEqual(testee.checkpoints.isEmpty, true)
     }
 
     func test_updateCheckpoints_whenNotEmpty() {
         let item = APIDiscussionTopic.make(
-            id: "42",
+            assignment: .make(id: "ass id"),
+            id: "disc id",
             checkpoints: [
                 .make(tag: "tag1"),
                 .make(tag: "tag2")
@@ -149,7 +150,7 @@ class DiscussionTopicTests: CoreTestCase {
         XCTAssertEqual(sortedCheckpoints.last?.tag, "tag2")
 
         let fetchedCheckpoints: [CDAssignmentCheckpoint] = databaseClient
-            .all(where: \.assignmentId, equals: "42")
+            .all(where: \.assignmentId, equals: "ass id")
             .sorted(by: \.tag)
         XCTAssertEqual(fetchedCheckpoints.count, 2)
         XCTAssertEqual(fetchedCheckpoints.first?.tag, "tag1")

--- a/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
+++ b/Student/StudentE2ETests/Discussions/DiscussionsTest.swift
@@ -42,17 +42,20 @@ class DiscussionsTests: E2ETestCase {
         XCTAssertTrue(discussionButton.isVisible)
         XCTAssertContains(discussionButton.label, discussion.title)
 
-        let discussionLastPostLabel = Helper.discussionDataLabel(discussion: discussion, label: .lastPost)!.waitUntil(.visible)
-        XCTAssertTrue(discussionLastPostLabel.isVisible)
-
-        let discussionRepliesLabel = Helper.discussionDataLabel(discussion: discussion, label: .replies)!.waitUntil(.visible)
-        XCTAssertTrue(discussionRepliesLabel.isVisible)
-        XCTAssertEqual(discussionRepliesLabel.label, "\(discussion.discussion_subentry_count) Replies")
-
-        let discussionUnreadLabel = Helper.discussionDataLabel(discussion: discussion, label: .unread)!
+        let discussionLastPostLabel = discussionButton
+            .find(labelContaining: "Last post", type: .staticText)
             .waitUntil(.visible)
-        XCTAssertTrue(discussionUnreadLabel.isVisible)
-        XCTAssertEqual(discussionUnreadLabel.label, "\(discussion.unread_count) Unread")
+        XCTAssert(discussionLastPostLabel.isVisible)
+
+        let discussionRepliesLabel = discussionButton
+            .find(label: "\(discussion.discussion_subentry_count) Replies", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionRepliesLabel.isVisible)
+
+        let discussionUnreadLabel = discussionButton
+            .find(label: "\(discussion.unread_count) Unread", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionUnreadLabel.isVisible)
     }
 
     func testReplyToDiscussion() {
@@ -163,13 +166,16 @@ class DiscussionsTests: E2ETestCase {
 
         // On iPad: Discussion replies label is visible right after the reply is sent
         // On iPhone: Back button needs to be tapped for the label to get visible
-        var discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)
+        let discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)
         if discussionDataLabelReplies == nil {
             Helper.backButton.hit()
             app.pullToRefresh()
         }
-        discussionDataLabelReplies = Helper.discussionDataLabel(discussion: assignmentDiscussion, label: .replies)!.waitUntil(.visible)
-        XCTAssertEqual(discussionDataLabelReplies!.label, "1 Reply")
+        let discussionRepliesLabel = Helper.discussionButton(discussion: assignmentDiscussion)
+            .waitUntil(.visible)
+            .find(label: "1 Reply", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionRepliesLabel.isVisible)
 
         // MARK: Navigate to Grades and check for updates regarding submission
         Helper.backButton.hit()

--- a/Teacher/TeacherE2ETests/Discussions/DiscussionsTests.swift
+++ b/Teacher/TeacherE2ETests/Discussions/DiscussionsTests.swift
@@ -40,16 +40,21 @@ class DiscussionsTests: E2ETestCase {
         // MARK: Navigate to Discussions and check visibility of buttons and labels
         Helper.navigateToDiscussions(course: course)
         let discussionButton = Helper.discussionButton(discussion: discussion).waitUntil(.visible)
-        let discussionLastPostLabel = Helper.discussionDataLabel(discussion: discussion, label: .lastPost)!.waitUntil(.visible)
-        let discussionRepliesLabel = Helper.discussionDataLabel(discussion: discussion, label: .replies)!.waitUntil(.visible)
-        let discussionUnreadLabel = Helper.discussionDataLabel(discussion: discussion, label: .unread)!.waitUntil(.visible)
-        XCTAssertTrue(discussionButton.isVisible)
-        XCTAssertContains(discussionButton.label, discussion.title)
-        XCTAssertTrue(discussionLastPostLabel.isVisible)
-        XCTAssertTrue(discussionRepliesLabel.isVisible)
-        XCTAssertEqual(discussionRepliesLabel.label, "\(discussion.discussion_subentry_count) Replies")
-        XCTAssertTrue(discussionUnreadLabel.isVisible)
-        XCTAssertEqual(discussionUnreadLabel.label, "\(discussion.unread_count) Unread")
+
+        let discussionLastPostLabel = discussionButton
+            .find(labelContaining: "Last post", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionLastPostLabel.isVisible)
+
+        let discussionRepliesLabel = discussionButton
+            .find(label: "\(discussion.discussion_subentry_count) Replies", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionRepliesLabel.isVisible)
+
+        let discussionUnreadLabel = discussionButton
+            .find(label: "\(discussion.unread_count) Unread", type: .staticText)
+            .waitUntil(.visible)
+        XCTAssert(discussionUnreadLabel.isVisible)
     }
 
     func testDiscussionDetails() {


### PR DESCRIPTION
refs: [MBL-19120](https://instructure.atlassian.net/browse/MBL-19120)
builds: Student, Teacher
affects: Student, Teacher
release note: Discussion checkpoints are now handled in discussion list.

- Add DCPs support for Discussion List
- Changed due date text priority, now MultipleDueDates priority over AvailabilityClosed (aligned with product)
- Extracted due date text calculation logic to `AssignmentDueDateTextsProvider`

## Test plan
- Verify Discussion List display due dates for both checkpoints if applicable, in both apps
- Smoke test Assignment List in both apps (due dates are still displayed)

## Screenshots
<table>
<tr><th>Student Before</th><th>Student After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/7e672dbd-bb28-45c7-8417-5a17e9aa732b" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/20ab64de-ceb6-4705-add4-c3c6a751e070" maxHeight=500></td>
</tr>
</table>

<table>
<tr><th>Teacher Before</th><th>Teacher After</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/85e1d698-f104-4975-bed5-a4377dd0f437" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/6df23873-dd51-4f25-996d-707f9bd8dea4" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19120]: https://instructure.atlassian.net/browse/MBL-19120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ