### PR TITLE
[MBL-19986][S/T/P] Pendo - setup for different regions

### DIFF
--- a/Core/Core/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTracker.swift
+++ b/Core/Core/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTracker.swift
@@ -28,6 +28,7 @@ public final class PendoAnalyticsTracker {
     private var pendoApiKey: String?
 
     private var isSetupCalled: Bool = false
+    private var isApiKeyCurrent: Bool = false
     private var isSessionInProgress: Bool = false
 
     // MARK: Initialization
@@ -39,7 +40,11 @@ public final class PendoAnalyticsTracker {
     ) {
         self.interactor = interactor
         self.pendoManager = pendoManager
+
         self.pendoApiKey = pendoApiKey?.nilIfEmpty
+        if pendoApiKey?.nilIfEmpty != nil {
+            isApiKeyCurrent = true
+        }
     }
 
     // MARK: - Setup & Start Session
@@ -49,7 +54,15 @@ public final class PendoAnalyticsTracker {
     }
 
     public func storeApiKey(_ apiKey: String) {
-        pendoApiKey = apiKey.nilIfEmpty
+        if isSetupCalled && pendoApiKey != apiKey {
+            // This can happen after a new login with a different api key.
+            // It that case we should disable tracking,
+            // since we can't resetup pendo with the new api key.
+            isApiKeyCurrent = false
+        } else {
+            pendoApiKey = apiKey
+            isApiKeyCurrent = true
+        }
     }
 
     /// Start the session asynchronously.
@@ -62,7 +75,7 @@ public final class PendoAnalyticsTracker {
 
     // extracted for testing purposes
     internal func startSessionAsync() async throws {
-        guard let pendoApiKey else { return }
+        guard let pendoApiKey, isApiKeyCurrent else { return }
 
         await setupManagerIfNeeded(apiKey: pendoApiKey)
 
@@ -99,7 +112,7 @@ public final class PendoAnalyticsTracker {
 
     @MainActor
     public func endSession() {
-        guard let pendoApiKey else { return }
+        guard let pendoApiKey, isApiKeyCurrent else { return }
 
         setupManagerIfNeeded(apiKey: pendoApiKey)
 

--- a/Core/Core/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTracker.swift
+++ b/Core/Core/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTracker.swift
@@ -19,17 +19,6 @@
 import Foundation
 import Pendo
 
-// This is only needed to make testing possible
-public protocol PendoManagerWrapper: AnyObject {
-    func initWith(_ url: URL)
-    func setup(_ appKey: String)
-    func startSession(_ visitorId: String?, accountId: String?, visitorData: [AnyHashable: Any]?, accountData: [AnyHashable: Any]?)
-    func endSession()
-    func track(_ event: String, properties: [AnyHashable: Any]?)
-}
-
-extension PendoManager: PendoManagerWrapper {}
-
 public final class PendoAnalyticsTracker {
 
     // MARK: Properties
@@ -53,6 +42,8 @@ public final class PendoAnalyticsTracker {
         self.pendoApiKey = pendoApiKey?.nilIfEmpty
     }
 
+    // MARK: - Setup & Start Session
+
     public func initManager(with url: URL) {
         pendoManager.initWith(url)
     }
@@ -61,33 +52,13 @@ public final class PendoAnalyticsTracker {
         pendoApiKey = apiKey.nilIfEmpty
     }
 
-    // MARK: Publics
-
-    /// Start the session asynchronously
+    /// Start the session asynchronously.
     public func startSession(completion: (() -> Void)? = nil) {
         Task { [weak self] in
             try? await self?.startSessionAsync()
             completion?()
         }
     }
-
-    @MainActor
-    public func endSession() {
-        guard let pendoApiKey else { return }
-
-        setupManagerIfNeeded(apiKey: pendoApiKey)
-
-        isSessionInProgress = false
-        pendoManager.endSession()
-    }
-
-    public func track(_ eventName: String, properties: [String: Any]?) {
-        guard isSessionInProgress else { return }
-
-        pendoManager.track(eventName, properties: properties)
-    }
-
-    // MARK: Internals & Privates
 
     // extracted for testing purposes
     internal func startSessionAsync() async throws {
@@ -122,5 +93,25 @@ public final class PendoAnalyticsTracker {
         )
 
         isSessionInProgress = true
+    }
+
+    // MARK: - End Session
+
+    @MainActor
+    public func endSession() {
+        guard let pendoApiKey else { return }
+
+        setupManagerIfNeeded(apiKey: pendoApiKey)
+
+        isSessionInProgress = false
+        pendoManager.endSession()
+    }
+
+    // MARK: - Track
+
+    public func track(_ eventName: String, properties: [String: Any]?) {
+        guard isSessionInProgress else { return }
+
+        pendoManager.track(eventName, properties: properties)
     }
 }

--- a/Core/Core/Common/CommonModels/Analytics/Pendo/PendoManagerWrapper.swift
+++ b/Core/Core/Common/CommonModels/Analytics/Pendo/PendoManagerWrapper.swift
@@ -1,0 +1,32 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+
+import Foundation
+import Pendo
+
+// This is only needed to make testing possible
+public protocol PendoManagerWrapper: AnyObject {
+    func initWith(_ url: URL)
+    func setup(_ appKey: String)
+    func startSession(_ visitorId: String?, accountId: String?, visitorData: [AnyHashable: Any]?, accountData: [AnyHashable: Any]?)
+    func endSession()
+    func track(_ event: String, properties: [AnyHashable: Any]?)
+}
+
+extension PendoManager: PendoManagerWrapper {}

--- a/Core/Core/Common/CommonModels/Analytics/Pendo/PendoManagerWrapper.swift
+++ b/Core/Core/Common/CommonModels/Analytics/Pendo/PendoManagerWrapper.swift
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
-
 import Foundation
 import Pendo
 

--- a/Core/CoreTests/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTrackerTests.swift
+++ b/Core/CoreTests/Common/CommonModels/Analytics/Pendo/PendoAnalyticsTrackerTests.swift
@@ -37,6 +37,7 @@ class PendoAnalyticsTrackerTests: XCTestCase {
             pendoManager: pendoManager,
             pendoApiKey: "some api key"
         )
+        testee.storeApiKey("some api key")
     }
 
     override func tearDown() {
@@ -135,12 +136,34 @@ class PendoAnalyticsTrackerTests: XCTestCase {
         XCTAssertEqual(pendoManager.setupInput, "some remote key")
     }
 
-    func test_storeApiKey_whenEmpty_shouldPreventSetup() async throws {
-        testee.storeApiKey("")
+    func test_storeApiKey_whenCalledWithDifferentKeyAfterSetup_shouldDisableStartSession() async throws {
+        try await testee.startSessionAsync()
+        XCTAssertEqual(pendoManager.startSessionCallsCount, 1)
+
+        testee.storeApiKey("some other key")
 
         try await testee.startSessionAsync()
+        XCTAssertEqual(pendoManager.startSessionCallsCount, 1)
+    }
 
-        XCTAssertEqual(pendoManager.setupCallsCount, 0)
+    @MainActor
+    func test_storeApiKey_whenCalledWithDifferentKeyAfterSetup_shouldDisableEndSession() async throws {
+        try await testee.startSessionAsync()
+
+        testee.storeApiKey("some other key")
+        testee.endSession()
+
+        XCTAssertEqual(pendoManager.endSessionCallsCount, 0)
+    }
+
+    func test_storeApiKey_whenCalledWithSameKeyAfterSetup_shouldKeepStartSessionEnabled() async throws {
+        try await testee.startSessionAsync()
+        XCTAssertEqual(pendoManager.startSessionCallsCount, 1)
+
+        testee.storeApiKey("some api key")
+
+        try await testee.startSessionAsync()
+        XCTAssertEqual(pendoManager.startSessionCallsCount, 2)
     }
 
     // MARK: - track


### PR DESCRIPTION
## PR Info

refs: [MBL-19986](https://instructure.atlassian.net/browse/MBL-19986)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: none

See ticket for details.

## Test Plan
The region dependent API is currently available only on beta env.

Testing on the PROD env:
- Enable send_usage_metrics FF
- Login with a user
- Verify tracking works

Testing on the BETA env:
- Enable send_usage_metrics FF
- Login with a user
- Verify tracking works
- Login with a second user
  - Swap the student/teacher api keys in the response to apply a valid but different key
- Verify tracking is blocked (no outgoing Pendo requests)
- Login with the first user again
- Verify tracking works again

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [x] Tested on tablet
- [ ] Tested in dark mode
- [x] Tested in light mode
- [ ] Approve from product

[MBL-19986]: https://instructure.atlassian.net/browse/MBL-19986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ