### PR TITLE
[MBL-19796][S] Offline Mode - Add offline sync support for Studio videos in course modules

### DIFF
--- a/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/URLExtensions.swift
@@ -317,3 +317,9 @@ public extension Array where Element == URL {
         }
     }
 }
+
+public extension URL {
+    var isStudioMediaLTILaunchURL: Bool {
+        path().hasSuffix("lti/launch") && queryValue(for: "custom_arc_media_id") != nil
+    }
+}

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractor.swift
@@ -565,6 +565,10 @@ public final class CourseSyncInteractorLive: CourseSyncInteractor {
             downloaders.append(modulesDownloaders)
         }
 
+        downloaders.append(
+            modulesInteractor.createStudioModulePlaceholders(courseId: entry.syncID, moduleItems: moduleItems)
+        )
+
         return downloaders
     }
 
@@ -732,6 +736,8 @@ private extension Collection where Element == ModuleItem {
                 return false
             case .discussion:
                 return false
+            case .externalTool:
+                return true
             default:
                 return true
             }

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -22,6 +22,7 @@ import Foundation
 public protocol CourseSyncModulesInteractor {
     func getModuleItems(courseId: CourseSyncID) -> AnyPublisher<[ModuleItem], Error>
     func getAssociatedModuleItems(courseId: CourseSyncID, moduleItemTypes: Set<TabName>, moduleItems: [ModuleItem]) -> AnyPublisher<Void, Error>
+    func createStudioModulePlaceholders(courseId: CourseSyncID, moduleItems: [ModuleItem]) -> AnyPublisher<Void, Error>
 }
 
 public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor {
@@ -98,6 +99,7 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
             if type == .files {
                 downloaders.append(getModuleFiles(filesInteractor: filesInteractor, courseId: courseId, moduleItems: moduleItems))
             }
+
         }
 
         return downloaders.zip()
@@ -139,6 +141,31 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
                 )
                 .getEntities(ignoreCache: true)
                 .parseHtmlContent(attribute: \.details, id: \.id, courseId: courseId, baseURLKey: \.htmlURL, htmlParser: quizHtmlParser)
+            }
+            .collect()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    public func createStudioModulePlaceholders(
+        courseId: CourseSyncID,
+        moduleItems: [ModuleItem]
+    ) -> AnyPublisher<Void, Error> {
+        let studioItems = moduleItems.filter { $0.type?.studioMediaLTILaunchID != nil }
+
+        return studioItems.publisher
+            .tryMap { [envResolver] item in
+                guard let ltiLaunchID = item.type?.studioMediaLTILaunchID else { return }
+                let folderURL = URL.Paths.Offline.courseSectionResourceFolderURL(
+                    sessionId: envResolver.sessionId(for: courseId),
+                    courseId: courseId.value,
+                    sectionName: OfflineFolderPrefix.studioModuleItems.rawValue,
+                    resourceId: item.id
+                )
+                let htmlURL = folderURL.appendingPathComponent("body.html")
+                let html = "<html><body><iframe src=\"/?custom_arc_media_id%3D\(ltiLaunchID)\"></iframe></body></html>"
+                try FileManager.default.createDirectory(at: folderURL, withIntermediateDirectories: true)
+                try html.write(to: htmlURL, atomically: true, encoding: .utf8)
             }
             .collect()
             .mapToVoid()
@@ -208,5 +235,10 @@ private extension ModuleItemType {
         } else {
             return nil
         }
+    }
+
+    var studioMediaLTILaunchID: String? {
+        guard case let .externalTool(_, url) = self else { return nil }
+        return url.queryValue(for: "custom_arc_media_id")
     }
 }

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -99,7 +99,6 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
             if type == .files {
                 downloaders.append(getModuleFiles(filesInteractor: filesInteractor, courseId: courseId, moduleItems: moduleItems))
             }
-
         }
 
         return downloaders.zip()

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractor.swift
@@ -150,11 +150,13 @@ public final class CourseSyncModulesInteractorLive: CourseSyncModulesInteractor 
         courseId: CourseSyncID,
         moduleItems: [ModuleItem]
     ) -> AnyPublisher<Void, Error> {
-        let studioItems = moduleItems.filter { $0.type?.studioMediaLTILaunchID != nil }
+        let studioItems = moduleItems.compactMap { item -> (ModuleItem, String)? in
+            guard let id = item.type?.studioMediaLTILaunchID else { return nil }
+            return (item, id)
+        }
 
         return studioItems.publisher
-            .tryMap { [envResolver] item in
-                guard let ltiLaunchID = item.type?.studioMediaLTILaunchID else { return }
+            .tryMap { [envResolver] (item, ltiLaunchID) in
                 let folderURL = URL.Paths.Offline.courseSectionResourceFolderURL(
                     sessionId: envResolver.sessionId(for: courseId),
                     courseId: courseId.value,

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractor.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncStudioMediaInteractor.swift
@@ -169,13 +169,24 @@ public class CourseSyncStudioMediaInteractorLive: CourseSyncStudioMediaInteracto
             .collect()
             .tryMap { [studioIFrameReplaceInteractor] offlineVideos in
 
+                var catchedErrors: [Error] = []
                 for (htmlURL, iframes) in mediaData.iframes {
-                    try studioIFrameReplaceInteractor.replaceStudioIFrames(
-                        inHtmlAtURL: htmlURL,
-                        iframes: iframes,
-                        offlineVideos: offlineVideos
-                    )
+
+                    do {
+                        try studioIFrameReplaceInteractor.replaceStudioIFrames(
+                            inHtmlAtURL: htmlURL,
+                            iframes: iframes,
+                            offlineVideos: offlineVideos
+                        )
+                    } catch {
+                        catchedErrors.append(error)
+                    }
                 }
+
+                // This is to avoid blocking the whole replacing process
+                // if a single iframe failed to be replaced.
+                if let lastError = catchedErrors.last { throw lastError }
+
                 return ()
             }
             .eraseToAnyPublisher()

--- a/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/HTMLParser/OfflineFolderPrefix.swift
+++ b/Core/Core/Features/CourseSync/CourseSyncDownloader/Model/HTMLParser/OfflineFolderPrefix.swift
@@ -25,4 +25,5 @@ public enum OfflineFolderPrefix: String {
     case discussions
     case quizzes
     case calendarEvents
+    case studioModuleItems
 }

--- a/Core/Core/Features/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Features/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -115,7 +115,16 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         updateNavBar()
     }
 
-    private var viewTitle: String {
+    private func updateNavBar() {
+        // When embedded view controllers adapt course color for their own spinner view,
+        // we should enable this line below.
+        // spinnerView.color = course.first?.color
+        if #available(iOS 26, *) {
+            navigationItem.subtitle = course.first?.name
+        } else {
+            updateNavBar(subtitle: course.first?.name, color: course.first?.color)
+        }
+
         let title: String
         switch item?.type {
         case .assignment:
@@ -137,23 +146,11 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         case nil, .subHeader:
             title = String(localized: "Module Item", bundle: .core)
         }
-        return title
-    }
-
-    private func updateNavBar() {
-        // When embedded view controllers adapt course color for their own spinner view,
-        // we should enable this line below.
-//        spinnerView.color = course.first?.color
-        if #available(iOS 26, *) {
-            navigationItem.subtitle = course.first?.name
-        } else {
-            updateNavBar(subtitle: course.first?.name, color: course.first?.color)
-        }
 
         if #available(iOS 26, *) {
-            navigationItem.title = viewTitle
+            navigationItem.title = title
         } else {
-            setupTitleViewInNavbar(title: viewTitle)
+            setupTitleViewInNavbar(title: title)
         }
 
         if item?.completionRequirementType == .must_mark_done {
@@ -170,14 +167,12 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         case let .externalTool(toolID, url):
 
             if isOfflineStudioItem, let sessionID = env.currentSession?.uniqueID {
-                let offlineView = StudioOfflineModuleItemViewController.create(
+                return StudioOfflineModuleItemViewController.create(
                     sessionID: sessionID,
                     courseID: courseID,
                     moduleItemID: itemID,
                     title: item.title
                 )
-                offlineView.title = viewTitle
-                return offlineView
             }
 
             let tools = LTITools(

--- a/Core/Core/Features/Modules/ModuleItems/ModuleItemDetailsViewController.swift
+++ b/Core/Core/Features/Modules/ModuleItems/ModuleItemDetailsViewController.swift
@@ -23,6 +23,7 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
     var courseID: String!
     var moduleID: String!
     var itemID: String!
+    var offlineModeInteractor: OfflineModeInteractor = OfflineModeAssembly.make()
 
     @IBOutlet weak var container: UIView!
     @IBOutlet weak var errorView: ListErrorView!
@@ -51,6 +52,13 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
     private var item: ModuleItem? { store.first }
     private var observations: [NSKeyValueObservation]?
     private var isMarkingModule = false
+    private var isOfflineStudioItem: Bool {
+        guard
+            offlineModeInteractor.isNetworkOffline(),
+            case let .externalTool(_, url) = item?.type
+        else { return false }
+        return url.isStudioMediaLTILaunchURL
+    }
 
     public static func create(env: AppEnvironment, courseID: String, moduleID: String, itemID: String) -> Self {
         let controller = loadFromStoryboard()
@@ -107,22 +115,15 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         updateNavBar()
     }
 
-    private func updateNavBar() {
-        // When embedded view controllers adapt course color for their own spinner view,
-        // we should enable this line below.
-//        spinnerView.color = course.first?.color
-        if #available(iOS 26, *) {
-            navigationItem.subtitle = course.first?.name
-        } else {
-            updateNavBar(subtitle: course.first?.name, color: course.first?.color)
-        }
-
+    private var viewTitle: String {
         let title: String
         switch item?.type {
         case .assignment:
             title = String(localized: "Assignment Details", bundle: .core)
         case .discussion:
             title = String(localized: "Discussion Details", bundle: .core)
+        case .externalTool where isOfflineStudioItem:
+            title = item?.title ?? String(localized: "External Tool", bundle: .core)
         case .externalTool:
             title = String(localized: "External Tool", bundle: .core)
         case .externalURL:
@@ -136,11 +137,23 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         case nil, .subHeader:
             title = String(localized: "Module Item", bundle: .core)
         }
+        return title
+    }
+
+    private func updateNavBar() {
+        // When embedded view controllers adapt course color for their own spinner view,
+        // we should enable this line below.
+//        spinnerView.color = course.first?.color
+        if #available(iOS 26, *) {
+            navigationItem.subtitle = course.first?.name
+        } else {
+            updateNavBar(subtitle: course.first?.name, color: course.first?.color)
+        }
 
         if #available(iOS 26, *) {
-            navigationItem.title = title
+            navigationItem.title = viewTitle
         } else {
-            setupTitleViewInNavbar(title: title)
+            setupTitleViewInNavbar(title: viewTitle)
         }
 
         if item?.completionRequirementType == .must_mark_done {
@@ -155,6 +168,18 @@ public final class ModuleItemDetailsViewController: UIViewController, ColoredNav
         case .externalURL(let url):
             return ExternalURLViewController.create(env: env, name: item.title, url: url, courseID: item.courseID)
         case let .externalTool(toolID, url):
+
+            if isOfflineStudioItem, let sessionID = env.currentSession?.uniqueID {
+                let offlineView = StudioOfflineModuleItemViewController.create(
+                    sessionID: sessionID,
+                    courseID: courseID,
+                    moduleItemID: itemID,
+                    title: item.title
+                )
+                offlineView.title = viewTitle
+                return offlineView
+            }
+
             let tools = LTITools(
                 context: .course(courseID),
                 id: toolID,

--- a/Core/Core/Features/Modules/ModuleItems/StudioOfflineModuleItemViewController.swift
+++ b/Core/Core/Features/Modules/ModuleItems/StudioOfflineModuleItemViewController.swift
@@ -1,0 +1,74 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import UIKit
+
+public final class StudioOfflineModuleItemViewController: UIViewController {
+    private let webView = CoreWebView(features: [])
+    private let sessionID: String
+    private let courseID: String
+    private let moduleItemID: String
+
+    public static func create(
+        sessionID: String,
+        courseID: String,
+        moduleItemID: String,
+        title: String
+    ) -> StudioOfflineModuleItemViewController {
+        let vc = StudioOfflineModuleItemViewController(
+            sessionID: sessionID,
+            courseID: courseID,
+            moduleItemID: moduleItemID
+        )
+        vc.navigationItem.title = title
+        return vc
+    }
+
+    private init(sessionID: String, courseID: String, moduleItemID: String) {
+        self.sessionID = sessionID
+        self.courseID = courseID
+        self.moduleItemID = moduleItemID
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { nil }
+
+    public override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .backgroundLightest
+        view.addSubview(webView)
+        webView.pinWithThemeSwitchButton(inside: view)
+        loadOfflineContent()
+    }
+
+    private func loadOfflineContent() {
+        let filePath = URL.Paths.Offline.courseSectionResourceFolderURL(
+            sessionId: sessionID,
+            courseId: courseID,
+            sectionName: OfflineFolderPrefix.studioModuleItems.rawValue,
+            resourceId: moduleItemID
+        ).appendingPathComponent("body.html")
+
+        webView.loadContent(
+            isOffline: true,
+            filePath: filePath,
+            content: nil,
+            originalBaseURL: nil
+        )
+    }
+}

--- a/Core/Core/Features/Modules/ModuleItems/StudioOfflineModuleItemViewController.swift
+++ b/Core/Core/Features/Modules/ModuleItems/StudioOfflineModuleItemViewController.swift
@@ -36,6 +36,7 @@ public final class StudioOfflineModuleItemViewController: UIViewController {
             moduleItemID: moduleItemID
         )
         vc.navigationItem.title = title
+        vc.title = title
         return vc
     }
 

--- a/Core/CoreTests/Common/Extensions/Foundation/URLExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/Foundation/URLExtensionsTests.swift
@@ -199,6 +199,23 @@ class DatabaseURLTests: XCTestCase {
                       testee.absoluteString)
     }
 
+    // MARK: - isStudioMediaLTILaunchURL
+
+    func test_isStudioMediaLTILaunchURL_whenPathEndsWithLtiLaunchAndHasMediaId_shouldBeTrue() {
+        let url = URL(string: "https://canvas.instructure.com/courses/1/lti/launch?custom_arc_media_id=media-1")!
+        XCTAssertEqual(url.isStudioMediaLTILaunchURL, true)
+    }
+
+    func test_isStudioMediaLTILaunchURL_whenPathEndsWithLtiLaunchButNoMediaId_shouldBeFalse() {
+        let url = URL(string: "https://canvas.instructure.com/courses/1/lti/launch")!
+        XCTAssertEqual(url.isStudioMediaLTILaunchURL, false)
+    }
+
+    func test_isStudioMediaLTILaunchURL_whenHasMediaIdButPathDoesNotEndWithLtiLaunch_shouldBeFalse() {
+        let url = URL(string: "https://canvas.instructure.com/courses/1/external_tools?custom_arc_media_id=media-1")!
+        XCTAssertEqual(url.isStudioMediaLTILaunchURL, false)
+    }
+
     private func match(_ url: URL, regex pattern: String) -> Bool {
         let string = url.absoluteString
         let regexp = try! NSRegularExpression(pattern: pattern)

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -1124,7 +1124,7 @@ private class CourseSyncModulesInteractorMock2: CourseSyncModulesInteractor {
     }
 
     func createStudioModulePlaceholders(courseId _: CourseSyncID, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
-        Empty().setFailureType(to: Error.self).eraseToAnyPublisher()
+        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
 

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -1105,6 +1105,10 @@ private class CourseSyncModulesInteractorMock: CourseSyncModulesInteractor {
     func getAssociatedModuleItems(courseId _: CourseSyncID, moduleItemTypes _: Set<Core.TabName>, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
         Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
+
+    func createStudioModulePlaceholders(courseId _: CourseSyncID, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
+        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+    }
 }
 
 private class CourseSyncModulesInteractorMock2: CourseSyncModulesInteractor {
@@ -1117,6 +1121,10 @@ private class CourseSyncModulesInteractorMock2: CourseSyncModulesInteractor {
 
     func getAssociatedModuleItems(courseId _: CourseSyncID, moduleItemTypes _: Set<Core.TabName>, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
         associatedModuleItemsPublisher.eraseToAnyPublisher()
+    }
+
+    func createStudioModulePlaceholders(courseId _: CourseSyncID, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
+        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
 

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/CourseSyncInteractorLiveTests.swift
@@ -1107,7 +1107,7 @@ private class CourseSyncModulesInteractorMock: CourseSyncModulesInteractor {
     }
 
     func createStudioModulePlaceholders(courseId _: CourseSyncID, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
-        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+        Empty().setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
 
@@ -1124,7 +1124,7 @@ private class CourseSyncModulesInteractorMock2: CourseSyncModulesInteractor {
     }
 
     func createStudioModulePlaceholders(courseId _: CourseSyncID, moduleItems _: [Core.ModuleItem]) -> AnyPublisher<Void, Error> {
-        Just(()).setFailureType(to: Error.self).eraseToAnyPublisher()
+        Empty().setFailureType(to: Error.self).eraseToAnyPublisher()
     }
 }
 

--- a/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/CourseSync/CourseSyncDownloader/Model/Downloaders/CourseSyncModulesInteractorLiveTests.swift
@@ -129,6 +129,49 @@ class CourseSyncModulesInteractorLiveTests: CoreTestCase {
         subscription.cancel()
     }
 
+    // MARK: - createStudioModulePlaceholders
+
+    func test_createStudioModulePlaceholders_withStudioItem_shouldCreateHtmlFile() {
+        let mediaID = "media-1"
+        let studioURL = URL(string: "https://canvas.instructure.com/lti/launch?custom_arc_media_id=\(mediaID)")!
+        let moduleItem = ModuleItem.make(from: .make(id: "item-1", content: .externalTool("tool-1", studioURL)))
+        let sessionId = envResolver.sessionId(for: "course-1")
+        let folderURL = URL.Paths.Offline.courseSectionResourceFolderURL(
+            sessionId: sessionId,
+            courseId: "course-1",
+            sectionName: OfflineFolderPrefix.studioModuleItems.rawValue,
+            resourceId: "item-1"
+        )
+        defer { try? FileManager.default.removeItem(at: folderURL) }
+
+        XCTAssertFinish(testee.createStudioModulePlaceholders(courseId: "course-1", moduleItems: [moduleItem]))
+
+        let htmlFileURL = folderURL.appendingPathComponent("body.html")
+        let expectedHTML = "<html><body><iframe src=\"/?custom_arc_media_id%3D\(mediaID)\"></iframe></body></html>"
+        XCTAssertEqual(FileManager.default.fileExists(atPath: htmlFileURL.path), true)
+        XCTAssertEqual(try? String(contentsOf: htmlFileURL, encoding: .utf8), expectedHTML)
+    }
+
+    func test_createStudioModulePlaceholders_withNonStudioItems_shouldNotCreateFiles() {
+        let assignmentItem = ModuleItem.make(from: .make(id: "item-1", content: .assignment("assign-1")))
+        let externalToolWithoutMediaID = ModuleItem.make(
+            from: .make(id: "item-2", content: .externalTool("tool-1", URL(string: "https://canvas.instructure.com/lti/launch")!))
+        )
+
+        XCTAssertFinish(testee.createStudioModulePlaceholders(
+            courseId: "course-1",
+            moduleItems: [assignmentItem, externalToolWithoutMediaID]
+        ))
+
+        let sessionId = envResolver.sessionId(for: "course-1")
+        let sectionFolderURL = URL.Paths.Offline.courseSectionFolderURL(
+            sessionId: sessionId,
+            courseId: "course-1",
+            sectionName: OfflineFolderPrefix.studioModuleItems.rawValue
+        )
+        XCTAssertEqual(FileManager.default.fileExists(atPath: sectionFolderURL.path), false)
+    }
+
     private func mockModules() {
         api.mock(
             GetModulesRequest(courseID: "course-1"),


### PR DESCRIPTION
## PR Info

refs: [MBL-19796](https://instructure.atlassian.net/browse/MBL-19796)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: Studio videos in course modules can now be synced for offline mode.

## PR Description

**Add offline sync support for Studio videos in course modules**

Studio media module items are identified via the `custom_arc_media_id` query parameter on their LTI launch URL. During course sync, `createStudioModulePlaceholders` writes a `body.html` placeholder for each such item under the offline course directory:

```
Offline/<sessionId>/course-<id>/studioModuleItems/studioModuleItems-<itemId>/body.html
```

The placeholder contains an iframe with the percent-encoded media ID:
```html
<html><body><iframe src="/?custom_arc_media_id%3D<mediaID>"></iframe></body></html>
```

This piggybacks on the existing `StudioIFrameDiscoveryInteractor`, which already scans every `*.html` file in the offline course directory looking for `custom_arc_media_id%3D` iframes. By writing the placeholder into that same directory tree, module-based Studio items are automatically picked up by the discovery pass and queued for download by `CourseSyncStudioMediaInteractor` — no changes needed in those components.

When the device is offline and the user opens the module item, `ModuleItemDetailsViewController` routes to `StudioOfflineModuleItemViewController`, which loads the placeholder HTML via `CoreWebView`. The Studio offline player handles playback from there.

**Changes:**
- `CourseSyncModulesInteractor` — `createStudioModulePlaceholders` writes one placeholder `body.html` per Studio module item
- `CourseSyncInteractor` — calls `createStudioModulePlaceholders` in the modules sync pipeline; marks `externalTool` items as syncable
- `StudioOfflineModuleItemViewController` — new VC that loads the Studio placeholder HTML for offline playback
- `ModuleItemDetailsViewController` — routes offline Studio items to `StudioOfflineModuleItemViewController`; shows the item's title in the nav bar
- `URL.isStudioMediaLTILaunchURL` — helper to detect Studio LTI launch URLs
- `OfflineFolderPrefix.studioModuleItems` — new folder prefix constant

---

## Test Plan

- [ ] **Offline Studio playback** — Sync a course with a Studio video module item. Go offline. Open the module → tap the item → video should play via the offline player. Nav bar title should match the item's title.
- [ ] **Non-Studio external tools offline** — Go offline and open a non-Studio external tool module item. It should show the standard error state, not the Studio player.
- [ ] **Online routing unchanged** — While online, open a Studio module item. It should open via the normal LTI flow.
- [ ] **No placeholder for non-Studio items** — Sync a course with only assignment/quiz/page module items. Confirm no `studioModuleItems` folder is created.

## Screen Recording

https://github.com/user-attachments/assets/d87a4afe-1b02-4b8e-9c57-533144ca8ba2

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19796]: https://instructure.atlassian.net/browse/MBL-19796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ