### PR TITLE
[MBL-19974][S] Offline Mode - Continue Studio iframe tags replacement when some videos are not downloaded

### DIFF
--- a/Core/Core/Features/Studio/Model/StudioIFrameReplaceInteractor.swift
+++ b/Core/Core/Features/Studio/Model/StudioIFrameReplaceInteractor.swift
@@ -57,9 +57,11 @@ public class StudioIFrameReplaceInteractorLive: StudioIFrameReplaceInteractor {
             throw StudioIFrameReplaceError.failedToConvertDataToString
         }
 
+        var nonFoundFrames: [StudioIFrame] = []
         for iframe in iframes {
             guard let offlineVideo = offlineVideos.first(where: { $0.ltiLaunchID == iframe.mediaLTILaunchID }) else {
-                throw StudioIFrameReplaceError.offlineVideoIDNotFound
+                nonFoundFrames.append(iframe)
+                continue
             }
             htmlString = replaceStudioIFrame(
                 html: htmlString,
@@ -76,6 +78,10 @@ public class StudioIFrameReplaceInteractorLive: StudioIFrameReplaceInteractor {
             try updatedHtmlData.write(to: htmlURL)
         } catch {
             throw StudioIFrameReplaceError.failedToSaveUpdatedHtml
+        }
+
+        if nonFoundFrames.isNotEmpty {
+            throw StudioIFrameReplaceError.offlineVideoIDNotFound
         }
     }
 

--- a/Core/CoreTests/Features/Studio/Model/StudioIFrameReplaceInteractorLiveTests.swift
+++ b/Core/CoreTests/Features/Studio/Model/StudioIFrameReplaceInteractorLiveTests.swift
@@ -133,6 +133,41 @@ class StudioIFrameReplaceInteractorLiveTests: CoreTestCase {
         )
     }
 
+    func test_replaceStudioIFrames_whenOneIframeHasNoMatchingOfflineVideo_shouldReplaceMatchedIframesAndThrow() throws {
+        let unmatchedIframeID = "unmatched-lti-id"
+        let unmatchedIframeHtml = "<iframe src=\"https://test.com/lti?id=\(unmatchedIframeID)\"></iframe>"
+        let htmlWithTwoIframes = "<p>\n\(StudioTestData.iframe)\n\(unmatchedIframeHtml)\n</p>"
+        try htmlWithTwoIframes.write(to: htmlFileURL, atomically: false, encoding: .utf8)
+
+        let matchedOfflineVideo = try StudioOfflineVideo(
+            ltiLaunchID: StudioTestData.ltiLaunchID,
+            videoLocation: testData.videoURL,
+            videoPosterLocation: nil,
+            videoMimeType: testData.mimeType,
+            captionLocations: [],
+            baseURL: workingDirectory
+        )
+        let unmatchedIframe = StudioIFrame(mediaLTILaunchID: unmatchedIframeID, sourceHtml: unmatchedIframeHtml)
+
+        XCTAssertThrowsError(
+            try StudioIFrameReplaceInteractorLive().replaceStudioIFrames(
+                inHtmlAtURL: htmlFileURL,
+                iframes: [testData.iframe, unmatchedIframe],
+                offlineVideos: [matchedOfflineVideo]
+            )
+        ) { error in
+            XCTAssertEqual(
+                (error as? StudioIFrameReplaceError)?.debugDescription,
+                StudioIFrameReplaceError.offlineVideoIDNotFound.debugDescription
+            )
+        }
+
+        let savedHtml = try String(contentsOf: htmlFileURL, encoding: .utf8)
+        XCTAssertFalse(savedHtml.contains(StudioTestData.iframe))
+        XCTAssertTrue(savedHtml.contains("<video"))
+        XCTAssertTrue(savedHtml.contains(unmatchedIframeHtml))
+    }
+
     func testErrorDescription() {
         XCTAssertEqual(
             StudioIFrameReplaceError.failedToConvertDataToString.debugDescription,


### PR DESCRIPTION
## PR Info

refs: [MBL-19974](https://instructure.atlassian.net/browse/MBL-19974)
builds: Student
affects: Student
release note: None.

## Changes

- The iframe replacement loop previously threw `offlineVideoIDNotFound` as soon as it encountered any iframe with no matching offline video, discarding all replacements computed so far and never writing the file.
- This fix collects unmatched iframes into a `nonFoundFrames` array, continues replacing the rest, writes the updated HTML to disk, and only then throws `offlineVideoIDNotFound` if any frames were unmatched.
- Net result: pages with a mix of matched and unmatched iframes now correctly render the videos that did download offline.

## Test Plan

- [ ] Sync a course offline that has a page with **two or more Studio videos**. See ticket's description for test account.
- [ ] Confirm all synced Studio videos play inline as `<video>` elements when offline.
- [ ] Simulate the failure case: if one video is missing from the offline sync, verify the remaining videos on the same page still render correctly.

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19974]: https://instructure.atlassian.net/browse/MBL-19974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ