### PR TITLE
[Student] Default to Learner Experience as a Learning Provider

### DIFF
--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -440,7 +440,7 @@ extension StudentAppDelegate {
                     UIApplication.shared.registerForPushNotifications()
                 }
             })
-        case .careerLearner:
+        case .careerLearner, .careerLearningProvider:
             AppEnvironment.shared.app = .horizon
             AppEnvironment.shared.router = Router(routes: HorizonRoutes.routeHandlers())
             HorizonUI.setInstitutionColor(Brand.shared.primary)
@@ -455,8 +455,8 @@ extension StudentAppDelegate {
                     UIApplication.shared.registerForPushNotifications()
                 }
             })
-        case .careerLearningProvider:
-            showIncorrectAppExperienceAlert(session: session)
+//        case .careerLearningProvider:
+//            showIncorrectAppExperienceAlert(session: session)
         }
     }
 }


### PR DESCRIPTION
Since `experience_summary` only stores `current_app` per session, if an account is switched to `learning_provider` then it becomes impossible to log in. Until a proper solution is implemented behind the endpoint, we'll default to `learner` as an LP. 

builds: student
[ignore-commit-lint]
