### PR TITLE
Allow Document Scan to fallback to pdfs

### DIFF
--- a/Core/Core/Common/Extensions/PDFKit/PDFDocumentExtensions.swift
+++ b/Core/Core/Common/Extensions/PDFKit/PDFDocumentExtensions.swift
@@ -1,0 +1,38 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import PDFKit
+
+extension PDFDocument {
+
+    @discardableResult
+    public func write(to url: URL? = nil, nameIt name: String? = nil) throws -> URL {
+        let directory = url ?? URL.Directories.temporary.appendingPathComponent("documents", isDirectory: true)
+        let name = name ?? String(Clock.now.timeIntervalSince1970)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true, attributes: nil)
+        let url = directory.appendingPathComponent(name, isDirectory: false).appendingPathExtension("pdf")
+        guard let data = dataRepresentation() else {
+            throw NSError.instructureError(String(localized: "Failed to save pdf", bundle: .core))
+        }
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+        try data.write(to: url)
+        return url
+    }
+}

--- a/Core/Core/Features/Files/Model/Entities/UTI.swift
+++ b/Core/Core/Features/Files/Model/Entities/UTI.swift
@@ -131,6 +131,9 @@ public struct UTI: Equatable, Hashable {
     public var isImage: Bool {
         return uttype?.conforms(to: .image) ?? false
     }
+    public var isPdf: Bool {
+        return uttype?.conforms(to: .pdf) ?? false
+    }
 
     public var isAudio: Bool {
         return uttype?.conforms(to: .audio) ?? false

--- a/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
+++ b/Student/Student/Submissions/SubmissionButton/SubmissionButtonPresenter.swift
@@ -231,6 +231,8 @@ extension SubmissionButtonPresenter: FilePickerControllerDelegate {
         if assignment.allowedExtensions.isEmpty == true || allowedUTIs.contains(where: { $0.isImage || $0.isVideo }) {
             filePicker.sources.append(contentsOf: [.library, .camera])
             if !isMediaRecording { filePicker.sources.append(.documentScan) }
+        } else if allowedUTIs.contains(where: { $0.isPdf }) {
+            filePicker.sources.append(.documentScan)
         }
         if isMediaRecording { filePicker.sources.append(.audio) }
         filePicker.utis = allowedUTIs


### PR DESCRIPTION
Scanner is now enabled for assigments that allow pdfs and not images, submitting the scanned document as a multipage pdf

refs: none
builds: Student, Teacher
affects: Student
release note: none
test plan:
- Launch app
- Test scanner submission of assigment that allows pdfs and not jpegs

This is visually the same as uploading JPEGs; the only difference lies when saving: the file outputted is a single multipage pdf.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
