### PR TITLE
Added Loading Spinner To ``CoreWebView``

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -71,6 +71,8 @@ open class CoreWebView: WKWebView {
     private var env: AppEnvironment = .shared
     private var subscriptions = Set<AnyCancellable>()
 
+    private weak var progressIndicator: CircleProgressView?
+
     public required init?(coder: NSCoder) {
         super.init(coder: coder)
         setup()
@@ -188,6 +190,33 @@ open class CoreWebView: WKWebView {
         }
 
         registerForTraitChanges()
+        addProgressIndicator()
+        showProgressIndicator()
+    }
+
+    private func addProgressIndicator() {
+        let progressView = CircleProgressView()
+        progressView.translatesAutoresizingMaskIntoConstraints = false
+        self.addSubview(progressView)
+        NSLayoutConstraint.activate([
+            progressView.widthAnchor.constraint(equalToConstant: 40),
+            progressView.heightAnchor.constraint(equalToConstant: 40),
+            progressView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
+            progressView.centerYAnchor.constraint(equalTo: self.centerYAnchor)
+        ])
+        self.progressIndicator = progressView
+    }
+
+    private func showProgressIndicator() {
+        progressIndicator?.startAnimating()
+    }
+
+    private func hideProgressIndicator() {
+        UIView.animate(withDuration: 0.2) { [weak self] in
+            self?.progressIndicator?.alpha = 0
+        } completion: { [weak self] _ in
+            self?.progressIndicator?.stopAnimating()
+        }
     }
 
     @discardableResult
@@ -548,7 +577,7 @@ extension CoreWebView: WKNavigationDelegate {
         if let fragment = url?.fragment {
             scrollIntoView(fragment: fragment)
         }
-
+        hideProgressIndicator()
         features.forEach { $0.webView(webView, didFinish: navigation) }
     }
 
@@ -557,6 +586,7 @@ extension CoreWebView: WKNavigationDelegate {
         didFail navigation: WKNavigation!,
         withError error: any Error
     ) {
+        hideProgressIndicator()
         checkFileLoadNavigationAndExecuteCallback(navigation: navigation, error: error)
     }
 
@@ -565,6 +595,7 @@ extension CoreWebView: WKNavigationDelegate {
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: any Error
     ) {
+        hideProgressIndicator()
         checkFileLoadNavigationAndExecuteCallback(navigation: navigation, error: error)
     }
 


### PR DESCRIPTION
# What's New
Added a loading spinner to ``CoreWebView``. This makes it clear when the ``WebView`` is still loading vs just having an empty page

# Screenshots
# Before
https://github.com/user-attachments/assets/1c3b9885-c62d-4049-8ab0-798862a42ebe

# After
https://github.com/user-attachments/assets/283da9ff-d54c-4729-971b-1b0af7fe51d9

# Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
