### PR TITLE
Update jira updater script

### DIFF
--- a/scripts/update-jira-issues.js
+++ b/scripts/update-jira-issues.js
@@ -109,6 +109,7 @@ exports.commands = {
 
     let nextPageToken = null
     let totalCount = 0
+    let isLast = false
     do {
       let results = await searchJira(`
         project = "MBL" AND
@@ -120,6 +121,11 @@ exports.commands = {
         maxResults: 10,
         fields: [ 'id', 'key', 'labels', 'summary' ],
       })
+
+      if (!results.issues || results.issues.length === 0) {
+        console.log('No more issues found, ending pagination')
+        break
+      }
 
       await Promise.all(results.issues.map(issue => {
         const labels = [ { add: releasedLabel } ]
@@ -139,8 +145,9 @@ exports.commands = {
       }))
 
       totalCount += results.issues.length
-      nextPageToken = results.nextPageToken
-    } while (!results.isLast && nextPageToken)
+      nextPageToken = results.nextPageToken || null
+      isLast = results.isLast !== false
+    } while (!isLast && nextPageToken)
     return totalCount
   },
 }


### PR DESCRIPTION
Despite the latest version bump and migration to version 3 API of the `jira-client` package, the search API it uses under the hood is still deprecated. I have no idea why it worked for a while but now it throws errors again. `jira-client` seems to be abandoned so I added a manual API call to search JIRA with JQL. The script now completes but it finds no new issues to be labeled so the real test of it will come after we make a new release.

A successful build from this branch can be found [here](https://app.bitrise.io/build/9ec3b033-8400-463c-bae5-694552728830).

[ignore-commit-lint]