### PR TITLE
[MBL-19904] NextGen - Preparations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ xctestrun/
 Core/Core.xcodeproj/
 Student/Student.xcodeproj/
 Horizon/Horizon.xcodeproj/
+NextGen/NextGen.xcodeproj/
 Teacher/Teacher.xcodeproj/
 Parent/Parent.xcodeproj/
 Brewfile.lock

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -18,6 +18,7 @@ included: # paths to include during linting. `--path` is ignored if present.
   - Student
   - Teacher
   - Horizon
+  - NextGen
   - Parent
   - TestsFoundation
   - packages/HorizonUI/Sources/HorizonUI

--- a/Canvas.xcworkspace/contents.xcworkspacedata
+++ b/Canvas.xcworkspace/contents.xcworkspacedata
@@ -8,6 +8,9 @@
       location = "group:Horizon/Horizon.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:NextGen/NextGen.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:Parent/Parent.xcodeproj">
    </FileRef>
    <FileRef

--- a/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
+++ b/Core/Core/Common/CommonModels/Analytics/AnalyticsHandler.swift
@@ -199,7 +199,7 @@ private extension AppEnvironment {
         guard let app else { return nil }
 
         return switch app {
-        case .student, .horizon: Secret.studentPendoApiKey.string
+        case .student, .horizon, .nextgen: Secret.studentPendoApiKey.string
         case .teacher: Secret.teacherPendoApiKey.string
         case .parent: Secret.parentPendoApiKey.string
         }

--- a/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
@@ -30,7 +30,7 @@ public protocol AppEnvironmentDelegate {
 
 open class AppEnvironment {
     public enum App: String {
-        case parent, student, teacher, horizon
+        case parent, student, teacher, horizon, nextgen
     }
 
     public internal(set) lazy var uploadManager = UploadManager(

--- a/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/AppEnvironment.swift
@@ -30,7 +30,11 @@ public protocol AppEnvironmentDelegate {
 
 open class AppEnvironment {
     public enum App: String {
-        case parent, student, teacher, horizon, nextgen
+        case parent
+        case teacher
+        case student
+        case horizon // Student app experience
+        case nextgen // Student app experience
     }
 
     public internal(set) lazy var uploadManager = UploadManager(

--- a/Core/Core/Common/CommonModels/AppEnvironment/ExperimentalFeature.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/ExperimentalFeature.swift
@@ -31,6 +31,7 @@ public enum ExperimentalFeature: String, CaseIterable, Codable {
     case rebuiltCalendar = "rebuilt_calendar"
     case revertToOldStudentToDo = "revert_to_old_student_todo"
     case revertToOldStudentDashboard = "revert_to_old_student_dashboard"
+    case nextgenStudent = "nextgen_student"
 
     private static var sharedUserDefaults: UserDefaults {
         UserDefaults(suiteName: Bundle.main.appGroupID()) ?? .standard

--- a/Core/Core/Common/CommonModels/Constants/App.swift
+++ b/Core/Core/Common/CommonModels/Constants/App.swift
@@ -23,4 +23,5 @@ public enum App: String {
     case teacher
     case parent
     case horizon
+    case nextgen
 }

--- a/Core/Core/Common/CommonModels/Router/Router.swift
+++ b/Core/Core/Common/CommonModels/Router/Router.swift
@@ -105,7 +105,7 @@ open class Router {
 
     public var count: Int { handlers.count }
 
-    private let handlers: [RouteHandler]
+    public let handlers: [RouteHandler]
     private let fallback: FallbackHandler
 
     public init(

--- a/Core/Core/Features/Login/GetSSOLogin.swift
+++ b/Core/Core/Features/Login/GetSSOLogin.swift
@@ -38,14 +38,12 @@ public class GetSSOLogin {
 
     static func codeForApp(_ app: App) -> String {
         switch app {
-        case .student, .nextgen:
+        case .student, .horizon, .nextgen:
             return "code"
         case .teacher:
             return "code_ios_teacher"
         case .parent:
             return "code" // "code_ios_parent"
-        case .horizon:
-            return "code"
         }
     }
 

--- a/Core/Core/Features/Login/GetSSOLogin.swift
+++ b/Core/Core/Features/Login/GetSSOLogin.swift
@@ -38,7 +38,7 @@ public class GetSSOLogin {
 
     static func codeForApp(_ app: App) -> String {
         switch app {
-        case .student:
+        case .student, .nextgen:
             return "code"
         case .teacher:
             return "code_ios_teacher"

--- a/Core/Core/Features/Offline/Model/OfflineModeEnabledByApp.swift
+++ b/Core/Core/Features/Offline/Model/OfflineModeEnabledByApp.swift
@@ -21,7 +21,7 @@ extension Optional where Wrapped == AppEnvironment.App {
     var isOfflineModeEnabled: Bool {
         switch self {
         case .parent: return false
-        case .student: return true
+        case .student, .nextgen: return true
         case .teacher: return false
         case .horizon: return false
         case .none: return false

--- a/Core/Core/Features/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
+++ b/Core/Core/Features/Planner/CalendarFilter/Model/Interactor/CalendarFilterCountLimit.swift
@@ -35,7 +35,7 @@ public extension Optional where Wrapped == AppEnvironment.App {
     var isCalendarFilterLimitEnabled: Bool {
         switch self {
         case .teacher: return true
-        case .none, .parent, .student, .horizon: return false
+        case .none, .parent, .student, .horizon, .nextgen: return false
         }
     }
 }

--- a/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
+++ b/Core/Core/Features/Planner/CalendarMain/PlannerListViewController.swift
@@ -172,7 +172,7 @@ extension PlannerListViewController: UITableViewDataSource, UITableViewDelegate 
         selectedPlannableId = plannable.id
 
         switch env.app {
-        case .student, .teacher:
+        case .student, .teacher, .nextgen:
             switch plannable.plannableType {
             case .planner_note:
                 let vc = PlannerAssembly.makeToDoDetailsViewController(plannable: plannable)

--- a/Core/Core/Features/Planner/Model/UseCase/GetPlannables.swift
+++ b/Core/Core/Features/Planner/Model/UseCase/GetPlannables.swift
@@ -121,7 +121,7 @@ public class GetPlannables: UseCase {
                 completionHandler(.init(calendarEvents: events, plannerNotes: notes), urlResponse, error)
             }
 
-        case .student:
+        case .student, .nextgen:
             let request = GetPlannablesRequest(
                 userID: userID,
                 startDate: startDate,

--- a/Core/Core/Features/Planner/PlannerAssembly.swift
+++ b/Core/Core/Features/Planner/PlannerAssembly.swift
@@ -245,7 +245,7 @@ public enum PlannerAssembly {
         switch app {
         case .parent:
             return CalendarFilterEntryProviderParent(observedUserId: observedUserId)
-        case .student, .none:
+        case .student, .none, .nextgen:
             return CalendarFilterEntryProviderStudent()
         case .teacher:
             return CalendarFilterEntryProviderTeacher(purpose: forCreating ? .creating : .viewing)

--- a/Core/Core/Features/Users/UserSettings/UseCase/GetUserSettings.swift
+++ b/Core/Core/Features/Users/UserSettings/UseCase/GetUserSettings.swift
@@ -57,7 +57,7 @@ private extension APIUserSettings {
         guard let app = AppEnvironment.shared.app else { return nil }
 
         return switch app {
-        case .student, .horizon: pendo_mobile_student_api_key
+        case .student, .horizon, .nextgen: pendo_mobile_student_api_key
         case .teacher: pendo_mobile_teacher_api_key
         case .parent: pendo_mobile_parent_api_key
         }

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ sync: ## xproj file generation
 	@echo 🟡 Running xcodegen
 	@cd Core; xcodegen
 	@cd Horizon; xcodegen
+	@cd NextGen; xcodegen
 	@cd Student; xcodegen
 	@cd Teacher; xcodegen
 	@cd Parent; xcodegen
@@ -20,6 +21,7 @@ sync-ci: ## CI specific xproj file generation
 	@echo 🟡 Running xcodegen
 	@cd Core; xcodegen
 	@cd Horizon; xcodegen
+	@cd NextGen; xcodegen
 	@cd Student; xcodegen --spec "project-ci.yml"
 	@cd Teacher; xcodegen --spec "project-ci.yml"
 	@cd Parent; xcodegen --spec "project-ci.yml"

--- a/NextGen/.swiftlint.yml
+++ b/NextGen/.swiftlint.yml
@@ -1,0 +1,3 @@
+parent_config: ../.swiftlint.yml
+excluded:
+  - ../Core

--- a/NextGen/NextGen/Resources/Info.plist
+++ b/NextGen/NextGen/Resources/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/NextGen/NextGen/Sources/Routing/NextGenRoutes.swift
+++ b/NextGen/NextGen/Sources/Routing/NextGenRoutes.swift
@@ -1,0 +1,32 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+
+public enum NextGenRoutes {
+    public static func makeRouter(
+        academicRoutes: [RouteHandler],
+        nextgenRoutes: [RouteHandler] = NextGenRoutes.nextgenRoutes
+    ) -> Router {
+        let overriddenTemplates = Set(nextgenRoutes.map { $0.route.template })
+        let mergedRoutes = nextgenRoutes + academicRoutes.filter { !overriddenTemplates.contains($0.route.template) }
+        return Router(routes: mergedRoutes)
+    }
+
+    public static var nextgenRoutes: [RouteHandler] { [] }
+}

--- a/NextGen/NextGen/nextgen.yml
+++ b/NextGen/NextGen/nextgen.yml
@@ -1,0 +1,29 @@
+---
+targets:
+  NextGen:
+    type: framework
+    platform: iOS
+    transitivelyLinkDependencies: false
+    settings:
+      APPLICATION_EXTENSION_API_ONLY: false
+      SWIFT_EMIT_LOC_STRINGS: true
+      PRODUCT_BUNDLE_IDENTIFIER: com.instructure.nextgen
+      TARGETED_DEVICE_FAMILY: 1,2
+    sources:
+      - path: ./
+        excludes:
+          - ".swiftlint.yml"
+          - "nextgen.yml"
+    dependencies:
+      - target: Core/Core
+      - package: BusinessLogic
+      - package: InstUI
+    preBuildScripts:
+      - path: ../../scripts/xcode-build-phases/swiftLint.sh
+        name: SwiftLint
+        basedOnDependencyAnalysis: false
+schemes:
+  NextGen:
+    build:
+      targets:
+        NextGen: all

--- a/NextGen/NextGen/nextgen.yml
+++ b/NextGen/NextGen/nextgen.yml
@@ -27,3 +27,7 @@ schemes:
     build:
       targets:
         NextGen: all
+    test:
+      testPlans:
+        - path: ../NextGenTests.xctestplan
+          defaultPlan: true

--- a/NextGen/NextGenTests.xctestplan
+++ b/NextGen/NextGenTests.xctestplan
@@ -1,0 +1,25 @@
+{
+  "configurations" : [
+    {
+      "id" : "F3E9CFE8-317D-4085-9041-3C7270B2368E",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "language" : "en",
+    "region" : "US"
+  },
+  "testTargets" : [
+    {
+      "target" : {
+        "containerPath" : "container:NextGen.xcodeproj",
+        "identifier" : "42119C763396499B7891C45E",
+        "name" : "NextGenUnitTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/NextGen/NextGenUnitTests/.swiftlint.yml
+++ b/NextGen/NextGenUnitTests/.swiftlint.yml
@@ -1,0 +1,4 @@
+disabled_rules:
+  - force_try
+  - force_cast
+  - xctfail_message

--- a/NextGen/NextGenUnitTests/Helpers/NextGenTestCase.swift
+++ b/NextGen/NextGenUnitTests/Helpers/NextGenTestCase.swift
@@ -1,0 +1,62 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import CoreData
+import TestsFoundation
+import XCTest
+@testable import Core
+@testable import NextGen
+
+class NextGenTestCase: XCTestCase {
+    var database: NSPersistentContainer { TestsFoundation.singleSharedTestDatabase }
+    var databaseClient: NSManagedObjectContext { database.viewContext }
+
+    var api: API { environment.api }
+    var environment: TestEnvironment!
+    var router = TestRouter()
+    var logger = TestLogger()
+
+    let window = UIWindow()
+
+    override func setUp() {
+        super.setUp()
+        OfflineModeAssembly.mock(OfflineModeInteractorMock(mockIsFeatureFlagEnabled: false))
+        Clock.reset()
+        API.resetMocks()
+        LoginSession.clearAll()
+        TestsFoundation.singleSharedTestDatabase = resetSingleSharedTestDatabase()
+        environment = TestEnvironment()
+        AppEnvironment.shared = environment
+        environment.api = API()
+        environment.database = singleSharedTestDatabase
+        environment.globalDatabase = singleSharedTestDatabase
+        environment.router = router
+        environment.logger = logger
+        environment.currentSession = LoginSession.make()
+        environment.window = window
+        environment.app = .nextgen
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        LoginSession.clearAll()
+        window.rootViewController = UIViewController()
+    }
+}

--- a/NextGen/NextGenUnitTests/Info.plist
+++ b/NextGen/NextGenUnitTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/NextGen/NextGenUnitTests/Routing/NextGenRoutesTests.swift
+++ b/NextGen/NextGenUnitTests/Routing/NextGenRoutesTests.swift
@@ -1,0 +1,64 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import XCTest
+@testable import Core
+@testable import NextGen
+
+final class NextGenRoutesTests: NextGenTestCase {
+
+    private static let testData = (
+        route1: "/some/route/1",
+        route2: "/some/route/2",
+        academicVC: UIViewController(),
+        academicVC2: UIViewController(),
+        nextgenVC: UIViewController()
+    )
+    private lazy var testData = Self.testData
+
+    // MARK: - makeRouter
+
+    func test_makeRouter_shouldUseAcademicRouteHandlers() {
+        let academicRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.academicVC }]
+
+        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: [])
+
+        XCTAssertIdentical(router.match(testData.route1), testData.academicVC)
+    }
+
+    func test_makeRouter_whenNextgenRouteOverridesAcademicRoute_shouldUseNextgenHandler() {
+        let academicRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.academicVC }]
+        let nextgenRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.nextgenVC }]
+
+        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
+
+        XCTAssertIdentical(router.match(testData.route1), testData.nextgenVC)
+    }
+
+    func test_makeRouter_whenNextgenRouteOverridesAcademicRoute_shouldKeepOtherAcademicRouteHandlers() {
+        let academicRoutes = [
+            RouteHandler(testData.route1) { _, _, _ in self.testData.academicVC2 },
+            RouteHandler(testData.route2) { _, _, _ in self.testData.academicVC }
+        ]
+        let nextgenRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.nextgenVC }]
+
+        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
+
+        XCTAssertIdentical(router.match(testData.route2), testData.academicVC)
+    }
+}

--- a/NextGen/NextGenUnitTests/nextgen-unit-tests.yml
+++ b/NextGen/NextGenUnitTests/nextgen-unit-tests.yml
@@ -1,0 +1,15 @@
+---
+targets:
+  NextGenUnitTests:
+    type: bundle.unit-test
+    platform: iOS
+    settings:
+      APPLICATION_EXTENSION_API_ONLY: false
+      ENABLE_TESTABILITY: true
+    sources:
+      - path: ./
+        excludes:
+          - ".swiftlint.yml"
+    dependencies:
+      - target: NextGen
+      - target: Core/TestsFoundation

--- a/NextGen/project.yml
+++ b/NextGen/project.yml
@@ -1,0 +1,39 @@
+---
+name: NextGen
+attributes: {
+  LastUpgradeCheck: "2640"
+}
+options:
+  groupSortPosition: top
+  bundleIdPrefix: com.instructure.nextgen
+  deploymentTarget:
+    iOS: 18.0
+  createIntermediateGroups: true
+settings:
+  CODE_SIGN_STYLE: Automatic
+  DEVELOPMENT_TEAM: B6333T4PXQ
+  CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED: true
+  LOCALIZATION_PREFERS_STRING_CATALOGS: true
+  ENABLE_USER_SCRIPT_SANDBOXING: false
+  ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS: false
+  STRING_CATALOG_GENERATE_SYMBOLS: false
+  CURRENT_PROJECT_VERSION: 0.0.1
+  MARKETING_VERSION: 0.0.1
+  platform: iOS
+  ENABLE_MODULE_VERIFIER: true
+  MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS: 'gnu11 gnu++14'
+sources:
+  - path: ./
+    excludes:
+      - ".swiftlint.yml"
+include:
+  - NextGen/nextgen.yml
+  - NextGenUnitTests/nextgen-unit-tests.yml
+projectReferences:
+  Core:
+    path: ../Core/Core.xcodeproj
+packages:
+  BusinessLogic:
+    path: ../packages/BusinessLogic
+  InstUI:
+    path: ../packages/InstUI

--- a/Student/Student/LearnerDashboard/Settings/View/LearnerDashboardSettingsScreen.swift
+++ b/Student/Student/LearnerDashboard/Settings/View/LearnerDashboardSettingsScreen.swift
@@ -32,7 +32,9 @@ struct LearnerDashboardSettingsScreen: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 16) {
-                newDashboardToggle
+                if viewModel.isOptOutAllowed {
+                    newDashboardToggle
+                }
                 dashboardColorSelector
                 widgetsSection
                 feedbackSection

--- a/Student/Student/LearnerDashboard/Settings/ViewModel/LearnerDashboardSettingsViewModel.swift
+++ b/Student/Student/LearnerDashboard/Settings/ViewModel/LearnerDashboardSettingsViewModel.swift
@@ -26,6 +26,7 @@ import UIKit
 @Observable
 final class LearnerDashboardSettingsViewModel {
     var useNewLearnerDashboard: Bool
+    var isOptOutAllowed: Bool { environment.app != .nextgen }
     var mainColor: Color {
         didSet { didChangeColor(to: mainColor) }
     }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -22,6 +22,7 @@ import Core
 import Firebase
 import Horizon
 import HorizonUI
+import NextGen
 import PSPDFKit
 import UIKit
 import UserNotifications
@@ -430,8 +431,10 @@ extension StudentAppDelegate {
     private func setTabBarControllerFor(experience: Experience, isStartup: Bool, session: LoginSession?) {
         switch experience {
         case .academic:
-            AppEnvironment.shared.app = .student
-            AppEnvironment.shared.router = academicRouter
+            AppEnvironment.shared.app = ExperimentalFeature.nextgenStudent.isEnabled ? .nextgen : .student
+            AppEnvironment.shared.router = AppEnvironment.shared.app == .nextgen
+                ? NextGenRoutes.makeRouter(academicRoutes: academicRouter.handlers)
+                : academicRouter
             guard let window else { return }
             let userInterfaceStyle = AppEnvironment.shared.userDefaults?.academicInterfaceStyle ?? AppEnvironment.shared.userDefaults?.interfaceStyle
             window.updateInterfaceStyleWithoutTransition(userInterfaceStyle)

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -431,8 +431,9 @@ extension StudentAppDelegate {
     private func setTabBarControllerFor(experience: Experience, isStartup: Bool, session: LoginSession?) {
         switch experience {
         case .academic:
-            AppEnvironment.shared.app = ExperimentalFeature.nextgenStudent.isEnabled ? .nextgen : .student
-            AppEnvironment.shared.router = AppEnvironment.shared.app == .nextgen
+            let app: AppEnvironment.App = ExperimentalFeature.nextgenStudent.isEnabled ? .nextgen : .student
+            AppEnvironment.shared.app = app
+            AppEnvironment.shared.router = (app == .nextgen)
                 ? NextGenRoutes.makeRouter(academicRoutes: academicRouter.handlers)
                 : academicRouter
             guard let window else { return }

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -59,6 +59,11 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         reportScreenView(for: selectedIndex, viewController: viewControllers![selectedIndex])
         addSnackBar()
         registerForTraitChanges()
+
+        if AppEnvironment.shared.app == .nextgen {
+            viewControllers = Array(viewControllers?.prefix(1) ?? [])
+            tabBar.isHidden = true
+        }
     }
 
     override func viewIsAppearing(_ animated: Bool) {

--- a/Student/Student/StudentTabBarController.swift
+++ b/Student/Student/StudentTabBarController.swift
@@ -60,6 +60,9 @@ class StudentTabBarController: UITabBarController, SnackBarProvider {
         addSnackBar()
         registerForTraitChanges()
 
+        // Placeholder until the nextgen navigation is figured out:
+        // - We only keep the first tab that is the dashboard
+        // - Hide the tab controller since we only have one tab and there's no point in showing it
         if AppEnvironment.shared.app == .nextgen {
             viewControllers = Array(viewControllers?.prefix(1) ?? [])
             tabBar.isHidden = true

--- a/Student/Student/student.yml
+++ b/Student/Student/student.yml
@@ -30,6 +30,7 @@ targets:
       - target: SubmitAssignment
       - target: Widgets
       - target: Horizon/Horizon
+      - target: NextGen/NextGen
     preBuildScripts:
       - path: ../../scripts/xcode-build-phases/swiftLint.sh
         name: SwiftLint
@@ -60,4 +61,4 @@ schemes:
         - name: Core/CoreTester
           skipped: true
       gatherCoverageData: true
-      coverageTargets: [Core/Core, Horizon/Horizon, Student]
+      coverageTargets: [Core/Core, Horizon/Horizon, NextGen/NextGen, Student]

--- a/Student/StudentUnitTests/LearnerDashboard/Settings/ViewModel/LearnerDashboardSettingsViewModelTests.swift
+++ b/Student/StudentUnitTests/LearnerDashboard/Settings/ViewModel/LearnerDashboardSettingsViewModelTests.swift
@@ -56,6 +56,22 @@ final class LearnerDashboardSettingsViewModelTests: StudentTestCase {
         XCTAssertEqual(testee.useNewLearnerDashboard, false)
     }
 
+    // MARK: - isOptOutAllowed
+
+    func test_isOptOutAllowed_whenAppIsStudent_shouldBeTrue() {
+        env.app = .student
+        testee = makeTestee()
+
+        XCTAssertEqual(testee.isOptOutAllowed, true)
+    }
+
+    func test_isOptOutAllowed_whenAppIsNextgen_shouldBeFalse() {
+        env.app = .nextgen
+        testee = makeTestee()
+
+        XCTAssertEqual(testee.isOptOutAllowed, false)
+    }
+
     // MARK: - Color change analytics
 
     func test_mainColor_whenChanged_shouldLogCustomizationEvent() {

--- a/Student/project-ci.yml
+++ b/Student/project-ci.yml
@@ -34,6 +34,8 @@ projectReferences:
     path: ../Core/Core.xcodeproj
   Horizon:
     path: ../Horizon/Horizon.xcodeproj
+  NextGen:
+    path: ../NextGen/NextGen.xcodeproj
 packages:
   BusinessLogic:
     path: ../packages/BusinessLogic

--- a/Student/project.yml
+++ b/Student/project.yml
@@ -36,6 +36,8 @@ projectReferences:
     path: ../Core/Core.xcodeproj
   Horizon:
     path: ../Horizon/Horizon.xcodeproj
+  NextGen:
+    path: ../NextGen/NextGen.xcodeproj
 packages:
   BusinessLogic:
     path: ../packages/BusinessLogic

--- a/TestPlans/CITests.xctestplan
+++ b/TestPlans/CITests.xctestplan
@@ -98,6 +98,13 @@
         "identifier" : "73B1A2AD90A7970B7DB39CDC",
         "name" : "CoreTests"
       }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:NextGen\/NextGen.xcodeproj",
+        "identifier" : "42119C763396499B7891C45E",
+        "name" : "NextGenUnitTests"
+      }
     }
   ],
   "version" : 1


### PR DESCRIPTION
## PR Info

refs: [MBL-19904](https://instructure.atlassian.net/browse/MBL-19904)
builds: Student, Teacher, Parent
affects: Student
release note: none

## What's new?
- Introduced NextGen, a new iOS framework flavor of the Student app (alongside Horizon), with its own XcodeGen project, SwiftLint config, unit test target, test plan, and workspace integration.
- Added .nextgen as a new AppEnvironment.App case, wired up across all relevant switch statements to match Student behavior.
- Added a nextgen_student feature flag that sets AppEnvironment.app = .nextgen at login, which limits the Student tab bar to the dashboard only and hides the tab bar chrome. This is because the navigation for the new gen experience is not yet been decided, so it's just there as a visible placeholder change.
- Introduced NextGenRoutes — a routing layer that merges NextGen-specific route overrides with the academic routes, deduplicating any overridden templates so NextGen handlers always win.
- Exposed Router.handlers as public let to allow route composition without duplicating the route array.
- Hidden the "opt out of new dashboard" toggle in LearnerDashboardSettingsScreen when running as NextGen. This was a requested change and will stay like this.

[MBL-19904]: https://instructure.atlassian.net/browse/MBL-19904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ