### PR TITLE
[MBL-19332][Teacher] - Fixes issue of disappearing PDF annotation toolbar in SpeedGrader intermittently

### DIFF
--- a/Core/Core/Features/DocViewer/DocViewerConstants.swift
+++ b/Core/Core/Features/DocViewer/DocViewerConstants.swift
@@ -86,6 +86,10 @@ public func stylePSPDFKit() {
     let styleManager = SDK.shared.styleManager
     styleManager.setupDefaultStylesIfNeeded()
 
+    // This is necessary to solve an issue with different styles applied to annotation
+    // toolbar shown in different contexts (File Details & SpeedGrader/DocViewer)
+    AnnotationToolbar.appearance().tintColor = nil
+
     let highlightPresets = DocViewerHighlightColor.allCases.map { return ColorPreset(color: $0.color) }
     let inkPresets = DocViewerAnnotationColor.allCases.map { return ColorPreset(color: $0.color) }
     let textColorPresets = DocViewerAnnotationColor.allCases.map { return ColorPreset(color: $0.color, fill: .textLightest.variantForLightMode, alpha: 1) }


### PR DESCRIPTION
refs: MBL-19332
affects: Student, Teacher
builds: Student, Teacher
release note: Fixed issue of disappearing PDF annotation toolbar in SpeedGrader intermittently

## Analysis

This issue show up consistently when user opens a PDF file for viewing, either from a link or through Files tab. Then after that goes on opening SpeedGrader to view student annotation submission of a student.

What causes the issue is actually the setting of `tintColor` property on global appearance of `AnnotationToolbar` right before showing PDF document at line `FileDetailsViewController:681`

## Test Plan

**Note:** You need to use a locally-built build to test this feature. For PSPDFKit currently is **_not_** fully functional on adhoc builds.

- Opened PDF document either via link or through Files tab.
- Showed/Hid annotation toolbar on PDF file details screen.
- Opened student annotation submission of an assignment.
- Annotation toolbar now must be showing the correct tint color

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
