### PR TITLE
[MBL-19886 ][S/P/T] Inconsistent grades on dashboard

### DIFF
--- a/Core/Core/Features/Courses/Course.swift
+++ b/Core/Core/Features/Courses/Course.swift
@@ -315,8 +315,21 @@ extension Course {
         return settings?.restrictQuantitativeData ?? false
     }
 
-    public var hideTotalGrade: Bool {
-        let enrollment = enrollments?.filter({ $0.isStudent }).first
+    public func enrollmentForGrade(userID: String?) -> Enrollment? {
+        func first(of state: EnrollmentState) -> Enrollment? {
+            enrollments?.first {
+                $0.id != nil &&
+                $0.state == state &&
+                $0.userID == userID &&
+                $0.isStudent
+            }
+        }
+        return first(of: .active) ?? first(of: .completed)
+    }
+
+    public func hideTotalGrade(userID: String?) -> Bool {
+        let enrollment = enrollmentForGrade(userID: userID)
+
         return hideFinalGrades == true || (
             enrollment?.multipleGradingPeriodsEnabled == true &&
             enrollment?.totalsForAllGradingPeriodsOption == false &&

--- a/Core/Core/Features/Courses/Course.swift
+++ b/Core/Core/Features/Courses/Course.swift
@@ -315,20 +315,8 @@ extension Course {
         return settings?.restrictQuantitativeData ?? false
     }
 
-    public func enrollmentForGrade(userID: String?) -> Enrollment? {
-        func first(of state: EnrollmentState) -> Enrollment? {
-            enrollments?.first {
-                $0.id != nil &&
-                $0.state == state &&
-                $0.userID == userID &&
-                $0.isStudent
-            }
-        }
-        return first(of: .active) ?? first(of: .completed)
-    }
-
     public func hideTotalGrade(userID: String?) -> Bool {
-        let enrollment = enrollmentForGrade(userID: userID)
+        let enrollment = enrollmentForGrades(userId: userID, includingCompleted: true)
 
         return hideFinalGrades == true || (
             enrollment?.multipleGradingPeriodsEnabled == true &&

--- a/Core/Core/Features/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
+++ b/Core/Core/Features/Dashboard/CourseCardList/View/DashboardCourseCardView.swift
@@ -174,7 +174,7 @@ struct DashboardCourseCardView: View {
     private var gradePill: some View {
         if showGrade, let course = courseCard.course {
             HStack {
-                if course.hideTotalGrade {
+                if course.hideTotalGrade(userID: env.currentSession?.userID) {
                     Image.lockSolid.size(14)
                 } else {
                     Text(course.displayGrade).font(.semibold14)

--- a/Core/CoreTests/Features/Courses/CourseTests.swift
+++ b/Core/CoreTests/Features/Courses/CourseTests.swift
@@ -21,6 +21,8 @@ import XCTest
 @testable import Core
 
 class CourseTests: CoreTestCase {
+    private let userID = "some user id"
+
     func testColor() {
         ContextColor.make(canvasContextID: "course_1", color: .red)
         let a = Course.make(from: .make(id: "1"))
@@ -417,17 +419,18 @@ class CourseTests: CoreTestCase {
     // MARK: - hideTotalGrade
 
     func test_hideTotalGrade_whenHideFinalGradesIsTrue_shouldBeTrue() {
+        let userID = userID
         let course = Course.make(from: .make(
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: false
             )],
             hide_final_grades: true
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), true)
     }
 
     func test_hideTotalGrade_whenHideFinalGradesIsFalseAndNoEnrollment_shouldBeFalse() {
@@ -436,7 +439,7 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), false)
     }
 
     func test_hideTotalGrade_whenMGPEnabledAndTotalsFalseAndNoCurrentPeriod_shouldBeTrue() {
@@ -444,7 +447,7 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: true,
                 totals_for_all_grading_periods_option: false,
                 current_grading_period_id: nil
@@ -452,7 +455,7 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), true)
     }
 
     func test_hideTotalGrade_whenMGPEnabledAndTotalsTrueAndNoCurrentPeriod_shouldBeFalse() {
@@ -460,7 +463,7 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: true,
                 totals_for_all_grading_periods_option: true,
                 current_grading_period_id: nil
@@ -468,7 +471,7 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), false)
     }
 
     func test_hideTotalGrade_whenMGPEnabledAndTotalsFalseAndHasCurrentPeriod_shouldBeFalse() {
@@ -476,7 +479,7 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: true,
                 totals_for_all_grading_periods_option: false,
                 current_grading_period_id: "42"
@@ -484,7 +487,7 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), false)
     }
 
     func test_hideTotalGrade_whenMGPDisabled_shouldBeFalse() {
@@ -492,13 +495,13 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: false
             )],
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), false)
     }
 
     func test_hideTotalGrade_whenEnrollmentIsCompletedAndMGPConditionMet_shouldBeTrue() {
@@ -506,7 +509,7 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .completed,
-                user_id: "12",
+                user_id: userID,
                 multiple_grading_periods_enabled: true,
                 totals_for_all_grading_periods_option: false,
                 current_grading_period_id: nil
@@ -514,7 +517,23 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), true)
+    }
+
+    func test_hideTotalGrade_whenUserIDIsNil_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: userID,
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: false,
+                current_grading_period_id: nil
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: nil), false)
     }
 
     func test_hideTotalGrade_whenUserIDDoesNotMatch_shouldBeFalse() {
@@ -522,7 +541,7 @@ class CourseTests: CoreTestCase {
             enrollments: [.make(
                 id: nil,
                 enrollment_state: .active,
-                user_id: "99",
+                user_id: "other user id",
                 multiple_grading_periods_enabled: true,
                 totals_for_all_grading_periods_option: false,
                 current_grading_period_id: nil
@@ -530,7 +549,7 @@ class CourseTests: CoreTestCase {
             hide_final_grades: false
         ))
 
-        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+        XCTAssertEqual(course.hideTotalGrade(userID: userID), false)
     }
 
     // MARK: - Grading periods

--- a/Core/CoreTests/Features/Courses/CourseTests.swift
+++ b/Core/CoreTests/Features/Courses/CourseTests.swift
@@ -414,6 +414,125 @@ class CourseTests: CoreTestCase {
         XCTAssertFalse(courseWithoutNickName.hasNickName)
     }
 
+    // MARK: - hideTotalGrade
+
+    func test_hideTotalGrade_whenHideFinalGradesIsTrue_shouldBeTrue() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "12",
+                multiple_grading_periods_enabled: false
+            )],
+            hide_final_grades: true
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+    }
+
+    func test_hideTotalGrade_whenHideFinalGradesIsFalseAndNoEnrollment_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+    }
+
+    func test_hideTotalGrade_whenMGPEnabledAndTotalsFalseAndNoCurrentPeriod_shouldBeTrue() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "12",
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: false,
+                current_grading_period_id: nil
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+    }
+
+    func test_hideTotalGrade_whenMGPEnabledAndTotalsTrueAndNoCurrentPeriod_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "12",
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: true,
+                current_grading_period_id: nil
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+    }
+
+    func test_hideTotalGrade_whenMGPEnabledAndTotalsFalseAndHasCurrentPeriod_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "12",
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: false,
+                current_grading_period_id: "42"
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+    }
+
+    func test_hideTotalGrade_whenMGPDisabled_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "12",
+                multiple_grading_periods_enabled: false
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+    }
+
+    func test_hideTotalGrade_whenEnrollmentIsCompletedAndMGPConditionMet_shouldBeTrue() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .completed,
+                user_id: "12",
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: false,
+                current_grading_period_id: nil
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), true)
+    }
+
+    func test_hideTotalGrade_whenUserIDDoesNotMatch_shouldBeFalse() {
+        let course = Course.make(from: .make(
+            enrollments: [.make(
+                id: nil,
+                enrollment_state: .active,
+                user_id: "99",
+                multiple_grading_periods_enabled: true,
+                totals_for_all_grading_periods_option: false,
+                current_grading_period_id: nil
+            )],
+            hide_final_grades: false
+        ))
+
+        XCTAssertEqual(course.hideTotalGrade(userID: "12"), false)
+    }
+
     // MARK: - Grading periods
 
     func test_save_whenGradingPeriodIsDeleted_shouldNotSaveIt() {

--- a/Parent/Parent/Courses/CourseListViewController.swift
+++ b/Parent/Parent/Courses/CourseListViewController.swift
@@ -126,7 +126,7 @@ class CourseListCell: UITableViewCell {
             return ""
         }
 
-        if course.hideTotalGrade {
+        if course.hideTotalGrade(userID: studentID) {
             // this condition also triggers when multipleGradingPeriodsEnabled is true, currentGradingPeriodID is nil and totalsForAllGradingPeriodsOption is false
             return course.hideFinalGrades ? "" : String(localized: "N/A", bundle: .parent)
         }

--- a/Student/Student/LearnerDashboard/Widgets/CoursesAndGroupsWidget/Model/CoursesAndGroupsWidgetInteractor.swift
+++ b/Student/Student/LearnerDashboard/Widgets/CoursesAndGroupsWidget/Model/CoursesAndGroupsWidgetInteractor.swift
@@ -103,12 +103,13 @@ final class CoursesAndGroupsWidgetInteractorLive: CoursesAndGroupsWidgetInteract
                 .filterUsingDashboardCards(sortedCourseCards)
             let courseItems = courses.map {
                 let announcements = announcementsByContextId[$0.canvasContextID] ?? []
+                let userID = self?.env.currentSession?.userID
                 return CoursesAndGroupsWidgetCourseItem(
                     id: $0.id,
                     title: $0.name ?? "",
                     color: $0.color.asColor,
                     imageUrl: $0.imageDownloadURL,
-                    grade: $0.hideTotalGrade ? nil : $0.displayGradeForLearnerDashboard,
+                    grade: $0.hideTotalGrade(userID: userID) ? nil : $0.displayGradeForLearnerDashboard,
                     unreadAnnouncementCount: announcements.count,
                     singleUnreadAnnouncementId: announcements.count == 1 ? announcements.first?.id : nil
                 )


### PR DESCRIPTION
refs: [MBL-19886](https://instructure.atlassian.net/browse/MBL-19886)
builds: Student, Teacher
affects: Student, Teacher
release note: Fixed inconsistent grades appearing on Dashboard.

The problem appears when a course's total grade is hidden.
Grades were inconsistent on the old dashboard too. The enrollment selection logic is reused from `GradeListInteractor`'s `gradeEnrollment` function.

Test plan:
Check that grades are consistent on both dashboard by doing multiple PTR's. Check if grades are the same as on Grade List. See ticket for account.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19886]: https://instructure.atlassian.net/browse/MBL-19886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ