### PR TITLE
[Chore] Change make sync and secret install steps

### DIFF
--- a/.bitrise/bitrise.yml
+++ b/.bitrise/bitrise.yml
@@ -25,19 +25,6 @@ workflows:
         inputs:
         - reset_repository: 'Yes'
     - script@1:
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -e
-            # Set scheme to "All" and configuration to "Adhoc" to install all production secrets at once
-            envman add --key BITRISE_SCHEME --value All
-            envman add --key BITRISE_CONFIGURATION --value Adhoc
-            echo "BITRISE_SCHEME set to: All"
-            echo "BITRISE_CONFIGURATION set to: Adhoc"
-        title: Set Scheme and Configuration for Secrets Setup
-    - git::https://github.com/instructure/steps-canvas-ios-secrets.git@master:
-        title: Canvas iOS Secrets
-    - script@1:
         title: XcodeGen
         inputs:
         - content: |-
@@ -50,6 +37,19 @@ workflows:
             cd $BITRISE_SOURCE_DIR
             make provision-ci
             make sync-ci
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -e
+            # Set scheme to "All" and configuration to "Adhoc" to install all production secrets at once
+            envman add --key BITRISE_SCHEME --value All
+            envman add --key BITRISE_CONFIGURATION --value Adhoc
+            echo "BITRISE_SCHEME set to: All"
+            echo "BITRISE_CONFIGURATION set to: Adhoc"
+        title: Set Scheme and Configuration for Secrets Setup
+    - git::https://github.com/instructure/steps-canvas-ios-secrets.git@master:
+        title: Canvas iOS Secrets
     summary: 'This step contains all the necessary steps to prepare the Xcode workspace
       for building/testing.'
 meta:


### PR DESCRIPTION
## PR Info
- During ad-hoc PR builds, secrets were installed first that copied `GoogleService-Info.plist` files into the app.
- The next step was `make provision-ci` that generates empty `GoogleService-Info.plist` files, effectively overwriting the installed secrets.
- The fix is to change the order of the two steps so those plist files won't get overwritten.

builds: Student, Teacher, Parent

[ignore-pr-lint]