### PR TITLE
[MBL-19967][S/T/P] Privacy Consent - Logic update

### DIFF
--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractor.swift
@@ -21,19 +21,27 @@ import Foundation
 
 public protocol AnalyticsConsentInteractor {
 
-    /// Returns whether analytics tracking is enabled.
-    /// - Returns `true` or `false` if feature flags govern that it's always enabled/disabled.
-    ///   In this case no consent is required.
-    /// - Returns `false` if the user is masqueareding.
-    /// - Returns `true` or `false` if consent is required and the user had already chosen.
-    /// - Returns `nil` if consent is required but it's not yet provided by the user.
-    func isTrackingEnabled() -> AnyPublisher<Bool?, Error>
+    /// Returns whether analytics tracking is enabled, disabled or consent is needed.
+    /// - Returns `.trackingEnabled`
+    ///   - if feature flags govern that it's always enabled (no consent required),
+    ///   - OR if consent is required and the user had already accepted.
+    /// - Returns `.trackingDisabled`
+    ///   - if feature flags govern that it's always disabled (no consent required),
+    ///   - OR if consent is required and the user had already declined (for the given device),
+    ///   - OR if the user is masqueareding.
+    /// - Returns `.askForConsent`
+    ///   - if consent is required but it's not yet provided by the user.
+    func getTrackingPolicy(ignoreCache: Bool) -> AnyPublisher<TrackingPolicy, Error>
+
+    /// Returns `true` when consent is required based on feature flags and the user is not masqueareding.
+    /// Ignores whether user consent was given or not.
+    func isConsentRequired(ignoreCache: Bool) -> AnyPublisher<Bool, Error>
 
     /// Returns the value of the analytics tracking consent, if any.
     /// - Returns `true` or `false` if consent is required and the user had already chosen.
     /// - Returns `nil` if consent is not required (or if the user had not yet provided it).
     /// - Returns `nil` if the user is masqueareding.
-    func getConsentIfRequired(ignoreCache: Bool) -> AnyPublisher<Bool?, Error>
+    func getConsentIfRequired() -> AnyPublisher<Bool?, Error>
 
     /// Sets the consent to `value`.
     func setConsent(_ value: Bool) throws
@@ -48,6 +56,7 @@ extension AnalyticsConsentInteractor where Self == AnalyticsConsentInteractorLiv
 public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
 
     private let featureFlagStore: ReactiveStore<GetEnvironmentFeatureFlags>
+    private let userSettingsStore: ReactiveStore<GetUserSettings>
 
     private var userProvidedConsent: Bool? {
         get { environment.userDefaults?.userProvidedAnalyticsConsent }
@@ -63,54 +72,82 @@ public class AnalyticsConsentInteractorLive: AnalyticsConsentInteractor {
             useCase: GetEnvironmentFeatureFlags(context: Context.currentUser),
             backgroundEnv: environment
         )
+
+        self.userSettingsStore = ReactiveStore(
+            useCase: GetUserSettings(),
+            backgroundEnv: environment
+        )
     }
 
-    public func isTrackingEnabled() -> AnyPublisher<Bool?, Error> {
-        featureFlagStore
-            .getEntities()
-            .map { [weak self] featureFlags in
-                guard let self else { return nil }
+    public func getTrackingPolicy(ignoreCache: Bool) -> AnyPublisher<TrackingPolicy, Error> {
+        getPreConsentTrackingPolicy(ignoreCache: ignoreCache)
+            .map { [weak self] preConsentPolicy in
+                guard let self else { return .trackingDisabled }
 
-                if let value = isTrackingEnabledPreConsent(featureFlags: featureFlags) {
+                // return predefined enabled/disabled policy
+                if preConsentPolicy.isPredefined {
                     clearUserProvidedConsent()
-                    return value
+                    return preConsentPolicy
                 }
+
+                // return user consent based policy
+                if let userProvidedConsent {
+                    return userProvidedConsent ? .trackingEnabled : .trackingDisabled
+                }
+
+                return .askForConsent
+            }
+            .eraseToAnyPublisher()
+    }
+
+    public func isConsentRequired(ignoreCache: Bool) -> AnyPublisher<Bool, Error> {
+        getPreConsentTrackingPolicy(ignoreCache: ignoreCache)
+            .map { $0 == .askForConsent }
+            .eraseToAnyPublisher()
+    }
+
+    public func getConsentIfRequired() -> AnyPublisher<Bool?, Error> {
+        getPreConsentTrackingPolicy(ignoreCache: false)
+            .map { [weak self] in
+                guard $0 == .askForConsent,
+                      let userProvidedConsent = self?.userProvidedConsent
+                else { return nil }
 
                 return userProvidedConsent
             }
             .eraseToAnyPublisher()
     }
 
-    public func getConsentIfRequired(ignoreCache: Bool) -> AnyPublisher<Bool?, Error> {
+    private func getPreConsentTrackingPolicy(ignoreCache: Bool) -> AnyPublisher<TrackingPolicy, Error> {
+        if isMasqueareding {
+            return Publishers.typedJust(.trackingDisabled)
+        }
+
+        return userSettingsStore
+            .getEntities(ignoreCache: ignoreCache)
+            .map(\.first?.trackingPolicy)
+            .flatMap { [weak self] trackingPolicy -> AnyPublisher<TrackingPolicy, Error> in
+                guard let self else { return Publishers.noInstanceFailure() }
+
+                if let trackingPolicy {
+                    return Publishers.typedJust(trackingPolicy)
+                }
+
+                return getLegacyTrackingFlag(ignoreCache: ignoreCache)
+                    .map { $0 ? .trackingEnabled : .trackingDisabled }
+                    .eraseToAnyPublisher()
+            }
+            .eraseToAnyPublisher()
+    }
+
+    /// We use this FF as a fallback in case `user/self/settings` does not return the `user_metrics` field.
+    /// Once that field is reliably returned, we won't need this fallback anymore.
+    /// (The FF's value will be already checked on backend side.)
+    private func getLegacyTrackingFlag(ignoreCache: Bool) -> AnyPublisher<Bool, Error> {
         featureFlagStore
             .getEntities(ignoreCache: ignoreCache)
-            .map { [weak self] featureFlags in
-                guard let self else { return nil }
-
-                if isTrackingEnabledPreConsent(featureFlags: featureFlags) != nil {
-                    clearUserProvidedConsent()
-                    return nil
-                }
-
-                return userProvidedConsent
-            }
+            .map { $0.isFeatureEnabled(.send_usage_metrics) }
             .eraseToAnyPublisher()
-    }
-
-    private func isTrackingEnabledPreConsent(featureFlags: [FeatureFlag]) -> Bool? {
-        if isMasqueareding {
-            return false
-        }
-
-        guard featureFlags.isFeatureEnabled(.send_usage_metrics) else {
-            return false
-        }
-
-        if featureFlags.isFeatureEnabled(.cookie_consent_necessary) {
-            return nil
-        } else {
-            return true
-        }
     }
 
     public func setConsent(_ value: Bool) throws {

--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorMock.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorMock.swift
@@ -23,19 +23,27 @@ public final class AnalyticsConsentInteractorMock: AnalyticsConsentInteractor {
 
     public init() { }
 
-    // MARK: - isTrackingEnabled
+    // MARK: - getTrackingPolicy
 
-    public var isTrackingEnabledResult: Bool? = false
+    public var getTrackingPolicyResult: TrackingPolicy = .trackingDisabled
 
-    public func isTrackingEnabled() -> AnyPublisher<Bool?, Error> {
-        Publishers.typedJust(isTrackingEnabledResult)
+    public func getTrackingPolicy(ignoreCache: Bool) -> AnyPublisher<TrackingPolicy, Error> {
+        Publishers.typedJust(getTrackingPolicyResult)
+    }
+
+    // MARK: - isConsentRequired
+
+    public var isConsentRequiredResult: Bool = false
+
+    public func isConsentRequired(ignoreCache: Bool) -> AnyPublisher<Bool, Error> {
+        Publishers.typedJust(isConsentRequiredResult)
     }
 
     // MARK: - getConsentIfRequired
 
     public var getConsentIfRequiredResult: Bool?
 
-    public func getConsentIfRequired(ignoreCache: Bool) -> AnyPublisher<Bool?, Error> {
+    public func getConsentIfRequired() -> AnyPublisher<Bool?, Error> {
         Publishers.typedJust(getConsentIfRequiredResult)
     }
 

--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
@@ -168,11 +168,12 @@ public final class AnalyticsHandlerLive: @MainActor AnalyticsHandler {
     public func handleConsentChange(to isAnalyticsEnabled: Bool, sessionStartCompletion: @escaping () -> Void) {
         if isAnalyticsEnabled {
             analyticsTracker.startSession(completion: sessionStartCompletion)
-            PageViewEventController.instance.startTracking()
         } else {
             analyticsTracker.endSession()
-            PageViewEventController.instance.endTracking()
         }
+
+        // This is internal-only tracking, it is always enabled
+        PageViewEventController.instance.startTracking()
     }
 
     public func handleEvent(_ name: String, parameters: [String: Any]?) {

--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
@@ -99,7 +99,7 @@ public final class AnalyticsHandlerLive: @MainActor AnalyticsHandler {
 
         return getUserSettings(environment: environment)
             .flatMap { [weak self] in
-                self?.isTrackingEnabled() ?? Publishers.typedEmpty()
+                self?.isTrackingEnabled() ?? Publishers.noInstanceFailure()
             }
             .receive(on: DispatchQueue.main)
             .map { [weak self] isEnabled in
@@ -128,17 +128,19 @@ public final class AnalyticsHandlerLive: @MainActor AnalyticsHandler {
             return Publishers.typedJust(false)
         }
 
-        return consentInteractor.isTrackingEnabled()
+        return consentInteractor.getTrackingPolicy(ignoreCache: false)
             .receive(on: DispatchQueue.main)
-            .flatMap { [weak self] isEnabled -> AnyPublisher<Bool, Error> in
-                // If the user had already chosen or the feature flags enforce something
-                if let isEnabled {
-                    return Publishers.typedJust(isEnabled)
-                }
+            .flatMap { [weak self] trackingPolicy -> AnyPublisher<Bool, Error> in
+                guard let self else { return Publishers.noInstanceFailure() }
 
-                // If the user must be asked
-                return self?.showAndHandleConsentDialog()
-                    ?? Publishers.typedEmpty()
+                switch trackingPolicy {
+                case .trackingEnabled:
+                    return Publishers.typedJust(true)
+                case .trackingDisabled:
+                    return Publishers.typedJust(false)
+                case .askForConsent:
+                    return showAndHandleConsentDialog()
+                }
             }
             .eraseToAnyPublisher()
     }

--- a/Core/Core/Common/CommonModels/Analytics/ScreenViewTracking/PageViewAnalytics/PageViewEventController.swift
+++ b/Core/Core/Common/CommonModels/Analytics/ScreenViewTracking/PageViewAnalytics/PageViewEventController.swift
@@ -59,6 +59,8 @@ public class PageViewEventController: NSObject {
     }
 
     public func startTracking() {
+        guard !isTrackingEnabled else { return }
+
         isTrackingEnabled = true
         resetTracking()
     }

--- a/Core/Core/Features/Profile/Settings/PrivacySettingsViewModel.swift
+++ b/Core/Core/Features/Profile/Settings/PrivacySettingsViewModel.swift
@@ -55,11 +55,16 @@ public final class PrivacySettingsViewModel {
     func loadConsent() {
         state = .loading
 
-        interactor.getConsentIfRequired(ignoreCache: false)
+        interactor.getConsentIfRequired()
             .replaceError(with: nil)
-            .compactMap { $0 } // consent value should exist already
             .receive(on: mainScheduler)
             .sink { [weak self] value in
+                // consent value should exist already
+                guard let value else {
+                    self?.state = .error
+                    return
+                }
+
                 self?.isAnalyticsEnabled = value
                 self?.state = .data
             }

--- a/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
+++ b/Core/Core/Features/Profile/Settings/ProfileSettingsViewController.swift
@@ -30,7 +30,7 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     private var isAnalyticsConsentRequired: Bool = false
     private var offlineModeInteractor = OfflineModeAssembly.make()
     private lazy var inboxSettingsInteractor = InboxSettingsInteractorLive(environment: env)
-    private lazy var analyticsConsentInteractor = AnalyticsConsentInteractorLive(environment: env)
+    private lazy var analyticsConsentInteractor: AnalyticsConsentInteractor = .live(environment: env)
     private var subscriptions = Set<AnyCancellable>()
 
     private var landingPage: LandingPage {
@@ -120,10 +120,10 @@ public class ProfileSettingsViewController: ScreenViewTrackableViewController {
     }
 
     private func loadAnalyticsConsent(isForced: Bool) {
-        analyticsConsentInteractor.getConsentIfRequired(ignoreCache: isForced)
-            .replaceError(with: nil)
-            .sink { [weak self] consentValue in
-                self?.isAnalyticsConsentRequired = consentValue != nil
+        analyticsConsentInteractor.isConsentRequired(ignoreCache: isForced)
+            .replaceError(with: false)
+            .sink { [weak self] in
+                self?.isAnalyticsConsentRequired = $0
                 self?.reloadData()
             }
             .store(in: &subscriptions)

--- a/Core/Core/Features/Users/UserSettings/API/APIUserSettings.swift
+++ b/Core/Core/Features/Users/UserSettings/API/APIUserSettings.swift
@@ -19,10 +19,14 @@
 import Foundation
 
 public struct APIUserSettings: Codable, Equatable {
+
     let manual_mark_as_read: Bool
     let collapse_global_nav: Bool
     let hide_dashcard_color_overlays: Bool
     let comment_library_suggestions_enabled: Bool
+
+    // include[]=mobile_settings
+    let usage_metrics: String?
     let pendo_mobile_student_api_key: String?
     let pendo_mobile_teacher_api_key: String?
     let pendo_mobile_parent_api_key: String?
@@ -36,6 +40,7 @@ extension APIUserSettings {
         collapse_global_nav: Bool = false,
         hide_dashcard_color_overlays: Bool = false,
         comment_library_suggestions_enabled: Bool = false,
+        usage_metrics: String? = nil,
         pendo_mobile_student_api_key: String? = nil,
         pendo_mobile_teacher_api_key: String? = nil,
         pendo_mobile_parent_api_key: String? = nil
@@ -45,6 +50,7 @@ extension APIUserSettings {
             collapse_global_nav: collapse_global_nav,
             hide_dashcard_color_overlays: hide_dashcard_color_overlays,
             comment_library_suggestions_enabled: comment_library_suggestions_enabled,
+            usage_metrics: usage_metrics,
             pendo_mobile_student_api_key: pendo_mobile_student_api_key,
             pendo_mobile_teacher_api_key: pendo_mobile_teacher_api_key,
             pendo_mobile_parent_api_key: pendo_mobile_parent_api_key

--- a/Core/Core/Features/Users/UserSettings/Entities/TrackingPolicy.swift
+++ b/Core/Core/Features/Users/UserSettings/Entities/TrackingPolicy.swift
@@ -21,6 +21,13 @@ public enum TrackingPolicy: String {
     case trackingDisabled
     case askForConsent
 
+    var isPredefined: Bool {
+        switch self {
+        case .trackingEnabled, .trackingDisabled: true
+        case .askForConsent: false
+        }
+    }
+
     init?(usageMetrics: String?) {
         guard let usageMetrics else { return nil }
 

--- a/Core/Core/Features/Users/UserSettings/Entities/TrackingPolicy.swift
+++ b/Core/Core/Features/Users/UserSettings/Entities/TrackingPolicy.swift
@@ -1,0 +1,34 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+public enum TrackingPolicy: String {
+    case trackingEnabled
+    case trackingDisabled
+    case askForConsent
+
+    init?(usageMetrics: String?) {
+        guard let usageMetrics else { return nil }
+
+        self = switch usageMetrics {
+        case "track_usage": .trackingEnabled
+        case "no_track_usage": .trackingDisabled
+        case "ask_for_consent": .askForConsent
+        default: .trackingDisabled // safest fallback in case backend introduces new values
+        }
+    }
+}

--- a/Core/Core/Features/Users/UserSettings/Entities/UserSettings.swift
+++ b/Core/Core/Features/Users/UserSettings/Entities/UserSettings.swift
@@ -27,6 +27,12 @@ public final class UserSettings: NSManagedObject, WriteableModel {
     @NSManaged public var hideDashcardColorOverlays: Bool
     @NSManaged public var commentLibrarySuggestionsEnabled: Bool
 
+    @NSManaged private var trackingPolicyRaw: String?
+    public var trackingPolicy: TrackingPolicy? {
+        get { trackingPolicyRaw.flatMap { .init(rawValue: $0) } }
+        set { trackingPolicyRaw = newValue?.rawValue }
+    }
+
     @discardableResult
     public static func save(_ item: APIUserSettings, in context: NSManagedObjectContext) -> UserSettings {
         let model: UserSettings = context.fetch(nil).first ?? context.insert()
@@ -34,6 +40,7 @@ public final class UserSettings: NSManagedObject, WriteableModel {
         model.collapseGlobalNav = item.collapse_global_nav
         model.hideDashcardColorOverlays = item.hide_dashcard_color_overlays
         model.commentLibrarySuggestionsEnabled = item.comment_library_suggestions_enabled
+        model.trackingPolicy = .init(usageMetrics: item.usage_metrics)
         return model
     }
 }

--- a/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
+++ b/Core/Core/Resources/Database.xcdatamodeld/Database.xcdatamodel/contents
@@ -1553,6 +1553,7 @@
         <attribute name="commentLibrarySuggestionsEnabled" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="hideDashcardColorOverlays" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="manualMarkAsRead" attributeType="Boolean" usesScalarValueType="YES"/>
+        <attribute name="trackingPolicyRaw" optional="YES" attributeType="String"/>
     </entity>
     <entity name="CDDashboardWeeklySummaryEntry" representedClassName="Core.CDDashboardWeeklySummaryEntry" syncable="YES">
         <attribute name="categoryRaw" attributeType="String"/>

--- a/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsConsent/Model/AnalyticsConsentInteractorTests.swift
@@ -24,6 +24,7 @@ import TestsFoundation
 final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
 
     private static let featureFlagRequest = GetEnvironmentFeatureFlagsRequest(context: .currentUser)
+    private static let userSettingsRequest = GetUserSettingsRequest(userID: "self")
 
     private var testee: AnalyticsConsentInteractorLive!
 
@@ -38,131 +39,167 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
         super.tearDown()
     }
 
-    // MARK: - isTrackingEnabled
+    // MARK: - getTrackingPolicy
 
-    func test_isTrackingEnabled_whenSendUsageMetricsFlagIsOff_shouldReturnFalse() {
-        mockFeatureFlags(sendUsageMetrics: false, cookieConsentNecessary: false)
+    func test_getTrackingPolicy_whenUserSettingsHasTrackingEnabled_shouldReturnTrackingEnabled() {
+        mockUserSettings(usageMetrics: "track_usage")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
-            false
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingEnabled
         )
     }
 
-    func test_isTrackingEnabled_whenSendUsageMetricsIsOnAndConsentNotRequired_shouldReturnTrue() {
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
+    func test_getTrackingPolicy_whenUserSettingsHasTrackingDisabled_shouldReturnTrackingDisabled() {
+        mockUserSettings(usageMetrics: "no_track_usage")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
-            true
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingDisabled
         )
     }
 
-    func test_isTrackingEnabled_whenConsentRequiredAndUserAccepted_shouldReturnTrue() {
+    func test_getTrackingPolicy_whenConsentRequiredAndUserAccepted_shouldReturnTrackingEnabled() {
         environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+        mockUserSettings(usageMetrics: "ask_for_consent")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingEnabled
+        )
+    }
+
+    func test_getTrackingPolicy_whenConsentRequiredAndUserDeclined_shouldReturnTrackingDisabled() {
+        environment.userDefaults?.userProvidedAnalyticsConsent = false
+        mockUserSettings(usageMetrics: "ask_for_consent")
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingDisabled
+        )
+    }
+
+    func test_getTrackingPolicy_whenConsentRequiredAndNotYetProvided_shouldReturnAskForConsent() {
+        mockUserSettings(usageMetrics: "ask_for_consent")
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getTrackingPolicy(ignoreCache: false),
+            .askForConsent
+        )
+    }
+
+    func test_getTrackingPolicy_whenUserSettingsHasNoTrackingPolicyAndLegacyFlagIsOn_shouldReturnTrackingEnabled() {
+        mockUserSettings(usageMetrics: nil)
+        mockFeatureFlags(sendUsageMetrics: true)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingEnabled
+        )
+    }
+
+    func test_getTrackingPolicy_whenUserSettingsHasNoTrackingPolicyAndLegacyFlagIsOff_shouldReturnTrackingDisabled() {
+        mockUserSettings(usageMetrics: nil)
+        mockFeatureFlags(sendUsageMetrics: false)
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingDisabled
+        )
+    }
+
+    func test_getTrackingPolicy_whenMasquerading_shouldReturnTrackingDisabled() {
+        environment.currentSession = .make(masquerader: URL(string: "/"))
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.getTrackingPolicy(ignoreCache: false),
+            .trackingDisabled
+        )
+    }
+
+    // MARK: - isConsentRequired
+
+    func test_isConsentRequired_whenUserSettingsHasAskForConsent_shouldReturnTrue() {
+        mockUserSettings(usageMetrics: "ask_for_consent")
+
+        XCTAssertSingleOutputEqualsAndFinish(
+            testee.isConsentRequired(ignoreCache: false),
             true
         )
     }
 
-    func test_isTrackingEnabled_whenConsentRequiredAndUserDeclined_shouldReturnFalse() {
-        environment.userDefaults?.userProvidedAnalyticsConsent = false
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+    func test_isConsentRequired_whenUserSettingsHasTrackingEnabled_shouldReturnFalse() {
+        mockUserSettings(usageMetrics: "track_usage")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
+            testee.isConsentRequired(ignoreCache: false),
             false
         )
     }
 
-    func test_isTrackingEnabled_whenConsentRequiredAndNotYetProvided_shouldReturnNil() {
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+    func test_isConsentRequired_whenUserSettingsHasTrackingDisabled_shouldReturnFalse() {
+        mockUserSettings(usageMetrics: "no_track_usage")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
-            nil
-        )
-    }
-
-    func test_isTrackingEnabled_whenMasqueradingAndConsentRequired_shouldReturnFalse() {
-        environment.currentSession = .make(masquerader: URL(string: "/"))
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
-
-        XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
+            testee.isConsentRequired(ignoreCache: false),
             false
         )
     }
 
-    func test_isTrackingEnabled_whenMasqueradingAndConsentNotRequired_shouldReturnFalse() {
+    func test_isConsentRequired_whenMasquerading_shouldReturnFalse() {
         environment.currentSession = .make(masquerader: URL(string: "/"))
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.isTrackingEnabled(),
+            testee.isConsentRequired(ignoreCache: false),
             false
         )
     }
 
     // MARK: - getConsentIfRequired
 
-    func test_getConsentIfRequired_whenConsentNotRequired_shouldReturnNil() {
-        mockFeatureFlags(sendUsageMetrics: false, cookieConsentNecessary: true)
-
-        XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
-            nil
-        )
-    }
-
     func test_getConsentIfRequired_whenConsentRequiredAndUserAccepted_shouldReturnTrue() {
         environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+        mockUserSettings(usageMetrics: "ask_for_consent")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
+            testee.getConsentIfRequired(),
             true
         )
     }
 
     func test_getConsentIfRequired_whenConsentRequiredAndUserDeclined_shouldReturnFalse() {
         environment.userDefaults?.userProvidedAnalyticsConsent = false
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+        mockUserSettings(usageMetrics: "ask_for_consent")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
+            testee.getConsentIfRequired(),
             false
         )
     }
 
     func test_getConsentIfRequired_whenConsentRequiredAndNotYetProvided_shouldReturnNil() {
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+        mockUserSettings(usageMetrics: "ask_for_consent")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
+            testee.getConsentIfRequired(),
             nil
         )
     }
 
-    func test_getConsentIfRequired_whenMasqueradingAndConsentRequired_shouldReturnNil() {
-        environment.currentSession = .make(masquerader: URL(string: "/"))
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
+    func test_getConsentIfRequired_whenConsentNotRequired_shouldReturnNil() {
+        mockUserSettings(usageMetrics: "track_usage")
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
+            testee.getConsentIfRequired(),
             nil
         )
     }
 
-    func test_getConsentIfRequired_whenMasqueradingAndConsentNotRequired_shouldReturnNil() {
+    func test_getConsentIfRequired_whenMasquerading_shouldReturnNil() {
         environment.currentSession = .make(masquerader: URL(string: "/"))
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
 
         XCTAssertSingleOutputEqualsAndFinish(
-            testee.getConsentIfRequired(ignoreCache: true),
+            testee.getConsentIfRequired(),
             nil
         )
     }
@@ -181,39 +218,29 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
 
     // MARK: - Storing consent in session defaults
 
-    func test_isTrackingEnabled_whenSendUsageMetricsFlagIsOff_shouldClearConsentInSessionDefaults() {
+    func test_getTrackingPolicy_whenPredefinedPolicy_shouldClearConsentInSessionDefaults() {
         environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: false, cookieConsentNecessary: false)
+        mockUserSettings(usageMetrics: "track_usage")
 
-        XCTAssertFinish(testee.isTrackingEnabled())
+        XCTAssertFinish(testee.getTrackingPolicy(ignoreCache: false))
 
         XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, nil)
     }
 
-    func test_isTrackingEnabled_whenConsentNotRequired_shouldClearConsentInSessionDefaults() {
+    func test_getTrackingPolicy_whenConsentRequired_shouldPreserveConsentInSessionDefaults() {
         environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: false)
+        mockUserSettings(usageMetrics: "ask_for_consent")
 
-        XCTAssertFinish(testee.isTrackingEnabled())
-
-        XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, nil)
-    }
-
-    func test_isTrackingEnabled_whenConsentRequired_shouldPreserveConsentInSessionDefaults() {
-        environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
-
-        XCTAssertFinish(testee.isTrackingEnabled())
+        XCTAssertFinish(testee.getTrackingPolicy(ignoreCache: false))
 
         XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, true)
     }
 
-    func test_isTrackingEnabled_whenMasqueradingAndConsentRequired_shouldClearConsentInSessionDefaults() {
+    func test_getTrackingPolicy_whenMasquerading_shouldClearConsentInSessionDefaults() {
         environment.currentSession = .make(masquerader: URL(string: "/"))
         environment.userDefaults?.userProvidedAnalyticsConsent = true
-        mockFeatureFlags(sendUsageMetrics: true, cookieConsentNecessary: true)
 
-        XCTAssertFinish(testee.isTrackingEnabled())
+        XCTAssertFinish(testee.getTrackingPolicy(ignoreCache: false))
 
         XCTAssertEqual(environment.userDefaults?.userProvidedAnalyticsConsent, nil)
     }
@@ -226,13 +253,17 @@ final class AnalyticsConsentInteractorLiveTests: CoreTestCase {
 
     // MARK: - Private helpers
 
-    private func mockFeatureFlags(sendUsageMetrics: Bool, cookieConsentNecessary: Bool) {
+    private func mockUserSettings(usageMetrics: String?) {
+        api.mock(
+            Self.userSettingsRequest,
+            value: .make(usage_metrics: usageMetrics)
+        )
+    }
+
+    private func mockFeatureFlags(sendUsageMetrics: Bool) {
         api.mock(
             Self.featureFlagRequest,
-            value: [
-                "send_usage_metrics": sendUsageMetrics,
-                "cookie_consent_necessary": cookieConsentNecessary
-            ]
+            value: ["send_usage_metrics": sendUsageMetrics]
         )
     }
 }

--- a/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsHandlerTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/AnalyticsHandlerTests.swift
@@ -48,7 +48,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
 
     @MainActor
     func test_initializeTracking_whenTrackingIsEnabled_shouldStartSession() {
-        consentInteractor.isTrackingEnabledResult = true
+        consentInteractor.getTrackingPolicyResult = .trackingEnabled
 
         let sessionStarted = expectation(description: "session start completion called")
         XCTAssertFinish(testee.initializeTracking(environment: environment) {
@@ -62,7 +62,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
 
     @MainActor
     func test_initializeTracking_whenTrackingIsDisabled_shouldEndSession() {
-        consentInteractor.isTrackingEnabledResult = false
+        consentInteractor.getTrackingPolicyResult = .trackingDisabled
 
         XCTAssertFinish(testee.initializeTracking(environment: environment))
 
@@ -71,8 +71,8 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
     }
 
     @MainActor
-    func test_initializeTracking_whenConsentIsNil_shouldShowConsentDialogAndNotFinish() {
-        consentInteractor.isTrackingEnabledResult = nil
+    func test_initializeTracking_whenConsentNeeded_shouldShowConsentDialogAndNotFinish() {
+        consentInteractor.getTrackingPolicyResult = .askForConsent
 
         XCTAssertNoOutput(testee.initializeTracking(environment: environment))
 
@@ -82,7 +82,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
 
     @MainActor
     func test_initializeTracking_shouldSetupPendoManagerExactlyOnce() {
-        consentInteractor.isTrackingEnabledResult = true
+        consentInteractor.getTrackingPolicyResult = .trackingEnabled
 
         let sessionStarted = expectation(description: "first session start")
         XCTAssertFinish(testee.initializeTracking(environment: environment) { sessionStarted.fulfill() })
@@ -97,7 +97,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
 
     @MainActor
     func test_initializeTracking_shouldFetchUserSettings() {
-        consentInteractor.isTrackingEnabledResult = false
+        consentInteractor.getTrackingPolicyResult = .trackingDisabled
         let userSettingsFetched = expectation(description: "GetUserSettings API called")
         api.mock(GetUserSettingsRequest(userID: "self"), expectation: userSettingsFetched, value: .make())
 
@@ -111,7 +111,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
     @MainActor
     func test_storePendoApiKey_shouldUseStoredKeyToSetupPendo() {
         testee.storePendoApiKey("some remote key")
-        consentInteractor.isTrackingEnabledResult = true
+        consentInteractor.getTrackingPolicyResult = .trackingEnabled
 
         let sessionStarted = expectation(description: "session start")
         XCTAssertFinish(testee.initializeTracking(environment: environment) { sessionStarted.fulfill() })
@@ -214,7 +214,7 @@ final class AnalyticsHandlerLiveTests: CoreTestCase {
 
     @MainActor
     private func startTrackerSession() {
-        consentInteractor.isTrackingEnabledResult = true
+        consentInteractor.getTrackingPolicyResult = .trackingEnabled
         let sessionStarted = expectation(description: "session started")
         XCTAssertFinish(testee.initializeTracking(environment: environment) { sessionStarted.fulfill() })
         wait(for: [sessionStarted], timeout: 2)

--- a/Core/CoreTests/Features/Profile/Settings/PrivacySettingsViewModelTests.swift
+++ b/Core/CoreTests/Features/Profile/Settings/PrivacySettingsViewModelTests.swift
@@ -58,12 +58,12 @@ final class PrivacySettingsViewModelTests: CoreTestCase {
         XCTAssertEqual(testee.state, .data)
     }
 
-    func test_loadConsent_whenConsentIsNil_shouldNotTransitionToDataState() {
+    func test_loadConsent_whenConsentIsNil_shouldSetErrorState() {
         interactor.getConsentIfRequiredResult = nil
 
         testee.loadConsent()
 
-        XCTAssertEqual(testee.state, .loading)
+        XCTAssertEqual(testee.state, .error)
     }
 
     // MARK: - setAnalyticsConsent (via binding)

--- a/Core/CoreTests/Features/Users/UserSettings/Entities/TrackingPolicyTests.swift
+++ b/Core/CoreTests/Features/Users/UserSettings/Entities/TrackingPolicyTests.swift
@@ -1,0 +1,50 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+
+final class TrackingPolicyTests: XCTestCase {
+
+    // MARK: - init(usageMetrics:)
+
+    func test_init_withKnownValues_shouldReturnMatchingCase() {
+        // WHEN track_usage
+        var testee = TrackingPolicy(usageMetrics: "track_usage")
+        // THEN
+        XCTAssertEqual(testee, .trackingEnabled)
+
+        // WHEN no_track_usage
+        testee = TrackingPolicy(usageMetrics: "no_track_usage")
+        // THEN
+        XCTAssertEqual(testee, .trackingDisabled)
+
+        // WHEN ask_for_consent
+        testee = TrackingPolicy(usageMetrics: "ask_for_consent")
+        // THEN
+        XCTAssertEqual(testee, .askForConsent)
+    }
+
+    func test_init_whenNil_shouldReturnNil() {
+        XCTAssertEqual(TrackingPolicy(usageMetrics: nil), nil)
+    }
+
+    func test_init_whenUnknown_shouldFallbackToTrackingDisabled() {
+        XCTAssertEqual(TrackingPolicy(usageMetrics: "some_unknown_value"), .trackingDisabled)
+    }
+}

--- a/Core/CoreTests/Features/Users/UserSettings/Entities/TrackingPolicyTests.swift
+++ b/Core/CoreTests/Features/Users/UserSettings/Entities/TrackingPolicyTests.swift
@@ -47,4 +47,12 @@ final class TrackingPolicyTests: XCTestCase {
     func test_init_whenUnknown_shouldFallbackToTrackingDisabled() {
         XCTAssertEqual(TrackingPolicy(usageMetrics: "some_unknown_value"), .trackingDisabled)
     }
+
+    // MARK: - isPredefined
+
+    func test_isPredefined() {
+        XCTAssertEqual(TrackingPolicy.trackingEnabled.isPredefined, true)
+        XCTAssertEqual(TrackingPolicy.trackingDisabled.isPredefined, true)
+        XCTAssertEqual(TrackingPolicy.askForConsent.isPredefined, false)
+    }
 }

--- a/Core/CoreTests/Features/Users/UserSettings/Entities/UserSettingsTests.swift
+++ b/Core/CoreTests/Features/Users/UserSettings/Entities/UserSettingsTests.swift
@@ -36,4 +36,11 @@ class UserSettingsTests: CoreTestCase {
         XCTAssertTrue(settings.hideDashcardColorOverlays)
         XCTAssertTrue(settings.commentLibrarySuggestionsEnabled)
     }
+
+    // MARK: - trackingPolicy
+
+    func test_save_shouldPropagateUsageMetricsToTrackingPolicy() {
+        let testee = UserSettings.save(.make(usage_metrics: "ask_for_consent"), in: databaseClient)
+        XCTAssertEqual(testee.trackingPolicy, .askForConsent)
+    }
 }

--- a/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
+++ b/Parent/Parent/Profile/Settings/ViewModel/ProfileSettingsViewModel.swift
@@ -195,11 +195,10 @@ extension ProfileSettingsViewModel {
 
         let legalGroupView = SettingsGroupView(viewModel: groupViewModel)
 
-        analyticsConsentInteractor
-            .getConsentIfRequired(ignoreCache: false)
-            .replaceError(with: nil)
-            .sink { isConsentRequired in
-                privacySettingsView.viewModel.isHidden = isConsentRequired == nil
+        analyticsConsentInteractor.isConsentRequired(ignoreCache: false)
+            .replaceError(with: false)
+            .sink {
+                privacySettingsView.viewModel.isHidden = !$0
                 groupViewModel.itemViews = groupViewModel.itemViews
             }
             .store(in: &subscriptions)


### PR DESCRIPTION
## PR Info

refs: [MBL-19967](https://instructure.atlassian.net/browse/MBL-19967)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: none

## What's new
See ticket for details.

## Test Plan
The API is currently available only on beta env.

Testing on the PROD env, the tracking policy should fall back to the `send_usage_metrics` FF:
- Verify when the FF is enabled tracking is enabled
- Verify when the FF is disabled tracking is disabled
- Verify Profile Menu > Settings shows no Privacy Settings in all 3 apps

Testing on the BETA env, the `usage_metrics` value can be governed by adjusting the FFs:
1. Tracking always enabled
  - Set `send_usage_metrics_after_consent` FF to enabled
  - Set `cookie_consent_necessary` FF to disabled
  - (will result in: `usage_metrics: "track_usage"`)
  - Verify no consent dialog is shown at login
  - Verify tracking is enabled (regardless of the above FF)
  - Verify Profile Menu > Settings shows no Privacy Settings row in all 3 apps

2. Tracking always disabled
  - Set `send_usage_metrics_after_consent` FF to disabled
  - Set `cookie_consent_necessary` FF to disabled
  - (will result in: `usage_metrics: "no_track_usage"`)
  - Verify no consent dialog is shown at login
  - Verify tracking is disabled (regardless of the above FF)
  - Verify Profile Menu > Settings shows no Privacy Settings row in all 3 apps

3. Tracking requires consent
  - Set `send_usage_metrics_after_consent` FF to enabled
  - Set `cookie_consent_necessary` FF to enabled
  - (will result in: `usage_metrics: "ask_for_consent"`)
  - Verify consent dialog is shown at login
  - Clear the user consent by logging out and in (or via the developer menu)
  - Verify tracking follows the choice (regardless of the above FF)
  - Verify Profile Menu > Settings shows Privacy Settings row in all 3 apps, and the value matches the choice
  - Verify Setting changes enabled/disable tracking as expected

## Checklist
- [ ] Follow-up e2e test ticket created
- [ ] Tested on phone
- [x] Tested on tablet
- [x] Approve from product

[MBL-19967]: https://instructure.atlassian.net/browse/MBL-19967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ