### PR TITLE
[MBL-19997][S/P/T] Force update

### DIFF
--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 //
 
+import BusinessLogic
 import Foundation
 import UIKit.UIDevice
 
@@ -37,11 +38,13 @@ public struct ForceUpdateInfo: Codable {
     }
 
     public var shouldForceUpdate: Bool {
-        guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return false }
-        let systemVersion = UIDevice.current.systemVersion
-
-        return systemVersion.compare(minimumSystemVersion, options: .numeric) != .orderedAscending
-            && appVersion.compare(belowAppVersion, options: .numeric) == .orderedAscending
+        let forceUpdateLogic: BusinessLogic.ForceUpdate = .live
+        return forceUpdateLogic.shouldForceUpdate(
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            systemVersion: UIDevice.current.systemVersion,
+            minimumSystemVersion: minimumSystemVersion,
+            belowAppVersion: belowAppVersion
+        )
     }
 }
 

--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
@@ -32,8 +32,8 @@ public struct ForceUpdateInfo: Codable {
         }
     }
 
-    public static func isForceUpdateInfo(_ key: String) -> Bool {
-        key == "force_update_info"
+    public static func isForceUpdateInfo(of app: AppEnvironment.App, key: String) -> Bool {
+        app.forceUpdateRemoteConfigKey == key
     }
 
     public var shouldForceUpdate: Bool {
@@ -59,5 +59,23 @@ public extension ForceUpdateInfo {
     static func fromUserDefaults() -> ForceUpdateInfo? {
         guard let data = Self.sharedUserDefaults.data(forKey: userDefaultsKey) else { return nil }
         return ForceUpdateInfo(data: data)
+    }
+}
+
+public extension AppEnvironment.App {
+    var forceUpdateRemoteConfigKey: String {
+        switch self {
+        case .student, .horizon: "student_force_update_info"
+        case .parent: "parent_force_update_info"
+        case .teacher: "teacher_force_update_info"
+        }
+    }
+
+    var appID: String {
+        switch self {
+        case .student, .horizon: Bundle.studentAppID
+        case .parent: Bundle.parentAppID
+        case .teacher: Bundle.teacherAppID
+        }
     }
 }

--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
@@ -1,0 +1,63 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+import UIKit.UIDevice
+
+public struct ForceUpdateInfo: Codable {
+    private let belowAppVersion: String
+    private let minimumSystemVersion: String
+    public let isDismissable: Bool
+
+    public init?(data: Data) {
+        do {
+            self = try JSONDecoder().decode(ForceUpdateInfo.self, from: data)
+        } catch {
+            return nil
+        }
+    }
+
+    static func isForceUpdateInfo(_ key: String) -> Bool {
+        key == "force_update_info"
+    }
+
+    var shouldForceUpdate: Bool {
+        guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return false }
+        let systemVersion = UIDevice.current.systemVersion
+
+        return systemVersion.compare(minimumSystemVersion, options: .numeric) != .orderedAscending
+            && appVersion.compare(belowAppVersion, options: .numeric) == .orderedAscending
+    }
+}
+
+public extension ForceUpdateInfo {
+    private static let userDefaultsKey = "force_update_info"
+
+    private static var sharedUserDefaults: UserDefaults {
+        UserDefaults(suiteName: Bundle.main.appGroupID()) ?? .standard
+    }
+
+    func saveToUserDefaults() {
+        Self.sharedUserDefaults.set(try? JSONEncoder().encode(self), forKey: Self.userDefaultsKey)
+    }
+
+    static func fromUserDefaults() -> ForceUpdateInfo? {
+        guard let data = Self.sharedUserDefaults.data(forKey: userDefaultsKey) else { return nil }
+        return ForceUpdateInfo(data: data)
+    }
+}

--- a/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
+++ b/Core/Core/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfo.swift
@@ -32,11 +32,11 @@ public struct ForceUpdateInfo: Codable {
         }
     }
 
-    static func isForceUpdateInfo(_ key: String) -> Bool {
+    public static func isForceUpdateInfo(_ key: String) -> Bool {
         key == "force_update_info"
     }
 
-    var shouldForceUpdate: Bool {
+    public var shouldForceUpdate: Bool {
         guard let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String else { return false }
         let systemVersion = UIDevice.current.systemVersion
 

--- a/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
+++ b/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
@@ -1,0 +1,78 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import StoreKit
+import SwiftUI
+
+public struct ForceUpdateView: View {
+    @Environment(\.viewController) private var viewController
+    @Environment(\.dismiss) private var dismiss
+
+    let isDismissable: Bool
+    let appID: String
+
+    public init(appID: String, isDismissable: Bool = false) {
+        self.isDismissable = isDismissable
+        self.appID = appID
+    }
+
+    public var body: some View {
+        ZStack(alignment: .topTrailing) {
+            if isDismissable {
+                Button {
+                    dismiss()
+                } label: {
+                    Text("Later")
+                }
+                .buttonStyle(.bordered)
+                .padding()
+            }
+
+            VStack(spacing: 24) {
+                Image(systemName: "icloud.and.arrow.down")
+                    .font(.system(size: 80))
+                    .foregroundStyle(.textDark)
+
+                Text(verbatim: "Canvas needs updating.")
+                    .foregroundStyle(.textDarkest)
+
+                Button(action: loadAppStorePage) {
+                    Label("App Store", systemImage: "applelogo")
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.backgroundDarkest)
+                .foregroundStyle(.textLightest)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+
+    private func loadAppStorePage() {
+        Task {
+            let controller = SKStoreProductViewController()
+            let parameters = [SKStoreProductParameterITunesItemIdentifier: appID]
+            try await controller.loadProduct(withParameters: parameters)
+
+            viewController.value.present(controller, animated: true)
+        }
+    }
+}
+
+#Preview {
+    ForceUpdateView(appID: "", isDismissable: true)
+}

--- a/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
+++ b/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
@@ -26,9 +26,9 @@ public struct ForceUpdateView: View {
     let isDismissable: Bool
     let appID: String
 
-    public init(appID: String, isDismissable: Bool = false) {
+    public init(app: AppEnvironment.App, isDismissable: Bool) {
         self.isDismissable = isDismissable
-        self.appID = appID
+        self.appID = app.appID
     }
 
     public var body: some View {
@@ -74,5 +74,5 @@ public struct ForceUpdateView: View {
 }
 
 #Preview {
-    ForceUpdateView(appID: "", isDismissable: true)
+    ForceUpdateView(app: .student, isDismissable: true)
 }

--- a/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
+++ b/Core/Core/Common/CommonUI/ForceUpdate/ForceUpdateView.swift
@@ -23,6 +23,8 @@ public struct ForceUpdateView: View {
     @Environment(\.viewController) private var viewController
     @Environment(\.dismiss) private var dismiss
 
+    @State private var isErrorAlertPresented = false
+
     let isDismissable: Bool
     let appID: String
 
@@ -60,15 +62,20 @@ public struct ForceUpdateView: View {
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
+        .alert("Failed to open the App Store", isPresented: $isErrorAlertPresented, actions: { })
     }
 
     private func loadAppStorePage() {
         Task {
-            let controller = SKStoreProductViewController()
-            let parameters = [SKStoreProductParameterITunesItemIdentifier: appID]
-            try await controller.loadProduct(withParameters: parameters)
+            do {
+                let controller = SKStoreProductViewController()
+                let parameters = [SKStoreProductParameterITunesItemIdentifier: appID]
+                try await controller.loadProduct(withParameters: parameters)
 
-            viewController.value.present(controller, animated: true)
+                viewController.value.present(controller, animated: true)
+            } catch {
+                isErrorAlertPresented = true
+            }
         }
     }
 }

--- a/Core/Core/Common/Extensions/Foundation/BundleExtensions.swift
+++ b/Core/Core/Common/Extensions/Foundation/BundleExtensions.swift
@@ -28,6 +28,10 @@ public extension Bundle {
     static let parentBundleID = "com.instructure.parentapp"
     static let horizonBundleID = "com.instructure.horizon"
 
+    static let studentAppID = "480883488"
+    static let teacherAppID = "1257834464"
+    static let parentAppID = "1097996698"
+
     static let coreBundleID = "com.instructure.core"
 
     static let studentUITestsBundleID = "com.instructure.StudentUITests.xctrunner"

--- a/Core/Core/Common/Extensions/UIKit/UIApplicationDelegateExtensions.swift
+++ b/Core/Core/Common/Extensions/UIKit/UIApplicationDelegateExtensions.swift
@@ -23,4 +23,21 @@ extension UIApplicationDelegate {
     public func updateInterfaceStyle(for window: UIWindow?) {
         window?.updateInterfaceStyle(AppEnvironment.shared.userDefaults?.interfaceStyle)
     }
+
+    public func showForceUpdateModal(of app: AppEnvironment.App, on controller: UIViewController) {
+        let modal = CoreHostingController(ForceUpdateView(app: app, isDismissable: true))
+        modal.modalPresentationStyle = .overFullScreen
+        controller.present(modal, animated: true)
+    }
+
+    public func setForceUpdateView(window: UIWindow?, completion: @escaping () -> Void) {
+        guard let window = window else { return }
+        let controller = CoreHostingController(ForceUpdateView(app: .student, isDismissable: false))
+        controller.view.layoutIfNeeded()
+        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
+            window.rootViewController = controller
+        } completion: { _ in
+            completion()
+        }
+    }
 }

--- a/Core/Core/Resources/Localizable.xcstrings
+++ b/Core/Core/Resources/Localizable.xcstrings
@@ -47326,6 +47326,9 @@
         }
       }
     },
+    "App Store" : {
+
+    },
     "Appearance" : {
       "localizations" : {
         "ar" : {
@@ -214568,6 +214571,9 @@
           }
         }
       }
+    },
+    "Later" : {
+
     },
     "Latest" : {
       "localizations" : {

--- a/Core/CoreTests/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfoTests.swift
+++ b/Core/CoreTests/Common/CommonModels/AppEnvironment/FeatureFlags/ForceUpdateInfoTests.swift
@@ -1,0 +1,144 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+@testable import Core
+import XCTest
+
+final class ForceUpdateInfoTests: XCTestCase {
+
+    private static let testData = (
+        belowAppVersion: "5.0.0",
+        minimumSystemVersion: "16.0",
+        isDismissable: true
+    )
+    private lazy var testData = Self.testData
+
+    // MARK: - init(data:)
+
+    func test_init_withValidJSON_shouldDecodeSuccessfully() {
+        let testee = makeForceUpdateInfo(
+            belowAppVersion: testData.belowAppVersion,
+            minimumSystemVersion: testData.minimumSystemVersion,
+            isDismissable: testData.isDismissable
+        )
+
+        XCTAssertNotNil(testee)
+        XCTAssertEqual(testee?.isDismissable, true)
+    }
+
+    func test_init_withInvalidJSON_shouldReturnNil() {
+        let data = Data("not valid json".utf8)
+
+        let testee = ForceUpdateInfo(data: data)
+
+        XCTAssertNil(testee)
+    }
+
+    func test_init_withEmptyData_shouldReturnNil() {
+        let testee = ForceUpdateInfo(data: Data())
+
+        XCTAssertNil(testee)
+    }
+
+    func test_init_withMissingFields_shouldReturnNil() {
+        let json = #"{"belowAppVersion": "5.0.0"}"#
+        let data = Data(json.utf8)
+
+        let testee = ForceUpdateInfo(data: data)
+
+        XCTAssertNil(testee)
+    }
+
+    func test_init_shouldDecodeIsDismissable() {
+        var testee = makeForceUpdateInfo(isDismissable: true)
+        XCTAssertEqual(testee?.isDismissable, true)
+
+        testee = makeForceUpdateInfo(isDismissable: false)
+        XCTAssertEqual(testee?.isDismissable, false)
+    }
+
+    // MARK: - isForceUpdateInfo(of:key:)
+
+    func test_isForceUpdateInfo_whenKeyMatchesApp_shouldReturnTrue() {
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .student, key: "student_force_update_info"), true)
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .teacher, key: "teacher_force_update_info"), true)
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .parent, key: "parent_force_update_info"), true)
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .horizon, key: "student_force_update_info"), true)
+    }
+
+    func test_isForceUpdateInfo_whenKeyDoesNotMatchApp_shouldReturnFalse() {
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .student, key: "teacher_force_update_info"), false)
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .teacher, key: "parent_force_update_info"), false)
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .parent, key: "student_force_update_info"), false)
+    }
+
+    func test_isForceUpdateInfo_withArbitraryKey_shouldReturnFalse() {
+        XCTAssertEqual(ForceUpdateInfo.isForceUpdateInfo(of: .student, key: "some_other_key"), false)
+    }
+
+    // MARK: - forceUpdateRemoteConfigKey
+
+    func test_forceUpdateRemoteConfigKey() {
+        XCTAssertEqual(AppEnvironment.App.student.forceUpdateRemoteConfigKey, "student_force_update_info")
+        XCTAssertEqual(AppEnvironment.App.horizon.forceUpdateRemoteConfigKey, "student_force_update_info")
+        XCTAssertEqual(AppEnvironment.App.teacher.forceUpdateRemoteConfigKey, "teacher_force_update_info")
+        XCTAssertEqual(AppEnvironment.App.parent.forceUpdateRemoteConfigKey, "parent_force_update_info")
+    }
+
+    // MARK: - appID
+
+    func test_appID() {
+        XCTAssertEqual(AppEnvironment.App.student.appID, Bundle.studentAppID)
+        XCTAssertEqual(AppEnvironment.App.horizon.appID, Bundle.studentAppID)
+        XCTAssertEqual(AppEnvironment.App.teacher.appID, Bundle.teacherAppID)
+        XCTAssertEqual(AppEnvironment.App.parent.appID, Bundle.parentAppID)
+    }
+
+    // MARK: - UserDefaults round-trip
+
+    func test_saveToUserDefaults_andFromUserDefaults_shouldRoundTrip() {
+        let testee = makeForceUpdateInfo(
+            belowAppVersion: testData.belowAppVersion,
+            minimumSystemVersion: testData.minimumSystemVersion,
+            isDismissable: testData.isDismissable
+        )
+        testee?.saveToUserDefaults()
+
+        let restored = ForceUpdateInfo.fromUserDefaults()
+
+        XCTAssertNotNil(restored)
+        XCTAssertEqual(restored?.isDismissable, testData.isDismissable)
+    }
+
+    // MARK: - Private helpers
+
+    private func makeForceUpdateInfo(
+        belowAppVersion: String = "5.0.0",
+        minimumSystemVersion: String = "16.0",
+        isDismissable: Bool = true
+    ) -> ForceUpdateInfo? {
+        let json = """
+        {
+            "belowAppVersion": "\(belowAppVersion)",
+            "minimumSystemVersion": "\(minimumSystemVersion)",
+            "isDismissable": \(isDismissable)
+        }
+        """
+        return ForceUpdateInfo(data: Data(json.utf8))
+    }
+}

--- a/Core/CoreTests/Common/Extensions/UIKit/UIApplicationDelegateExtensionsTests.swift
+++ b/Core/CoreTests/Common/Extensions/UIKit/UIApplicationDelegateExtensionsTests.swift
@@ -22,6 +22,14 @@ import UIKit
 
 class UIApplicationDelegateExtensionsTests: XCTestCase {
 
+    private class SpyViewController: UIViewController {
+        var presentedVC: UIViewController?
+        override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
+            presentedVC = viewControllerToPresent
+            completion?()
+        }
+    }
+
     func testUpdateInterfaceStyle() {
         guard let appDelegate = UIApplication.shared.delegate else { return XCTFail() }
         AppEnvironment.shared.userDefaults?.interfaceStyle = .dark
@@ -33,5 +41,43 @@ class UIApplicationDelegateExtensionsTests: XCTestCase {
         AppEnvironment.shared.userDefaults?.interfaceStyle = .unspecified
         appDelegate.updateInterfaceStyle(for: appDelegate.window!)
         XCTAssertEqual(appDelegate.window!?.overrideUserInterfaceStyle, .unspecified)
+    }
+
+    // MARK: - showForceUpdateModal
+
+    func test_showForceUpdateModal_shouldPresentForceUpdateViewOverFullScreen() {
+        guard let appDelegate = UIApplication.shared.delegate else { return XCTFail() }
+        let controller = SpyViewController()
+
+        appDelegate.showForceUpdateModal(of: .student, on: controller)
+
+        XCTAssertNotNil(controller.presentedVC as? CoreHostingController<ForceUpdateView>)
+        XCTAssertEqual(controller.presentedVC?.modalPresentationStyle, .overFullScreen)
+    }
+
+    // MARK: - setForceUpdateView
+
+    func test_setForceUpdateView_whenWindowIsNil_shouldNotCallCompletion() {
+        guard let appDelegate = UIApplication.shared.delegate else { return XCTFail() }
+        var completionCalled = false
+
+        appDelegate.setForceUpdateView(window: nil) {
+            completionCalled = true
+        }
+
+        XCTAssertEqual(completionCalled, false)
+    }
+
+    func test_setForceUpdateView_whenWindowIsProvided_shouldSetRootViewControllerAndCallCompletion() {
+        guard let appDelegate = UIApplication.shared.delegate else { return XCTFail() }
+        let window = UIWindow()
+        let completionExpectation = expectation(description: "completion called")
+
+        appDelegate.setForceUpdateView(window: window) {
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 2)
+        XCTAssertNotNil(window.rootViewController as? CoreHostingController<ForceUpdateView>)
     }
 }

--- a/Core/project.yml
+++ b/Core/project.yml
@@ -20,6 +20,8 @@ settings:
   STRING_CATALOG_GENERATE_SYMBOLS: false
   platform: iOS
 packages:
+  BusinessLogic:
+    path: ../packages/BusinessLogic
   CombineSchedulers:
     url: https://github.com/pointfreeco/combine-schedulers
     exactVersion: 1.1.0
@@ -45,6 +47,7 @@ targets:
     sources:
       - path: Core
     dependencies:
+      - package: BusinessLogic
       - package: CombineSchedulers
       - package: CombineExt
       - package: Lottie

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -166,7 +166,10 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     func showRootView() {
         let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
         if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
-            setForceUpdateView()
+            setForceUpdateView(window: window) {
+                self.environment.startupDidComplete()
+                UIApplication.shared.registerForPushNotifications()
+            }
         } else {
             guard let window = self.window else { return }
             let controller = ParentContainerNavigationController(rootViewController: DashboardViewController.create())
@@ -177,7 +180,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
                 self.environment.startupDidComplete()
 
                 if forceUpdateInfo?.shouldForceUpdate ?? false {
-                    self.showForceUpdateModal(on: controller)
+                    self.showForceUpdateModal(of: .parent, on: controller)
                 }
             })
         }
@@ -220,24 +223,6 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
         }
-    }
-
-    private func setForceUpdateView() {
-        guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(app: .parent, isDismissable: false))
-        controller.view.layoutIfNeeded()
-        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
-            window.rootViewController = controller
-        } completion: { [weak self] _ in
-            self?.environment.startupDidComplete()
-            UIApplication.shared.registerForPushNotifications()
-        }
-    }
-
-    private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(app: .parent, isDismissable: true))
-        modal.modalPresentationStyle = .overFullScreen
-        controller.present(modal, animated: true)
     }
 }
 

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -205,7 +205,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
             remoteConfig.activate { _, _ in
                 let keys = remoteConfig.allKeys(from: .remote)
                 for key in keys {
-                    if ForceUpdateInfo.isForceUpdateInfo(key) {
+                    if ForceUpdateInfo.isForceUpdateInfo(of: .parent, key: key) {
                         let data = remoteConfig.configValue(forKey: key).dataValue
                         let info = ForceUpdateInfo(data: data)
                         info?.saveToUserDefaults()
@@ -224,7 +224,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
 
     private func setForceUpdateView() {
         guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        let controller = CoreHostingController(ForceUpdateView(app: .parent, isDismissable: false))
         controller.view.layoutIfNeeded()
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
             window.rootViewController = controller
@@ -235,7 +235,7 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        let modal = CoreHostingController(ForceUpdateView(app: .parent, isDismissable: true))
         modal.modalPresentationStyle = .overFullScreen
         controller.present(modal, animated: true)
     }

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -164,14 +164,23 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func showRootView() {
-        guard let window = self.window else { return }
-        let controller = ParentContainerNavigationController(rootViewController: DashboardViewController.create())
-        controller.view.layoutIfNeeded()
-        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
-            window.rootViewController = controller
-        }, completion: { _ in
-            self.environment.startupDidComplete()
-        })
+        let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
+        if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
+            setForceUpdateView()
+        } else {
+            guard let window = self.window else { return }
+            let controller = ParentContainerNavigationController(rootViewController: DashboardViewController.create())
+            controller.view.layoutIfNeeded()
+            UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
+                window.rootViewController = controller
+            }, completion: { _ in
+                self.environment.startupDidComplete()
+
+                if forceUpdateInfo?.shouldForceUpdate ?? false {
+                    self.showForceUpdateModal(on: controller)
+                }
+            })
+        }
     }
 
     static func getPreferences(env: AppEnvironment) -> AnyPublisher<APIUser, Error> {
@@ -196,6 +205,13 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
             remoteConfig.activate { _, _ in
                 let keys = remoteConfig.allKeys(from: .remote)
                 for key in keys {
+                    if ForceUpdateInfo.isForceUpdateInfo(key) {
+                        let data = remoteConfig.configValue(forKey: key).dataValue
+                        let info = ForceUpdateInfo(data: data)
+                        info?.saveToUserDefaults()
+                        continue
+                    }
+
                     guard let feature = ExperimentalFeature(rawValue: key) else { continue }
                     let value = remoteConfig.configValue(forKey: key).boolValue
                     feature.isEnabled = value
@@ -204,6 +220,24 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
                 }
             }
         }
+    }
+
+    private func setForceUpdateView() {
+        guard let window = window else { return }
+        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        controller.view.layoutIfNeeded()
+        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
+            window.rootViewController = controller
+        } completion: { [weak self] _ in
+            self?.environment.startupDidComplete()
+            UIApplication.shared.registerForPushNotifications()
+        }
+    }
+
+    private func showForceUpdateModal(on controller: UIViewController) {
+        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        modal.modalPresentationStyle = .overFullScreen
+        controller.present(modal, animated: true)
     }
 }
 

--- a/Parent/Parent/ParentAppDelegate.swift
+++ b/Parent/Parent/ParentAppDelegate.swift
@@ -168,7 +168,6 @@ class ParentAppDelegate: UIResponder, UIApplicationDelegate {
         if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
             setForceUpdateView(window: window) {
                 self.environment.startupDidComplete()
-                UIApplication.shared.registerForPushNotifications()
             }
         } else {
             guard let window = self.window else { return }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -250,7 +250,7 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
             remoteConfig.activate { _, _ in
                 let keys = remoteConfig.allKeys(from: .remote)
                 for key in keys {
-                    if ForceUpdateInfo.isForceUpdateInfo(key) {
+                    if ForceUpdateInfo.isForceUpdateInfo(of: .student, key: key) {
                         let data = remoteConfig.configValue(forKey: key).dataValue
                         let info = ForceUpdateInfo(data: data)
                         info?.saveToUserDefaults()
@@ -496,7 +496,7 @@ extension StudentAppDelegate {
 
     private func setForceUpdateView() {
         guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        let controller = CoreHostingController(ForceUpdateView(app: .student, isDismissable: false))
         controller.view.layoutIfNeeded()
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
             window.rootViewController = controller
@@ -507,7 +507,7 @@ extension StudentAppDelegate {
     }
 
     private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        let modal = CoreHostingController(ForceUpdateView(app: .student, isDismissable: true))
         modal.modalPresentationStyle = .overFullScreen
         controller.present(modal, animated: true)
     }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -157,7 +157,10 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
 
                     let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
                     if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
-                        unownedSelf.setForceUpdateView()
+                        unownedSelf.setForceUpdateView(window: unownedSelf.window) {
+                            unownedSelf.environment.startupDidComplete()
+                            UIApplication.shared.registerForPushNotifications()
+                        }
                     } else {
                         unownedSelf.setTabBarControllerFor(
                             experience: experience,
@@ -496,18 +499,6 @@ extension StudentAppDelegate {
 
         if shouldShowForceUpdateModal {
             showForceUpdateModal(of: .student, on: controller)
-        }
-    }
-
-    private func setForceUpdateView() {
-        guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(app: .student, isDismissable: false))
-        controller.view.layoutIfNeeded()
-        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
-            window.rootViewController = controller
-        } completion: { [weak self] _ in
-            self?.environment.startupDidComplete()
-            UIApplication.shared.registerForPushNotifications()
         }
     }
 }

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -445,7 +445,12 @@ extension StudentAppDelegate {
             .store(in: &subscriptions)
     }
 
-    private func setTabBarControllerFor(experience: Experience, isStartup: Bool, session: LoginSession?, shouldShowForceUpdateModal: Bool = false) {
+    private func setTabBarControllerFor(
+        experience: Experience,
+        isStartup: Bool,
+        session: LoginSession?,
+        shouldShowForceUpdateModal: Bool = false
+    ) {
         var controller: UIViewController
         switch experience {
         case .academic:

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -495,7 +495,7 @@ extension StudentAppDelegate {
         }
 
         if shouldShowForceUpdateModal {
-            showForceUpdateModal(on: controller)
+            showForceUpdateModal(of: .student, on: controller)
         }
     }
 
@@ -509,12 +509,6 @@ extension StudentAppDelegate {
             self?.environment.startupDidComplete()
             UIApplication.shared.registerForPushNotifications()
         }
-    }
-
-    private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(app: .student, isDismissable: true))
-        modal.modalPresentationStyle = .overFullScreen
-        controller.present(modal, animated: true)
     }
 }
 

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -154,7 +154,18 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
                 receiveValue: { experience in
                     unownedSelf.refreshNotificationTab()
                     Analytics.shared.logSession(session)
-                    unownedSelf.setTabBarControllerFor(experience: experience, isStartup: true, session: session)
+
+                    let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
+                    if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
+                        unownedSelf.setForceUpdateView()
+                    } else {
+                        unownedSelf.setTabBarControllerFor(
+                            experience: experience,
+                            isStartup: true,
+                            session: session,
+                            shouldShowForceUpdateModal: forceUpdateInfo?.shouldForceUpdate ?? false
+                        )
+                    }
                 }
             )
             .store(in: &subscriptions)
@@ -239,6 +250,13 @@ class StudentAppDelegate: UIResponder, UIApplicationDelegate, AppEnvironmentDele
             remoteConfig.activate { _, _ in
                 let keys = remoteConfig.allKeys(from: .remote)
                 for key in keys {
+                    if ForceUpdateInfo.isForceUpdateInfo(key) {
+                        let data = remoteConfig.configValue(forKey: key).dataValue
+                        let info = ForceUpdateInfo(data: data)
+                        info?.saveToUserDefaults()
+                        continue
+                    }
+
                     guard let feature = ExperimentalFeature(rawValue: key) else { continue }
                     let value = remoteConfig.configValue(forKey: key).boolValue
                     feature.isEnabled = value
@@ -427,7 +445,8 @@ extension StudentAppDelegate {
             .store(in: &subscriptions)
     }
 
-    private func setTabBarControllerFor(experience: Experience, isStartup: Bool, session: LoginSession?) {
+    private func setTabBarControllerFor(experience: Experience, isStartup: Bool, session: LoginSession?, shouldShowForceUpdateModal: Bool = false) {
+        var controller: UIViewController
         switch experience {
         case .academic:
             AppEnvironment.shared.app = .student
@@ -440,7 +459,7 @@ extension StudentAppDelegate {
             appearance.tintColor = nil
             appearance.titleTextAttributes = nil
 
-            let controller = StudentTabBarController(isLearnerDashboardEnabledOnInstance: isLearnerDashboardEnabledOnInstance)
+            controller = StudentTabBarController(isLearnerDashboardEnabledOnInstance: isLearnerDashboardEnabledOnInstance)
             controller.view.layoutIfNeeded()
             UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
                 window.rootViewController = controller
@@ -456,7 +475,7 @@ extension StudentAppDelegate {
             HorizonUI.setInstitutionColor(Brand.shared.primary)
             guard let window = window else { return }
             window.updateInterfaceStyleWithoutTransition(.light)
-            let controller = HorizonTabBarController()
+            controller = HorizonTabBarController()
             controller.view.layoutIfNeeded()
             UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
                 window.rootViewController = controller
@@ -469,6 +488,28 @@ extension StudentAppDelegate {
 //        case .careerLearningProvider:
 //            showIncorrectAppExperienceAlert(session: session)
         }
+
+        if shouldShowForceUpdateModal {
+            showForceUpdateModal(on: controller)
+        }
+    }
+
+    private func setForceUpdateView() {
+        guard let window = window else { return }
+        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        controller.view.layoutIfNeeded()
+        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
+            window.rootViewController = controller
+        } completion: { [weak self] _ in
+            self?.environment.startupDidComplete()
+            UIApplication.shared.registerForPushNotifications()
+        }
+    }
+
+    private func showForceUpdateModal(on controller: UIViewController) {
+        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        modal.modalPresentationStyle = .overFullScreen
+        controller.present(modal, animated: true)
     }
 }
 

--- a/Student/Student/StudentAppDelegate.swift
+++ b/Student/Student/StudentAppDelegate.swift
@@ -454,7 +454,6 @@ extension StudentAppDelegate {
         session: LoginSession?,
         shouldShowForceUpdateModal: Bool = false
     ) {
-        var controller: UIViewController
         switch experience {
         case .academic:
             AppEnvironment.shared.app = .student
@@ -467,7 +466,7 @@ extension StudentAppDelegate {
             appearance.tintColor = nil
             appearance.titleTextAttributes = nil
 
-            controller = StudentTabBarController(isLearnerDashboardEnabledOnInstance: isLearnerDashboardEnabledOnInstance)
+            let controller = StudentTabBarController(isLearnerDashboardEnabledOnInstance: isLearnerDashboardEnabledOnInstance)
             controller.view.layoutIfNeeded()
             UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
                 window.rootViewController = controller
@@ -475,6 +474,9 @@ extension StudentAppDelegate {
                 if isStartup {
                     self?.environment.startupDidComplete()
                     UIApplication.shared.registerForPushNotifications()
+                }
+                if shouldShowForceUpdateModal {
+                    self?.showForceUpdateModal(of: .student, on: controller)
                 }
             })
         case .careerLearner, .careerLearningProvider:
@@ -483,7 +485,7 @@ extension StudentAppDelegate {
             HorizonUI.setInstitutionColor(Brand.shared.primary)
             guard let window = window else { return }
             window.updateInterfaceStyleWithoutTransition(.light)
-            controller = HorizonTabBarController()
+            let controller = HorizonTabBarController()
             controller.view.layoutIfNeeded()
             UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight, animations: {
                 window.rootViewController = controller
@@ -492,13 +494,12 @@ extension StudentAppDelegate {
                     self?.environment.startupDidComplete()
                     UIApplication.shared.registerForPushNotifications()
                 }
+                if shouldShowForceUpdateModal {
+                    self?.showForceUpdateModal(of: .student, on: controller)
+                }
             })
 //        case .careerLearningProvider:
 //            showIncorrectAppExperienceAlert(session: session)
-        }
-
-        if shouldShowForceUpdateModal {
-            showForceUpdateModal(of: .student, on: controller)
         }
     }
 }

--- a/Teacher/Teacher/TeacherAppDelegate.swift
+++ b/Teacher/Teacher/TeacherAppDelegate.swift
@@ -101,13 +101,19 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
                 },
                 receiveValue: {
                     Analytics.shared.logSession(session)
-                    unownedSelf.setTabBarController()
+
+                    let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
+                    if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
+                        unownedSelf.setForceUpdateView()
+                    } else {
+                        unownedSelf.setTabBarController(shouldShowForceUpdateModal: forceUpdateInfo?.shouldForceUpdate ?? false)
+                    }
                 }
             )
             .store(in: &subscriptions)
     }
 
-    func setTabBarController() {
+    func setTabBarController(shouldShowForceUpdateModal: Bool) {
         guard let window else { return }
 
         let controller = TeacherTabBarController()
@@ -118,6 +124,10 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
             self?.environment.startupDidComplete()
             UIApplication.shared.registerForPushNotifications()
         })
+
+        if shouldShowForceUpdateModal {
+            showForceUpdateModal(on: controller)
+        }
     }
 
     func application(
@@ -189,6 +199,24 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
                 }
             }
         }
+    }
+
+    private func setForceUpdateView() {
+        guard let window = window else { return }
+        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        controller.view.layoutIfNeeded()
+        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
+            window.rootViewController = controller
+        } completion: { [weak self] _ in
+            self?.environment.startupDidComplete()
+            UIApplication.shared.registerForPushNotifications()
+        }
+    }
+
+    private func showForceUpdateModal(on controller: UIViewController) {
+        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        modal.modalPresentationStyle = .overFullScreen
+        controller.present(modal, animated: true)
     }
 }
 

--- a/Teacher/Teacher/TeacherAppDelegate.swift
+++ b/Teacher/Teacher/TeacherAppDelegate.swift
@@ -192,6 +192,13 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
             remoteConfig.activate { _, _ in
                 let keys = remoteConfig.allKeys(from: .remote)
                 for key in keys {
+                    if ForceUpdateInfo.isForceUpdateInfo(of: .teacher, key: key) {
+                        let data = remoteConfig.configValue(forKey: key).dataValue
+                        let info = ForceUpdateInfo(data: data)
+                        info?.saveToUserDefaults()
+                        continue
+                    }
+
                     guard let feature = ExperimentalFeature(rawValue: key) else { continue }
                     let value = remoteConfig.configValue(forKey: key).boolValue
                     feature.isEnabled = value
@@ -203,7 +210,7 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
 
     private func setForceUpdateView() {
         guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID))
+        let controller = CoreHostingController(ForceUpdateView(app: .teacher, isDismissable: false))
         controller.view.layoutIfNeeded()
         UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
             window.rootViewController = controller
@@ -214,7 +221,7 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
     }
 
     private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(appID: Bundle.studentAppID, isDismissable: true))
+        let modal = CoreHostingController(ForceUpdateView(app: .teacher, isDismissable: true))
         modal.modalPresentationStyle = .overFullScreen
         controller.present(modal, animated: true)
     }

--- a/Teacher/Teacher/TeacherAppDelegate.swift
+++ b/Teacher/Teacher/TeacherAppDelegate.swift
@@ -126,11 +126,11 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
         }, completion: { [weak self] _ in
             self?.environment.startupDidComplete()
             UIApplication.shared.registerForPushNotifications()
-        })
 
-        if shouldShowForceUpdateModal {
-            showForceUpdateModal(of: .teacher, on: controller)
-        }
+            if shouldShowForceUpdateModal {
+                self?.showForceUpdateModal(of: .teacher, on: controller)
+            }
+        })
     }
 
     func application(

--- a/Teacher/Teacher/TeacherAppDelegate.swift
+++ b/Teacher/Teacher/TeacherAppDelegate.swift
@@ -104,7 +104,10 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
 
                     let forceUpdateInfo = ForceUpdateInfo.fromUserDefaults()
                     if let forceUpdateInfo, forceUpdateInfo.shouldForceUpdate, !forceUpdateInfo.isDismissable {
-                        unownedSelf.setForceUpdateView()
+                        unownedSelf.setForceUpdateView(window: unownedSelf.window) {
+                            unownedSelf.environment.startupDidComplete()
+                            UIApplication.shared.registerForPushNotifications()
+                        }
                     } else {
                         unownedSelf.setTabBarController(shouldShowForceUpdateModal: forceUpdateInfo?.shouldForceUpdate ?? false)
                     }
@@ -126,7 +129,7 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
         })
 
         if shouldShowForceUpdateModal {
-            showForceUpdateModal(on: controller)
+            showForceUpdateModal(of: .teacher, on: controller)
         }
     }
 
@@ -206,24 +209,6 @@ class TeacherAppDelegate: UIResponder, UIApplicationDelegate, UNUserNotification
                 }
             }
         }
-    }
-
-    private func setForceUpdateView() {
-        guard let window = window else { return }
-        let controller = CoreHostingController(ForceUpdateView(app: .teacher, isDismissable: false))
-        controller.view.layoutIfNeeded()
-        UIView.transition(with: window, duration: 0.5, options: .transitionFlipFromRight) {
-            window.rootViewController = controller
-        } completion: { [weak self] _ in
-            self?.environment.startupDidComplete()
-            UIApplication.shared.registerForPushNotifications()
-        }
-    }
-
-    private func showForceUpdateModal(on controller: UIViewController) {
-        let modal = CoreHostingController(ForceUpdateView(app: .teacher, isDismissable: true))
-        modal.modalPresentationStyle = .overFullScreen
-        controller.present(modal, animated: true)
     }
 }
 

--- a/packages/BusinessLogic/Sources/BusinessLogic/ForceUpdate/BusinessLogic.ForceUpdate.swift
+++ b/packages/BusinessLogic/Sources/BusinessLogic/ForceUpdate/BusinessLogic.ForceUpdate.swift
@@ -1,0 +1,49 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+extension BusinessLogic {
+    public protocol ForceUpdate {
+        func shouldForceUpdate(
+            appVersion: String?,
+            systemVersion: String,
+            minimumSystemVersion: String,
+            belowAppVersion: String
+        ) -> Bool
+    }
+
+    public struct ForceUpdateLive: ForceUpdate, Sendable {
+        public init() {}
+
+        public func shouldForceUpdate(
+            appVersion: String?,
+            systemVersion: String,
+            minimumSystemVersion: String,
+            belowAppVersion: String
+        ) -> Bool {
+            guard let appVersion else { return false }
+            return systemVersion.compare(minimumSystemVersion, options: .numeric) != .orderedAscending
+                && appVersion.compare(belowAppVersion, options: .numeric) == .orderedAscending
+        }
+    }
+}
+
+extension BusinessLogic.ForceUpdate where Self == BusinessLogic.ForceUpdateLive {
+    public static var live: BusinessLogic.ForceUpdateLive { .init() }
+}

--- a/packages/BusinessLogic/Sources/BusinessLogic/ForceUpdate/BusinessLogic.ForceUpdateMock.swift
+++ b/packages/BusinessLogic/Sources/BusinessLogic/ForceUpdate/BusinessLogic.ForceUpdateMock.swift
@@ -1,0 +1,47 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+#if DEBUG
+
+extension BusinessLogic {
+    public final class ForceUpdateMock: ForceUpdate {
+        public var shouldForceUpdateReturnValue = false
+        public private(set) var shouldForceUpdateReceivedInvocations: [(
+            appVersion: String?,
+            systemVersion: String,
+            minimumSystemVersion: String,
+            belowAppVersion: String
+        )] = []
+
+        public init(shouldForceUpdateReturnValue: Bool = false) {
+            self.shouldForceUpdateReturnValue = shouldForceUpdateReturnValue
+        }
+
+        public func shouldForceUpdate(
+            appVersion: String?,
+            systemVersion: String,
+            minimumSystemVersion: String,
+            belowAppVersion: String
+        ) -> Bool {
+            shouldForceUpdateReceivedInvocations.append((appVersion, systemVersion, minimumSystemVersion, belowAppVersion))
+            return shouldForceUpdateReturnValue
+        }
+    }
+}
+
+#endif

--- a/packages/BusinessLogic/Tests/BusinessLogicTests/ForceUpdate/BusinessLogic.ForceUpdateTests.swift
+++ b/packages/BusinessLogic/Tests/BusinessLogicTests/ForceUpdate/BusinessLogic.ForceUpdateTests.swift
@@ -1,0 +1,90 @@
+//
+// This file is part of Canvas.
+// Copyright (C) 2026-present  Instructure, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Testing
+@testable import BusinessLogic
+
+struct BusinessLogicForceUpdateTests {
+    private let testee = BusinessLogic.ForceUpdateLive()
+
+    @Test
+    func shouldForceUpdate_returnsFalseWhenAppVersionIsNil() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: nil,
+            systemVersion: "18.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(!shouldForceUpdate)
+    }
+
+    @Test
+    func shouldForceUpdate_returnsTrueWhenAppVersionBelowThresholdAndSystemMeetsMinimum() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: "4.9.0",
+            systemVersion: "18.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(shouldForceUpdate)
+    }
+
+    @Test
+    func shouldForceUpdate_returnsFalseWhenAppVersionEqualsThreshold() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: "5.0.0",
+            systemVersion: "18.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(!shouldForceUpdate)
+    }
+
+    @Test
+    func shouldForceUpdate_returnsFalseWhenAppVersionAboveThreshold() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: "6.0.0",
+            systemVersion: "18.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(!shouldForceUpdate)
+    }
+
+    @Test
+    func shouldForceUpdate_returnsFalseWhenSystemVersionBelowMinimum() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: "4.9.0",
+            systemVersion: "15.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(!shouldForceUpdate)
+    }
+
+    @Test
+    func shouldForceUpdate_returnsTrueWhenSystemVersionEqualsMinimum() {
+        let shouldForceUpdate = testee.shouldForceUpdate(
+            appVersion: "4.9.0",
+            systemVersion: "16.0",
+            minimumSystemVersion: "16.0",
+            belowAppVersion: "5.0.0"
+        )
+        #expect(shouldForceUpdate)
+    }
+}


### PR DESCRIPTION
## PR Info

refs: [MBL-19978](https://instructure.atlassian.net/browse/MBL-19978)
builds: Student, Teacher, Parent
affects: Student, Teacher, Parent
release note: Added support for prompting users when a required app update is available.

The goal of this PR to enable us to warn users that they need to update their app, or completely block them from using the app below a specific app version. This is configurable via Firebase Remote Config's `#app_name#_force_update_info` key. The key contains a JSON with three properties:
- belowAppVersion: App versions below the specified will warn or block the user.
- minimumSystemVersion: The warning or block will only happen on devices above or at the specified system version. This is to ensure that we don't force users to update if the new version is not available on their system.
- isDismissable: If `true` only a warning will appear on startup that can be dismissed. If `false` the app functionality is limited, the user cannot use the app until it's updated.

## Test Plan

Test if the update screen appears correctly. Test the behavior by configuring the `force_update_info` remote config flag.

## Merge
Leave merging to me. I'll have to correctly set the remote config.

## Screenshots

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img src="" maxHeight=500></td>
<td><img src="" maxHeight=500></td>
</tr>
</table>

## Checklist

- [ ] Follow-up e2e test ticket created
- [ ] A11y checked
- [ ] Tested on phone
- [ ] Tested on tablet
- [ ] Tested in dark mode
- [ ] Tested in light mode
- [ ] Approve from product


[MBL-19978]: https://instructure.atlassian.net/browse/MBL-19978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ