### PR TITLE
Apple Intelligence showcase

### DIFF
--- a/Core/Core/Common/CommonUI/FoundationModels/FoundationModelsStatusView.swift
+++ b/Core/Core/Common/CommonUI/FoundationModels/FoundationModelsStatusView.swift
@@ -1,0 +1,65 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import SwiftUI
+import FoundationModels
+
+struct FoundationModelsStatusView<Content: View>: View {
+    @ViewBuilder
+    let availableContent: () -> Content
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            switch SystemLanguageModel.default.availability {
+            case .available: availableContent()
+            case .unavailable(let reason):
+                Label {
+                    switch reason {
+                    case .deviceNotEligible:
+                        Text(verbatim: "The device does not support Apple Intelligence")
+                    case .appleIntelligenceNotEnabled:
+                        Text(verbatim: "Apple Intelligence is not enabled on the system")
+                    case .modelNotReady:
+                        Text(verbatim: "Apple Intelligence model is downloading")
+                    @unknown default:
+                        Text(verbatim: "Apple Intelligence is not available")
+                    }
+                } icon: {
+                    Image(systemName: "apple.intelligence.badge.xmark")
+                }
+            }
+        } else {
+            Label {
+                Text(verbatim: "Apple Intelligence requires iOS 26 or later")
+            } icon: {
+                Image(systemName: "apple.intelligence.badge.xmark")
+            }
+
+        }
+    }
+}
+
+#Preview {
+    if #available(iOS 26.0, *) {
+        FoundationModelsStatusView {
+            Text("Model is available")
+        }
+    } else {
+        Text("iOS 26 is required for this view")
+    }
+}

--- a/Core/Core/Common/CommonUI/FoundationModels/FoundationModelsStatusView.swift
+++ b/Core/Core/Common/CommonUI/FoundationModels/FoundationModelsStatusView.swift
@@ -31,7 +31,7 @@ struct FoundationModelsStatusView<Content: View>: View {
                 Label {
                     switch reason {
                     case .deviceNotEligible:
-                        Text(verbatim: "The device does not support Apple Intelligence")
+                        Text(verbatim: "This device does not support Apple Intelligence")
                     case .appleIntelligenceNotEnabled:
                         Text(verbatim: "Apple Intelligence is not enabled on the system")
                     case .modelNotReady:

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -143,8 +143,9 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                                 Image(systemName: "apple.intelligence.badge.xmark")
                             }
 
+                        } else {
+                            quickReplies
                         }
-                        quickReplies
                     }
                     .frame(maxWidth: .infinity)
                     .foregroundStyle(.textDark)

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -149,7 +149,7 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                     }
                     .frame(maxWidth: .infinity)
                     .foregroundStyle(.textDark)
-                    .padding(.top)
+                    .padding(.top, 8)
 
                     bodyView(geometry: geometry)
                     attachmentsView
@@ -182,6 +182,12 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
     @ViewBuilder
     private var quickReplies: some View {
+        let gradient = LinearGradient(
+            colors: [.blue, .purple, .red, .orange],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+
         ScrollView(.horizontal) {
             HStack {
                 ForEach(model.quickReplies, id: \.self) { quickReply in
@@ -192,7 +198,14 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                             .foregroundStyle(.textDarkest)
                             .padding(.horizontal, 12)
                             .padding(.vertical, 8)
-                            .background(.backgroundMedium, in: Capsule())
+                            .background(.backgroundLight, in: Capsule())
+                            .padding(1)
+                            .background {
+                                Capsule()
+                                    .fill(gradient)
+                                    .blur(radius: 2)
+                            }
+                            .padding(.vertical, 4)
                     }
                 }
             }

--- a/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/View/ComposeMessageView.swift
@@ -135,6 +135,21 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
                     propertiesView
                     separator
 
+                    FoundationModelsStatusView {
+                        if let errorMessage = model.generationErrorMessage {
+                            Label {
+                                Text(verbatim: errorMessage)
+                            } icon: {
+                                Image(systemName: "apple.intelligence.badge.xmark")
+                            }
+
+                        }
+                        quickReplies
+                    }
+                    .frame(maxWidth: .infinity)
+                    .foregroundStyle(.textDark)
+                    .padding(.top)
+
                     bodyView(geometry: geometry)
                     attachmentsView
                     if !model.includedMessages.isEmpty {
@@ -162,6 +177,28 @@ public struct ComposeMessageView: View, ScreenViewTrackable {
 
             }
         }
+    }
+
+    @ViewBuilder
+    private var quickReplies: some View {
+        ScrollView(.horizontal) {
+            HStack {
+                ForEach(model.quickReplies, id: \.self) { quickReply in
+                    Button {
+                        model.bodyText = quickReply
+                    } label: {
+                        Text(quickReply)
+                            .foregroundStyle(.textDarkest)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(.backgroundMedium, in: Capsule())
+                    }
+                }
+            }
+            .padding(.horizontal)
+        }
+        .scrollIndicators(.hidden)
+        .animation(.default, value: model.quickReplies)
     }
 
     @available(iOS, introduced: 26, message: "Legacy version exists")

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -112,6 +112,7 @@ final class ComposeMessageViewModel: ObservableObject {
     private var sendIndividualToggleLastValue: Bool = false
     private let maxRecipientCount = 100
 
+    
     // MARK: Public interface
     public init(
         options: ComposeMessageOptions,

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -68,7 +68,7 @@ final class ComposeMessageViewModel: ObservableObject {
     @Published public var subject: String = ""
     @Published public var selectedContext: RecipientContext?
     @Published public var conversation: Conversation?
-    @Published public private(set) var generationErrorMessage: String?
+    @Published public var generationErrorMessage: String?
     @Published public var includedMessages: [ConversationMessage] = []
     @Published public var quickReplies: [String] = []
     @Published public var attachments: [File] = []
@@ -595,13 +595,13 @@ final class ComposeMessageViewModel: ObservableObject {
 
     @available(iOS 26.0, *)
     private func generateQuickReplies() {
-        let model = SystemLanguageModel.default
-        guard let message = includedMessages.first?.body, model.isAvailable  else { return }
+        guard let message = includedMessages.first?.body, SystemLanguageModel.default.isAvailable else { return }
 
+        // ObservableObject needs changes to be published from the Main Actor, the generation happens in the background regardless
         Task { @MainActor in
             do {
                 let instructions = "Your task is to write exactly 3 **short** replies to the following message. One sentence each."
-                let session = LanguageModelSession(model: model, instructions: instructions)
+                let session = LanguageModelSession(instructions: instructions)
                 let options = GenerationOptions(temperature: 0.2)
 
                 for try await chunk in session.streamResponse(to: message, generating: [QuickReply].self, options: options) {

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -20,6 +20,7 @@ import Combine
 import CombineExt
 import CombineSchedulers
 import UIKit
+import FoundationModels
 
 final class ComposeMessageViewModel: ObservableObject {
     // MARK: - Outputs
@@ -67,7 +68,9 @@ final class ComposeMessageViewModel: ObservableObject {
     @Published public var subject: String = ""
     @Published public var selectedContext: RecipientContext?
     @Published public var conversation: Conversation?
+    @Published public private(set) var generationErrorMessage: String?
     @Published public var includedMessages: [ConversationMessage] = []
+    @Published public var quickReplies: [String] = []
     @Published public var attachments: [File] = []
     @Published public var isShowingCancelDialog = false
     @Published var showSearchRecipientsView: Bool = false
@@ -129,6 +132,10 @@ final class ComposeMessageViewModel: ObservableObject {
         self.env = env
         setIncludedMessages(messageType: options.messageType)
         setOptionItems(options: options)
+
+        if #available(iOS 26.0, *) {
+            generateQuickReplies()
+        }
 
         setupOutputBindings()
         setupInputBindings()
@@ -584,6 +591,37 @@ final class ComposeMessageViewModel: ObservableObject {
         changedMessageProperties.courseName = selectedContext?.name
         changedMessageProperties.recipients = selectedRecipients.value
         return changedMessageProperties != initialMessageProperties
+    }
+
+    @available(iOS 26.0, *)
+    private func generateQuickReplies() {
+        let model = SystemLanguageModel.default
+        guard let message = includedMessages.first?.body, model.isAvailable  else { return }
+
+        Task { @MainActor in
+            do {
+                let instructions = "Your task is to write exactly 3 **short** replies to the following message. One sentence each."
+                let session = LanguageModelSession(model: model, instructions: instructions)
+                let options = GenerationOptions(temperature: 0.2)
+
+                for try await chunk in session.streamResponse(to: message, generating: [QuickReply].self, options: options) {
+                    quickReplies = chunk.content.map { $0.body ?? "" }
+                }
+            } catch let error as LanguageModelSession.GenerationError {
+                debugPrint(error)
+
+                switch error {
+                case .exceededContextWindowSize: generationErrorMessage = "Message is too long to generate quick replies"
+                case .assetsUnavailable: generationErrorMessage = "Apple Intelligence got disabled"
+                case .guardrailViolation: generationErrorMessage = "The generated content violates Apple Intelligence's guardrails"
+                case .unsupportedLanguageOrLocale: generationErrorMessage = "Language is not supported by Apple Intelligence"
+                case .refusal(_, let context): generationErrorMessage = context.debugDescription
+                default: generationErrorMessage = "Failed to generate quick replies"
+                }
+            } catch {
+                debugPrint(error)
+            }
+        }
     }
 }
 

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/ComposeMessageViewModel.swift
@@ -112,7 +112,6 @@ final class ComposeMessageViewModel: ObservableObject {
     private var sendIndividualToggleLastValue: Bool = false
     private let maxRecipientCount = 100
 
-    
     // MARK: Public interface
     public init(
         options: ComposeMessageOptions,

--- a/Core/Core/Features/Inbox/ComposeMessage/ViewModel/QuickReply.swift
+++ b/Core/Core/Features/Inbox/ComposeMessage/ViewModel/QuickReply.swift
@@ -1,0 +1,25 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import FoundationModels
+
+@available(iOS 26.0, *)
+@Generable
+struct QuickReply {
+    let body: String
+}


### PR DESCRIPTION
## PR Info

refs: 
builds: Student, Parent, Teacher
affects: Student, Parent, Teacher
release note: none

## [Apple Intelligence](https://www.apple.com/apple-intelligence/)

Showcase of Apple Intelligence.
Requirements:
- iOS 26
- iPhone 15 Pro or later
- Apple Intelligence enabled in Settings

## Test Plan

Reply to a conversation from Inbox. The Quick Replies should appear. If not, there should be an explanation why.

## Screenshots

<img src="https://github.com/user-attachments/assets/da608e80-28ba-4263-bb37-ab66123e1509" maxWidth=200>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product
