### PR TITLE
[MBL-19946][S/T/P]  Add session cookie renewal when app goes online

### DIFF
--- a/Core/Core/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveService.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveService.swift
@@ -1,0 +1,125 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Combine
+import CombineExt
+import WebKit
+
+final class CoreWebViewCookieKeepAliveService {
+
+    private let webView = CoreWebView()
+    private var subscriptions = Set<AnyCancellable>()
+    private let manualRefreshSubject = PassthroughSubject<Void, Never>()
+    private let networkService: NetworkAvailabilityService
+
+    init(networkService: NetworkAvailabilityService = NetworkAvailabilityServiceLive()) {
+        self.networkService = networkService
+        networkService.startMonitoring()
+    }
+
+    @MainActor
+    func start(env: AppEnvironment) {
+        guard env.api.loginSession?.accessToken != nil, subscriptions.isEmpty else { return }
+
+        crossCookieInjectionPublisher()
+            .sink()
+            .store(in: &subscriptions)
+
+        Publishers.MergeMany([timerPublisher(), networkOnlinePublisher(), manualRefreshSubject.eraseToAnyPublisher()])
+            .prepend(()) // Renew immediately on start without waiting for the first timer tick or network change
+            .flatMap { [webView] in Self.renewCookies(api: env.api, webView: webView) }
+            .sink()
+            .store(in: &subscriptions)
+    }
+
+    @MainActor
+    func stop() {
+        subscriptions.removeAll()
+    }
+
+    func refresh() {
+        manualRefreshSubject.send()
+    }
+
+    @MainActor
+    func deleteAllCookies() -> AnyPublisher<Void, Never> {
+        webView.configuration.websiteDataStore.httpCookieStore.deleteAllCookies()
+    }
+
+    // MARK: - Private
+
+    private func crossCookieInjectionPublisher() -> AnyPublisher<Void, Never> {
+        CoreWebViewCrossCookieInjection()
+            .injectCrossSiteCookies(httpCookieStore: webView.configuration.websiteDataStore.httpCookieStore)
+    }
+
+    private func timerPublisher() -> AnyPublisher<Void, Never> {
+        Timer.publish(every: 10 * 60, on: .main, in: .common)
+            .autoconnect()
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    private func networkOnlinePublisher() -> AnyPublisher<Void, Never> {
+        networkService
+            .startObservingStatus()
+            .dropFirst() // Prevent initial subscription triggering an extra refresh
+            .compactMap { $0 }
+            .removeDuplicates() // The same status is reported multiple times by the OS
+            .filter { $0.isConnected }
+            .mapToVoid()
+            .eraseToAnyPublisher()
+    }
+
+    private static func renewCookies(api: API, webView: CoreWebView) -> AnyPublisher<Void, Never> {
+        api.makeRequest(GetWebSessionRequest(to: nil))
+            .map { $0.body.session_url }
+            .receive(on: DispatchQueue.main)
+            .handleEvents(receiveOutput: { url in
+                var request = URLRequest(url: url)
+                request.httpMethod = "HEAD"
+                webView.load(request)
+            })
+            .mapToVoid()
+            .catch { _ in Publishers.typedJust() }
+            .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - CoreWebView Cookie Keep-Alive
+
+extension CoreWebView {
+    private static let cookieKeepAliveService = CoreWebViewCookieKeepAliveService()
+
+    public static func keepCookieAlive(for env: AppEnvironment) {
+        cookieKeepAliveService.start(env: env)
+    }
+
+    public static func stopCookieKeepAlive() {
+        cookieKeepAliveService.stop()
+    }
+
+    /// Refreshes webview session cookies immediately outside of the scheduled renewal.
+    public static func refreshKeepAliveCookies() {
+        cookieKeepAliveService.refresh()
+    }
+
+    public static func deleteAllCookies() -> AnyPublisher<Void, Never> {
+        cookieKeepAliveService.deleteAllCookies()
+    }
+}

--- a/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
+++ b/Core/Core/Common/CommonUI/CoreWebView/View/CoreWebView.swift
@@ -743,61 +743,6 @@ extension CoreWebView: WKUIDelegate {
     }
 }
 
-// MARK: - Cookie Keep-Alive
-
-extension CoreWebView {
-    static var cookieKeepAliveTimer: Timer?
-    static var cookieKeepAliveWebView = CoreWebView()
-    private static var injectionSubscription: AnyCancellable?
-
-    public static func keepCookieAlive(for env: AppEnvironment) {
-        guard env.api.loginSession?.accessToken != nil,
-              cookieKeepAliveTimer == nil
-        else { return }
-
-        injectionSubscription = CoreWebViewCrossCookieInjection()
-            .injectCrossSiteCookies(httpCookieStore: cookieKeepAliveWebView.configuration.websiteDataStore.httpCookieStore)
-            .sink()
-
-        performUIUpdate {
-            cookieKeepAliveTimer?.invalidate()
-            let interval: TimeInterval = 10 * 60 // ten minutes
-            cookieKeepAliveTimer = Timer.scheduledTimer(withTimeInterval: interval, repeats: true) { _ in
-                let sessionTokenRequest = GetWebSessionRequest(to: nil)
-                env.api.makeRequest(sessionTokenRequest) { data, _, _ in performUIUpdate {
-                    guard let url = data?.session_url else { return }
-                    var keepAliveRequest = URLRequest(url: url)
-                    keepAliveRequest.httpMethod = "HEAD"
-                    cookieKeepAliveWebView.load(keepAliveRequest)
-                } }
-            }
-            refreshKeepAliveCookies()
-        }
-    }
-
-    public static func stopCookieKeepAlive() {
-        performUIUpdate {
-            cookieKeepAliveTimer?.invalidate()
-            cookieKeepAliveTimer = nil
-        }
-    }
-
-    /// Refreshes webview session cookies immediately outside of the scheduled renewal.
-    public static func refreshKeepAliveCookies() {
-        performUIUpdate {
-            cookieKeepAliveTimer?.fire()
-        }
-    }
-
-    public static func deleteAllCookies() -> AnyPublisher<Void, Never> {
-        cookieKeepAliveWebView
-            .configuration
-            .websiteDataStore
-            .httpCookieStore
-            .deleteAllCookies()
-    }
-}
-
 // MARK: - Input Accessory View For RCE Editor
 
 extension CoreWebView {

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveServiceTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveServiceTests.swift
@@ -1,0 +1,189 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import Network
+import XCTest
+@testable import Core
+
+final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
+
+    private var testee: CoreWebViewCookieKeepAliveService!
+    private var monitor: NWPathMonitorWrapper!
+
+    private static let sessionURL = URL(string: "data:text/html,")!
+
+    override func setUp() {
+        super.setUp()
+        monitor = NWPathMonitorWrapper(start: { _ in () }, cancel: {})
+        let networkService = NetworkAvailabilityServiceLive(monitor: monitor)
+        testee = CoreWebViewCookieKeepAliveService(networkService: networkService)
+    }
+
+    override func tearDown() {
+        testee.stop()
+        testee = nil
+        monitor = nil
+        super.tearDown()
+    }
+
+    // MARK: - start
+
+    func test_start_whenNoAccessToken_shouldNotMakeRequest() {
+        environment.api = API(.make(accessToken: nil))
+        let notCalledExpectation = expectation(description: "No request made")
+        notCalledExpectation.isInverted = true
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            notCalledExpectation.fulfill()
+            return (nil, nil, nil)
+        })
+
+        testee.start(env: environment)
+
+        wait(for: [notCalledExpectation], timeout: 0.5)
+    }
+
+    func test_start_whenAccessTokenPresent_shouldImmediatelyRenewCookies() {
+        let requestExpectation = expectation(description: "Session request made")
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            requestExpectation.fulfill()
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+
+        testee.start(env: environment)
+
+        wait(for: [requestExpectation], timeout: 5)
+    }
+
+    func test_start_whenAlreadyRunning_shouldNotRestart() {
+        let requestExpectation = expectation(description: "Session request made")
+        requestExpectation.expectedFulfillmentCount = 1
+        requestExpectation.assertForOverFulfill = true
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            requestExpectation.fulfill()
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+
+        testee.start(env: environment)
+        testee.start(env: environment)
+
+        wait(for: [requestExpectation], timeout: 5)
+    }
+
+    // MARK: - stop
+
+    func test_stop_shouldPreventFurtherRenewals() {
+        let initialRequestExpectation = expectation(description: "Initial request")
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            initialRequestExpectation.fulfill()
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+        testee.start(env: environment)
+        wait(for: [initialRequestExpectation], timeout: 5)
+
+        testee.stop()
+
+        let noRequestExpectation = expectation(description: "No request after stop")
+        noRequestExpectation.isInverted = true
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            noRequestExpectation.fulfill()
+            return (nil, nil, nil)
+        })
+        testee.refresh()
+        wait(for: [noRequestExpectation], timeout: 0.5)
+    }
+
+    // MARK: - refresh
+
+    func test_refresh_whenRunning_shouldRenewCookies() {
+        var callCount = 0
+        let firstCallExpectation = expectation(description: "First request")
+        let secondCallExpectation = expectation(description: "Second request from refresh")
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            callCount += 1
+            if callCount == 1 { firstCallExpectation.fulfill() }
+            if callCount == 2 { secondCallExpectation.fulfill() }
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+
+        testee.start(env: environment)
+        wait(for: [firstCallExpectation], timeout: 5)
+
+        testee.refresh()
+        wait(for: [secondCallExpectation], timeout: 5)
+    }
+
+    // MARK: - Network status
+
+    func test_start_whenNetworkComesOnline_shouldRenewCookies() {
+        var callCount = 0
+        let firstCallExpectation = expectation(description: "Initial renewal")
+        let secondCallExpectation = expectation(description: "Renewal after coming online")
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            callCount += 1
+            if callCount == 1 { firstCallExpectation.fulfill() }
+            if callCount == 2 { secondCallExpectation.fulfill() }
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+
+        testee.start(env: environment)
+        wait(for: [firstCallExpectation], timeout: 5)
+
+        monitor.updateHandler?(NWPathWrapper(status: .unsatisfied, isExpensive: false))
+        monitor.updateHandler?(NWPathWrapper(status: .satisfied, isExpensive: false))
+
+        wait(for: [secondCallExpectation], timeout: 5)
+    }
+
+    func test_start_whenNetworkAlreadyConnected_shouldNotFireExtraRenewal() {
+        monitor.updateHandler?(NWPathWrapper(status: .satisfied, isExpensive: false))
+
+        let requestExpectation = expectation(description: "Session request made")
+        requestExpectation.expectedFulfillmentCount = 1
+        requestExpectation.assertForOverFulfill = true
+        api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
+            requestExpectation.fulfill()
+            return (GetWebSessionRequest.Response(
+                session_url: Self.sessionURL,
+                requires_terms_acceptance: false
+            ), nil, nil)
+        })
+
+        testee.start(env: environment)
+
+        wait(for: [requestExpectation], timeout: 5)
+        let noDoubleFireExpectation = expectation(description: "No second request")
+        noDoubleFireExpectation.isInverted = true
+        wait(for: [noDoubleFireExpectation], timeout: 0.2)
+    }
+}

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveServiceTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/Model/CoreWebViewCookieKeepAliveServiceTests.swift
@@ -36,7 +36,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
     }
 
     override func tearDown() {
-        testee.stop()
+        MainActor.assumeIsolated { testee.stop() }
         testee = nil
         monitor = nil
         super.tearDown()
@@ -44,6 +44,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
 
     // MARK: - start
 
+    @MainActor
     func test_start_whenNoAccessToken_shouldNotMakeRequest() {
         environment.api = API(.make(accessToken: nil))
         let notCalledExpectation = expectation(description: "No request made")
@@ -58,6 +59,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
         wait(for: [notCalledExpectation], timeout: 0.5)
     }
 
+    @MainActor
     func test_start_whenAccessTokenPresent_shouldImmediatelyRenewCookies() {
         let requestExpectation = expectation(description: "Session request made")
         api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
@@ -73,6 +75,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
         wait(for: [requestExpectation], timeout: 5)
     }
 
+    @MainActor
     func test_start_whenAlreadyRunning_shouldNotRestart() {
         let requestExpectation = expectation(description: "Session request made")
         requestExpectation.expectedFulfillmentCount = 1
@@ -93,6 +96,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
 
     // MARK: - stop
 
+    @MainActor
     func test_stop_shouldPreventFurtherRenewals() {
         let initialRequestExpectation = expectation(description: "Initial request")
         api.mock(GetWebSessionRequest(to: nil), dataHandler: { _ in
@@ -119,6 +123,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
 
     // MARK: - refresh
 
+    @MainActor
     func test_refresh_whenRunning_shouldRenewCookies() {
         var callCount = 0
         let firstCallExpectation = expectation(description: "First request")
@@ -142,6 +147,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
 
     // MARK: - Network status
 
+    @MainActor
     func test_start_whenNetworkComesOnline_shouldRenewCookies() {
         var callCount = 0
         let firstCallExpectation = expectation(description: "Initial renewal")
@@ -165,6 +171,7 @@ final class CoreWebViewCookieKeepAliveServiceTests: CoreTestCase {
         wait(for: [secondCallExpectation], timeout: 5)
     }
 
+    @MainActor
     func test_start_whenNetworkAlreadyConnected_shouldNotFireExtraRenewal() {
         monitor.updateHandler?(NWPathWrapper(status: .satisfied, isExpensive: false))
 

--- a/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewTests.swift
+++ b/Core/CoreTests/Common/CommonUI/CoreWebView/View/CoreWebViewTests.swift
@@ -217,22 +217,6 @@ class CoreWebViewTests: CoreTestCase {
         }
     }
 
-    func testKeepCookieAlive() {
-        environment.api = API(.make(accessToken: nil))
-        CoreWebView.keepCookieAlive(for: environment)
-        XCTAssertNil(CoreWebView.cookieKeepAliveTimer)
-
-        environment.api = API(.make(accessToken: "a"))
-        let value = GetWebSessionRequest.Response(session_url: URL(string: "data:text/html,")!, requires_terms_acceptance: false)
-        api.mock(GetWebSessionRequest(to: nil), value: value)
-        CoreWebView.keepCookieAlive(for: environment)
-        wait(for: [expectation(for: .all, evaluatedWith: api) { CoreWebView.cookieKeepAliveWebView.url != nil }], timeout: 10)
-        XCTAssertEqual(CoreWebView.cookieKeepAliveWebView.url, URL(string: "data:text/html,"))
-        XCTAssertNotNil(CoreWebView.cookieKeepAliveTimer)
-
-        CoreWebView.stopCookieKeepAlive()
-    }
-
     func testJsString() {
         XCTAssertEqual(CoreWebView.jsString(nil), "null")
         XCTAssertEqual(CoreWebView.jsString(""), "''")


### PR DESCRIPTION
## What's new?
- Extracted cookie refresh logic to a separate service and refactored to combine so it was easier to extend.
- Added extra refresh cycle when the app becomes online.

## PR Info

refs: [MBL-19946](https://instructure.atlassian.net/browse/MBL-19946)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: Fixed an issue that occasionally caused embedded rich content to display the login screen after app goes online.

## Test Plan
- Check scenario in ticket.
- Test if periodic cookie renewal still works.
- Check if cookie is present and embedded content (anything inside an iframe like studio LTI) displays properly.

## Checklist

- [ ] Tested on phone
- [ ] Tested on tablet

[MBL-19946]: https://instructure.atlassian.net/browse/MBL-19946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ