### PR TITLE
[MBL-19906] NGC - Add placeholder course details

### DIFF
--- a/NextGen/NextGen/Resources/Localizable.xcstrings
+++ b/NextGen/NextGen/Resources/Localizable.xcstrings
@@ -1,0 +1,21 @@
+{
+  "sourceLanguage" : "en",
+  "strings" : {
+    "" : {
+
+    },
+    "Home" : {
+
+    },
+    "Modules" : {
+
+    },
+    "More" : {
+
+    },
+    "My work" : {
+
+    }
+  },
+  "version" : "1.0"
+}

--- a/NextGen/NextGen/Sources/Common/Extensions/BundleExtension.swift
+++ b/NextGen/NextGen/Sources/Common/Extensions/BundleExtension.swift
@@ -18,8 +18,8 @@
 
 import Foundation
 
-private class Placeholder {}
-
 extension Bundle {
     public static let nextgen = Bundle(for: Placeholder.self)
 }
+
+private class Placeholder {}

--- a/NextGen/NextGen/Sources/Common/Extensions/BundleExtension.swift
+++ b/NextGen/NextGen/Sources/Common/Extensions/BundleExtension.swift
@@ -1,0 +1,25 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+private class Placeholder {}
+
+extension Bundle {
+    public static let nextgen = Bundle(for: Placeholder.self)
+}

--- a/NextGen/NextGen/Sources/Features/CourseDetails/NGCourseDetailsAssembly.swift
+++ b/NextGen/NextGen/Sources/Features/CourseDetails/NGCourseDetailsAssembly.swift
@@ -1,0 +1,30 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import UIKit
+
+public enum NGCourseDetailsAssembly {
+    public static func makeCourseDetailsViewController(courseID: String) -> UIViewController {
+        let viewModel = CourseDetailsViewModel(
+            context: .course(courseID),
+            offlineModeInteractor: OfflineModeAssembly.make()
+        )
+        return CoreHostingController(NGCourseDetailsView(viewModel: viewModel))
+    }
+}

--- a/NextGen/NextGen/Sources/Features/CourseDetails/View/NGCourseDetailsView.swift
+++ b/NextGen/NextGen/Sources/Features/CourseDetails/View/NGCourseDetailsView.swift
@@ -1,0 +1,95 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2025-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Core
+import SwiftUI
+
+struct NGCourseDetailsView: View {
+    @ObservedObject var viewModel: CourseDetailsViewModel
+    @State private var selectedTab: Tab = .home
+
+    private var screenState: ScreenState {
+        switch viewModel.state {
+        case .loading: return .loading
+        case .empty: return .empty
+        case .data: return .data
+        }
+    }
+
+    var body: some View {
+        BaseScreen(
+            state: screenState,
+            refreshAction: { completion in
+                Task {
+                    await viewModel.refresh()
+                    completion()
+                }
+            }
+        ) { _ in
+            VStack(spacing: 0) {
+                HStack(spacing: 8) {
+                    RoundedRectangle(cornerRadius: 4)
+                        .fill(Color(viewModel.courseColor))
+                        .frame(width: 48, height: 84)
+                    Text(viewModel.courseName)
+                        .font(.semibold16)
+                        .foregroundColor(.textDarkest)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Picker("", selection: $selectedTab) {
+                    ForEach(Tab.allCases) { tab in
+                        Text(tab.label).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.top, 8)
+                .padding(.bottom, 16)
+
+                Spacer()
+                Text(selectedTab.label)
+                    .foregroundColor(.textLight)
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 16)
+        }
+        .navigationTitle(viewModel.navigationBarTitle)
+        .onAppear {
+            viewModel.viewDidAppear()
+        }
+    }
+}
+
+private extension NGCourseDetailsView {
+    enum Tab: Int, CaseIterable, Identifiable {
+        case home, modules, myWork, more
+
+        var id: Int { rawValue }
+
+        var label: String {
+            switch self {
+            case .home: return String(localized: "Home", bundle: .nextgen)
+            case .modules: return String(localized: "Modules", bundle: .nextgen)
+            case .myWork: return String(localized: "My work", bundle: .nextgen)
+            case .more: return String(localized: "More", bundle: .nextgen)
+            }
+        }
+    }
+}

--- a/NextGen/NextGen/Sources/Features/CourseDetails/View/NGCourseDetailsView.swift
+++ b/NextGen/NextGen/Sources/Features/CourseDetails/View/NGCourseDetailsView.swift
@@ -22,6 +22,7 @@ import SwiftUI
 struct NGCourseDetailsView: View {
     @ObservedObject var viewModel: CourseDetailsViewModel
     @State private var selectedTab: Tab = .home
+    @State private var screenConfig: BaseScreenConfig = .init(backgroundColor: .backgroundLight)
 
     private var screenState: ScreenState {
         switch viewModel.state {
@@ -34,6 +35,7 @@ struct NGCourseDetailsView: View {
     var body: some View {
         BaseScreen(
             state: screenState,
+            config: screenConfig,
             refreshAction: { completion in
                 Task {
                     await viewModel.refresh()
@@ -62,10 +64,8 @@ struct NGCourseDetailsView: View {
                 .padding(.top, 8)
                 .padding(.bottom, 16)
 
-                Spacer()
                 Text(selectedTab.label)
-                    .foregroundColor(.textLight)
-                Spacer()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
             .padding(.horizontal, 16)
             .padding(.bottom, 16)

--- a/NextGen/NextGen/Sources/Routing/NGenRoutes.swift
+++ b/NextGen/NextGen/Sources/Routing/NGenRoutes.swift
@@ -19,10 +19,10 @@
 import Core
 import UIKit
 
-public enum NextGenRoutes {
+public enum NGRoutes {
     public static func makeRouter(
         academicRoutes: [RouteHandler],
-        nextgenRoutes: [RouteHandler] = NextGenRoutes.routes
+        nextgenRoutes: [RouteHandler] = NGRoutes.routes
     ) -> Router {
         let overriddenTemplates = Set(nextgenRoutes.map { $0.route.template })
         let mergedRoutes = nextgenRoutes + academicRoutes.filter { !overriddenTemplates.contains($0.route.template) }

--- a/NextGen/NextGen/Sources/Routing/NextGenRoutes.swift
+++ b/NextGen/NextGen/Sources/Routing/NextGenRoutes.swift
@@ -17,16 +17,27 @@
 //
 
 import Core
+import UIKit
 
 public enum NextGenRoutes {
     public static func makeRouter(
         academicRoutes: [RouteHandler],
-        nextgenRoutes: [RouteHandler] = NextGenRoutes.nextgenRoutes
+        nextgenRoutes: [RouteHandler] = NextGenRoutes.routes
     ) -> Router {
         let overriddenTemplates = Set(nextgenRoutes.map { $0.route.template })
         let mergedRoutes = nextgenRoutes + academicRoutes.filter { !overriddenTemplates.contains($0.route.template) }
         return Router(routes: mergedRoutes)
     }
 
-    public static var nextgenRoutes: [RouteHandler] { [] }
+    public static var routes: [RouteHandler] {
+        [
+            RouteHandler("/courses/:courseID", factory: makeCourseDetails),
+            RouteHandler("/courses/:courseID/tabs", factory: makeCourseDetails)
+        ]
+    }
+
+    private static func makeCourseDetails(_: URLComponents, params: [String: String], _: [String: Any]?) -> UIViewController? {
+        guard let courseID = params["courseID"] else { return nil }
+        return NGCourseDetailsAssembly.makeCourseDetailsViewController(courseID: courseID)
+    }
 }

--- a/NextGen/NextGenUnitTests/Helpers/NGTestCase.swift
+++ b/NextGen/NextGenUnitTests/Helpers/NGTestCase.swift
@@ -22,7 +22,7 @@ import XCTest
 @testable import Core
 @testable import NextGen
 
-class NextGenTestCase: XCTestCase {
+class NGTestCase: XCTestCase {
     var database: NSPersistentContainer { TestsFoundation.singleSharedTestDatabase }
     var databaseClient: NSManagedObjectContext { database.viewContext }
 

--- a/NextGen/NextGenUnitTests/Routing/NGRoutesTests.swift
+++ b/NextGen/NextGenUnitTests/Routing/NGRoutesTests.swift
@@ -20,7 +20,7 @@ import XCTest
 @testable import Core
 @testable import NextGen
 
-final class NextGenRoutesTests: NextGenTestCase {
+final class NGRoutesTests: NGTestCase {
 
     private static let testData = (
         route1: "/some/route/1",
@@ -36,7 +36,7 @@ final class NextGenRoutesTests: NextGenTestCase {
     func test_makeRouter_shouldUseAcademicRouteHandlers() {
         let academicRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.academicVC }]
 
-        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: [])
+        let router = NGRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: [])
 
         XCTAssertIdentical(router.match(testData.route1), testData.academicVC)
     }
@@ -45,7 +45,7 @@ final class NextGenRoutesTests: NextGenTestCase {
         let academicRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.academicVC }]
         let nextgenRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.nextgenVC }]
 
-        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
+        let router = NGRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
 
         XCTAssertIdentical(router.match(testData.route1), testData.nextgenVC)
     }
@@ -57,7 +57,7 @@ final class NextGenRoutesTests: NextGenTestCase {
         ]
         let nextgenRoutes = [RouteHandler(testData.route1) { _, _, _ in self.testData.nextgenVC }]
 
-        let router = NextGenRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
+        let router = NGRoutes.makeRouter(academicRoutes: academicRoutes, nextgenRoutes: nextgenRoutes)
 
         XCTAssertIdentical(router.match(testData.route2), testData.academicVC)
     }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -434,7 +434,7 @@ extension StudentAppDelegate {
             let app: AppEnvironment.App = ExperimentalFeature.nextgenStudent.isEnabled ? .nextgen : .student
             AppEnvironment.shared.app = app
             AppEnvironment.shared.router = (app == .nextgen)
-                ? NextGenRoutes.makeRouter(academicRoutes: academicRouter.handlers)
+                ? NGRoutes.makeRouter(academicRoutes: academicRouter.handlers)
                 : academicRouter
             guard let window else { return }
             let userInterfaceStyle = AppEnvironment.shared.userDefaults?.academicInterfaceStyle ?? AppEnvironment.shared.userDefaults?.interfaceStyle

--- a/scripts/translations/localizables.json
+++ b/scripts/translations/localizables.json
@@ -10,5 +10,6 @@
   "Student/SubmitAssignment/Localizable.xcstrings",
   "Student/Widgets/Resources/InfoPlist.xcstrings",
   "Student/Widgets/Resources/Localizable.xcstrings",
-  "Horizon/Horizon/Resources/Localizable.xcstrings"
+  "Horizon/Horizon/Resources/Localizable.xcstrings",
+  "NextGen/NextGen/Resources/Localizable.xcstrings"
 ]


### PR DESCRIPTION
## PR Info

refs: [MBL-19906](https://instructure.atlassian.net/browse/MBL-19906)
builds: Student
affects: Student
release note: none
test plan:
- When next-gen feature flag is on we should show the placeholder course details, otherwise the academic course details should be presented.

## What's new?
- A placeholder course details mainly to have a container for the grades list.
- Setup translations for the NextGen project.
- Started using the `NG` prefix for files in this project.
- The figma for this placeholder isn't based on InstUI so I just used hardcoded values for now.

## Screenshots

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/d9bc6ba8-d08b-4795-a0f5-527010c2743e" width=300></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19906]: https://instructure.atlassian.net/browse/MBL-19906?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ