### PR TITLE
[HorizonUI] WrappingHStack

### DIFF
--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.Storybook.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.Storybook.swift
@@ -1,0 +1,238 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+extension HorizonUI.WrappingHStack {
+    struct Storybook: View {
+        var body: some View {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 32) {
+                    singleLineWithoutSpacersSection
+                    singleLineWithSpacersSection
+                    wrappingWithoutSpacersSection
+                    wrappingWithSpacersIgnoredSection
+                    alignmentVariationsSection
+                    spacingVariationsSection
+                }
+                .padding()
+            }
+            .navigationTitle("HWrappingHStack")
+        }
+
+        private var singleLineWithoutSpacersSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Single Line - No Spacers")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Fits in one line:")
+                    HorizonUI.WrappingHStack {
+                        sampleButton("Button 1")
+                        sampleButton("Button 2")
+                        sampleButton("Button 3")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+            }
+        }
+
+        private var singleLineWithSpacersSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Single Line - With Spacers")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Single spacer (should distribute):")
+                    HorizonUI.WrappingHStack {
+                        sampleButton("Left")
+                        Spacer()
+                        sampleButton("Right")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.yellow.opacity(0.2))
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Multiple spacers (should distribute equally):")
+                    HorizonUI.WrappingHStack {
+                        sampleButton("A")
+                        Spacer()
+                        sampleButton("B")
+                        Spacer()
+                        sampleButton("C")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.yellow.opacity(0.2))
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Leading and trailing spacers:")
+                    HorizonUI.WrappingHStack {
+                        Spacer()
+                        sampleButton("Center")
+                        Spacer()
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(Color.yellow.opacity(0.2))
+                    .border(Color.gray, width: 1)
+                }
+            }
+        }
+
+        private var wrappingWithoutSpacersSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Wrapping - No Spacers")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Too wide, should wrap:")
+                    HStack {
+                        HorizonUI.WrappingHStack {
+                            sampleButton("Very Long Button 1")
+                            sampleButton("Very Long Button 2")
+                            sampleButton("Very Long Button 3")
+                            sampleButton("Very Long Button 4")
+                        }
+                        .border(Color.gray, width: 1)
+                        Spacer()
+                    }
+                }
+            }
+        }
+
+        private var wrappingWithSpacersIgnoredSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Wrapping - Spacers Ignored")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Spacers ignored when wrapping:")
+                    HStack {
+                        HorizonUI.WrappingHStack {
+                            sampleButton("Very Long Button 1")
+                            Spacer()
+                            sampleButton("Very Long Button 2")
+                            sampleButton("Very Long Button 3")
+                            Spacer()
+                            sampleButton("Very Long Button 4")
+                        }
+                        .border(Color.gray, width: 1)
+                        Spacer()
+                    }
+                }
+            }
+        }
+
+        private var alignmentVariationsSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Alignment Variations")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Top alignment:")
+                    HorizonUI.WrappingHStack(alignment: .top) {
+                        sampleButton("Short", height: 30)
+                        sampleButton("Medium Height", height: 50)
+                        sampleButton("Tall Button", height: 70)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Center alignment (default):")
+                    HorizonUI.WrappingHStack(alignment: .center) {
+                        sampleButton("Short", height: 30)
+                        sampleButton("Medium Height", height: 50)
+                        sampleButton("Tall Button", height: 70)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Bottom alignment:")
+                    HorizonUI.WrappingHStack(alignment: .bottom) {
+                        sampleButton("Short", height: 30)
+                        sampleButton("Medium Height", height: 50)
+                        sampleButton("Tall Button", height: 70)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+            }
+        }
+
+        private var spacingVariationsSection: some View {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Spacing Variations")
+                    .font(.headline)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("No spacing:")
+                    HorizonUI.WrappingHStack(spacing: 0) {
+                        sampleButton("A")
+                        sampleButton("B")
+                        sampleButton("C")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Large spacing:")
+                    HorizonUI.WrappingHStack(spacing: 20) {
+                        sampleButton("A")
+                        sampleButton("B")
+                        sampleButton("C")
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .border(Color.gray, width: 1)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Large line spacing (wrapping):")
+                    HorizonUI.WrappingHStack(spacing: 8, lineSpacing: 20) {
+                        sampleButton("Very Long Button 1")
+                        sampleButton("Very Long Button 2")
+                        sampleButton("Very Long Button 3")
+                        sampleButton("Very Long Button 4")
+                    }
+                    .border(Color.gray, width: 1)
+                }
+            }
+        }
+
+        private func sampleButton(_ text: String, height: CGFloat = 40) -> some View {
+            Text(text)
+                .padding(.horizontal, 12)
+                .frame(height: height)
+                .background(Color.blue.opacity(0.7))
+                .foregroundColor(.white)
+                .cornerRadius(8)
+        }
+    }
+}
+
+#Preview {
+    HorizonUI.WrappingHStack.Storybook()
+}

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.swift
@@ -178,7 +178,7 @@ public extension HorizonUI {
                 if isSpacer {
                     currentX += spacerWidth
                 } else {
-                    let yPosition = currentY + (line.height - size.height) / 2
+                    let yPosition = calculateYPosition(currentY: currentY, lineHeight: line.height, itemHeight: size.height)
                     subview.place(
                         at: CGPoint(x: currentX, y: yPosition),
                         proposal: ProposedViewSize(width: size.width, height: size.height)
@@ -199,7 +199,7 @@ public extension HorizonUI {
                     currentX += spacing
                 }
 
-                let yPosition = currentY + (line.height - size.height) / 2
+                let yPosition = calculateYPosition(currentY: currentY, lineHeight: line.height, itemHeight: size.height)
                 subview.place(
                     at: CGPoint(x: currentX, y: yPosition),
                     proposal: ProposedViewSize(width: size.width, height: size.height)
@@ -207,6 +207,19 @@ public extension HorizonUI {
 
                 currentX += size.width
                 isFirst = false
+            }
+        }
+
+        private func calculateYPosition(currentY: CGFloat, lineHeight: CGFloat, itemHeight: CGFloat) -> CGFloat {
+            switch alignment {
+            case .top:
+                return currentY
+            case .bottom:
+                return currentY + lineHeight - itemHeight
+            case .center:
+                return currentY + (lineHeight - itemHeight) / 2
+            default:
+                return currentY + (lineHeight - itemHeight) / 2
             }
         }
 

--- a/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.swift
+++ b/packages/HorizonUI/Sources/HorizonUI/Sources/Components/WrappingHStack/HorizonUI.WrappingHStack.swift
@@ -1,0 +1,226 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+
+public extension HorizonUI {
+    struct WrappingHStack: Layout {
+        private let alignment: VerticalAlignment
+        private let spacing: CGFloat
+        private let lineSpacing: CGFloat
+
+        public init(
+            alignment: VerticalAlignment = .center,
+            spacing: CGFloat = 8,
+            lineSpacing: CGFloat = 8
+        ) {
+            self.alignment = alignment
+            self.spacing = spacing
+            self.lineSpacing = lineSpacing
+        }
+
+        public func sizeThatFits(
+            proposal: ProposedViewSize,
+            subviews: Subviews,
+            cache _: inout ()
+        ) -> CGSize {
+            let maxWidth = proposal.width ?? .infinity
+
+            guard !subviews.isEmpty else {
+                return CGSize(width: 0, height: 0)
+            }
+
+            let (lines, totalHeight) = calculateLayout(subviews: subviews, maxWidth: maxWidth)
+
+            if lines.count == 1 && lines.first?.hasSpacers == true {
+                return CGSize(width: maxWidth, height: totalHeight)
+            } else if lines.count == 1 {
+                return CGSize(width: lines.first?.contentWidth ?? 0, height: totalHeight)
+            } else {
+                let maxLineWidth = lines.map { $0.contentWidth }.max() ?? 0
+                return CGSize(width: maxLineWidth, height: totalHeight)
+            }
+        }
+
+        public func placeSubviews(
+            in bounds: CGRect,
+            proposal _: ProposedViewSize,
+            subviews: Subviews,
+            cache _: inout ()
+        ) {
+            guard !subviews.isEmpty else { return }
+
+            let (lines, _) = calculateLayout(subviews: subviews, maxWidth: bounds.width)
+            var currentY = bounds.minY
+
+            for (index, line) in lines.enumerated() {
+                if line.hasSpacers, lines.count == 1 {
+                    placeSingleLineWithSpacers(line: line, bounds: bounds, currentY: currentY)
+                } else {
+                    placeRegularLine(line: line, bounds: bounds, currentY: currentY)
+                }
+
+                currentY += line.height
+                if index < lines.count - 1 {
+                    currentY += lineSpacing
+                }
+            }
+        }
+
+        private func calculateLayout(subviews: Subviews, maxWidth: CGFloat) -> ([Line], CGFloat) {
+            var lines: [Line] = []
+            var currentLineItems: [(LayoutSubview, CGSize, Bool)] = []
+            var currentLineWidth: CGFloat = 0
+            var currentLineHeight: CGFloat = 0
+
+            let subviewSizes = subviews.map { subview in
+                subview.sizeThatFits(ProposedViewSize(width: maxWidth, height: nil))
+            }
+
+            let regularItems = subviews.enumerated().compactMap { index, subview in
+                isSpacer(subview) ? nil : (subview, subviewSizes[index])
+            }
+            let singleLineWidth = regularItems.reduce(0) { $0 + $1.1.width } +
+                CGFloat(max(0, regularItems.count - 1)) * spacing
+            let hasSpacers = subviews.contains { isSpacer($0) }
+
+            if singleLineWidth <= maxWidth {
+                // Single line
+                let items = subviews.enumerated().map { index, subview in
+                    (subview, subviewSizes[index], isSpacer(subview))
+                }
+                let lineHeight = subviewSizes.map(\.height).max() ?? 0
+                let line = Line(
+                    items: items,
+                    height: lineHeight,
+                    contentWidth: hasSpacers ? maxWidth : singleLineWidth,
+                    hasSpacers: hasSpacers
+                )
+                return ([line], lineHeight)
+            } else {
+                // Multi-line wrapping
+                for (index, subview) in subviews.enumerated() {
+                    if isSpacer(subview) { continue }
+
+                    let size = subviewSizes[index]
+                    let spacingToAdd = currentLineWidth > 0 ? spacing : 0
+                    let neededWidth = currentLineWidth + spacingToAdd + size.width
+
+                    if neededWidth > maxWidth, currentLineWidth > 0 {
+                        let line = Line(
+                            items: currentLineItems,
+                            height: currentLineHeight,
+                            contentWidth: currentLineWidth,
+                            hasSpacers: false
+                        )
+                        lines.append(line)
+
+                        currentLineItems = []
+                        currentLineWidth = 0
+                        currentLineHeight = 0
+                    }
+
+                    currentLineItems.append((subview, size, false))
+                    currentLineWidth += spacingToAdd + size.width
+                    currentLineHeight = max(currentLineHeight, size.height)
+                }
+
+                if !currentLineItems.isEmpty {
+                    let line = Line(
+                        items: currentLineItems,
+                        height: currentLineHeight,
+                        contentWidth: currentLineWidth,
+                        hasSpacers: false
+                    )
+                    lines.append(line)
+                }
+
+                let totalHeight = lines.enumerated().reduce(0) { total, item in
+                    let (index, line) = item
+                    return total + line.height + (index > 0 ? lineSpacing : 0)
+                }
+
+                return (lines, totalHeight)
+            }
+        }
+
+        private func placeSingleLineWithSpacers(line: Line, bounds: CGRect, currentY: CGFloat) {
+            let regularItems = line.items.filter { !$0.2 }
+            let spacerCount = line.items.filter { $0.2 }.count
+
+            guard spacerCount > 0, !regularItems.isEmpty else {
+                placeRegularLine(line: line, bounds: bounds, currentY: currentY)
+                return
+            }
+
+            let totalRegularWidth = regularItems.reduce(0) { $0 + $1.1.width }
+            let availableSpacerWidth = bounds.width - totalRegularWidth
+            let spacerWidth = availableSpacerWidth / CGFloat(spacerCount)
+
+            var currentX = bounds.minX
+
+            for (subview, size, isSpacer) in line.items {
+                if isSpacer {
+                    currentX += spacerWidth
+                } else {
+                    let yPosition = currentY + (line.height - size.height) / 2
+                    subview.place(
+                        at: CGPoint(x: currentX, y: yPosition),
+                        proposal: ProposedViewSize(width: size.width, height: size.height)
+                    )
+                    currentX += size.width
+                }
+            }
+        }
+
+        private func placeRegularLine(line: Line, bounds: CGRect, currentY: CGFloat) {
+            var currentX = bounds.minX
+            var isFirst = true
+
+            for (subview, size, isSpacer) in line.items {
+                if isSpacer { continue }
+
+                if !isFirst {
+                    currentX += spacing
+                }
+
+                let yPosition = currentY + (line.height - size.height) / 2
+                subview.place(
+                    at: CGPoint(x: currentX, y: yPosition),
+                    proposal: ProposedViewSize(width: size.width, height: size.height)
+                )
+
+                currentX += size.width
+                isFirst = false
+            }
+        }
+
+        private func isSpacer(_ subview: LayoutSubview) -> Bool {
+            let flexibleWidth = subview.sizeThatFits(ProposedViewSize(width: 1000, height: nil)).width
+            let constrainedWidth = subview.sizeThatFits(ProposedViewSize(width: 100, height: nil)).width
+            return flexibleWidth > constrainedWidth * 2
+        }
+
+        private struct Line {
+            let items: [(LayoutSubview, CGSize, Bool)] // (subview, size, isSpacer)
+            let height: CGFloat
+            let contentWidth: CGFloat
+            let hasSpacers: Bool
+        }
+    }
+}


### PR DESCRIPTION
Adds an HStack that is capable of wrapping its content to a new line when it wouldn't fit into a single line. Additionally it supports filling a single row if there are spacers inside the child views which is not possible using the existing `HFlow`. 

<table>
<tr><th>Examples</th></tr>
<tr>
<td><img src="https://github.com/user-attachments/assets/30830282-d3cf-45a1-abfe-0577ce4333ce" maxHeight=500></td>
<td><img src="https://github.com/user-attachments/assets/1fcba39b-a41f-4672-9191-adf585951c2f" maxHeight=500></td>
</tr>
</table>

[ignore-commit-lint]
builds: Student



