### PR TITLE
[MBL-19876][S/T/P] Privacy Consent WebView support

### DIFF
--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
@@ -67,14 +67,17 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
         featureFlagStore
             .getEntities()
             .flatMap { [weak self] featureFlags -> AnyPublisher<Bool?, Error> in
+                guard let self else { return Publishers.typedEmpty() }
+
                 guard featureFlags.isFeatureEnabled(.send_usage_metrics) else {
+                    storeUserProvidedAnalyticsConsent(nil)
                     return Publishers.typedJust(false)
                 }
 
                 if featureFlags.isFeatureEnabled(.cookie_consent_necessary) {
-                    return self?.getConsent(ignoreCache: ignoreConsentCache)
-                        ?? Publishers.typedEmpty()
+                    return getConsent(ignoreCache: ignoreConsentCache)
                 } else {
+                    storeUserProvidedAnalyticsConsent(nil)
                     return Publishers.typedJust(true)
                 }
             }
@@ -85,13 +88,15 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
         featureFlagStore
             .getEntities()
             .flatMap { [weak self] featureFlags -> AnyPublisher<Bool?, Error> in
+                guard let self else { return Publishers.typedEmpty() }
+
                 let isConsentRequired = featureFlags.isFeatureEnabled(.send_usage_metrics)
                     && featureFlags.isFeatureEnabled(.cookie_consent_necessary)
 
                 if isConsentRequired {
-                    return self?.getConsent(ignoreCache: ignoreConsentCache)
-                        ?? Publishers.typedEmpty()
+                    return getConsent(ignoreCache: ignoreConsentCache)
                 } else {
+                    storeUserProvidedAnalyticsConsent(nil)
                     return Publishers.typedJust(nil)
                 }
             }
@@ -101,17 +106,32 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
     private func getConsent(ignoreCache: Bool) -> AnyPublisher<Bool?, Error> {
         consentStore
             .getEntities(ignoreCache: ignoreCache)
-            .map { entities in entities.first?.consentValue }
+            .map { [weak self] entities in
+                let value = entities.first?.consentValue
+                self?.storeUserProvidedAnalyticsConsent(value)
+                return value
+            }
             .eraseToAnyPublisher()
     }
 
     public func setConsent(_ value: Bool) -> AnyPublisher<Void, Error> {
-        ReactiveStore(
+        return ReactiveStore(
             useCase: PutAnalyticsConsent(app: environment.app ?? .student, value: value),
             backgroundEnv: environment
         )
         .getEntities(ignoreCache: true)
-        .map { _ in }
+        .map { [weak self] _ in
+            self?.storeUserProvidedAnalyticsConsent(value)
+            return
+        }
         .eraseToAnyPublisher()
+    }
+
+    /// Stores user's consent in UserDefaults to allow for sync readout.
+    /// This sync usage is needed in `GetWebSessionRequest`.
+    /// It's only supposed to have a value when consent is actualy required
+    /// and the user already accepted/declined.
+    private func storeUserProvidedAnalyticsConsent(_ value: Bool?) {
+        environment.userDefaults?.userProvidedAnalyticsConsent = value
     }
 }

--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
@@ -22,14 +22,18 @@ import Foundation
 public protocol AnalyticsConsentInteractor {
 
     /// Returns whether analytics tracking is enabled.
-    /// Returns `true` or `false` if feature flags govern that it's always enabled/disabled,
-    /// or if consent is required and the user had already chosen.
-    /// Returns `nil` if consent is required but it's not yet provided by the user.
+    /// - Returns `true` or `false` if feature flags govern that it's always enabled/disabled.
+    ///   In this case no consent is required.
+    /// - Returns `true` or `false` if consent is required and the user had already chosen.
+    /// - Returns `nil` if consent is required but it's not yet provided by the user.
+    /// - Returns `false` if consent is required and the user is masqueareding.
+    ///   In this case the actual consent is ignored: tracking is disabled.
     func isTrackingEnabled(ignoreConsentCache: Bool) -> AnyPublisher<Bool?, Error>
 
     /// Returns the value of the analytics tracking consent, if any.
-    /// Returns `true` or `false` if consent is required and the user had already chosen.
-    /// Returns `nil` if consent is not required (or if the user had not yet provided it).
+    /// - Returns `true` or `false` if consent is required and the user had already chosen.
+    /// - Returns `false` if consent is required and the user is masqueareding.
+    /// - Returns `nil` if consent is not required (or if the user had not yet provided it).
     func getConsentIfRequired(ignoreConsentCache: Bool) -> AnyPublisher<Bool?, Error>
 
     /// Sets the consent to `value`.
@@ -104,7 +108,12 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
     }
 
     private func getConsent(ignoreCache: Bool) -> AnyPublisher<Bool?, Error> {
-        consentStore
+        if isMasqueareding {
+            storeUserProvidedAnalyticsConsent(false)
+            return Publishers.typedJust(false)
+        }
+
+        return consentStore
             .getEntities(ignoreCache: ignoreCache)
             .map { [weak self] entities in
                 let value = entities.first?.consentValue
@@ -115,6 +124,10 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
     }
 
     public func setConsent(_ value: Bool) -> AnyPublisher<Void, Error> {
+        if isMasqueareding {
+            return Publishers.typedFailure(error: AnalyticsConsentError())
+        }
+
         return ReactiveStore(
             useCase: PutAnalyticsConsent(app: environment.app ?? .student, value: value),
             backgroundEnv: environment
@@ -127,6 +140,10 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
         .eraseToAnyPublisher()
     }
 
+    private var isMasqueareding: Bool {
+        AppEnvironment.shared.currentSession?.masquerader != nil
+    }
+
     /// Stores user's consent in UserDefaults to allow for sync readout.
     /// This sync usage is needed in `GetWebSessionRequest`.
     /// It's only supposed to have a value when consent is actualy required
@@ -135,3 +152,5 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
         environment.userDefaults?.userProvidedAnalyticsConsent = value
     }
 }
+
+private struct AnalyticsConsentError: Error { }

--- a/Core/Core/Common/CommonModels/AppEnvironment/SessionDefaults.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/SessionDefaults.swift
@@ -342,4 +342,11 @@ public struct SessionDefaults: Equatable {
             self["shouldShowDashboardFeedback"] = newValue
         }
     }
+
+    // MARK: - Analytics
+
+    public var userProvidedAnalyticsConsent: Bool? {
+        get { self["userProvidedAnalyticsConsent"] as? Bool }
+        set { self["userProvidedAnalyticsConsent"] = newValue }
+    }
 }

--- a/Core/Core/Features/DeveloperMenu/DeveloperMenuView.swift
+++ b/Core/Core/Features/DeveloperMenu/DeveloperMenuView.swift
@@ -182,7 +182,9 @@ public struct DeveloperMenuView: View {
                 guard let app = env.app else { return }
                 env.api.makeRequest(DeleteAnalyticsConsentRequest(namespace: app.consentNamespace)) { _, _, error in
                     if error == nil {
-                        snackBarViewModel.showSnack("Analytics consent cleared")
+                        performUIUpdate {
+                            snackBarViewModel.showSnack("Analytics consent cleared. Restart the app!")
+                        }
                     }
                 }
             }

--- a/Core/Core/Features/DeveloperMenu/DeveloperMenuView.swift
+++ b/Core/Core/Features/DeveloperMenu/DeveloperMenuView.swift
@@ -185,7 +185,9 @@ public struct DeveloperMenuView: View {
                 guard let app = env.app else { return }
                 env.api.makeRequest(DeleteAnalyticsConsentRequest(namespace: app.consentNamespace)) { _, _, error in
                     if error == nil {
-                        snackBarViewModel.showSnack("Analytics consent cleared")
+                        performUIUpdate {
+                            snackBarViewModel.showSnack("Analytics consent cleared. Restart the app!")
+                        }
                     }
                 }
             }

--- a/Core/Core/Features/Login/APIOAuth.swift
+++ b/Core/Core/Features/Login/APIOAuth.swift
@@ -217,11 +217,20 @@ public struct GetWebSessionRequest: APIRequestable {
     public let path: String
 
     public var query: [APIQueryItem] {
-        guard let to else { return [] }
+        let mobileConsent = AppEnvironment.shared.userDefaults?.userProvidedAnalyticsConsent
+
+        return [
+            returnToUrl.map { .value("return_to", $0.absoluteString) },
+            mobileConsent.map { .value("mobile_consent", $0 ? "true" : "false") }
+        ].compactMap { $0 }
+    }
+
+    private var returnToUrl: URL? {
+        guard let to else { return nil }
 
         // Inline data content URLs need no extra query params
         if to.scheme == "data" {
-            return [ .value("return_to", to.absoluteString) ]
+            return to
         }
 
         var returnToUrlQueryItems = [
@@ -236,7 +245,8 @@ public struct GetWebSessionRequest: APIRequestable {
         returnToUrlQueryItems.forEach {
             returnToUrl = returnToUrl.appendingQueryItems($0)
         }
-        return [ .value("return_to", returnToUrl.absoluteString) ]
+
+        return returnToUrl
     }
 
     public init(to: URL?) {

--- a/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
@@ -142,6 +142,44 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
         XCTAssertEqual(stored.first?.consentValue, true)
     }
 
+    // MARK: - Storing consent in session defaults
+
+    func test_isTrackingEnabled_whenSendUsageMetricsFlagIsOff_shouldClearConsentInSessionDefaults() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = true
+        mockFeatureFlags(sendUsageMetrics: false, cookieConsentNecessary: false)
+
+        XCTAssertFinish(testee.isTrackingEnabled(ignoreConsentCache: true))
+
+        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, nil)
+    }
+
+    func test_isTrackingEnabled_whenConsentNotRequired_shouldClearConsentInSessionDefaults() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = true
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
+
+        XCTAssertFinish(testee.isTrackingEnabled(ignoreConsentCache: true))
+
+        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, nil)
+    }
+
+    func test_isTrackingEnabled_whenConsentRequired_shouldStoreConsentValueInSessionDefaults() {
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+        mockConsent(.make(data: .init(mobile_consent: true)))
+
+        XCTAssertFinish(testee.isTrackingEnabled(ignoreConsentCache: true))
+
+        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, true)
+    }
+
+    func test_setConsent_shouldStoreConsentValueInSessionDefaults() {
+        let putRequest = PutAnalyticsConsentRequest(namespace: .student, value: true)
+        api.mock(putRequest, value: .make(data: .init(mobile_consent: true)))
+
+        XCTAssertFinish(testee.setConsent(true))
+
+        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, true)
+    }
+
     // MARK: - Private helpers
 
     private func mockFeatureFlags(sendUsageMetrics: Bool, cookieConsentNecessary: Bool) {

--- a/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
@@ -89,6 +89,26 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
         )
     }
 
+    func test_isTrackingEnabled_whenMasqueradingAndConsentRequired_shouldReturnFalse() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.isTrackingEnabled(ignoreConsentCache: true),
+            false
+        )
+    }
+
+    func test_isTrackingEnabled_whenMasqueradingAndConsentNotRequired_shouldReturnTrue() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.isTrackingEnabled(ignoreConsentCache: true),
+            true
+        )
+    }
+
     // MARK: - getConsentIfRequired
 
     func test_getConsentIfRequired_whenConsentNotRequired_shouldReturnNil() {
@@ -130,6 +150,26 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
         )
     }
 
+    func test_getConsentIfRequired_whenMasqueradingAndConsentRequired_shouldReturnFalse() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getConsentIfRequired(ignoreConsentCache: true),
+            false
+        )
+    }
+
+    func test_getConsentIfRequired_whenMasqueradingAndConsentNotRequired_shouldReturnNil() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getConsentIfRequired(ignoreConsentCache: true),
+            nil
+        )
+    }
+
     // MARK: - setConsent
 
     func test_setConsent_shouldPersistConsentValueInCoreData() {
@@ -140,6 +180,12 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
 
         let stored: [CDAnalyticsConsent] = databaseClient.fetch()
         XCTAssertEqual(stored.first?.consentValue, true)
+    }
+
+    func test_setConsent_whenMasquerading_shouldFail() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+
+        XCTAssertFailure(testee.setConsent(true))
     }
 
     // MARK: - Storing consent in session defaults
@@ -169,6 +215,16 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
         XCTAssertFinish(testee.isTrackingEnabled(ignoreConsentCache: true))
 
         XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, true)
+    }
+
+    func test_isTrackingEnabled_whenMasqueradingAndConsentRequired_shouldStoreConsentValueFalseInSessionDefaults() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+        environment.userDefaults?.userProvidedAnalyticsConsent = true
+        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+
+        XCTAssertFinish(testee.isTrackingEnabled(ignoreConsentCache: true))
+
+        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, false)
     }
 
     func test_setConsent_shouldStoreConsentValueInSessionDefaults() {

--- a/Core/CoreTests/Features/Login/APIOAuthTests.swift
+++ b/Core/CoreTests/Features/Login/APIOAuthTests.swift
@@ -82,4 +82,39 @@ class APIOAuthTests: CoreTestCase {
             URLQueryItem(name: "return_to", value: "/?display=borderless&as_user_id=42")
         ])
     }
+
+    // MARK: - mobile_consent query param
+
+    func test_getWebSessionRequest_whenUserProvidedConsentIsTrue_shouldIncludeMobileConsentParam() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = true
+
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [
+            URLQueryItem(name: "mobile_consent", value: "true")
+        ])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless"),
+            URLQueryItem(name: "mobile_consent", value: "true")
+        ])
+    }
+
+    func test_getWebSessionRequest_whenUserProvidedConsentIsFalse_shouldIncludeMobileConsentParam() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = false
+
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [
+            URLQueryItem(name: "mobile_consent", value: "false")
+        ])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless"),
+            URLQueryItem(name: "mobile_consent", value: "false")
+        ])
+    }
+
+    func test_getWebSessionRequest_whenUserProvidedConsentIsNil_shouldNotIncludeMobileConsentParam() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = nil
+
+        XCTAssertEqual(GetWebSessionRequest(to: nil).queryItems, [])
+        XCTAssertEqual(GetWebSessionRequest(to: URL(string: "/")).queryItems, [
+            URLQueryItem(name: "return_to", value: "/?display=borderless")
+        ])
+    }
 }

--- a/Core/TestsFoundation/Mocks/TestEnvironment.swift
+++ b/Core/TestsFoundation/Mocks/TestEnvironment.swift
@@ -27,7 +27,9 @@ public class TestEnvironment: AppEnvironment {
 
     override public init() {
         super.init()
+
         let session = LoginSession.make()
+
         self.api = API(session)
         self.database = singleSharedTestDatabase
         self.globalDatabase = singleSharedTestDatabase
@@ -35,6 +37,8 @@ public class TestEnvironment: AppEnvironment {
         self.logger = TestLogger()
         self.currentSession = session
         self.userDefaults = SessionDefaults(sessionID: session.uniqueID)
+
+        userDefaults?.reset()
     }
 
     override public func subscribe<U>(_ useCase: U, _ callback: @escaping Store<U>.EventHandler = { }) -> Store<U> where U: UseCase {

--- a/Student/StudentUnitTests/StudentTestCase.swift
+++ b/Student/StudentUnitTests/StudentTestCase.swift
@@ -62,7 +62,6 @@ class StudentTestCase: XCTestCase {
         logger = env.logger as? TestLogger
         currentSession = env.currentSession
         userDefaults = env.userDefaults!
-        userDefaults.reset()
         analytics = .init()
         Analytics.shared.handler = analytics
         AppEnvironment.shared = env


### PR DESCRIPTION
## PR Info

refs: [MBL-19876](https://instructure.atlassian.net/browse/MBL-19876)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: none

## What's new
- When consent is required `/login/session_token` requests now has the `mobile_consent` query item
- When consent is required ActAsUser sessions
  - don't display the consent dialog
  - disable tracking
  - disallow enabling the consent in Settings menu (it's still visible es disabled, but toggling it fails)

## Test Plan
The consent choice can be cleared from the Developer Menu for debug builds, for testing purposes.

Enable `send_usage_metrics` FF (not available in all sandboxes)
Enable `cookie_consent_necessary` FF (available only after the above FF is enabled)
Verify `mobile_consent` has the proper value when consent is required
Verify `mobile_consent` is omitted when consent is not required (change the FFs accordingly)

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product

[MBL-19876]: https://instructure.atlassian.net/browse/MBL-19876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ